### PR TITLE
ci: Speed up debug builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,10 @@ jobs:
           nix develop --profile sprocket-shell -c true
           cachix push spikonado sprocket-shell
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cmd-format: nix develop --profile sprocket-shell -c {0}
+
       - name: Bun install
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,8 @@
 	"desktopName": "com.spikonado.sprocket.desktop",
 	"scripts": {
 		"dev": "cargo build -q -p sprocket-cli && node ./launch.cjs",
-		"build": "cargo build --release -p sprocket-cli && bun run --cwd ../web build && electron-builder"
+		"build": "cargo build -p sprocket-cli",
+		"build:release": "cargo build --release -p sprocket-cli && electron-builder"
 	},
 	"build": {
 		"appId": "com.spikonado.sprocket",

--- a/apps/desktop/turbo.json
+++ b/apps/desktop/turbo.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://turborepo.dev/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"cache": false
+		},
+		"build:release": {
+			"cache": false,
+			"dependsOn": ["@sprocket/web#build:release"]
+		}
+	}
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && vite build",
+		"build:release": "bun run build",
 		"test": "vitest --run",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"lint": "eslint . && convex typecheck"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"license": "Apache-2.0",
 	"scripts": {
 		"build": "node ./scripts/create-turbo-cache-key.js && bunx turbo run build",
+		"build:release": "node ./scripts/create-turbo-cache-key.js && bunx turbo run build:release",
 		"dev": "concurrently -k -n api,web -c blue,green \"cargo run -p sprocket-cli -- serve --data-dir .sprocket-dev --api-only\" \"node scripts/wait-for-api.mjs && bun run --cwd apps/web dev\"",
 		"dev:desktop": "concurrently -k -n web,electron -c green,magenta \"node scripts/wait-for-api.mjs && bun run --cwd apps/web dev\" \"bun run --cwd apps/desktop dev\"",
 		"test": "turbo run test"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "svelte-kit sync && svelte-package --watch --input=src",
 		"build": "svelte-kit sync && svelte-package --input=src",
+		"build:release": "bun run build",
 		"lint": "eslint .",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
 	},

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,11 @@
 			"inputs": ["$TURBO_DEFAULT$", "turbo-cache-key.json"],
 			"outputs": [".svelte-kit/**", ".vercel/**", "dist/**", "target/**"]
 		},
+		"build:release": {
+			"dependsOn": ["^build:release"],
+			"inputs": ["$TURBO_DEFAULT$", "turbo-cache-key.json"],
+			"outputs": [".svelte-kit/**", ".vercel/**", "dist/**", "target/**"]
+		},
 		"check": {
 			"dependsOn": ["^check"]
 		},


### PR DESCRIPTION
Split debug and release packaging paths and cache Cargo artifacts in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/spikonado/codesmith/sprocket/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786334998&installation_id=140601463&pr_number=38&repository=spikonado%2Fsprocket&return_to=https%3A%2F%2Fgithub.com%2Fspikonado%2Fsprocket%2Fpull%2F38&signature=b93a101c03481d19c999464ac518a736ae5a2f61a46c1c5bb2e352f4a1244fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR splits debug and release build paths and adds CI caching. The main changes are:

- Rust cache setup in the build-test workflow.
- A new root `build:release` Turbo task.
- Desktop debug builds that only compile the Rust CLI.
- Desktop release packaging moved behind `build:release`.
- Matching `build:release` aliases for web and UI packages.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The direct desktop release command can package missing or stale web assets.

Root Turbo release builds have an explicit web-before-desktop edge, but the package-level desktop release script does not rebuild the web app before `electron-builder` reads `../web/dist`; the CI cache change follows the Nix-wrapped command pattern.

apps/desktop/package.json
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The repro harness moved apps/web/dist aside and executed the actual desktop release script with the cargo step stubbed.
- Electron-builder loaded package.json build configuration and produced a Linux package with no web/dist assets included.
- After the run, the harness restored apps/web/dist to its original location.
- Dry-runs showed the desktop build sequence and dependencies, and the actual desktop debug command completed successfully with the dev profile and exit code 0.

