### PR TITLE
feat(auth): Switch to browser-based login for desktop app

### DIFF
--- a/apps/desktop/main.mjs
+++ b/apps/desktop/main.mjs
@@ -1,23 +1,28 @@
 import electron from 'electron';
+import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { API_HOST, API_PORT, DEV_HOST, DEV_WEB_URL } from '../../scripts/dev-config.mjs';
+import { API_PORT, DEV_WEB_URL } from '../../scripts/dev-config.mjs';
 
-const { app, BrowserWindow, Menu, ipcMain } = electron;
+const { app, BrowserWindow, Menu, ipcMain, shell } = electron;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const isDevelopment = !app.isPackaged;
 const serverPort = Number(process.env.SPROCKET_PORT ?? API_PORT);
-const serverHost = process.env.SPROCKET_HOST ?? API_HOST;
+// WorkOS AuthKit only allows 127.0.0.1 loopback redirect URIs for native desktop login.
+const serverHost = '127.0.0.1';
+const desktopLoginCallbackUrl = `http://${serverHost}:${serverPort}/api/auth/desktop-login/callback`;
 const devRendererUrl = process.env.SPROCKET_ELECTRON_RENDERER_URL ?? DEV_WEB_URL;
 const preloadEntry = path.join(__dirname, 'preload.cjs');
 
 let serverProcess = null;
 let serverBaseUrl = null;
 let serverPairingCredential = null;
+let serverDesktopLoginCallbackUrl = null;
+let mainWindowRef = null;
 
 function getServerBinaryPath() {
 	return isDevelopment
@@ -140,6 +145,11 @@ async function startLocalServer() {
 	const bootstrap = await bootstrapResponse.json();
 	serverPairingCredential = bootstrap.pairingCredential;
 	serverBaseUrl = bootstrap.httpBaseUrl ?? serverBaseUrl;
+	serverDesktopLoginCallbackUrl =
+		typeof bootstrap.desktopLoginCallbackUrl === 'string' &&
+		bootstrap.desktopLoginCallbackUrl.trim().length > 0
+			? bootstrap.desktopLoginCallbackUrl.trim()
+			: desktopLoginCallbackUrl;
 
 	return serverBaseUrl;
 }
@@ -186,6 +196,18 @@ function createMainWindow() {
 			preload: preloadEntry
 		}
 	});
