### PR TITLE
build(ui-deps): use workspace versions for shared configs

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,8 +33,8 @@
 	"devDependencies": {
 		"@eslint/compat": "^2.0.3",
 		"@eslint/js": "^9.39.4",
-		"@sprocket/eslint-config": "*",
-		"@sprocket/typescript-config": "*",
+		"@sprocket/eslint-config": "workspace:*",
+		"@sprocket/typescript-config": "workspace:*",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/kit": "^2.59.0",
 		"@sveltejs/package": "^2.5.7",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `packages/ui/package.json` to use the `workspace:*` protocol for the two internal shared-config devDependencies, matching how `apps/web` already declares them. The change ensures Bun's workspace resolver always picks the local packages rather than potentially resolving against the npm registry.

- Replaces bare `"*"` with `"workspace:*"` for `@sprocket/eslint-config` and `@sprocket/typescript-config` in `devDependencies`, making `packages/ui` consistent with `apps/web`.
- Both changed dependencies are `devDependencies` only, so they are not included in the published package — no impact on consumers of `@sprocket/ui`.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal change that aligns workspace dependency declarations across packages.

The change is a two-line diff in devDependencies, consistent with the pattern already used in apps/web. Both packages exist in the monorepo and are resolvable via workspace:* with Bun. Since these are devDependencies, they have no effect on published package consumers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/package.json | Upgrades @sprocket/eslint-config and @sprocket/typescript-config from "*" to "workspace:*" in devDependencies, aligning with how apps/web already declares these same packages. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/ui installs devDependencies"] --> B{Resolution strategy}

    B -->|"Before: @sprocket/eslint-config: '*'"| C["npm registry lookup\n(any matching version)"]
    B -->|"After: @sprocket/eslint-config: 'workspace:*'"| D["Bun workspace resolver\n(local package)"]

    C --> E["Could resolve to a published\nnpm registry version\nor local workspace"]
    D --> F["Always resolves to\npackages/eslint-config\nin this monorepo"]

    B -->|"Before: @sprocket/typescript-config: '*'"| G["npm registry lookup\n(any matching version)"]
    B -->|"After: @sprocket/typescript-config: 'workspace:*'"| H["Bun workspace resolver\n(local package)"]

    G --> I["Could resolve to a published\nnpm registry version\nor local workspace"]
    H --> J["Always resolves to\npackages/typescript-config\nin this monorepo"]

    F --> K["Consistent with apps/web\ndependency declarations"]
    J --> K
```

<sub>Reviews (1): Last reviewed commit: ["build(ui-deps): use workspace versions f..."](https://github.com/spikonado/sprocket/commit/4f385538f293ac94fe8880a38e7674d581d94320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37566176)</sub>

<!-- /greptile_comment -->