<a href="https://app.greptile.com/trex/runs/14070594/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-test.yml | Adds Rust cache setup with the Nix shell command wrapper. |
| apps/desktop/package.json | Splits desktop debug and release scripts, but direct release packaging no longer rebuilds web assets. |
| apps/desktop/turbo.json | Adds desktop-specific Turbo rules and root release ordering for web assets. |
| apps/web/package.json | Adds a release build alias for the existing web build. |
| packages/ui/package.json | Adds a release build alias for the existing UI build. |
| package.json | Adds the root release build command. |
| turbo.json | Adds the root release build task and outputs. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fpackage.json%3A12%0A**Release%20Assets%20Become%20Stale**%0A%0AWhen%20%60apps%2Fdesktop%60%20is%20released%20directly%20with%20%60bun%20run%20--cwd%20apps%2Fdesktop%20build%3Arelease%60%2C%20this%20script%20now%20runs%20%60electron-builder%60%20without%20first%20rebuilding%20%60..%2Fweb%2Fdist%60.%20The%20old%20script%20built%20the%20web%20app%20in%20the%20same%20command%2C%20so%20a%20clean%20checkout%20can%20fail%20packaging%20and%20a%20dirty%20checkout%20can%20ship%20stale%20web%20assets%20inside%20the%20desktop%20app.%0A%0A&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fpackage.json%3A12%0A**Release%20Assets%20Become%20Stale**%0A%0AWhen%20%60apps%2Fdesktop%60%20is%20released%20directly%20with%20%60bun%20run%20--cwd%20apps%2Fdesktop%20build%3Arelease%60%2C%20this%20script%20now%20runs%20%60electron-builder%60%20without%20first%20rebuilding%20%60..%2Fweb%2Fdist%60.%20The%20old%20script%20built%20the%20web%20app%20in%20the%20same%20command%2C%20so%20a%20clean%20checkout%20can%20fail%20packaging%20and%20a%20dirty%20checkout%20can%20ship%20stale%20web%20assets%20inside%20the%20desktop%20app.%0A%0A&repo=spikonado%2Fsprocket&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22cursor%2Fsplit-build-profiles-rust-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fsplit-build-profiles-rust-cache%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fpackage.json%3A12%0A**Release%20Assets%20Become%20Stale**%0A%0AWhen%20%60apps%2Fdesktop%60%20is%20released%20directly%20with%20%60bun%20run%20--cwd%20apps%2Fdesktop%20build%3Arelease%60%2C%20this%20script%20now%20runs%20%60electron-builder%60%20without%20first%20rebuilding%20%60..%2Fweb%2Fdist%60.%20The%20old%20script%20built%20the%20web%20app%20in%20the%20same%20command%2C%20so%20a%20clean%20checkout%20can%20fail%20packaging%20and%20a%20dirty%20checkout%20can%20ship%20stale%20web%20assets%20inside%20the%20desktop%20app.%0A%0A&repo=spikonado%2Fsprocket&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22cursor%2Fsplit-build-profiles-rust-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fsplit-build-profiles-rust-cache%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fpackage.json%3A12%0A**Release%20Assets%20Become%20Stale**%0A%0AWhen%20%60apps%2Fdesktop%60%20is%20released%20directly%20with%20%60bun%20run%20--cwd%20apps%2Fdesktop%20build%3Arelease%60%2C%20this%20script%20now%20runs%20%60electron-builder%60%20without%20first%20rebuilding%20%60..%2Fweb%2Fdist%60.%20The%20old%20script%20built%20the%20web%20app%20in%20the%20same%20command%2C%20so%20a%20clean%20checkout%20can%20fail%20packaging%20and%20a%20dirty%20checkout%20can%20ship%20stale%20web%20assets%20inside%20the%20desktop%20app.%0A%0A&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/package.json:12
**Release Assets Become Stale**

When `apps/desktop` is released directly with `bun run --cwd apps/desktop build:release`, this script now runs `electron-builder` without first rebuilding `../web/dist`. The old script built the web app in the same command, so a clean checkout can fail packaging and a dirty checkout can ship stale web assets inside the desktop app.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["build(ci): speed up debug builds"](https://github.com/spikonado/sprocket/commit/b1e04ff39553431b8b9beed63a67e66a05f8e432) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43467922)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->