+	mainWindowRef = mainWindow;
+	mainWindow.on('closed', () => {
+		if (mainWindowRef === mainWindow) {
+			mainWindowRef = null;
+		}
+	});
+	mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+		void openExternalHttpsUrl(url).catch((error) => {
+			console.error('Failed to open external URL', error);
+		});
+		return { action: 'deny' };
+	});
 	mainWindow.webContents.on(
 		'did-fail-load',
 		(_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
@@ -221,8 +243,97 @@ ipcMain.handle('sprocket:get-local-bootstrap', () => {
 
 	return {
 		httpBaseUrl: serverBaseUrl,
+		desktopLoginCallbackUrl: serverDesktopLoginCallbackUrl ?? desktopLoginCallbackUrl,
 		pairingCredential: serverPairingCredential
 	};
+});
+
+function openWithXdgOpen(url) {
+	return new Promise((resolve, reject) => {
+		const systemOpeners = [
+			'/run/current-system/sw/bin/xdg-open',
+			'/usr/bin/xdg-open',
+			'/usr/local/bin/xdg-open'
+		];
+		const openerCommand = systemOpeners.find((candidate) => fs.existsSync(candidate)) ?? 'xdg-open';
+		const openerEnv = { ...process.env };
+		for (const key of [
+			'GIO_EXTRA_MODULES',
+			'GI_TYPELIB_PATH',
+			'GSETTINGS_SCHEMA_DIR',
+			'GTK_PATH',
+			'LD_LIBRARY_PATH'
+		]) {
+			delete openerEnv[key];
+		}
+		const opener = spawn(openerCommand, [url], {
+			env: openerEnv,
+			stdio: ['ignore', 'ignore', 'pipe']
+		});
+		let stderr = '';
+
+		opener.once('error', reject);
+		opener.stderr.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+		opener.once('close', (code, signal) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+
+			const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+			const details = stderr.trim();
+			reject(new Error(`xdg-open failed with ${reason}${details ? `: ${details}` : ''}`));
+		});
+	});
+}
+
+function parseExternalHttpsUrl(url) {
+	if (typeof url !== 'string' || url.trim().length === 0) {
+		throw new Error('A URL is required.');
+	}
+
+	let parsed;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new Error('Invalid URL.');
+	}
+
+	if (parsed.protocol !== 'https:') {
+		throw new Error('Only https URLs can be opened externally.');
+	}
+
+	return parsed.toString();
+}
+
+async function openExternalHttpsUrl(url) {
+	const parsedUrl = parseExternalHttpsUrl(url);
+	if (process.platform === 'linux') {
+		await openWithXdgOpen(parsedUrl);
+		return;
+	}
+
+	await shell.openExternal(parsedUrl);
+}
+
+ipcMain.handle('sprocket:open-external', async (_event, url) => {
+	await openExternalHttpsUrl(url);
+});
+
+ipcMain.handle('sprocket:focus-window', () => {
+	const mainWindow = mainWindowRef;
+	if (!mainWindow || mainWindow.isDestroyed()) {
+		return false;
+	}
+
+	if (mainWindow.isMinimized()) {
+		mainWindow.restore();
+	}
+	mainWindow.show();
+	mainWindow.focus();
+	return true;
 });
 
 app.whenReady().then(async () => {

--- a/apps/desktop/preload.cjs
+++ b/apps/desktop/preload.cjs
@@ -1,5 +1,7 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('sprocketDesktopBridge', {
-	getLocalBootstrap: () => ipcRenderer.invoke('sprocket:get-local-bootstrap')
+	getLocalBootstrap: () => ipcRenderer.invoke('sprocket:get-local-bootstrap'),
+	openExternal: (url) => ipcRenderer.invoke('sprocket:open-external', url),
+	focusWindow: () => ipcRenderer.invoke('sprocket:focus-window')
 });

--- a/apps/web/convex.json
+++ b/apps/web/convex.json
@@ -2,7 +2,10 @@
 	"authKit": {
 		"dev": {
 			"configure": {
-				"redirectUris": ["http://localhost:5173/callback", "sprocket://app/callback"],
+				"redirectUris": [
+					"http://localhost:5173/callback",
+					"http://127.0.0.1:*/api/auth/desktop-login/callback"
+				],
 				"appHomepageUrl": "http://localhost:5173",
 				"corsOrigins": ["http://localhost:5173"]
 			}
@@ -11,7 +14,7 @@
 			"configure": {
 				"redirectUris": [
 					"https://${buildEnv.VERCEL_BRANCH_URL}/callback",
-					"sprocket://app/callback"
+					"http://127.0.0.1:*/api/auth/desktop-login/callback"
 				],
 				"appHomepageUrl": "https://${buildEnv.VERCEL_PROJECT_PRODUCTION_URL}",
 				"corsOrigins": ["https://${buildEnv.VERCEL_BRANCH_URL}"]
@@ -21,7 +24,7 @@
 			"configure": {
 				"redirectUris": [
 					"https://${buildEnv.VERCEL_PROJECT_PRODUCTION_URL}/callback",
-					"sprocket://app/callback"
+					"http://127.0.0.1:*/api/auth/desktop-login/callback"
 				],
 				"appHomepageUrl": "https://${buildEnv.VERCEL_PROJECT_PRODUCTION_URL}",
 				"corsOrigins": ["https://${buildEnv.VERCEL_PROJECT_PRODUCTION_URL}"]

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -3,8 +3,11 @@ declare global {
 		sprocketDesktopBridge?: {
 			getLocalBootstrap: () => Promise<{
 				httpBaseUrl: string;
+				desktopLoginCallbackUrl: string;
 				pairingCredential: string;
 			}>;
+			openExternal: (url: string) => Promise<void>;
+			focusWindow: () => Promise<boolean>;
 		};
 	}
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -6,6 +6,8 @@ import { get, writable } from 'svelte/store';
 type AuthStatus = {
 	isLoading: boolean;
 	isReady: boolean;
+	isWaitingForBrowserSignIn: boolean;
+	browserSignInUrl: string | null;
 	user: User | null;
 	error: string | null;
 };
@@ -13,6 +15,8 @@ type AuthStatus = {
 const initialState: AuthStatus = {
 	isLoading: true,
 	isReady: false,
+	isWaitingForBrowserSignIn: false,
+	browserSignInUrl: null,
 	user: null,
 	error: null
 };
@@ -27,10 +31,19 @@ type AuthBootstrapClient = {
 	) => Promise<{ workosClientId: string | null }>;
 };
 
+const DESKTOP_LOGIN_POLL_INTERVAL_MS = 1_500;
+const DESKTOP_LOGIN_TIMEOUT_MS = 5 * 60 * 1_000;
+
 let authClientPromise: Promise<AuthClient | null> | null = null;
 let authConfigPromise: Promise<{ workosClientId: string | null }> | null = null;
 let bootstrapClient: AuthBootstrapClient | null = null;
 let isSigningOut = false;
+type DesktopSignInAttempt = {
+	nonce: string;
+	abort: AbortController;
+};
+let desktopSignInAttempt: DesktopSignInAttempt | null = null;
+let desktopLoginStartQueue: Promise<void> = Promise.resolve();
 
 function getAuthBootstrapClient() {
 	if (bootstrapClient) {
@@ -60,6 +73,19 @@ async function getClientId() {
 	return config.workosClientId?.trim() || undefined;
 }
 
+function getDesktopBridge() {
+	if (!browser) {
+		return null;
+	}
+
+	const bridge = window.sprocketDesktopBridge;
+	if (!bridge?.getLocalBootstrap || !bridge.openExternal || !bridge.focusWindow) {
+		return null;
+	}
+
+	return bridge;
+}
+
 async function getAuthClient() {
 	if (!browser) {
 		return null;
@@ -75,6 +101,8 @@ async function getAuthClient() {
 			authState.set({
 				isLoading: false,
 				isReady: true,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
 				user: null,
 				error: 'Missing WORKOS_CLIENT_ID.'
 			});
@@ -108,6 +136,8 @@ async function getAuthClient() {
 			authState.set({
 				isLoading: false,
 				isReady: true,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
 				user: client.getUser(),
 				error: null
 			});
@@ -133,6 +163,8 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 		authState.set({
 			isLoading: false,
 			isReady: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
 			user: client?.getUser() ?? null,
 			error: null
 		});
@@ -140,15 +172,295 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 		authState.set({
 			isLoading: false,
 			isReady: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
 			user: null,
 			error: error instanceof Error ? error.message : 'Failed to initialize authentication.'
 		});
 	}
 }
 
+function extractNonceFromState(state: string): string | null {
+	try {
+		const parsed = JSON.parse(state) as { nonce?: unknown };
+		return typeof parsed.nonce === 'string' && parsed.nonce.trim().length > 0
+			? parsed.nonce.trim()
+			: null;
+	} catch {
+		return state.trim() || null;
+	}
+}
+
+async function startDesktopLogin(nonce: string): Promise<void> {
+	const response = await fetch('/api/auth/desktop-login/start', {
+		method: 'POST',
+		credentials: 'include',
+		headers: {
+			'content-type': 'application/json'
+		},
+		body: JSON.stringify({ state: nonce })
+	});
+
+	if (!response.ok) {
+		const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+		throw new Error(payload?.error ?? 'Failed to start desktop sign-in.');
+	}
+}
+
+function isCurrentDesktopSignIn(attempt: DesktopSignInAttempt): boolean {
+	return desktopSignInAttempt === attempt && !attempt.abort.signal.aborted;
+}
+
+function requireCurrentDesktopSignIn(attempt: DesktopSignInAttempt): void {
+	if (!isCurrentDesktopSignIn(attempt)) {
+		throw new DOMException('Aborted', 'AbortError');
+	}
+}
+
+async function startDesktopLoginInOrder(attempt: DesktopSignInAttempt): Promise<void> {
+	const previousStart = desktopLoginStartQueue;
+	let releaseStart!: () => void;
+	desktopLoginStartQueue = new Promise<void>((resolve) => {
+		releaseStart = resolve;
+	});
+
+	await previousStart;
+	try {
+		requireCurrentDesktopSignIn(attempt);
+
+		// Do not abort this request: a client-side abort does not prove the server
+		// stopped processing it. Serializing complete responses guarantees that a
+		// replacement attempt is the last /start request handled by the server.
+		await startDesktopLogin(attempt.nonce);
+		requireCurrentDesktopSignIn(attempt);
+	} finally {
+		releaseStart();
+	}
+}
+
+function resolveDesktopLoginCallbackUrl(bootstrap: {
+	httpBaseUrl: string;
+	desktopLoginCallbackUrl?: string;
+}): string {
+	const configured = bootstrap.desktopLoginCallbackUrl?.trim();
+	if (configured) {
+		return configured.replace(/\/$/, '');
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(bootstrap.httpBaseUrl);
+	} catch {
+		throw new Error('Local server bootstrap URL is invalid.');
+	}
+
+	const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+	return `http://127.0.0.1:${port}/api/auth/desktop-login/callback`;
+}
+
+async function pollDesktopLoginResult(
+	nonce: string,
+	signal: AbortSignal
+): Promise<{ code: string; state: string }> {
+	const startedAt = Date.now();
+
+	while (!signal.aborted) {
+		if (Date.now() - startedAt > DESKTOP_LOGIN_TIMEOUT_MS) {
+			throw new Error('Sign-in timed out. Try again.');
+		}
+
+		const response = await fetch('/api/auth/desktop-login/result', {
+			credentials: 'include',
+			signal
+		});
+
+		if (!response.ok) {
+			const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+			throw new Error(payload?.error ?? 'Failed to check desktop sign-in status.');
+		}
+
+		const payload = (await response.json()) as
+			| { status: 'pending' }
+			| { status: 'complete'; code: string; state: string }
+			| { status: 'failed'; error: string };
+
+		if (payload.status === 'failed') {
+			throw new Error(payload.error || 'Desktop sign-in failed.');
+		}
+
+		if (payload.status === 'complete') {
+			const returnedNonce = extractNonceFromState(payload.state);
+			if (returnedNonce !== nonce) {
+				throw new Error('Desktop sign-in state mismatch.');
+			}
+			return { code: payload.code, state: payload.state };
+		}
+
+		await new Promise<void>((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				signal.removeEventListener('abort', onAbort);
+				resolve();
+			}, DESKTOP_LOGIN_POLL_INTERVAL_MS);
+
+			function onAbort() {
+				clearTimeout(timeout);
+				reject(new DOMException('Aborted', 'AbortError'));
+			}
+
+			signal.addEventListener('abort', onAbort, { once: true });
+		});
+	}
+
+	throw new DOMException('Aborted', 'AbortError');
+}
+
+async function signInWithSystemBrowser(clientId: string) {
+	const bridge = getDesktopBridge();
+	if (!bridge) {
+		throw new Error('Desktop bridge is unavailable.');
+	}
+
+	stopDesktopSignInPolling();
+
+	const attempt: DesktopSignInAttempt = {
+		nonce: crypto.randomUUID(),
+		abort: new AbortController()
+	};
+	desktopSignInAttempt = attempt;
+
+	authState.update((current) => ({
+		...current,
+		isWaitingForBrowserSignIn: true,
+		browserSignInUrl: null,
+		error: null
+	}));
+
+	try {
+		const bootstrap = await bridge.getLocalBootstrap();
+		requireCurrentDesktopSignIn(attempt);
+		const redirectUri = resolveDesktopLoginCallbackUrl(bootstrap);
+
+		await startDesktopLoginInOrder(attempt);
+		requireCurrentDesktopSignIn(attempt);
+
+		// Temporary client so AuthKit stores the PKCE verifier and builds an authorize URL
+		// that returns to the local loopback callback instead of the in-app /callback route.
+		// Do not dispose(): dispose() resets the shared AuthKit memory store used by the
+		// main client. This temporary client has no refresh timer unless a session exists.
+		const authorizeClient = await createClient(clientId, {
+			redirectUri
+		});
+		requireCurrentDesktopSignIn(attempt);
+		const authorizeUrl = await authorizeClient.getSignInUrl({ state: { nonce: attempt.nonce } });
+		requireCurrentDesktopSignIn(attempt);
+
+		authState.update((current) => ({
+			...current,
+			browserSignInUrl: authorizeUrl
+		}));
+		requireCurrentDesktopSignIn(attempt);
+		void bridge.openExternal(authorizeUrl).catch((error) => {
+			if (!isCurrentDesktopSignIn(attempt)) {
+				return;
+			}
+			authState.update((current) => ({
+				...current,
+				error:
+					error instanceof Error
+						? `Could not open your browser automatically: ${error.message}`
+						: 'Could not open your browser automatically. Use the link shown to continue.'
+			}));
+		});
+		const result = await pollDesktopLoginResult(attempt.nonce, attempt.abort.signal);
+		requireCurrentDesktopSignIn(attempt);
+		try {
+			await bridge.focusWindow();
+		} catch (error) {
+			if (isCurrentDesktopSignIn(attempt)) {
+				console.warn('Failed to focus desktop window after sign-in', error);
+			}
+		}
+		requireCurrentDesktopSignIn(attempt);
+
+		const callbackUrl = new URL('/callback', window.location.origin);
+		callbackUrl.searchParams.set('code', result.code);
+		callbackUrl.searchParams.set('state', result.state);
+		requireCurrentDesktopSignIn(attempt);
+		window.location.href = callbackUrl.toString();
+	} catch (error) {
+		if (desktopSignInAttempt !== attempt) {
+			return;
+		}
+
+		if (error instanceof DOMException && error.name === 'AbortError') {
+			authState.update((current) => ({
+				...current,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				error: null
+			}));
+			return;
+		}
+
+		authState.update((current) => ({
+			...current,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
+			error: error instanceof Error ? error.message : 'Failed to sign in with the system browser.'
+		}));
+	} finally {
+		if (desktopSignInAttempt === attempt) {
+			desktopSignInAttempt = null;
+		}
+	}
+}
+
+function stopDesktopSignInPolling() {
+	desktopSignInAttempt?.abort.abort();
+	desktopSignInAttempt = null;
+}
+
+export function cancelDesktopSignIn() {
+	const cancelledAttempt = desktopSignInAttempt;
+	const pendingStarts = desktopLoginStartQueue;
+	stopDesktopSignInPolling();
+	authState.update((current) => ({
+		...current,
+		isWaitingForBrowserSignIn: false,
+		browserSignInUrl: null
+	}));
+	if (!cancelledAttempt) {
+		return;
+	}
+	void pendingStarts
+		.then(async () => {
+			await fetch('/api/auth/desktop-login/cancel', {
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'content-type': 'application/json'
+				},
+				body: JSON.stringify({ state: cancelledAttempt.nonce })
+			});
+		})
+		.catch(() => {
+			// Best-effort server cleanup; local UI already cancelled.
+		});
+}
+
 export async function signIn() {
 	const client = await getAuthClient();
 	if (!client) {
+		return;
+	}
+
+	const clientId = await getClientId();
+	if (!clientId) {
+		return;
+	}
+
+	if (getDesktopBridge()) {
+		await signInWithSystemBrowser(clientId);
 		return;
 	}
 
@@ -161,6 +473,7 @@ export async function signOut() {
 		return;
 	}
 
+	cancelDesktopSignIn();
 	isSigningOut = true;
 	authState.update((current) => ({ ...current, isLoading: true }));
 
@@ -172,6 +485,8 @@ export async function signOut() {
 		authState.set({
 			isLoading: false,
 			isReady: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
 			user: null,
 			error: null
 		});
@@ -179,6 +494,8 @@ export async function signOut() {
 		authState.set({
 			isLoading: false,
 			isReady: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
 			user: null,
 			error: error instanceof Error ? error.message : 'Failed to sign out.'
 		});

--- a/apps/web/src/lib/components/home/browser-signin-overlay.svelte
+++ b/apps/web/src/lib/components/home/browser-signin-overlay.svelte
@@ -1,0 +1,229 @@
+<script lang="ts">
+	import { Check, Copy, ExternalLink, LoaderCircle } from '@lucide/svelte';
+	import { tick } from 'svelte';
+
+	type Props = {
+		open: boolean;
+		signInUrl: string | null;
+		error?: string | null;
+		onCancel: () => void;
+	};
+
+	let { open, signInUrl, error = null, onCancel }: Props = $props();
+
+	let copied = $state(false);
+	let copyError = $state<string | null>(null);
+	let dialogEl = $state<HTMLDivElement | null>(null);
+	let copiedTimeout: number | null = null;
+
+	$effect(() => {
+		if (!open) {
+			copied = false;
+			copyError = null;
+			return;
+		}
+
+		const previouslyFocused =
+			document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		let disposed = false;
+		void tick().then(() => {
+			if (!disposed) {
+				dialogEl?.focus();
+			}
+		});
+
+		function handleWindowKeydown(event: KeyboardEvent) {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				event.stopPropagation();
+				onCancel();
+				return;
+			}
+
+			if (event.key !== 'Tab' || !dialogEl) {
+				return;
+			}
+
+			const focusable = Array.from(
+				dialogEl.querySelectorAll<HTMLElement>(
+					'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			).filter((element) => !element.hasAttribute('hidden') && element.offsetParent !== null);
+
+			if (focusable.length === 0) {
+				event.preventDefault();
+				dialogEl.focus();
+				return;
+			}
+
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			const active = document.activeElement;
+			if (
+				event.shiftKey &&
+				(active === dialogEl || active === first || !dialogEl.contains(active))
+			) {
+				event.preventDefault();
+				last.focus();
+			} else if (
+				!event.shiftKey &&
+				(active === dialogEl || active === last || !dialogEl.contains(active))
+			) {
+				event.preventDefault();
+				first.focus();
+			}
+		}
+
+		window.addEventListener('keydown', handleWindowKeydown, true);
+		return () => {
+			disposed = true;
+			window.removeEventListener('keydown', handleWindowKeydown, true);
+			if (copiedTimeout !== null) {
+				window.clearTimeout(copiedTimeout);
+				copiedTimeout = null;
+			}
+			if (previouslyFocused?.isConnected) {
+				previouslyFocused.focus();
+			}
+		};
+	});
+
+	async function copySignInUrl() {
+		if (!signInUrl) {
+			return;
+		}
+
+		try {
+			await navigator.clipboard.writeText(signInUrl);
+			copied = true;
+			copyError = null;
+			if (copiedTimeout !== null) {
+				window.clearTimeout(copiedTimeout);
+			}
+			copiedTimeout = window.setTimeout(() => {
+				copied = false;
+				copiedTimeout = null;
+			}, 2_000);
+		} catch {
+			copied = false;
+			copyError = 'Could not copy the sign-in link. Select it above and copy manually.';
+		}
+	}
+
+	function openSignInUrl() {
+		if (!signInUrl) {
+			return;
+		}
+
+		window.open(signInUrl, '_blank', 'noopener,noreferrer');
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-[2px]"
+		role="presentation"
+		onclick={(event) => {
+			if (event.target === event.currentTarget) {
+				onCancel();
+			}
+		}}
+	>
+		<div
+			bind:this={dialogEl}
+			class="flex w-full max-w-xl flex-col overflow-hidden rounded-3xl border border-white/10 bg-[#1c1c1f] text-white shadow-2xl outline-none"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="browser-signin-title"
+			tabindex="-1"
+		>
+			<div class="flex flex-col items-center gap-4 px-10 pt-10 pb-7 text-center">
+				<span
+					class="flex size-16 items-center justify-center rounded-full border border-sky-400/25 bg-sky-400/10 text-sky-200"
+				>
+					<LoaderCircle class="size-7 animate-spin" />
+				</span>
+				<div>
+					<h2 id="browser-signin-title" class="text-xl font-semibold text-white">
+						Finish signing in
+					</h2>
+					<p class="mt-2 text-sm leading-6 text-slate-400">
+						We opened your browser to complete sign-in. Waiting for you to finish there.
+					</p>
+				</div>
+			</div>
+
+			<div class="px-10 pb-6">
+				<p class="text-[11px] tracking-[0.16em] text-slate-500 uppercase">Sign-in link</p>
+				<p
+					class="mt-2 max-h-24 overflow-y-auto rounded-xl border border-white/8 bg-black/25 px-4 py-3 font-mono text-[11px] leading-5 break-all text-slate-400 select-all"
+					title={signInUrl ?? undefined}
+				>
+					{signInUrl ?? 'Preparing secure sign-in link…'}
+				</p>
+				<p class="mt-3 text-[13px] leading-5 text-slate-500">
+					If your browser did not open automatically, use the buttons below.
+				</p>
+
+				{#if error}
+					<p
+						class="mt-4 rounded-xl border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-[13px] text-rose-200"
+					>
+						{error}
+					</p>
+				{/if}
+				{#if copyError}
+					<p
+						class="mt-4 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-[13px] text-amber-100"
+					>
+						{copyError}
+					</p>
+				{/if}
+			</div>
+
+			<div class="flex gap-3 px-10 pb-6">
+				{#if signInUrl}
+					<button
+						type="button"
+						class="flex h-11 flex-1 items-center justify-center gap-2 rounded-full bg-sky-500/90 px-4 text-sm font-medium text-white transition hover:bg-sky-500"
+						onclick={openSignInUrl}
+					>
+						<ExternalLink class="size-4" />
+						Open browser
+					</button>
+				{:else}
+					<span
+						class="flex h-11 flex-1 items-center justify-center gap-2 rounded-full bg-sky-500/40 px-4 text-sm font-medium text-white/50"
+					>
+						<LoaderCircle class="size-4 animate-spin" />
+						Preparing link
+					</span>
+				{/if}
+				<button
+					type="button"
+					class="flex h-11 flex-1 items-center justify-center gap-2 rounded-full border border-white/10 px-4 text-sm text-slate-200 transition hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-40"
+					disabled={!signInUrl}
+					onclick={() => void copySignInUrl()}
+				>
+					{#if copied}
+						<Check class="size-4" />
+						Copied
+					{:else}
+						<Copy class="size-4" />
+						Copy link
+					{/if}
+				</button>
+			</div>
+
+			<footer class="flex justify-center border-t border-white/8 px-10 py-4">
+				<button
+					type="button"
+					class="text-[13px] text-slate-400 transition hover:text-slate-200"
+					onclick={onCancel}
+				>
+					Cancel
+				</button>
+			</footer>
+		</div>
+	</div>
+{/if}

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -3,6 +3,7 @@
 		ChevronRight,
 		Folder,
 		FolderOpen,
+		LoaderCircle,
 		LogIn,
 		LogOut,
 		SquarePen,
@@ -14,6 +15,7 @@
 
 	type Props = {
 		isAuthenticated: boolean;
+		isWaitingForBrowserSignIn?: boolean;
 		currentWorkspaceName: string | null;
 		currentThreadId: Id<'threadRecords'> | null;
 		groups: WorkspaceThreadGroup[];
@@ -27,6 +29,7 @@
 
 	let {
 		isAuthenticated,
+		isWaitingForBrowserSignIn = false,
 		currentWorkspaceName,
 		currentThreadId,
 		groups,
@@ -85,18 +88,28 @@
 			<div class="min-w-0">
 				<p class="truncate text-[1.05rem] font-semibold tracking-tighter text-white">Sprocket</p>
 			</div>
-			<button
-				type="button"
-				class="flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/2 text-slate-300 transition hover:border-white/12 hover:bg-white/5 hover:text-white"
-				onclick={onAccountAction}
-				aria-label={isAuthenticated ? 'Sign out' : 'Sign in'}
-			>
-				{#if isAuthenticated}
-					<LogOut class="size-3.5" />
-				{:else}
-					<LogIn class="size-3.5" />
-				{/if}
-			</button>
+			{#if isWaitingForBrowserSignIn}
+				<span
+					class="flex h-8 w-8 items-center justify-center rounded-full border border-sky-400/20 bg-sky-400/10 text-sky-200"
+					title="Complete sign-in in your browser"
+					aria-label="Waiting for browser sign-in"
+				>
+					<LoaderCircle class="size-3.5 animate-spin" />
+				</span>
+			{:else}
+				<button
+					type="button"
+					class="flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/2 text-slate-300 transition hover:border-white/12 hover:bg-white/5 hover:text-white"
+					onclick={onAccountAction}
+					aria-label={isAuthenticated ? 'Sign out' : 'Sign in'}
+				>
+					{#if isAuthenticated}
+						<LogOut class="size-3.5" />
+					{:else}
+						<LogIn class="size-3.5" />
+					{/if}
+				</button>
+			{/if}
 		</header>
 
 		<div class="border-b border-white/6 px-3.5 pb-3">

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -7,6 +7,7 @@ import type {
 
 export type LocalBootstrap = {
 	httpBaseUrl: string;
+	desktopLoginCallbackUrl?: string;
 	pairingCredential: string;
 };
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -5,7 +5,8 @@
 	import type { Id } from '$convex/_generated/dataModel';
 	import { api } from '$convex/_generated/api';
 	import { EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS } from '$convex/lib/workspaceConnection';
-	import { authState, getAccessToken, signIn, signOut } from '$lib/auth';
+	import { authState, cancelDesktopSignIn, getAccessToken, signIn, signOut } from '$lib/auth';
+	import BrowserSignInOverlay from '$lib/components/home/browser-signin-overlay.svelte';
 	import PromptComposer from '$lib/components/home/prompt-composer.svelte';
 	import ThreadTranscript from '$lib/components/home/thread-transcript.svelte';
 	import WorkspacePicker from '$lib/components/home/workspace-picker.svelte';
@@ -707,6 +708,7 @@
 		>
 			<WorkspaceSidebar
 				isAuthenticated={Boolean($authState.user)}
+				isWaitingForBrowserSignIn={$authState.isWaitingForBrowserSignIn}
 				{currentWorkspaceName}
 				{currentThreadId}
 				groups={groupedWorkspaceThreads}
@@ -825,5 +827,14 @@
 				}}
 			/>
 		{/if}
+
+		<BrowserSignInOverlay
+			open={$authState.isWaitingForBrowserSignIn}
+			signInUrl={$authState.browserSignInUrl}
+			error={$authState.error}
+			onCancel={() => {
+				cancelDesktopSignIn();
+			}}
+		/>
 	</div>
 {/if}

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -3,13 +3,13 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::http::HeaderMap;
 use axum_extra::extract::CookieJar;
 use cookie::{Cookie, SameSite};
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::config::SESSION_COOKIE_NAME;
@@ -19,6 +19,7 @@ const PAIRING_CREDENTIAL_FILE: &str = "pairing-credential";
 const SESSIONS_FILE: &str = "sessions.json";
 const SESSION_MAX_AGE_SECS: i64 = 60 * 60 * 24 * 30;
 const SESSION_MAX_AGE_MS: u64 = SESSION_MAX_AGE_SECS as u64 * 1000;
+const DESKTOP_LOGIN_TTL: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,6 +52,214 @@ pub struct AuthState {
     pairing_credential: String,
     sessions: RwLock<HashMap<String, SessionRecord>>,
     local_identity: RwLock<Option<LocalIdentityResponse>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesktopLoginStartResponse {
+    pub ok: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum DesktopLoginResultResponse {
+    Pending,
+    #[serde(rename_all = "camelCase")]
+    Complete {
+        code: String,
+        state: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    Failed {
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum DesktopLoginOutcome {
+    Complete { code: String, state: String },
+    Failed { error: String },
+}
+
+#[derive(Debug)]
+struct DesktopLoginAttempt {
+    nonce: String,
+    created_at: Instant,
+    outcome: Option<DesktopLoginOutcome>,
+}
+
+/// One-shot in-memory store for the RFC 8252 loopback desktop login handshake.
+///
+/// Attempts are keyed by local session token so concurrent desktop windows cannot
+/// overwrite or steal each other's authorization codes.
+pub struct DesktopLoginStore {
+    attempts: Mutex<HashMap<String, DesktopLoginAttempt>>,
+}
+
+impl DesktopLoginStore {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            attempts: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub async fn start(&self, session_token: &str, nonce: &str) -> anyhow::Result<()> {
+        let session_token = session_token.trim();
+        let nonce = nonce.trim();
+        if session_token.is_empty() {
+            anyhow::bail!("desktop login session is missing");
+        }
+        if nonce.is_empty() {
+            anyhow::bail!("desktop login state must not be empty");
+        }
+
+        let mut attempts = self.attempts.lock().await;
+        purge_expired(&mut attempts);
+        attempts.insert(
+            session_token.to_string(),
+            DesktopLoginAttempt {
+                nonce: nonce.to_string(),
+                created_at: Instant::now(),
+                outcome: None,
+            },
+        );
+        Ok(())
+    }
+
+    pub async fn complete_callback(&self, code: &str, state: &str) -> anyhow::Result<()> {
+        let code = code.trim();
+        if code.is_empty() {
+            anyhow::bail!("authorization code is missing");
+        }
+
+        let nonce = extract_nonce_from_state(state)?;
+        let mut attempts = self.attempts.lock().await;
+        purge_expired(&mut attempts);
+
+        let Some(attempt) = find_attempt_by_nonce_mut(&mut attempts, &nonce) else {
+            anyhow::bail!("no pending desktop login attempt");
+        };
+        if attempt.outcome.is_some() {
+            anyhow::bail!("desktop login already completed");
+        }
+
+        attempt.outcome = Some(DesktopLoginOutcome::Complete {
+            code: code.to_string(),
+            state: state.to_string(),
+        });
+        Ok(())
+    }
+
+    pub async fn fail_callback(&self, error: &str, state: &str) -> anyhow::Result<()> {
+        let error = error.trim();
+        if error.is_empty() {
+            anyhow::bail!("desktop login error is missing");
+        }
+
+        let nonce = extract_nonce_from_state(state)?;
+        let mut attempts = self.attempts.lock().await;
+        purge_expired(&mut attempts);
+
+        let Some(attempt) = find_attempt_by_nonce_mut(&mut attempts, &nonce) else {
+            anyhow::bail!("no pending desktop login attempt");
+        };
+        if attempt.outcome.is_some() {
+            anyhow::bail!("desktop login already completed");
+        }
+
+        attempt.outcome = Some(DesktopLoginOutcome::Failed {
+            error: error.to_string(),
+        });
+        Ok(())
+    }
+
+    pub async fn take_result(&self, session_token: &str) -> DesktopLoginResultResponse {
+        let mut attempts = self.attempts.lock().await;
+        purge_expired(&mut attempts);
+
+        let Some(attempt) = attempts.get(session_token) else {
+            return DesktopLoginResultResponse::Pending;
+        };
+
+        let Some(outcome) = attempt.outcome.clone() else {
+            return DesktopLoginResultResponse::Pending;
+        };
+
+        attempts.remove(session_token);
+        match outcome {
+            DesktopLoginOutcome::Complete { code, state } => {
+                DesktopLoginResultResponse::Complete { code, state }
+            }
+            DesktopLoginOutcome::Failed { error } => DesktopLoginResultResponse::Failed { error },
+        }
+    }
+
+    pub async fn cancel(&self, session_token: &str, nonce: &str) -> bool {
+        let nonce = nonce.trim();
+        let mut attempts = self.attempts.lock().await;
+        purge_expired(&mut attempts);
+
+        if attempts
+            .get(session_token)
+            .is_some_and(|attempt| attempt.nonce == nonce)
+        {
+            attempts.remove(session_token);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn expire_for_test(&self, session_token: &str) {
+        let mut attempts = self.attempts.lock().await;
+        if let Some(attempt) = attempts.get_mut(session_token) {
+            attempt.created_at = Instant::now() - DESKTOP_LOGIN_TTL - Duration::from_secs(1);
+        }
+    }
+}
+
+/// WorkOS AuthKit allows `http://127.0.0.1:*/...` loopback redirect URIs for native apps.
+pub fn desktop_login_callback_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/api/auth/desktop-login/callback")
+}
+
+/// Hosts that can accept connections to the dedicated 127.0.0.1 callback URL.
+pub fn host_supports_loopback_desktop_login(host: &str) -> bool {
+    matches!(host.trim(), "127.0.0.1" | "0.0.0.0")
+}
+
+fn extract_nonce_from_state(state: &str) -> anyhow::Result<String> {
+    let trimmed = state.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("desktop login state is missing");
+    }
+
+    // AuthKit round-trips `state` as JSON.stringify({ nonce }).
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(nonce) = value
+            .get("nonce")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(nonce.to_string());
+        }
+    }
+
+    // Also accept a bare nonce string for simpler clients/tests.
+    Ok(trimmed.to_string())
+}
+
+fn find_attempt_by_nonce_mut<'a>(
+    attempts: &'a mut HashMap<String, DesktopLoginAttempt>,
+    nonce: &str,
+) -> Option<&'a mut DesktopLoginAttempt> {
+    attempts.values_mut().find(|attempt| attempt.nonce == nonce)
+}
+
+fn purge_expired(attempts: &mut HashMap<String, DesktopLoginAttempt>) {
+    attempts.retain(|_, attempt| attempt.created_at.elapsed() <= DESKTOP_LOGIN_TTL);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -353,5 +562,197 @@ mod tests {
         assert_eq!(first.guest_id, third.guest_id);
 
         let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn desktop_login_completes_with_matching_nonce() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+
+        store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-1"}"#)
+            .await
+            .expect("callback");
+
+        match store.take_result("session-a").await {
+            DesktopLoginResultResponse::Complete { code, state } => {
+                assert_eq!(code, "auth-code");
+                assert_eq!(state, r#"{"nonce":"nonce-1"}"#);
+            }
+            other => panic!("expected complete result, got {other:?}"),
+        }
+
+        assert!(matches!(
+            store.take_result("session-a").await,
+            DesktopLoginResultResponse::Pending
+        ));
+    }
+
+    #[tokio::test]
+    async fn desktop_login_rejects_mismatched_nonce() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+
+        let error = store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-2"}"#)
+            .await
+            .expect_err("mismatched nonce should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("no pending desktop login attempt")
+        );
+    }
+
+    #[tokio::test]
+    async fn desktop_login_start_replaces_prior_attempt_for_same_session() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+        store.start("session-a", "nonce-2").await.expect("start");
+
+        let error = store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-1"}"#)
+            .await
+            .expect_err("old nonce should no longer match");
+        assert!(
+            error
+                .to_string()
+                .contains("no pending desktop login attempt")
+        );
+
+        store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-2"}"#)
+            .await
+            .expect("callback with latest nonce");
+    }
+
+    #[tokio::test]
+    async fn desktop_login_isolates_concurrent_sessions() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-a").await.expect("start a");
+        store.start("session-b", "nonce-b").await.expect("start b");
+
+        store
+            .complete_callback("code-a", r#"{"nonce":"nonce-a"}"#)
+            .await
+            .expect("callback a");
+
+        assert!(matches!(
+            store.take_result("session-b").await,
+            DesktopLoginResultResponse::Pending
+        ));
+
+        match store.take_result("session-a").await {
+            DesktopLoginResultResponse::Complete { code, .. } => assert_eq!(code, "code-a"),
+            other => panic!("expected complete for session-a, got {other:?}"),
+        }
+
+        store
+            .complete_callback("code-b", r#"{"nonce":"nonce-b"}"#)
+            .await
+            .expect("callback b");
+
+        match store.take_result("session-b").await {
+            DesktopLoginResultResponse::Complete { code, .. } => assert_eq!(code, "code-b"),
+            other => panic!("expected complete for session-b, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn desktop_login_provider_error_is_terminal() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+
+        store
+            .fail_callback(
+                "access_denied: Sign-in was cancelled or failed.",
+                r#"{"nonce":"nonce-1"}"#,
+            )
+            .await
+            .expect("fail callback");
+
+        match store.take_result("session-a").await {
+            DesktopLoginResultResponse::Failed { error } => {
+                assert!(error.contains("access_denied"));
+            }
+            other => panic!("expected failed result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn desktop_login_cancel_clears_pending_attempt() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+        assert!(store.cancel("session-a", "nonce-1").await);
+
+        let error = store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-1"}"#)
+            .await
+            .expect_err("cancelled attempt should be gone");
+        assert!(
+            error
+                .to_string()
+                .contains("no pending desktop login attempt")
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_desktop_login_cancel_preserves_replacement_attempt() {
+        let store = DesktopLoginStore::new();
+        store
+            .start("session-a", "nonce-old")
+            .await
+            .expect("start old");
+        store
+            .start("session-a", "nonce-new")
+            .await
+            .expect("start new");
+
+        assert!(!store.cancel("session-a", "nonce-old").await);
+
+        store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-new"}"#)
+            .await
+            .expect("replacement callback");
+        assert!(matches!(
+            store.take_result("session-a").await,
+            DesktopLoginResultResponse::Complete { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn desktop_login_expires_pending_attempt() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+        store.expire_for_test("session-a").await;
+
+        let error = store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-1"}"#)
+            .await
+            .expect_err("expired attempt should be gone");
+        assert!(
+            error
+                .to_string()
+                .contains("no pending desktop login attempt")
+        );
+        assert!(matches!(
+            store.take_result("session-a").await,
+            DesktopLoginResultResponse::Pending
+        ));
+    }
+
+    #[test]
+    fn desktop_login_callback_url_uses_loopback() {
+        assert_eq!(
+            desktop_login_callback_url(7731),
+            "http://127.0.0.1:7731/api/auth/desktop-login/callback"
+        );
+        assert!(host_supports_loopback_desktop_login("127.0.0.1"));
+        assert!(host_supports_loopback_desktop_login("0.0.0.0"));
+        assert!(!host_supports_loopback_desktop_login("localhost"));
+        assert!(!host_supports_loopback_desktop_login("::"));
+        assert!(!host_supports_loopback_desktop_login("[::]"));
+        assert!(!host_supports_loopback_desktop_login("::1"));
+        assert!(!host_supports_loopback_desktop_login("192.168.1.10"));
     }
 }

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -83,23 +83,31 @@ enum DesktopLoginOutcome {
 
 #[derive(Debug)]
 struct DesktopLoginAttempt {
-    nonce: String,
+    session_token: String,
     created_at: Instant,
     outcome: Option<DesktopLoginOutcome>,
 }
 
+#[derive(Debug, Default)]
+struct DesktopLoginAttempts {
+    /// Primary index: nonce uniquely identifies one pending/completed attempt.
+    by_nonce: HashMap<String, DesktopLoginAttempt>,
+    /// Secondary index for authenticated polling/cancel by local session token.
+    by_session: HashMap<String, String>,
+}
+
 /// One-shot in-memory store for the RFC 8252 loopback desktop login handshake.
 ///
-/// Attempts are keyed by local session token so concurrent desktop windows cannot
-/// overwrite or steal each other's authorization codes.
+/// Attempts are keyed by nonce so the unauthenticated callback binds deterministically
+/// to exactly one attempt. Polling and cancel remain authenticated by session token.
 pub struct DesktopLoginStore {
-    attempts: Mutex<HashMap<String, DesktopLoginAttempt>>,
+    attempts: Mutex<DesktopLoginAttempts>,
 }
 
 impl DesktopLoginStore {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
-            attempts: Mutex::new(HashMap::new()),
+            attempts: Mutex::new(DesktopLoginAttempts::default()),
         })
     }
 
@@ -115,14 +123,28 @@ impl DesktopLoginStore {
 
         let mut attempts = self.attempts.lock().await;
         purge_expired(&mut attempts);
-        attempts.insert(
-            session_token.to_string(),
+
+        if let Some(existing) = attempts.by_nonce.get(nonce)
+            && existing.session_token != session_token
+        {
+            anyhow::bail!("desktop login state is already in use");
+        }
+
+        if let Some(previous_nonce) = attempts.by_session.remove(session_token) {
+            attempts.by_nonce.remove(&previous_nonce);
+        }
+
+        attempts.by_nonce.insert(
+            nonce.to_string(),
             DesktopLoginAttempt {
-                nonce: nonce.to_string(),
+                session_token: session_token.to_string(),
                 created_at: Instant::now(),
                 outcome: None,
             },
         );
+        attempts
+            .by_session
+            .insert(session_token.to_string(), nonce.to_string());
         Ok(())
     }
 
@@ -136,7 +158,7 @@ impl DesktopLoginStore {
         let mut attempts = self.attempts.lock().await;
         purge_expired(&mut attempts);
 
-        let Some(attempt) = find_attempt_by_nonce_mut(&mut attempts, &nonce) else {
+        let Some(attempt) = attempts.by_nonce.get_mut(&nonce) else {
             anyhow::bail!("no pending desktop login attempt");
         };
         if attempt.outcome.is_some() {
@@ -160,7 +182,7 @@ impl DesktopLoginStore {
         let mut attempts = self.attempts.lock().await;
         purge_expired(&mut attempts);
 
-        let Some(attempt) = find_attempt_by_nonce_mut(&mut attempts, &nonce) else {
+        let Some(attempt) = attempts.by_nonce.get_mut(&nonce) else {
             anyhow::bail!("no pending desktop login attempt");
         };
         if attempt.outcome.is_some() {
@@ -177,7 +199,11 @@ impl DesktopLoginStore {
         let mut attempts = self.attempts.lock().await;
         purge_expired(&mut attempts);
 
-        let Some(attempt) = attempts.get(session_token) else {
+        let Some(nonce) = attempts.by_session.get(session_token).cloned() else {
+            return DesktopLoginResultResponse::Pending;
+        };
+        let Some(attempt) = attempts.by_nonce.get(&nonce) else {
+            attempts.by_session.remove(session_token);
             return DesktopLoginResultResponse::Pending;
         };
 
@@ -185,7 +211,7 @@ impl DesktopLoginStore {
             return DesktopLoginResultResponse::Pending;
         };
 
-        attempts.remove(session_token);
+        remove_attempt(&mut attempts, session_token, &nonce);
         match outcome {
             DesktopLoginOutcome::Complete { code, state } => {
                 DesktopLoginResultResponse::Complete { code, state }
@@ -200,10 +226,11 @@ impl DesktopLoginStore {
         purge_expired(&mut attempts);
 
         if attempts
+            .by_session
             .get(session_token)
-            .is_some_and(|attempt| attempt.nonce == nonce)
+            .is_some_and(|mapped| mapped == nonce)
         {
-            attempts.remove(session_token);
+            remove_attempt(&mut attempts, session_token, nonce);
             true
         } else {
             false
@@ -213,7 +240,10 @@ impl DesktopLoginStore {
     #[cfg(test)]
     pub async fn expire_for_test(&self, session_token: &str) {
         let mut attempts = self.attempts.lock().await;
-        if let Some(attempt) = attempts.get_mut(session_token) {
+        let Some(nonce) = attempts.by_session.get(session_token).cloned() else {
+            return;
+        };
+        if let Some(attempt) = attempts.by_nonce.get_mut(&nonce) {
             attempt.created_at = Instant::now() - DESKTOP_LOGIN_TTL - Duration::from_secs(1);
         }
     }
@@ -227,6 +257,13 @@ pub fn desktop_login_callback_url(port: u16) -> String {
 /// Hosts that can accept connections to the dedicated 127.0.0.1 callback URL.
 pub fn host_supports_loopback_desktop_login(host: &str) -> bool {
     matches!(host.trim(), "127.0.0.1" | "0.0.0.0")
+}
+
+/// Whether the TCP peer may complete the unauthenticated desktop login callback.
+///
+/// Uses the real socket peer address from Axum `ConnectInfo`, never request headers.
+pub fn peer_may_complete_desktop_login_callback(peer: std::net::SocketAddr) -> bool {
+    peer.ip().is_loopback()
 }
 
 fn extract_nonce_from_state(state: &str) -> anyhow::Result<String> {
@@ -251,15 +288,30 @@ fn extract_nonce_from_state(state: &str) -> anyhow::Result<String> {
     Ok(trimmed.to_string())
 }
 
-fn find_attempt_by_nonce_mut<'a>(
-    attempts: &'a mut HashMap<String, DesktopLoginAttempt>,
-    nonce: &str,
-) -> Option<&'a mut DesktopLoginAttempt> {
-    attempts.values_mut().find(|attempt| attempt.nonce == nonce)
+fn remove_attempt(attempts: &mut DesktopLoginAttempts, session_token: &str, nonce: &str) {
+    attempts.by_nonce.remove(nonce);
+    attempts.by_session.remove(session_token);
 }
 
-fn purge_expired(attempts: &mut HashMap<String, DesktopLoginAttempt>) {
-    attempts.retain(|_, attempt| attempt.created_at.elapsed() <= DESKTOP_LOGIN_TTL);
+fn purge_expired(attempts: &mut DesktopLoginAttempts) {
+    let expired_nonces: Vec<String> = attempts
+        .by_nonce
+        .iter()
+        .filter(|(_, attempt)| attempt.created_at.elapsed() > DESKTOP_LOGIN_TTL)
+        .map(|(nonce, _)| nonce.clone())
+        .collect();
+
+    for nonce in expired_nonces {
+        if let Some(attempt) = attempts.by_nonce.remove(&nonce) {
+            if attempts
+                .by_session
+                .get(&attempt.session_token)
+                .is_some_and(|mapped| mapped == &nonce)
+            {
+                attempts.by_session.remove(&attempt.session_token);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -739,6 +791,80 @@ mod tests {
             store.take_result("session-a").await,
             DesktopLoginResultResponse::Pending
         ));
+    }
+
+    #[tokio::test]
+    async fn desktop_login_rejects_nonce_collision_across_sessions() {
+        let store = DesktopLoginStore::new();
+        store
+            .start("session-a", "shared-nonce")
+            .await
+            .expect("start a");
+
+        let error = store
+            .start("session-b", "shared-nonce")
+            .await
+            .expect_err("colliding nonce should be rejected");
+        assert!(error.to_string().contains("already in use"));
+
+        store
+            .complete_callback("code-a", r#"{"nonce":"shared-nonce"}"#)
+            .await
+            .expect("original session still owns nonce");
+
+        match store.take_result("session-a").await {
+            DesktopLoginResultResponse::Complete { code, .. } => assert_eq!(code, "code-a"),
+            other => panic!("expected complete for session-a, got {other:?}"),
+        }
+        assert!(matches!(
+            store.take_result("session-b").await,
+            DesktopLoginResultResponse::Pending
+        ));
+    }
+
+    #[tokio::test]
+    async fn desktop_login_same_session_may_reuse_nonce_after_replace() {
+        let store = DesktopLoginStore::new();
+        store.start("session-a", "nonce-1").await.expect("start");
+        store
+            .start("session-a", "nonce-1")
+            .await
+            .expect("same session may restart with same nonce");
+
+        store
+            .complete_callback("auth-code", r#"{"nonce":"nonce-1"}"#)
+            .await
+            .expect("callback");
+        assert!(matches!(
+            store.take_result("session-a").await,
+            DesktopLoginResultResponse::Complete { .. }
+        ));
+    }
+
+    #[test]
+    fn peer_loopback_gate_uses_socket_address() {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+        assert!(peer_may_complete_desktop_login_callback(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            54321
+        )));
+        assert!(peer_may_complete_desktop_login_callback(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 42)),
+            1
+        )));
+        assert!(peer_may_complete_desktop_login_callback(SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            1
+        )));
+        assert!(!peer_may_complete_desktop_login_callback(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+            54321
+        )));
+        assert!(!peer_may_complete_desktop_login_callback(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            54321
+        )));
     }
 
     #[test]

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -55,8 +55,11 @@ impl StartupInfo {
 #[derive(Clone)]
 pub struct AppState {
     pub auth: Arc<auth::AuthState>,
+    pub desktop_login: Arc<auth::DesktopLoginStore>,
     pub workspace_sessions: Arc<workspace_sessions::WorkspaceSessionStore>,
     pub http_base_url: String,
+    pub desktop_login_callback_url: String,
+    pub loopback_desktop_login_supported: bool,
     pub convex_deployment_url: String,
     pub desktop_bootstrap_token: Option<Arc<Mutex<Option<String>>>>,
 }
@@ -97,8 +100,11 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
 
     let state = AppState {
         auth,
+        desktop_login: auth::DesktopLoginStore::new(),
         workspace_sessions,
         http_base_url: http_base_url.clone(),
+        desktop_login_callback_url: auth::desktop_login_callback_url(config.port),
+        loopback_desktop_login_supported: auth::host_supports_loopback_desktop_login(&config.host),
         convex_deployment_url,
         desktop_bootstrap_token,
     };

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -1,5 +1,7 @@
+use std::net::SocketAddr;
+
 use axum::Json;
-use axum::extract::{Query, State};
+use axum::extract::{ConnectInfo, Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
@@ -10,7 +12,7 @@ use crate::AppState;
 use crate::auth::{
     AuthSessionResponse, AuthState, BootstrapRequest, BootstrapResponse,
     DesktopLoginResultResponse, DesktopLoginStartResponse, LocalIdentityResponse,
-    extract_session_token, require_session,
+    extract_session_token, peer_may_complete_desktop_login_callback, require_session,
 };
 
 const DESKTOP_BOOTSTRAP_TOKEN_HEADER: &str = "x-sprocket-desktop-bootstrap-token";
@@ -151,8 +153,17 @@ async fn desktop_login_start(
 
 async fn desktop_login_callback(
     State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Query(query): Query<DesktopLoginCallbackQuery>,
 ) -> Response {
+    if !peer_may_complete_desktop_login_callback(peer) {
+        return desktop_login_html_response(
+            StatusCode::FORBIDDEN,
+            "Sign-in failed",
+            "Desktop login callback is only available from this machine.",
+        );
+    }
+
     let callback_state = query
         .state
         .as_deref()
@@ -360,7 +371,10 @@ impl IntoResponse for ApiError {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
     use axum::http::{Request, header};
     use tower::ServiceExt;
     use uuid::Uuid;
@@ -412,6 +426,19 @@ mod tests {
         format!("{}={session_token}", crate::SESSION_COOKIE_NAME)
     }
 
+    fn loopback_peer() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 54321)
+    }
+
+    fn lan_peer() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), 54321)
+    }
+
+    fn with_peer(mut request: Request<Body>, peer: SocketAddr) -> Request<Body> {
+        request.extensions_mut().insert(ConnectInfo(peer));
+        request
+    }
+
     #[tokio::test]
     async fn provider_error_terminates_pending_attempt() {
         let (state, session_token, _) = test_state(true).await;
@@ -434,12 +461,13 @@ mod tests {
 
         let callback = app
             .clone()
-            .oneshot(
+            .oneshot(with_peer(
                 Request::builder()
                     .uri("/api/auth/desktop-login/callback?error=access_denied&error_description=User%20cancelled&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
                     .body(Body::empty())
                     .unwrap(),
-            )
+                loopback_peer(),
+            ))
             .await
             .unwrap();
         assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
@@ -496,12 +524,13 @@ mod tests {
 
         let callback = app
             .clone()
-            .oneshot(
+            .oneshot(with_peer(
                 Request::builder()
                     .uri("/api/auth/desktop-login/callback?code=code-a&state=%7B%22nonce%22%3A%22nonce-a%22%7D")
                     .body(Body::empty())
                     .unwrap(),
-            )
+                loopback_peer(),
+            ))
             .await
             .unwrap();
         assert_eq!(callback.status(), StatusCode::OK);
@@ -571,12 +600,13 @@ mod tests {
         assert_eq!(cancel.status(), StatusCode::OK);
 
         let callback = app
-            .oneshot(
+            .oneshot(with_peer(
                 Request::builder()
                     .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
                     .body(Body::empty())
                     .unwrap(),
-            )
+                loopback_peer(),
+            ))
             .await
             .unwrap();
         assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
@@ -623,12 +653,13 @@ mod tests {
 
         let callback = app
             .clone()
-            .oneshot(
+            .oneshot(with_peer(
                 Request::builder()
                     .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-new%22%7D")
                     .body(Body::empty())
                     .unwrap(),
-            )
+                loopback_peer(),
+            ))
             .await
             .unwrap();
         assert_eq!(callback.status(), StatusCode::OK);
@@ -700,12 +731,13 @@ mod tests {
 
         let callback = app
             .clone()
-            .oneshot(
+            .oneshot(with_peer(
                 Request::builder()
                     .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
                     .body(Body::empty())
                     .unwrap(),
-            )
+                loopback_peer(),
+            ))
             .await
             .unwrap();
         assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
@@ -722,5 +754,151 @@ mod tests {
             .unwrap();
         let payload = read_json(result).await;
         assert_eq!(payload["status"], "pending");
+    }
+
+    #[tokio::test]
+    async fn loopback_peer_can_complete_callback() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::OK);
+
+        let callback = app
+            .clone()
+            .oneshot(with_peer(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::OK);
+
+        let result = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let payload = read_json(result).await;
+        assert_eq!(payload["status"], "complete");
+        assert_eq!(payload["code"], "auth-code");
+    }
+
+    #[tokio::test]
+    async fn non_loopback_peer_cannot_complete_callback() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::OK);
+
+        let callback = app
+            .clone()
+            .oneshot(with_peer(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=attacker-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
+                    .header("x-forwarded-for", "127.0.0.1")
+                    .header(header::HOST, "127.0.0.1:7731")
+                    .body(Body::empty())
+                    .unwrap(),
+                lan_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::FORBIDDEN);
+        let html = read_text(callback).await;
+        assert!(html.contains("only available from this machine"));
+
+        let result = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let payload = read_json(result).await;
+        assert_eq!(payload["status"], "pending");
+    }
+
+    #[tokio::test]
+    async fn start_rejects_nonce_collision_across_sessions() {
+        let (state, session_a, credential) = test_state(true).await;
+        let (_, session_b) = state
+            .auth
+            .bootstrap(&credential)
+            .await
+            .expect("second session");
+        let app = router(state);
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_a))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"shared-nonce"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let collision = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_b))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"shared-nonce"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(collision.status(), StatusCode::BAD_REQUEST);
+        let payload = read_json(collision).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("already in use")
+        );
     }
 }

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -1,13 +1,15 @@
 use axum::Json;
-use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum_extra::extract::CookieJar;
+use serde::Deserialize;
 
 use crate::AppState;
 use crate::auth::{
-    AuthSessionResponse, AuthState, BootstrapRequest, BootstrapResponse, LocalIdentityResponse,
+    AuthSessionResponse, AuthState, BootstrapRequest, BootstrapResponse,
+    DesktopLoginResultResponse, DesktopLoginStartResponse, LocalIdentityResponse,
     extract_session_token, require_session,
 };
 
@@ -17,7 +19,28 @@ const DESKTOP_BOOTSTRAP_TOKEN_HEADER: &str = "x-sprocket-desktop-bootstrap-token
 #[serde(rename_all = "camelCase")]
 struct DesktopBootstrapResponse {
     http_base_url: String,
+    desktop_login_callback_url: String,
     pairing_credential: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopLoginStartRequest {
+    state: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopLoginCancelRequest {
+    state: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DesktopLoginCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
 }
 
 pub fn routes() -> axum::Router<AppState> {
@@ -26,6 +49,10 @@ pub fn routes() -> axum::Router<AppState> {
         .route("/auth/bootstrap", post(bootstrap))
         .route("/auth/desktop-bootstrap", get(desktop_bootstrap))
         .route("/auth/local-identity", get(local_identity))
+        .route("/auth/desktop-login/start", post(desktop_login_start))
+        .route("/auth/desktop-login/callback", get(desktop_login_callback))
+        .route("/auth/desktop-login/result", get(desktop_login_result))
+        .route("/auth/desktop-login/cancel", post(desktop_login_cancel))
 }
 
 async fn session(
@@ -97,11 +124,199 @@ async fn desktop_bootstrap(
     Ok(desktop_bootstrap_response(&state))
 }
 
+async fn desktop_login_start(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<DesktopLoginStartRequest>,
+) -> Result<Json<DesktopLoginStartResponse>, ApiError> {
+    let session_token = require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(|_| ApiError::unauthorized())?;
+
+    if !state.loopback_desktop_login_supported {
+        return Err(ApiError::bad_request(anyhow::anyhow!(
+            "desktop browser sign-in requires the local server to accept 127.0.0.1 loopback connections; set SPROCKET_HOST to 127.0.0.1 or 0.0.0.0"
+        )));
+    }
+
+    state
+        .desktop_login
+        .start(&session_token, &payload.state)
+        .await
+        .map_err(ApiError::bad_request)?;
+
+    Ok(Json(DesktopLoginStartResponse { ok: true }))
+}
+
+async fn desktop_login_callback(
+    State(state): State<AppState>,
+    Query(query): Query<DesktopLoginCallbackQuery>,
+) -> Response {
+    let callback_state = query
+        .state
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if let Some(error) = query
+        .error
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let description = query
+            .error_description
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("Sign-in was cancelled or failed.");
+        let message = format!("{error}: {description}");
+
+        if let Some(callback_state) = callback_state {
+            if let Err(fail_error) = state
+                .desktop_login
+                .fail_callback(&message, callback_state)
+                .await
+            {
+                return desktop_login_html_response(
+                    StatusCode::BAD_REQUEST,
+                    "Sign-in failed",
+                    &fail_error.to_string(),
+                );
+            }
+        }
+
+        return desktop_login_html_response(StatusCode::BAD_REQUEST, "Sign-in failed", &message);
+    }
+
+    let Some(code) = query
+        .code
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return desktop_login_html_response(
+            StatusCode::BAD_REQUEST,
+            "Sign-in failed",
+            "Authorization code is missing.",
+        );
+    };
+    let Some(callback_state) = callback_state else {
+        return desktop_login_html_response(
+            StatusCode::BAD_REQUEST,
+            "Sign-in failed",
+            "Desktop login state is missing.",
+        );
+    };
+
+    match state
+        .desktop_login
+        .complete_callback(code, callback_state)
+        .await
+    {
+        Ok(()) => desktop_login_html_response(
+            StatusCode::OK,
+            "Signed in",
+            "Return to Sprocket. You can close this tab.",
+        ),
+        Err(error) => desktop_login_html_response(
+            StatusCode::BAD_REQUEST,
+            "Sign-in failed",
+            &error.to_string(),
+        ),
+    }
+}
+
+async fn desktop_login_result(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> Result<Json<DesktopLoginResultResponse>, ApiError> {
+    let session_token = require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(|_| ApiError::unauthorized())?;
+
+    Ok(Json(state.desktop_login.take_result(&session_token).await))
+}
+
+async fn desktop_login_cancel(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<DesktopLoginCancelRequest>,
+) -> Result<Json<DesktopLoginStartResponse>, ApiError> {
+    let session_token = require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(|_| ApiError::unauthorized())?;
+
+    state
+        .desktop_login
+        .cancel(&session_token, &payload.state)
+        .await;
+    Ok(Json(DesktopLoginStartResponse { ok: true }))
+}
+
 fn desktop_bootstrap_response(state: &AppState) -> Json<DesktopBootstrapResponse> {
     Json(DesktopBootstrapResponse {
         http_base_url: state.http_base_url.clone(),
+        desktop_login_callback_url: state.desktop_login_callback_url.clone(),
         pairing_credential: state.auth.pairing_credential().to_string(),
     })
+}
+
+fn desktop_login_html_response(status: StatusCode, title: &str, message: &str) -> Response {
+    let title = html_escape(title);
+    let message = html_escape(message);
+    let body = format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title} — Sprocket</title>
+  <style>
+    :root {{ color-scheme: dark; }}
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+      box-sizing: border-box;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif;
+      background: #0f1218;
+      color: #e2e8f0;
+      text-align: center;
+    }}
+    h1 {{ margin: 0 0 0.75rem; font-size: 1.35rem; }}
+    p {{ margin: 0; line-height: 1.55; color: #94a3b8; }}
+  </style>
+</head>
+<body>
+  <div>
+    <h1>{title}</h1>
+    <p>{message}</p>
+  </div>
+</body>
+</html>"#
+    );
+
+    (
+        status,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        Html(body),
+    )
+        .into_response()
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 #[derive(Debug)]
@@ -140,5 +355,372 @@ impl IntoResponse for ApiError {
             Json(serde_json::json!({ "error": self.message })),
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::auth::{self, DesktopLoginStore};
+    use crate::workspace_sessions::WorkspaceSessionStore;
+
+    async fn test_state(loopback_supported: bool) -> (AppState, String, String) {
+        let temp_dir =
+            std::env::temp_dir().join(format!("sprocket-auth-route-test-{}", Uuid::new_v4()));
+        let auth = auth::AuthState::load(&temp_dir).expect("auth state");
+        let credential = auth.pairing_credential().to_string();
+        let (_, session_token) = auth.bootstrap(&credential).await.expect("bootstrap");
+
+        let state = AppState {
+            auth,
+            desktop_login: DesktopLoginStore::new(),
+            workspace_sessions: WorkspaceSessionStore::new(temp_dir),
+            http_base_url: "http://127.0.0.1:7731".to_string(),
+            desktop_login_callback_url: auth::desktop_login_callback_url(7731),
+            loopback_desktop_login_supported: loopback_supported,
+            convex_deployment_url: "https://example.convex.cloud".to_string(),
+            desktop_bootstrap_token: None,
+        };
+
+        (state, session_token, credential)
+    }
+
+    fn router(state: AppState) -> axum::Router {
+        crate::build_router(state, None)
+    }
+
+    async fn read_json(response: axum::http::Response<Body>) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn read_text(response: axum::http::Response<Body>) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
+    fn session_cookie(session_token: &str) -> String {
+        format!("{}={session_token}", crate::SESSION_COOKIE_NAME)
+    }
+
+    #[tokio::test]
+    async fn provider_error_terminates_pending_attempt() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::OK);
+
+        let callback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?error=access_denied&error_description=User%20cancelled&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
+        let html = read_text(callback).await;
+        assert!(html.contains("access_denied"));
+
+        let result = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.status(), StatusCode::OK);
+        let payload = read_json(result).await;
+        assert_eq!(payload["status"], "failed");
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("access_denied")
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_sessions_cannot_steal_results() {
+        let (state, session_a, credential) = test_state(true).await;
+        let (_, session_b) = state
+            .auth
+            .bootstrap(&credential)
+            .await
+            .expect("second session");
+        let app = router(state);
+
+        for (token, nonce) in [(&session_a, "nonce-a"), (&session_b, "nonce-b")] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/auth/desktop-login/start")
+                        .header(header::COOKIE, session_cookie(token))
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(format!(r#"{{"state":"{nonce}"}}"#)))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let callback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=code-a&state=%7B%22nonce%22%3A%22nonce-a%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::OK);
+
+        let stolen = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_b))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let stolen_payload = read_json(stolen).await;
+        assert_eq!(stolen_payload["status"], "pending");
+
+        let owned = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_a))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let owned_payload = read_json(owned).await;
+        assert_eq!(owned_payload["status"], "complete");
+        assert_eq!(owned_payload["code"], "code-a");
+    }
+
+    #[tokio::test]
+    async fn cancel_clears_pending_attempt() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::OK);
+
+        let cancel = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/cancel")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(cancel.status(), StatusCode::OK);
+
+        let callback = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
+        let html = read_text(callback).await;
+        assert!(html.contains("no pending desktop login attempt"));
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_does_not_remove_replacement_attempt() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+
+        for nonce in ["nonce-old", "nonce-new"] {
+            let start = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/auth/desktop-login/start")
+                        .header(header::COOKIE, session_cookie(&session_token))
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(format!(r#"{{"state":"{nonce}"}}"#)))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(start.status(), StatusCode::OK);
+        }
+
+        let stale_cancel = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/cancel")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-old"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(stale_cancel.status(), StatusCode::OK);
+
+        let callback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-new%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::OK);
+
+        let result = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let payload = read_json(result).await;
+        assert_eq!(payload["status"], "complete");
+        assert_eq!(payload["code"], "auth-code");
+    }
+
+    #[tokio::test]
+    async fn start_rejects_incompatible_bind_host() {
+        let (state, session_token, _) = test_state(false).await;
+        let app = router(state);
+
+        let start = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::BAD_REQUEST);
+        let payload = read_json(start).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("127.0.0.1")
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_attempt_cannot_complete() {
+        let (state, session_token, _) = test_state(true).await;
+        let desktop_login = state.desktop_login.clone();
+        let app = router(state);
+
+        let start = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/desktop-login/start")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"state":"nonce-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start.status(), StatusCode::OK);
+
+        desktop_login.expire_for_test(&session_token).await;
+
+        let callback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/callback?code=auth-code&state=%7B%22nonce%22%3A%22nonce-1%22%7D")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
+
+        let result = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/auth/desktop-login/result")
+                    .header(header::COOKIE, session_cookie(&session_token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let payload = read_json(result).await;
+        assert_eq!(payload["status"], "pending");
     }
 }


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spikonado/codesmith/sprocket/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786331596&installation_id=140601463&pr_number=37&repository=spikonado%2Fsprocket&return_to=https%3A%2F%2Fgithub.com%2Fspikonado%2Fsprocket%2Fpull%2F37&signature=6a88c1a37bcb66e2528b70bddb7a0a85af4277cc8cb0f63e39261b92cfbe5831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves desktop login to a browser-based loopback flow. The main changes are:

- Adds a local desktop OAuth start, callback, result, and cancel flow.
- Stores desktop login attempts by nonce and session.
- Restricts the callback to loopback socket peers.
- Passes the loopback callback URL through desktop bootstrap.
- Adds desktop UI state and an overlay for browser sign-in.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Real app and Vite server were started; logs were captured for the live UI server and the Vite dev server.
- A Playwright harness was created and run multiple times to exercise the Auth UI.
- Partial runs showed the Sprocket home UI rendering in the real page body, while earlier attempts were blocked by a local auth/session bootstrap issue.
- An earlier blocker state indicated a local auth/session bootstrap failure that blocked progress.
- Remaining work was identified to finish the harness so AuthKit client initialization and sign-in URL generation are reliably stubbed, enabling a clean re-run to capture the overlay.

<a href="https://app.greptile.com/trex/runs/14069131/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/auth.rs | Adds the desktop login store, loopback callback helpers, expiry cleanup, and tests for nonce/session isolation. |
| crates/sprocket-server/src/routes/auth.rs | Adds desktop login endpoints with authenticated start/result/cancel handling and loopback-only callback handling. |
| apps/web/src/lib/auth.ts | Adds browser sign-in state, start serialization, polling, cancellation, nonce checks, and callback handoff. |
| apps/desktop/main.mjs | Pins the local server host to 127.0.0.1 and exposes callback URL, external-open, and window-focus bridge behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): Secure desktop login callback..."](https://github.com/spikonado/sprocket/commit/a80105cd1e12c39d51b922c4366bbf369b66f23f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43463743)</sub>

<!-- /greptile_comment -->