### PR TITLE
ci(renovate): Update config for faster dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,19 @@
 		"config:recommended",
 		"schedule:earlyMondays",
 		":dependencyDashboard",
-		":semanticCommitTypeAll(build)",
-		":prConcurrentLimit10"
+		":semanticCommitTypeAll(build)"
 	],
+	"prConcurrentLimit": 10,
+	"prHourlyLimit": 10,
 	"packageRules": [
 		{
+			"matchUpdateTypes": ["lockFileMaintenance"],
+			"prPriority": 100
+		},
+		{
 			"matchDepTypes": ["action", "devDependencies", "uses-with"],
-			"automerge": true
+			"automerge": true,
+			"prPriority": 20
 		}
 	],
 	"lockFileMaintenance": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates Renovate configuration to create dependency update PRs sooner.
- Moves the concurrent PR limit into an explicit root `prConcurrentLimit` option.
- Raises the hourly PR creation limit and prioritizes lockfile maintenance.
- Adds higher priority for automerged action, dev dependency, and `uses-with` updates.

<h3>Confidence Score: 4/5</h3>

The config-only change is low risk to application runtime, but the dependency update ordering can delay production fixes under backlog pressure.

The changed Renovate rules are straightforward, and the main concern is limited to update scheduling behavior rather than shipped application code.

renovate.json

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared prConcurrentLimit settings between the base and head configurations; both are effectively 10.
- Compared prHourlyLimit; the base configuration uses the default unlimited setting, while the head adds a limit of 10.
- Compared lockFileMaintenance prioritization; the base has no rule (default 0) and the head adds a prPriority of 100 for lockFileMaintenance updates.
- Validated both configurations with renovate-config-validator and confirmed that both pass.

<a href="https://app.greptile.com/trex/runs/11234180/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Arenovate.json%3A16-20%0A**Dev%20updates%20can%20starve%20runtime%20updates**%0A%0AThis%20rule%20gives%20all%20GitHub%20Actions%2C%20%60devDependencies%60%2C%20and%20%60uses-with%60%20updates%20priority%20%6020%60%2C%20while%20normal%20runtime%20dependencies%20stay%20at%20Renovate's%20default%20priority%20%600%60.%20Because%20this%20PR%20also%20caps%20creation%20with%20%60prHourlyLimit%60%20and%20%60prConcurrentLimit%60%2C%20a%20Monday%20backlog%20with%20many%20dev%2Faction%20updates%20can%20fill%20the%20available%20slots%20before%20production%20dependency%20patches%20are%20opened.%20That%20can%20delay%20runtime%20fixes%20even%20though%20the%20config%20is%20meant%20to%20make%20dependency%20updates%20faster.%0A%0A&pr=9&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22ci%2Fupdate-renovate-config%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fupdate-renovate-config%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Arenovate.json%3A16-20%0A**Dev%20updates%20can%20starve%20runtime%20updates**%0A%0AThis%20rule%20gives%20all%20GitHub%20Actions%2C%20%60devDependencies%60%2C%20and%20%60uses-with%60%20updates%20priority%20%6020%60%2C%20while%20normal%20runtime%20dependencies%20stay%20at%20Renovate's%20default%20priority%20%600%60.%20Because%20this%20PR%20also%20caps%20creation%20with%20%60prHourlyLimit%60%20and%20%60prConcurrentLimit%60%2C%20a%20Monday%20backlog%20with%20many%20dev%2Faction%20updates%20can%20fill%20the%20available%20slots%20before%20production%20dependency%20patches%20are%20opened.%20That%20can%20delay%20runtime%20fixes%20even%20though%20the%20config%20is%20meant%20to%20make%20dependency%20updates%20faster.%0A%0A&repo=spikonado%2Fsprocket&pr=9&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci(renovate): Update config for faster d..."](https://github.com/spikonado/sprocket/commit/3efab37b048795e20ea8621826d07cae31d73317) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37817635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->