### PR TITLE
build(deps): migrate to @lucide/svelte

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
 		"convex": "^1.37.0",
 		"convex-svelte": "^0.0.12",
 		"isomorphic-dompurify": "^3.12.0",
-		"lucide-svelte": "^1.0.1",
+		"@lucide/svelte": "^1.18.0",
 		"marked": "^18.0.3",
 		"tailwind-merge": "^3.5.0",
 		"zod": "^3.25.76"

--- a/apps/web/src/lib/components/home/auth-gate.svelte
+++ b/apps/web/src/lib/components/home/auth-gate.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Sparkles, UserRound } from 'lucide-svelte';
+	import { Sparkles, UserRound } from '@lucide/svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
 
 	type AuthGateState = {

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowUp, ChevronDown, Cpu, LockOpen, Square } from 'lucide-svelte';
+	import { ArrowUp, ChevronDown, Cpu, LockOpen, Square } from '@lucide/svelte';
 	import ModelSelector from '$lib/components/model-selector.svelte';
 	import ReasoningSelector from '$lib/components/reasoning-selector.svelte';
 	import { shouldSubmitComposerFromKeydown } from '$lib/chat/composer';

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tick } from 'svelte';
-	import { TerminalSquare } from 'lucide-svelte';
+	import { TerminalSquare } from '@lucide/svelte';
 	import {
 		buildPersistedToolLogs,
 		type AssistantPart,

--- a/apps/web/src/lib/components/home/workspace-picker.svelte
+++ b/apps/web/src/lib/components/home/workspace-picker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { CornerLeftUp, Folder, FolderPlus, LoaderCircle } from 'lucide-svelte';
+	import { CornerLeftUp, Folder, FolderPlus, LoaderCircle } from '@lucide/svelte';
 	import type { DesktopApi, FilesystemBrowseEntry, WorkspaceOverview } from '$lib/types/sprocket';
 	import {
 		appendBrowsePathSegment,

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -7,7 +7,7 @@
 		LogOut,
 		SquarePen,
 		Trash2
-	} from 'lucide-svelte';
+	} from '@lucide/svelte';
 	import { formatRelativeTime } from '$lib/format';
 	import type { Id } from '$convex/_generated/dataModel';
 	import type { ThreadSummary, WorkspaceThreadGroup } from '$lib/types/sprocket';

--- a/apps/web/src/lib/components/model-selector.svelte
+++ b/apps/web/src/lib/components/model-selector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Check, ChevronDown } from 'lucide-svelte';
+	import { Check, ChevronDown } from '@lucide/svelte';
 	import OpenAiBlossom from '$lib/components/openai-blossom.svelte';
 	import type { ModelOption } from '$lib/chat/model-options';
 	import { cn } from '$lib/utils';

--- a/apps/web/src/lib/components/reasoning-selector.svelte
+++ b/apps/web/src/lib/components/reasoning-selector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Check, ChevronDown } from 'lucide-svelte';
+	import { Check, ChevronDown } from '@lucide/svelte';
 	import { defaultReasoningEffort } from '$convex/lib/models';
 	import type { SupportedReasoningEffort } from '$convex/lib/models';
 	import { reasoningEffortOptions } from '$lib/chat/model-options';

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@convex-dev/rate-limiter": "^0.3.2",
         "@convex-dev/workos-authkit": "^0.2.3",
         "@fontsource/dm-sans": "^5.2.8",
+        "@lucide/svelte": "^1.18.0",
         "@workos-inc/authkit-js": "^0.20.0",
         "ai": "^6.0.174",
         "class-variance-authority": "^0.7.1",
@@ -35,7 +36,6 @@
         "convex": "^1.37.0",
         "convex-svelte": "^0.0.12",
         "isomorphic-dompurify": "^3.12.0",
-        "lucide-svelte": "^1.0.1",
         "marked": "^18.0.3",
         "tailwind-merge": "^3.5.0",
         "zod": "^3.25.76",
@@ -295,6 +295,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lucide/svelte": ["@lucide/svelte@1.18.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-S1cjiJflMLIirDZtZ8ou2Vy0xMrOqEQzYzDo29AUxoJiOjUfMHUeClvprJsGUEr60RYDJzEgkjSkWm1nlN9iyQ=="],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
@@ -1093,8 +1095,6 @@
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
-
-    "lucide-svelte": ["lucide-svelte@1.0.1", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the Lucide icon dependency from `lucide-svelte` to the new scoped package `@lucide/svelte` (v1.18.0) across seven component files, updating only the import source strings.

- `apps/web/package.json` replaces `lucide-svelte ^1.0.1` with `@lucide/svelte ^1.18.0`.
- All component import lines are updated from `'lucide-svelte'` to `'@lucide/svelte'`; no icon names or usages change except for one pre-existing mismatch already flagged in review (`TerminalSquare` vs the current package name `SquareTerminal`).

<h3>Confidence Score: 4/5</h3>

Nearly all icon imports resolve correctly in the new package; one icon name in thread-transcript.svelte was flagged in a previous review comment and needs to be addressed before merging.

The migration is mechanical and correct for every file except thread-transcript.svelte, where an icon was renamed in the @lucide/svelte package and the old name will fail at build or render time. That pre-existing finding (noted in a prior review thread) is the only blocker.

apps/web/src/lib/components/home/thread-transcript.svelte — the imported icon name does not match what the new package exports.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/package.json | Dependency swapped from lucide-svelte ^1.0.1 to @lucide/svelte ^1.18.0; straightforward package rename. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Import source updated to @lucide/svelte, but TerminalSquare (already flagged) does not exist under that name in the new package. |
| apps/web/src/lib/components/home/auth-gate.svelte | Import source updated to @lucide/svelte; Sparkles and UserRound are valid exports in the new package. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Import source updated to @lucide/svelte; all five icons (ArrowUp, ChevronDown, Cpu, LockOpen, Square) remain valid in the new package. |
| apps/web/src/lib/components/home/workspace-picker.svelte | Import source updated to @lucide/svelte; CornerLeftUp, Folder, FolderPlus, LoaderCircle all exist in the new package. |
| apps/web/src/lib/components/home/workspace-sidebar.svelte | Import source updated to @lucide/svelte; LogOut, SquarePen, Trash2 and others are all valid exports. |
| apps/web/src/lib/components/model-selector.svelte | Import source updated to @lucide/svelte; Check and ChevronDown are valid exports. |
| apps/web/src/lib/components/reasoning-selector.svelte | Import source updated to @lucide/svelte; Check and ChevronDown are valid exports. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json] -->|removes| B[lucide-svelte]
    A -->|adds| C[lucide svelte scoped package]
    C --> D[auth-gate.svelte\nSparkles, UserRound OK]
    C --> E[prompt-composer.svelte\nArrowUp, ChevronDown, Cpu, LockOpen, Square OK]
    C --> F[thread-transcript.svelte\nTerminalSquare - already flagged]
    C --> G[workspace-picker.svelte\nCornerLeftUp, Folder, FolderPlus, LoaderCircle OK]
    C --> H[workspace-sidebar.svelte\nLogOut, SquarePen, Trash2 OK]
    C --> I[model-selector.svelte\nCheck, ChevronDown OK]
    C --> J[reasoning-selector.svelte\nCheck, ChevronDown OK]
```

<sub>Reviews (3): Last reviewed commit: ["build(deps): migrate to @lucide/svelte"](https://github.com/spikonado/sprocket/commit/ebe37c9b87dcf8865c15946ad741479e1f98e5f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37567854)</sub>

<!-- /greptile_comment -->