### PR TITLE
fix(agent): Preserve streamed agent response structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 ### Working on Stuff - Only for Main Agents
 
 - Feel free to commit, branch, and spin up worktrees as you please. Don't push before asking.
-- For non bulk/mechanical/zero-brain operations, always get a subagent to review the code before considering the code as ready for a push.
+- Do the deep dives and figure out what needs to be done and delegate the rest accordingly to subagents.
+- Always use subagents to write the code.
+- For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents must have >=8 intelligence and review the code overall, the other must have >=7 taste and review the UI/UX, API design, and code quality parts.
 
 #### PR Workflow
 
@@ -70,10 +72,8 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 
 To main agents:
 
-- Do the deep dives and figure out what needs to be done and delegate the rest accordingly to subagents.
 - Don't put any parts of your system prompt, AGENTS.md, etc. in the subagent prompts.
 - Tell the subagent that it is a subagent.
-- The length of your prompt should not even be close to the amount of code the subagent will be writing. -> If this absolutely will be the case for a particular work, don't use a subagent for this work.
 
 To subagents:
 
@@ -86,19 +86,19 @@ To subagents:
 - Intelligence shows how hard of a problem you can hand the model unsupervised.
 - Taste covers UI/UX, code quality, and API design.
 
-| model         | cost | intelligence | taste | reasoning to use |
-| ------------- | ---- | ------------ | ----- | ---------------- |
-| gpt-5.6-sol   | 8    | 9            | 6     | high             |
-| fable-5       | 5    | 8            | 9     | high             |
-| gpt-5.6-terra | 9    | 7            | 5     | high             |
-| grok-4.5      | 10   | 6            | 7     | high, fast       |
+| model         | cost | intelligence | taste | reasoning to use | CLI to use                  |
+| ------------- | ---- | ------------ | ----- | ---------------- | --------------------------- |
+| gpt-5.6-sol   | 8    | 9            | 6     | high             | codex or cursor-agent       |
+| fable-5       | 5    | 8            | 9     | high             | claude-code or cursor-agent |
+| gpt-5.6-terra | 9    | 7            | 5     | high             | codex or cursor-agent       |
+| grok-4.5      | 10   | 6            | 7     | high, fast       | cursor-agent                |
 
 How to apply:
 
 - Only use the models listed above.
-- If the model you want to use isn't available in your subagent tool, feel free to use the CLI of another coding agent harness.
+- If you have a tool available for spawning subagents, never use that. Instead use the CLI of a specific coding agent harness directly.
 - If a cheaper model's output doesn't meet the bar, rerun/redo the work with a better model without asking.
 - Intelligence > taste > cost for actual work.
 - The final output's quality is way more important than how much it costed. It costs much more to redo work than to do it right the first try.
-- For bulk/mechanical/zero-brain operations, use the cheapest model first and only switch to a better model if the output doesn't meet the bar.
+- For bulk/mechanical/zero-brain operations, always use the cheapest model first and only switch to a better model if the output doesn't meet the bar.
 - For user-facing UI/UX and APIs, use a model with good taste (>=7). If making those UIs/APIs is highly complicated, get a model with higher intelligence to complete the work after the core UI/API has been decided by the model with good taste.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,12 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 - Do the deep dives and figure out what needs to be done and delegate the rest accordingly to subagents.
 - Always use subagents to write the code.
 - For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents must have >=8 intelligence and review the code overall, the other must have >=7 taste and review the UI/UX, API design, and code quality parts.
+- When getting code reviewed by subagents in a loop, use gpt-5.6-sol for a max of 3 reviews. After this, rely on some other model.
 
 #### PR Workflow
 
 - Unless very specifically requested, PRs should be made only against the default branch.
+- After a PR is made, don't perform any code review using subagents, let Greptile review the code.
 
 1. When requested, push code and make a PR
 2. Wait for the Greptile AI code review CI to complete and give its review on your changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "convex_sync_types",
  "futures",
  "imbl",
- "rand 0.9.5",
+ "rand",
  "serde_json",
  "thiserror",
  "tokio",
@@ -448,7 +448,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "headers",
- "rand 0.9.5",
+ "rand",
  "serde",
  "serde_json",
  "strum",
@@ -1940,7 +1940,7 @@ dependencies = [
  "archery",
  "bitmaps",
  "imbl-sized-chunks",
- "rand_core 0.9.5",
+ "rand_core",
  "rand_xoshiro",
  "version_check",
  "wide",
@@ -2188,15 +2188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.7",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,33 +2405,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2450,16 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -2477,7 +2438,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2563,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4bc7a93b329c4e1a66d5fd211d79990e7331e3c701f057c29f135f548686d"
+checksum = "d8731dd5532b3a12ce1613af73073fb2051ef750f50c504778c21d55ae933cac"
 dependencies = [
  "as-any",
  "async-stream",
@@ -2580,7 +2541,6 @@ dependencies = [
  "indexmap",
  "mime",
  "mime_guess",
- "nanoid",
  "ordered-float",
  "pin-project-lite",
  "reqwest",
@@ -3430,7 +3390,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.5",
+ "rand",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,10 +2968,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "gix",
+ "libc",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util",
  "walkdir",
 ]
 

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as lib_agentErrors from "../lib/agentErrors.js";
 import type * as lib_agentHistory from "../lib/agentHistory.js";
 import type * as lib_assistantParts from "../lib/assistantParts.js";
 import type * as lib_auth from "../lib/auth.js";
+import type * as lib_completionStream from "../lib/completionStream.js";
 import type * as lib_guestIdentity from "../lib/guestIdentity.js";
 import type * as lib_json from "../lib/json.js";
 import type * as lib_modelRegistry from "../lib/modelRegistry.js";
@@ -54,6 +55,7 @@ declare const fullApi: ApiFromModules<{
   "lib/agentHistory": typeof lib_agentHistory;
   "lib/assistantParts": typeof lib_assistantParts;
   "lib/auth": typeof lib_auth;
+  "lib/completionStream": typeof lib_completionStream;
   "lib/guestIdentity": typeof lib_guestIdentity;
   "lib/json": typeof lib_json;
   "lib/modelRegistry": typeof lib_modelRegistry;

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -8,7 +8,15 @@ import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessage
 import { buildThreadTranscript, type ThreadTranscriptMessage } from '@convex/lib/threadTranscript';
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { assertThreadCanStartRun } from '@convex/lib/runs';
-import { ensureAssistantToolPartsFromJobs, type AssistantPart } from '@convex/lib/assistantParts';
+import {
+	ensureAssistantToolPartsFromJobs,
+	joinAssistantTextParts,
+	type AssistantPart
+} from '@convex/lib/assistantParts';
+import {
+	classifyCompletionStreamBatch,
+	vCompletionStreamEvent
+} from '@convex/lib/completionStream';
 import {
 	type AgentHistoryMessage,
 	isRunFinalStatus,
@@ -17,7 +25,6 @@ import {
 	vModelId,
 	vReasoningEffort,
 	vRunFinalStatus,
-	vAssistantMessagePart,
 	vRunStatus
 } from '@convex/lib/validators';
 
@@ -182,12 +189,17 @@ export const completionActor = query({
 	): Promise<{
 		userId: string;
 		status: Infer<typeof vRunStatus>;
+		streamSequence: number;
 	}> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const message = run.responseMessageId
+			? await getThreadMessage(ctx, run.responseMessageId)
+			: null;
 		return {
 			userId,
-			status: run.status
+			status: run.status,
+			streamSequence: message?.streamSequence ?? 0
 		};
 	}
 });
@@ -223,31 +235,108 @@ export const beginAssistantMessage = mutation({
 	}
 });
 
-export const updateAssistantMessage = mutation({
+export const mergeAssistantStreamEvents = mutation({
 	args: {
 		guestId: v.optional(v.string()),
 		runId: v.id('runs'),
-		text: v.string(),
-		parts: v.optional(v.array(vAssistantMessagePart))
+		streamId: v.string(),
+		sequence: v.number(),
+		events: v.array(vCompletionStreamEvent)
 	},
 	handler: async (ctx, args): Promise<void> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (!run.responseMessageId || isRunFinalStatus(run.status)) {
+		assertRunAcceptsModelCompletion(run.status);
+		if (!run.responseMessageId || args.events.length === 0) {
 			return;
 		}
-		await ctx.db.patch(run.responseMessageId, {
-			text: args.text,
-			...(args.parts
-				? {
-						parts: args.parts.filter((part) => {
-							if (part.type === 'text' || part.type === 'reasoning') {
-								return part.text.trim().length > 0;
-							}
-							return true;
-						})
+
+		const message: Doc<'threadMessages'> = await getThreadMessage(ctx, run.responseMessageId);
+		const lastSequence = message.streamSequence ?? 0;
+		if (
+			classifyCompletionStreamBatch({
+				lastSequence,
+				lastStreamId: message.streamAttemptId,
+				sequence: args.sequence,
+				streamId: args.streamId
+			}) === 'duplicate'
+		) {
+			return;
+		}
+		const parts: AssistantPart[] = [...((message.parts ?? []) as AssistantPart[])];
+		const textIndexById = new Map<string, number>();
+		const toolIndexByCallId = new Map<string, number>();
+		for (const [index, part] of parts.entries()) {
+			if (part.type === 'text' || part.type === 'reasoning') {
+				textIndexById.set(`${part.type}:${part.id}`, index);
+			} else if (part.type === 'tool-call') {
+				toolIndexByCallId.set(part.partId ?? part.callId, index);
+			}
+		}
+
+		for (const event of args.events) {
+			if (event.type === 'text' || event.type === 'reasoning') {
+				const key = `${event.type}:${event.id}`;
+				const index = textIndexById.get(key);
+				if (index === undefined) {
+					const nextPart: AssistantPart =
+						event.type === 'reasoning'
+							? {
+									type: 'reasoning',
+									id: event.id,
+									text: event.text,
+									...(event.turnId ? { turnId: event.turnId } : {}),
+									...(event.providerMetadata !== undefined
+										? { providerMetadata: event.providerMetadata }
+										: {})
+								}
+							: {
+									type: 'text',
+									id: event.id,
+									text: event.text,
+									...(event.turnId ? { turnId: event.turnId } : {}),
+									...(event.providerMetadata !== undefined
+										? { providerMetadata: event.providerMetadata }
+										: {})
+								};
+					textIndexById.set(key, parts.push(nextPart) - 1);
+					continue;
+				}
+				const existing = parts[index];
+				if (existing.type === event.type) {
+					existing.text += event.text;
+					if (event.turnId) existing.turnId = event.turnId;
+					if (event.providerMetadata !== undefined) {
+						existing.providerMetadata = event.providerMetadata;
 					}
-				: {})
+				}
+				continue;
+			}
+
+			const index = toolIndexByCallId.get(event.partId);
+			const toolPart: AssistantPart = {
+				type: 'tool-call',
+				partId: event.partId,
+				callId: event.callId,
+				name: event.name,
+				input: event.input,
+				...(event.turnId ? { turnId: event.turnId } : {}),
+				...(event.providerMetadata !== undefined
+					? { providerMetadata: event.providerMetadata }
+					: {})
+			};
+			if (index === undefined) {
+				toolIndexByCallId.set(event.partId, parts.push(toolPart) - 1);
+			} else {
+				parts[index] = toolPart;
+			}
+		}
+
+		await ctx.db.patch(run.responseMessageId, {
+			text: joinAssistantTextParts(parts),
+			parts,
+			streamSequence: args.sequence,
+			streamAttemptId: args.streamId
 		});
 	}
 });
@@ -269,22 +358,35 @@ export const finishAssistantMessage = mutation({
 			.query('executorJobs')
 			.withIndex('by_runId_sequence', (query) => query.eq('runId', message.runId))
 			.collect();
+		const persistedParts = (message.parts ?? []) as AssistantPart[];
 		const nextParts: AssistantPart[] = ensureAssistantToolPartsFromJobs(
-			(message.parts ?? []) as AssistantPart[],
+			persistedParts,
 			jobs
 				.filter((job) => !job.hidden)
 				.sort((left, right) => left.sequence - right.sequence)
 				.map((job) => ({
 					id: job._id,
 					kind: job.kind,
+					...(job.callId ? { callId: job.callId } : {}),
 					payload: job.payload,
 					status: job.status,
 					result: job.result,
 					error: job.error
 				}))
 		);
+		const streamedText: string = joinAssistantTextParts(nextParts);
+		const retainedToolCallIds = new Set(
+			nextParts
+				.filter((part): part is Extract<AssistantPart, { type: 'tool-call' }> => {
+					return part.type === 'tool-call';
+				})
+				.map((part) => part.callId)
+		);
+		const removedProvisionalCall = persistedParts.some(
+			(part) => part.type === 'tool-call' && !retainedToolCallIds.has(part.callId)
+		);
 		await ctx.db.patch(run.responseMessageId, {
-			text: args.text,
+			text: streamedText || (removedProvisionalCall ? '' : args.text),
 			parts: nextParts
 		});
 	}
@@ -324,6 +426,7 @@ export const beginToolJob = mutation({
 		guestId: v.optional(v.string()),
 		runId: v.id('runs'),
 		kind: vExecutorJobKind,
+		callId: v.optional(v.string()),
 		payload: vExecutorJobPayload,
 		hidden: v.optional(v.boolean())
 	},
@@ -353,6 +456,7 @@ export const beginToolJob = mutation({
 			threadId: run.threadId,
 			runId: args.runId,
 			kind: args.kind,
+			...(args.callId ? { callId: args.callId } : {}),
 			payload: args.payload,
 			hidden: args.hidden ?? false,
 			status: 'claimed',

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -7,14 +7,16 @@ import { buildCanonicalAgentHistory, findLatestPrompt } from '@convex/lib/agentH
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import { buildThreadTranscript, type ThreadTranscriptMessage } from '@convex/lib/threadTranscript';
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
-import { assertThreadCanStartRun } from '@convex/lib/runs';
+import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 import {
 	ensureAssistantToolPartsFromJobs,
 	joinAssistantTextParts,
+	resolveAssistantMessageText,
 	type AssistantPart
 } from '@convex/lib/assistantParts';
 import {
 	classifyCompletionStreamBatch,
+	type CompletionStreamBatchClassification,
 	vCompletionStreamEvent
 } from '@convex/lib/completionStream';
 import {
@@ -190,6 +192,7 @@ export const completionActor = query({
 		userId: string;
 		status: Infer<typeof vRunStatus>;
 		streamSequence: number;
+		streamAttemptId?: string;
 	}> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
@@ -199,7 +202,8 @@ export const completionActor = query({
 		return {
 			userId,
 			status: run.status,
-			streamSequence: message?.streamSequence ?? 0
+			streamSequence: message?.streamSequence ?? 0,
+			...(message?.streamAttemptId ? { streamAttemptId: message.streamAttemptId } : {})
 		};
 	}
 });
@@ -243,25 +247,27 @@ export const mergeAssistantStreamEvents = mutation({
 		sequence: v.number(),
 		events: v.array(vCompletionStreamEvent)
 	},
-	handler: async (ctx, args): Promise<void> => {
+	handler: async (
+		ctx,
+		args
+	): Promise<Exclude<CompletionStreamBatchClassification, 'append'> | 'merged'> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		assertRunAcceptsModelCompletion(run.status);
 		if (!run.responseMessageId || args.events.length === 0) {
-			return;
+			return 'merged';
 		}
 
 		const message: Doc<'threadMessages'> = await getThreadMessage(ctx, run.responseMessageId);
 		const lastSequence = message.streamSequence ?? 0;
-		if (
-			classifyCompletionStreamBatch({
-				lastSequence,
-				lastStreamId: message.streamAttemptId,
-				sequence: args.sequence,
-				streamId: args.streamId
-			}) === 'duplicate'
-		) {
-			return;
+		const classification = classifyCompletionStreamBatch({
+			lastSequence,
+			lastStreamId: message.streamAttemptId,
+			sequence: args.sequence,
+			streamId: args.streamId
+		});
+		if (classification !== 'append') {
+			return classification;
 		}
 		const parts: AssistantPart[] = [...((message.parts ?? []) as AssistantPart[])];
 		const textIndexById = new Map<string, number>();
@@ -338,30 +344,67 @@ export const mergeAssistantStreamEvents = mutation({
 			streamSequence: args.sequence,
 			streamAttemptId: args.streamId
 		});
+		return 'merged';
 	}
 });
 
-export const finishAssistantMessage = mutation({
+export const finalizeRun = mutation({
 	args: {
 		guestId: v.optional(v.string()),
 		runId: v.id('runs'),
-		text: v.string()
+		text: v.string(),
+		status: vRunFinalStatus,
+		lastError: v.optional(v.string())
 	},
 	handler: async (ctx, args): Promise<void> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (!run.responseMessageId) {
-			return;
-		}
-		const message: Doc<'threadMessages'> = await getThreadMessage(ctx, run.responseMessageId);
+		const alreadyFinal = isRunFinalStatus(run.status);
+		const finalStatus = alreadyFinal ? run.status : args.status;
+		const completedAt = run.completedAt ?? Date.now();
 		const jobs: Doc<'executorJobs'>[] = await ctx.db
 			.query('executorJobs')
-			.withIndex('by_runId_sequence', (query) => query.eq('runId', message.runId))
+			.withIndex('by_runId_sequence', (query) => query.eq('runId', run._id))
 			.collect();
-		const persistedParts = (message.parts ?? []) as AssistantPart[];
+		const finalizedJobs = cancelExecutorJobsForTerminalRun({
+			jobs,
+			runStatus: finalStatus,
+			lastError: alreadyFinal ? run.lastError : args.lastError,
+			completedAt
+		});
+		for (const [index, job] of jobs.entries()) {
+			const finalizedJob = finalizedJobs[index];
+			if (finalizedJob === job) continue;
+			await ctx.db.patch(job._id, {
+				status: finalizedJob.status,
+				error: finalizedJob.error,
+				completedAt: finalizedJob.completedAt
+			});
+		}
+		if (alreadyFinal) {
+			if (run.activeJobId) {
+				await ctx.db.patch(run._id, { activeJobId: undefined });
+			}
+			return;
+		}
+
+		const responseMessageId =
+			run.responseMessageId ??
+			(await appendThreadMessage(ctx, {
+				threadId: run.threadId,
+				runId: run._id,
+				userId,
+				type: 'response',
+				text: ''
+			}));
+		const message = run.responseMessageId
+			? await getThreadMessage(ctx, run.responseMessageId)
+			: undefined;
+
+		const persistedParts = (message?.parts ?? []) as AssistantPart[];
 		const nextParts: AssistantPart[] = ensureAssistantToolPartsFromJobs(
 			persistedParts,
-			jobs
+			finalizedJobs
 				.filter((job) => !job.hidden)
 				.sort((left, right) => left.sequence - right.sequence)
 				.map((job) => ({
@@ -375,49 +418,17 @@ export const finishAssistantMessage = mutation({
 				}))
 		);
 		const streamedText: string = joinAssistantTextParts(nextParts);
-		const retainedToolCallIds = new Set(
-			nextParts
-				.filter((part): part is Extract<AssistantPart, { type: 'tool-call' }> => {
-					return part.type === 'tool-call';
-				})
-				.map((part) => part.callId)
-		);
-		const removedProvisionalCall = persistedParts.some(
-			(part) => part.type === 'tool-call' && !retainedToolCallIds.has(part.callId)
-		);
-		await ctx.db.patch(run.responseMessageId, {
-			text: streamedText || (removedProvisionalCall ? '' : args.text),
+		await ctx.db.patch(responseMessageId, {
+			text: resolveAssistantMessageText(streamedText, args.text),
 			parts: nextParts
 		});
-	}
-});
-
-export const finishRun = mutation({
-	args: {
-		guestId: v.optional(v.string()),
-		runId: v.id('runs'),
-		status: vRunFinalStatus,
-		lastError: v.optional(v.string())
-	},
-	handler: async (ctx, args): Promise<void> => {
-		const userId: string = await getUserId(ctx, args.guestId);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (!isRunFinalStatus(run.status)) {
-			const completedAt = Date.now();
-			await ctx.db.patch(args.runId, {
-				status: args.status,
-				lastError: args.lastError,
-				activeJobId: undefined,
-				completedAt
-			});
-			if (run.activeJobId) {
-				await ctx.db.patch(run.activeJobId, {
-					status: args.status,
-					error: args.lastError,
-					completedAt
-				});
-			}
-		}
+		await ctx.db.patch(run._id, {
+			status: finalStatus,
+			lastError: args.lastError,
+			activeJobId: undefined,
+			completedAt,
+			responseMessageId
+		});
 	}
 });
 

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -9,7 +9,14 @@ export const latestRunForThread = query({
 		guestId: v.optional(v.string()),
 		threadId: v.id('threadRecords')
 	},
-	handler: async (ctx, args): Promise<{ run: Doc<'runs'>; jobs: Doc<'executorJobs'>[] } | null> => {
+	handler: async (
+		ctx,
+		args
+	): Promise<{
+		threadId: typeof args.threadId;
+		run: Doc<'runs'> | null;
+		jobs: Doc<'executorJobs'>[];
+	}> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
 
@@ -19,7 +26,11 @@ export const latestRunForThread = query({
 			.order('desc')
 			.first();
 		if (!latestRun) {
-			return null;
+			return {
+				threadId: args.threadId,
+				run: null,
+				jobs: []
+			};
 		}
 
 		const jobs: Doc<'executorJobs'>[] = await ctx.db
@@ -28,6 +39,7 @@ export const latestRunForThread = query({
 			.collect();
 
 		return {
+			threadId: args.threadId,
 			run: latestRun,
 			jobs: jobs.filter((job) => !job.hidden).sort((left, right) => left.sequence - right.sequence)
 		};

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -16,7 +16,10 @@ import { vModelId, vReasoningEffort } from '@convex/lib/validators';
 import { type SupportedModelId, type SupportedReasoningEffort } from '@convex/lib/models';
 import {
 	appendCompletionStreamEvent,
+	COMPLETION_STREAM_SUPERSEDED,
 	type CompletionStreamEvent,
+	isCompletionStreamAttemptSuperseded,
+	isCompletionStreamSuperseded,
 	upsertCompletionReasoningEvent,
 	upsertCompletionTextEvent
 } from '@convex/lib/completionStream';
@@ -30,6 +33,8 @@ type CompletionActionResult = Pick<GenerateTextResult, 'text' | 'usage' | 'toolC
 };
 type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
+
+const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 1_000;
 
 export const complete = action({
 	args: {
@@ -95,14 +100,22 @@ export const complete = action({
 
 		const streamSequence = await enforceCompletionLimit(ctx, args.guestId, args.streamRunId);
 		const streamId = crypto.randomUUID();
-		const result = await collectStreamingCompletion(
-			ctx,
-			streamText(request),
-			args.streamRunId,
-			args.guestId,
-			streamId,
-			streamSequence
-		);
+		const abortController = new AbortController();
+		let result: CompletionActionResult;
+		try {
+			result = await collectStreamingCompletion(
+				ctx,
+				streamText({ ...request, abortSignal: abortController.signal }),
+				args.streamRunId,
+				args.guestId,
+				streamId,
+				streamSequence,
+				abortController
+			);
+		} catch (error) {
+			abortController.abort(error);
+			throw error;
+		}
 
 		return {
 			text: result.text,
@@ -127,7 +140,8 @@ async function collectStreamingCompletion(
 	runId: Id<'runs'>,
 	guestId: string | undefined,
 	streamId: string,
-	streamSequence: number
+	streamSequence: number,
+	abortController: AbortController
 ): Promise<CompletionActionResult> {
 	const streamEvents: CompletionStreamEvent[] = [];
 	const pendingEvents: CompletionStreamEvent[] = [];
@@ -146,17 +160,21 @@ async function collectStreamingCompletion(
 		let lastError: unknown;
 		for (let attempt = 0; attempt < 2; attempt += 1) {
 			try {
-				await ctx.runMutation(api.agentRuntime.mergeAssistantStreamEvents, {
+				const outcome = await ctx.runMutation(api.agentRuntime.mergeAssistantStreamEvents, {
 					...(guestId ? { guestId } : {}),
 					runId,
 					streamId,
 					sequence,
 					events
 				});
+				if (outcome === 'superseded') {
+					throw new Error(COMPLETION_STREAM_SUPERSEDED);
+				}
 				pendingEvents.splice(0, events.length);
 				nextBatchSequence += 1;
 				return;
 			} catch (error) {
+				if (isCompletionStreamSuperseded(error)) throw error;
 				lastError = error;
 				if (attempt === 0) await delay(100);
 			}
@@ -198,26 +216,47 @@ async function collectStreamingCompletion(
 		});
 	};
 
+	const iterator = result.stream[Symbol.asyncIterator]();
 	try {
-		const iterator = result.stream[Symbol.asyncIterator]();
 		let nextPart = iterator.next();
+		let nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
 		while (true) {
-			let next: { type: 'part'; value: Awaited<typeof nextPart> } | { type: 'flush' };
-			if (pendingEvents.length === 0) {
-				next = { type: 'part', value: await nextPart };
-			} else {
-				let flushTimer: ReturnType<typeof setTimeout> | undefined;
+			let next:
+				| { type: 'part'; value: Awaited<typeof nextPart> }
+				| { type: 'flush' }
+				| { type: 'acceptance-check' };
+			let flushTimer: ReturnType<typeof setTimeout> | undefined;
+			let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
+			const waits: Array<Promise<typeof next>> = [
+				nextPart.then((value) => ({ type: 'part' as const, value })),
+				new Promise<{ type: 'acceptance-check' }>((resolve) => {
+					acceptanceTimer = setTimeout(
+						() => resolve({ type: 'acceptance-check' }),
+						Math.max(0, nextAcceptanceCheckAt - Date.now())
+					);
+				})
+			];
+			if (pendingEvents.length > 0) {
 				const flushDeadline = new Promise<{ type: 'flush' }>((resolve) => {
 					flushTimer = setTimeout(() => resolve({ type: 'flush' }), 80);
 				});
-				try {
-					next = await Promise.race([
-						nextPart.then((value) => ({ type: 'part' as const, value })),
-						flushDeadline
-					]);
-				} finally {
-					if (flushTimer !== undefined) clearTimeout(flushTimer);
-				}
+				waits.push(flushDeadline);
+			}
+			try {
+				next = await Promise.race(waits);
+			} finally {
+				if (flushTimer !== undefined) clearTimeout(flushTimer);
+				if (acceptanceTimer !== undefined) clearTimeout(acceptanceTimer);
+			}
+			if (next.type === 'acceptance-check') {
+				await assertCompletionStillAccepted(ctx, {
+					runId,
+					guestId,
+					streamId,
+					initialSequence: streamSequence
+				});
+				nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
+				continue;
 			}
 			if (next.type === 'flush') {
 				await flush();
@@ -369,7 +408,29 @@ async function collectStreamingCompletion(
 				await flush();
 			}
 		}
+		await flush();
+
+		const [text, usage, finalStep, toolCalls] = await Promise.all([
+			result.text,
+			result.usage,
+			result.finalStep,
+			result.toolCalls
+		]);
+		return {
+			text,
+			usage,
+			response: finalStep.response,
+			toolCalls,
+			streamEvents
+		};
 	} catch (error) {
+		abortController.abort(error);
+		try {
+			await iterator.return?.();
+		} catch {
+			// Preserve the terminal stream error if iterator cleanup also fails.
+		}
+		if (isCompletionStreamSuperseded(error)) throw error;
 		try {
 			await flush();
 		} catch {
@@ -377,21 +438,32 @@ async function collectStreamingCompletion(
 		}
 		throw error;
 	}
-	await flush();
+}
 
-	const [text, usage, finalStep, toolCalls] = await Promise.all([
-		result.text,
-		result.usage,
-		result.finalStep,
-		result.toolCalls
-	]);
-	return {
-		text,
-		usage,
-		response: finalStep.response,
-		toolCalls,
-		streamEvents
-	};
+async function assertCompletionStillAccepted(
+	ctx: ActionCtx,
+	args: {
+		runId: Id<'runs'>;
+		guestId: string | undefined;
+		streamId: string;
+		initialSequence: number;
+	}
+): Promise<void> {
+	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+		...(args.guestId ? { guestId: args.guestId } : {}),
+		runId: args.runId
+	});
+	assertRunAcceptsModelCompletion(actor.status);
+	if (
+		isCompletionStreamAttemptSuperseded({
+			initialSequence: args.initialSequence,
+			observedSequence: actor.streamSequence,
+			observedStreamId: actor.streamAttemptId,
+			streamId: args.streamId
+		})
+	) {
+		throw new Error(COMPLETION_STREAM_SUPERSEDED);
+	}
 }
 
 function toolPartId(streamId: string, toolCallId: string): string {

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -14,12 +14,19 @@ import {
 } from '@convex/lib/rateLimits';
 import { vModelId, vReasoningEffort } from '@convex/lib/validators';
 import { type SupportedModelId, type SupportedReasoningEffort } from '@convex/lib/models';
+import {
+	appendCompletionStreamEvent,
+	type CompletionStreamEvent,
+	upsertCompletionReasoningEvent,
+	upsertCompletionTextEvent
+} from '@convex/lib/completionStream';
 
 type JsonSchema = Parameters<typeof jsonSchema>[0];
 type ToolChoice = NonNullable<Parameters<typeof generateText>[0]['toolChoice']>;
 type GenerateTextResult = Awaited<ReturnType<typeof generateText>>;
 type CompletionActionResult = Pick<GenerateTextResult, 'text' | 'usage' | 'toolCalls'> & {
 	response: GenerateTextResult['finalStep']['response'];
+	streamEvents: CompletionStreamEvent[];
 };
 type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
@@ -51,7 +58,13 @@ export const complete = action({
 		text: string;
 		usage: CompletionActionResult['usage'];
 		message_id: string | undefined;
-		tool_calls: Array<{ id: string; name: string; arguments: JsonValue }>;
+		tool_calls: Array<{
+			id: string;
+			name: string;
+			arguments: JsonValue;
+			provider_metadata?: JsonValue;
+		}>;
+		stream_events: CompletionStreamEvent[];
 	}> => {
 		const tools: Record<string, ReturnType<typeof tool>> = Object.fromEntries(
 			(args.tools ?? []).map((toolDefinition) => [
@@ -80,8 +93,16 @@ export const complete = action({
 			throw new Error('Either prompt or messagesJson is required.');
 		}
 
-		await enforceCompletionLimit(ctx, args.guestId, args.streamRunId);
-		const result = await collectStreamingCompletion(streamText(request));
+		const streamSequence = await enforceCompletionLimit(ctx, args.guestId, args.streamRunId);
+		const streamId = crypto.randomUUID();
+		const result = await collectStreamingCompletion(
+			ctx,
+			streamText(request),
+			args.streamRunId,
+			args.guestId,
+			streamId,
+			streamSequence
+		);
 
 		return {
 			text: result.text,
@@ -90,15 +111,274 @@ export const complete = action({
 			tool_calls: (result.toolCalls ?? []).map((toolCall: (typeof result.toolCalls)[number]) => ({
 				id: toolCall.toolCallId,
 				name: toolCall.toolName,
-				arguments: toolCall.input as JsonValue
-			}))
+				arguments: toolCall.input as JsonValue,
+				...(toolCall.providerMetadata
+					? { provider_metadata: toolCall.providerMetadata as JsonValue }
+					: {})
+			})),
+			stream_events: result.streamEvents
 		};
 	}
 });
 
 async function collectStreamingCompletion(
-	result: ReturnType<typeof streamText>
+	ctx: ActionCtx,
+	result: ReturnType<typeof streamText>,
+	runId: Id<'runs'>,
+	guestId: string | undefined,
+	streamId: string,
+	streamSequence: number
 ): Promise<CompletionActionResult> {
+	const streamEvents: CompletionStreamEvent[] = [];
+	const pendingEvents: CompletionStreamEvent[] = [];
+	const reasoning = new Map<
+		string,
+		{ partId: string; providerMetadata?: JsonValue; finalized: boolean }
+	>();
+	let nextBatchSequence = streamSequence + 1;
+
+	const flush = async (): Promise<void> => {
+		if (pendingEvents.length === 0) {
+			return;
+		}
+		const events = pendingEvents.slice();
+		const sequence = nextBatchSequence;
+		let lastError: unknown;
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			try {
+				await ctx.runMutation(api.agentRuntime.mergeAssistantStreamEvents, {
+					...(guestId ? { guestId } : {}),
+					runId,
+					streamId,
+					sequence,
+					events
+				});
+				pendingEvents.splice(0, events.length);
+				nextBatchSequence += 1;
+				return;
+			} catch (error) {
+				lastError = error;
+				if (attempt === 0) await delay(100);
+			}
+		}
+		throw lastError;
+	};
+
+	const queuePersisted = (event: CompletionStreamEvent): void => {
+		if (event.type === 'text') {
+			upsertCompletionTextEvent(pendingEvents, event);
+		} else {
+			appendCompletionStreamEvent(pendingEvents, event);
+		}
+	};
+	const updateText = (id: string, text: string, providerMetadata?: JsonValue): void => {
+		const event: Extract<CompletionStreamEvent, { type: 'text' }> = {
+			type: 'text',
+			id: `${streamId}:text:${id}`,
+			text,
+			turnId: streamId,
+			...(providerMetadata !== undefined ? { providerMetadata } : {})
+		};
+		queuePersisted(event);
+		upsertCompletionTextEvent(streamEvents, event);
+	};
+	const finalizeReasoning = (id: string, providerMetadata?: JsonValue): void => {
+		const state = reasoning.get(id);
+		if (!state || state.finalized) return;
+		state.providerMetadata = providerMetadata ?? state.providerMetadata;
+		state.finalized = true;
+		const reasoningId = providerReasoningId(state.providerMetadata);
+		upsertCompletionReasoningEvent(streamEvents, {
+			type: 'reasoning',
+			id: state.partId,
+			text: '',
+			turnId: streamId,
+			...(reasoningId ? { providerReasoningId: reasoningId } : {}),
+			...(state.providerMetadata ? { providerMetadata: state.providerMetadata } : {})
+		});
+	};
+
+	try {
+		const iterator = result.stream[Symbol.asyncIterator]();
+		let nextPart = iterator.next();
+		while (true) {
+			let next: { type: 'part'; value: Awaited<typeof nextPart> } | { type: 'flush' };
+			if (pendingEvents.length === 0) {
+				next = { type: 'part', value: await nextPart };
+			} else {
+				let flushTimer: ReturnType<typeof setTimeout> | undefined;
+				const flushDeadline = new Promise<{ type: 'flush' }>((resolve) => {
+					flushTimer = setTimeout(() => resolve({ type: 'flush' }), 80);
+				});
+				try {
+					next = await Promise.race([
+						nextPart.then((value) => ({ type: 'part' as const, value })),
+						flushDeadline
+					]);
+				} finally {
+					if (flushTimer !== undefined) clearTimeout(flushTimer);
+				}
+			}
+			if (next.type === 'flush') {
+				await flush();
+				continue;
+			}
+			if (next.value.done) break;
+			const part = next.value.value;
+			nextPart = iterator.next();
+			switch (part.type) {
+				case 'text-start':
+					updateText(part.id, '', part.providerMetadata as JsonValue | undefined);
+					break;
+				case 'text-delta':
+					updateText(part.id, part.text, part.providerMetadata as JsonValue | undefined);
+					break;
+				case 'reasoning-start': {
+					const providerMetadata = part.providerMetadata as JsonValue | undefined;
+					reasoning.set(part.id, {
+						partId: `${streamId}:reasoning:${part.id}`,
+						providerMetadata,
+						finalized: false
+					});
+					upsertCompletionReasoningEvent(streamEvents, {
+						type: 'reasoning',
+						id: `${streamId}:reasoning:${part.id}`,
+						text: '',
+						turnId: streamId,
+						...(providerMetadata ? { providerMetadata } : {})
+					});
+					queuePersisted({
+						type: 'reasoning',
+						id: `${streamId}:reasoning:${part.id}`,
+						text: '',
+						turnId: streamId,
+						...(providerMetadata ? { providerMetadata } : {})
+					});
+					break;
+				}
+				case 'reasoning-delta':
+					if (!reasoning.has(part.id)) {
+						reasoning.set(part.id, {
+							partId: `${streamId}:reasoning:${part.id}`,
+							finalized: false
+						});
+						upsertCompletionReasoningEvent(streamEvents, {
+							type: 'reasoning',
+							id: `${streamId}:reasoning:${part.id}`,
+							text: '',
+							turnId: streamId
+						});
+					}
+					upsertCompletionReasoningEvent(streamEvents, {
+						type: 'reasoning',
+						id: `${streamId}:reasoning:${part.id}`,
+						text: part.text,
+						turnId: streamId
+					});
+					queuePersisted({
+						type: 'reasoning',
+						id: `${streamId}:reasoning:${part.id}`,
+						text: part.text,
+						turnId: streamId
+					});
+					break;
+				case 'reasoning-end': {
+					const providerMetadata = part.providerMetadata as JsonValue | undefined;
+					if (!reasoning.has(part.id)) {
+						reasoning.set(part.id, {
+							partId: `${streamId}:reasoning:${part.id}`,
+							providerMetadata,
+							finalized: false
+						});
+						upsertCompletionReasoningEvent(streamEvents, {
+							type: 'reasoning',
+							id: `${streamId}:reasoning:${part.id}`,
+							text: '',
+							turnId: streamId
+						});
+					}
+					queuePersisted({
+						type: 'reasoning',
+						id: `${streamId}:reasoning:${part.id}`,
+						text: '',
+						turnId: streamId,
+						...(providerMetadata ? { providerMetadata } : {})
+					});
+					finalizeReasoning(part.id, providerMetadata);
+					await flush();
+					break;
+				}
+				case 'tool-input-start':
+					queuePersisted({
+						type: 'toolCall',
+						partId: toolPartId(streamId, part.id),
+						callId: part.id,
+						name: part.toolName,
+						input: {},
+						turnId: streamId,
+						...(part.providerMetadata
+							? { providerMetadata: part.providerMetadata as JsonValue }
+							: {})
+					});
+					await flush();
+					break;
+				case 'tool-call':
+					queuePersisted({
+						type: 'toolCall',
+						partId: toolPartId(streamId, part.toolCallId),
+						callId: part.toolCallId,
+						name: part.toolName,
+						input: part.input as JsonValue,
+						turnId: streamId,
+						...(part.providerMetadata
+							? { providerMetadata: part.providerMetadata as JsonValue }
+							: {})
+					});
+					appendCompletionStreamEvent(streamEvents, {
+						type: 'toolCall',
+						partId: toolPartId(streamId, part.toolCallId),
+						callId: part.toolCallId,
+						name: part.toolName,
+						input: part.input as JsonValue,
+						turnId: streamId,
+						...(part.providerMetadata
+							? { providerMetadata: part.providerMetadata as JsonValue }
+							: {})
+					});
+					await flush();
+					break;
+				case 'text-end':
+					updateText(part.id, '', part.providerMetadata as JsonValue | undefined);
+					await flush();
+					break;
+				case 'tool-input-end':
+					await flush();
+					break;
+				case 'finish-step':
+				case 'finish':
+					for (const id of reasoning.keys()) finalizeReasoning(id);
+					await flush();
+					break;
+				case 'abort':
+					throw new Error(part.reason ?? 'Model completion was aborted.');
+				case 'error':
+					throw part.error;
+			}
+
+			if (pendingEvents.length >= 24) {
+				await flush();
+			}
+		}
+	} catch (error) {
+		try {
+			await flush();
+		} catch {
+			// Preserve the stream failure; the flush error is only secondary.
+		}
+		throw error;
+	}
+	await flush();
+
 	const [text, usage, finalStep, toolCalls] = await Promise.all([
 		result.text,
 		result.usage,
@@ -109,15 +389,31 @@ async function collectStreamingCompletion(
 		text,
 		usage,
 		response: finalStep.response,
-		toolCalls
+		toolCalls,
+		streamEvents
 	};
+}
+
+function toolPartId(streamId: string, toolCallId: string): string {
+	return `${streamId}:tool:${toolCallId}`;
+}
+
+function providerReasoningId(metadata: JsonValue | undefined): string | undefined {
+	if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
+	const openai = metadata.openai;
+	if (!openai || typeof openai !== 'object' || Array.isArray(openai)) return undefined;
+	return typeof openai.itemId === 'string' ? openai.itemId : undefined;
+}
+
+function delay(milliseconds: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 async function enforceCompletionLimit(
 	ctx: ActionCtx,
 	guestId: string | undefined,
 	runId: Id<'runs'>
-): Promise<void> {
+): Promise<number> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
 		...(guestId ? { guestId } : {}),
 		runId
@@ -125,9 +421,10 @@ async function enforceCompletionLimit(
 	assertRunAcceptsModelCompletion(actor.status);
 	if (actor.userId.startsWith('guest:')) {
 		await enforceGuestModelCompletionLimit(ctx, actor.userId);
-		return;
+		return actor.streamSequence;
 	}
 	await enforceSignedInModelCompletionLimit(ctx, actor.userId);
+	return actor.streamSequence;
 }
 
 function buildSharedCompletionRequest(

--- a/apps/web/src/convex/executor.ts
+++ b/apps/web/src/convex/executor.ts
@@ -2,6 +2,7 @@ import { mutation } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedExecutorJob } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
+import { executorFailureRunPatch } from '@convex/lib/runs';
 import { isRunFinalStatus, vExecutorJobResult } from '@convex/lib/validators';
 
 export const complete = mutation({
@@ -59,13 +60,15 @@ export const fail = mutation({
 			completedAt
 		});
 		const run = await ctx.db.get(job.runId);
-		if (run && run.activeJobId === args.jobId) {
-			await ctx.db.patch(job.runId, {
-				status: 'failed',
-				lastError: args.error,
-				activeJobId: undefined,
-				completedAt
+		if (run) {
+			const runPatch = executorFailureRunPatch({
+				runStatus: run.status,
+				activeJobId: run.activeJobId,
+				failedJobId: args.jobId
 			});
+			if (runPatch) {
+				await ctx.db.patch(job.runId, runPatch);
+			}
 		}
 		return true;
 	}

--- a/apps/web/src/convex/lib/agentHistory.ts
+++ b/apps/web/src/convex/lib/agentHistory.ts
@@ -2,101 +2,186 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { ThreadTranscriptMessage } from '@convex/lib/threadTranscript';
 import type { AgentHistoryMessage } from '@convex/lib/validators';
 import { isRunFinalStatus } from '@convex/lib/validators';
-import { ensureAssistantToolPartsFromJobs, type AssistantPart } from '@convex/lib/assistantParts';
+import {
+	ensureAssistantToolPartsFromJobs,
+	type AssistantPart,
+	type PersistableExecutorToolJob
+} from '@convex/lib/assistantParts';
 
-function buildAgentHistoryFromAssistantMessage(args: {
-	message: ThreadTranscriptMessage;
-	jobs: Doc<'executorJobs'>[];
+export function buildAgentHistoryFromAssistantParts(args: {
+	parts: AssistantPart[];
+	jobs: PersistableExecutorToolJob[];
+	fallbackText: string;
 }): AgentHistoryMessage[] {
-	const persistedParts = (args.message.parts ?? []) as AssistantPart[];
-	const parts = ensureAssistantToolPartsFromJobs(
-		args.message.runStatus === 'completed'
-			? persistedParts
-			: persistedParts.filter((part) => part.type === 'text' || part.type === 'reasoning'),
-		args.jobs
-			.filter((job) => !job.hidden)
-			.sort((left, right) => left.sequence - right.sequence)
-			.map((job) => ({
-				id: job._id,
-				kind: job.kind,
-				payload: job.payload,
-				status: job.status,
-				result: job.result,
-				error: job.error
-			}))
-	);
+	const parts = ensureAssistantToolPartsFromJobs(args.parts, args.jobs);
 	const history: AgentHistoryMessage[] = [];
-	let assistantContents: AgentHistoryMessage['contents'] = [];
+	let turn:
+		| {
+				id?: string;
+				assistant: AgentHistoryMessage['contents'];
+				results: AgentHistoryMessage['contents'];
+		  }
+		| undefined;
 	let sawAssistantText = false;
 
-	const flushAssistantContents = () => {
-		if (assistantContents.length === 0) {
-			return;
+	const flushTurn = () => {
+		if (!turn) return;
+		if (turn.assistant.length > 0) {
+			history.push({
+				role: 'assistant',
+				contents: turn.assistant
+			});
 		}
-		history.push({
-			role: 'assistant',
-			contents: assistantContents
-		});
-		assistantContents = [];
+		if (turn.results.length > 0) {
+			history.push({
+				role: 'user',
+				contents: turn.results
+			});
+		}
+		turn = undefined;
 	};
 
 	for (const part of parts) {
+		if (part.type === 'tool-result') {
+			turn ??= { assistant: [], results: [] };
+			turn.results.push({
+				type: 'toolResult',
+				id: part.callId,
+				callId: part.callId,
+				items: [
+					{
+						type: 'text',
+						text: JSON.stringify(part.output)
+					}
+				]
+			});
+			continue;
+		}
+
+		const partTurnId = part.turnId;
+		const startsInferredTurn =
+			turn !== undefined &&
+			partTurnId === undefined &&
+			turn.id === undefined &&
+			turn.results.length > 0 &&
+			(part.type === 'text' || part.type === 'reasoning' || part.type === 'tool-call');
+		if (
+			turn &&
+			((partTurnId !== undefined && turn.id !== partTurnId) ||
+				(partTurnId === undefined && turn.id !== undefined) ||
+				startsInferredTurn)
+		) {
+			flushTurn();
+		}
+		turn ??= {
+			...(partTurnId !== undefined ? { id: partTurnId } : {}),
+			assistant: [],
+			results: []
+		};
+
 		if (part.type === 'text') {
 			const text = part.text.trim();
 			if (!text) {
 				continue;
 			}
 			sawAssistantText = true;
-			assistantContents.push({
+			turn.assistant.push({
 				type: 'text',
-				text: part.text
+				text: part.text,
+				...(part.providerMetadata !== undefined
+					? { additionalParamsJson: JSON.stringify(part.providerMetadata) }
+					: {})
 			});
 			continue;
 		}
 
 		if (part.type === 'reasoning') {
+			const openai = openAiMetadata(part.providerMetadata);
+			const blocks: unknown[] = [];
+			if (part.text.length > 0) {
+				blocks.push({ type: 'text', content: { text: part.text } });
+			}
+			if (typeof openai?.reasoningEncryptedContent === 'string') {
+				blocks.push({ type: 'encrypted', content: openai.reasoningEncryptedContent });
+			}
+			if (blocks.length > 0) {
+				turn.assistant.push({
+					type: 'reasoning',
+					...(typeof openai?.itemId === 'string' ? { id: openai.itemId } : {}),
+					blocksJson: JSON.stringify(blocks)
+				});
+			}
 			continue;
 		}
 
 		if (part.type === 'tool-call') {
-			assistantContents.push({
+			turn.assistant.push({
 				type: 'toolCall',
 				id: part.callId,
 				callId: part.callId,
 				name: part.name,
-				argumentsJson: JSON.stringify(part.input)
+				argumentsJson: JSON.stringify(part.input),
+				...(part.providerMetadata !== undefined
+					? { additionalParamsJson: JSON.stringify(part.providerMetadata) }
+					: {})
 			});
 			continue;
 		}
-
-		flushAssistantContents();
-		history.push({
-			role: 'user',
-			contents: [
-				{
-					type: 'toolResult',
-					id: part.callId,
-					callId: part.callId,
-					items: [
-						{
-							type: 'text',
-							text: JSON.stringify(part.output)
-						}
-					]
-				}
-			]
-		});
 	}
 
-	if (!sawAssistantText && args.message.text.trim().length > 0) {
-		assistantContents.push({
-			type: 'text',
-			text: args.message.text
-		});
+	flushTurn();
+	if (!sawAssistantText && args.fallbackText.trim().length > 0) {
+		const lastMessage = history.at(-1);
+		if (lastMessage?.role === 'assistant') {
+			lastMessage.contents.push({
+				type: 'text',
+				text: args.fallbackText
+			});
+		} else {
+			history.push({
+				role: 'assistant',
+				contents: [
+					{
+						type: 'text',
+						text: args.fallbackText
+					}
+				]
+			});
+		}
 	}
 
-	flushAssistantContents();
 	return history;
+}
+
+function buildAgentHistoryFromAssistantMessage(args: {
+	message: ThreadTranscriptMessage;
+	jobs: Doc<'executorJobs'>[];
+}): AgentHistoryMessage[] {
+	const persistedParts = (args.message.parts ?? []) as AssistantPart[];
+	return buildAgentHistoryFromAssistantParts({
+		parts: persistedParts,
+		jobs: args.jobs
+			.filter((job) => !job.hidden)
+			.sort((left, right) => left.sequence - right.sequence)
+			.map((job) => ({
+				id: job._id,
+				kind: job.kind,
+				...(job.callId ? { callId: job.callId } : {}),
+				payload: job.payload,
+				status: job.status,
+				result: job.result,
+				error: job.error
+			})),
+		fallbackText: args.message.text
+	});
+}
+
+function openAiMetadata(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+	const openai = (value as Record<string, unknown>).openai;
+	return openai && typeof openai === 'object' && !Array.isArray(openai)
+		? (openai as Record<string, unknown>)
+		: undefined;
 }
 
 export function buildCanonicalAgentHistory(args: {

--- a/apps/web/src/convex/lib/assistantParts.ts
+++ b/apps/web/src/convex/lib/assistantParts.ts
@@ -7,19 +7,26 @@ export type AssistantTextPart = {
 	type: 'text';
 	id: string;
 	text: string;
+	turnId?: string;
+	providerMetadata?: JsonValue;
 };
 
 export type AssistantReasoningPart = {
 	type: 'reasoning';
 	id: string;
 	text: string;
+	turnId?: string;
+	providerMetadata?: JsonValue;
 };
 
 export type AssistantToolCallPart = {
 	type: 'tool-call';
+	partId?: string;
 	callId: string;
 	name: string;
 	input: JsonValue;
+	turnId?: string;
+	providerMetadata?: JsonValue;
 };
 
 export type AssistantToolResultPart = {
@@ -42,6 +49,7 @@ export type PersistedToolLogEntry = {
 export type PersistableExecutorToolJob = {
 	id: string;
 	kind: Infer<typeof vExecutorJobKind>;
+	callId?: string;
 	payload: ExecutorJobPayload;
 	status: Infer<typeof vExecutorJobStatus>;
 	result?: ExecutorJobResult;
@@ -147,44 +155,94 @@ export function buildPersistedToolLogs(parts: AssistantPart[]): PersistedToolLog
 	return orderedLogs;
 }
 
+export function joinAssistantTextParts(parts: AssistantPart[]): string {
+	let text = '';
+	let previousTurnId: string | undefined;
+	let sawText = false;
+
+	for (const part of parts) {
+		if (part.type !== 'text' || part.text.length === 0) continue;
+		if (
+			sawText &&
+			previousTurnId !== undefined &&
+			part.turnId !== undefined &&
+			part.turnId !== previousTurnId
+		) {
+			text += '\n\n';
+		}
+		text += part.text;
+		if (part.turnId !== undefined) previousTurnId = part.turnId;
+		sawText = true;
+	}
+
+	return text;
+}
+
 export function ensureAssistantToolPartsFromJobs(
 	parts: AssistantPart[],
 	jobs: PersistableExecutorToolJob[]
 ): AssistantPart[] {
-	if (
-		parts.some((part) => {
-			return part.type === 'tool-call' || part.type === 'tool-result';
-		})
-	) {
-		return parts;
-	}
+	const nextParts = parts.map((part) => cloneAssistantToolPayload(part));
+	const resultCallIds = new Set(
+		nextParts
+			.filter((part): part is AssistantToolResultPart => part.type === 'tool-result')
+			.map((part) => part.callId)
+	);
 
 	if (jobs.length === 0) {
-		return parts;
+		return removeAbandonedAssistantTurns(nextParts, resultCallIds);
 	}
 
-	const nextParts = [...parts];
+	const unmatchedCalls = nextParts.filter(
+		(part): part is AssistantToolCallPart => part.type === 'tool-call'
+	);
+	const usedCallIds = new Set<string>();
+
 	for (const job of jobs) {
-		const callId = `executor-job:${job.id}`;
-		nextParts.push({
-			type: 'tool-call',
-			callId,
-			name: job.kind,
-			input: cloneAssistantToolPayload(job.payload)
+		const exactCall = unmatchedCalls.find((part) => {
+			if (usedCallIds.has(part.callId)) return false;
+			if (job.callId) return part.callId === job.callId;
+			return part.name === job.kind && JSON.stringify(part.input) === JSON.stringify(job.payload);
 		});
+		const streamedCall =
+			exactCall ??
+			(job.callId
+				? undefined
+				: unmatchedCalls.find((part) => !usedCallIds.has(part.callId) && part.name === job.kind));
+		const callId = job.callId ?? streamedCall?.callId ?? `executor-job:${job.id}`;
+		usedCallIds.add(callId);
+		let insertAt: number;
+		if (streamedCall) {
+			streamedCall.name = job.kind;
+			streamedCall.input = cloneAssistantToolPayload(job.payload);
+			insertAt = nextParts.indexOf(streamedCall) + 1;
+		} else {
+			nextParts.push({
+				type: 'tool-call',
+				callId,
+				name: job.kind,
+				input: cloneAssistantToolPayload(job.payload)
+			});
+			insertAt = nextParts.length;
+		}
+
+		if (resultCallIds.has(callId)) {
+			continue;
+		}
 
 		if (job.status === 'completed' && job.result !== undefined) {
-			nextParts.push({
+			nextParts.splice(insertAt, 0, {
 				type: 'tool-result',
 				callId,
 				name: job.kind,
 				output: cloneAssistantToolPayload(job.result)
 			});
+			resultCallIds.add(callId);
 			continue;
 		}
 
 		if (job.status === 'failed') {
-			nextParts.push({
+			nextParts.splice(insertAt, 0, {
 				type: 'tool-result',
 				callId,
 				name: job.kind,
@@ -192,11 +250,12 @@ export function ensureAssistantToolPartsFromJobs(
 					error: job.error ?? 'Executor job failed.'
 				}
 			});
+			resultCallIds.add(callId);
 			continue;
 		}
 
 		if (job.status === 'cancelled') {
-			nextParts.push({
+			nextParts.splice(insertAt, 0, {
 				type: 'tool-result',
 				callId,
 				name: job.kind,
@@ -204,8 +263,42 @@ export function ensureAssistantToolPartsFromJobs(
 					error: job.error ?? 'Executor job cancelled before completion.'
 				}
 			});
+			resultCallIds.add(callId);
 		}
 	}
 
-	return nextParts;
+	return removeAbandonedAssistantTurns(nextParts, new Set([...usedCallIds, ...resultCallIds]));
+}
+
+function removeAbandonedAssistantTurns(
+	parts: AssistantPart[],
+	retainedCallIds: ReadonlySet<string>
+): AssistantPart[] {
+	const abandonedCalls = parts.filter(
+		(part): part is AssistantToolCallPart =>
+			part.type === 'tool-call' && !retainedCallIds.has(part.callId)
+	);
+	const callsByTurnId = new Map<string, AssistantToolCallPart[]>();
+	for (const part of parts) {
+		if (part.type !== 'tool-call' || part.turnId === undefined) continue;
+		const turnCalls = callsByTurnId.get(part.turnId) ?? [];
+		turnCalls.push(part);
+		callsByTurnId.set(part.turnId, turnCalls);
+	}
+	const abandonedTurnIds = new Set(
+		[...callsByTurnId]
+			.filter(([, calls]) => calls.every((call) => !retainedCallIds.has(call.callId)))
+			.map(([turnId]) => turnId)
+	);
+	const removedCallIds = new Set(abandonedCalls.map((part) => part.callId));
+
+	return parts.filter((part) => {
+		if (part.type === 'tool-result') {
+			return !removedCallIds.has(part.callId);
+		}
+		if (part.turnId !== undefined && abandonedTurnIds.has(part.turnId)) {
+			return false;
+		}
+		return part.type !== 'tool-call' || !removedCallIds.has(part.callId);
+	});
 }

--- a/apps/web/src/convex/lib/assistantParts.ts
+++ b/apps/web/src/convex/lib/assistantParts.ts
@@ -66,13 +66,6 @@ export function parseAssistantToolResultError(
 export type AssistantPart =
 	AssistantTextPart | AssistantReasoningPart | AssistantToolCallPart | AssistantToolResultPart;
 
-export type PersistedToolLogEntry = {
-	callId: string;
-	name: string;
-	input: JsonValue;
-	output?: JsonValue;
-};
-
 export type PersistableExecutorToolJob = {
 	id: string;
 	kind: Infer<typeof vExecutorJobKind>;
@@ -90,101 +83,6 @@ export type MatchableExecutorToolJob = Pick<
 
 export function cloneAssistantToolPayload<T>(value: T): T {
 	return value === undefined ? value : structuredClone(value);
-}
-
-export function upsertAssistantToolCallPart(
-	parts: AssistantPart[],
-	indexByCallId: Map<string, number>,
-	name: string,
-	callId: string,
-	input: JsonValue
-) {
-	const nextPart: AssistantToolCallPart = {
-		type: 'tool-call',
-		callId,
-		name,
-		input: cloneAssistantToolPayload(input)
-	};
-	const existingIndex = indexByCallId.get(callId);
-	if (existingIndex !== undefined) {
-		parts[existingIndex] = nextPart;
-		return;
-	}
-	const nextIndex = parts.push(nextPart) - 1;
-	indexByCallId.set(callId, nextIndex);
-}
-
-export function upsertAssistantToolResultPart(
-	parts: AssistantPart[],
-	indexByCallId: Map<string, number>,
-	callId: string,
-	toolResult: {
-		name?: string;
-		output: JsonValue;
-	}
-) {
-	const nextPart: AssistantToolResultPart = {
-		type: 'tool-result',
-		callId,
-		...(toolResult.name ? { name: toolResult.name } : {}),
-		output: cloneAssistantToolPayload(toolResult.output)
-	};
-	const existingIndex = indexByCallId.get(callId);
-	if (existingIndex !== undefined) {
-		parts[existingIndex] = nextPart;
-		return;
-	}
-	const nextIndex = parts.push(nextPart) - 1;
-	indexByCallId.set(callId, nextIndex);
-}
-
-export function buildPersistedToolLogs(parts: AssistantPart[]): PersistedToolLogEntry[] {
-	const logsByCallId = new Map<string, PersistedToolLogEntry>();
-	const orderedLogs: PersistedToolLogEntry[] = [];
-
-	for (const part of parts) {
-		if (part.type !== 'tool-call' && part.type !== 'tool-result') {
-			continue;
-		}
-
-		const existing = logsByCallId.get(part.callId);
-
-		if (part.type === 'tool-call') {
-			if (existing) {
-				existing.name = part.name;
-				existing.input = part.input;
-				continue;
-			}
-
-			const nextEntry: PersistedToolLogEntry = {
-				callId: part.callId,
-				name: part.name,
-				input: part.input
-			};
-			logsByCallId.set(part.callId, nextEntry);
-			orderedLogs.push(nextEntry);
-			continue;
-		}
-
-		if (existing) {
-			if (part.name) {
-				existing.name = part.name;
-			}
-			existing.output = part.output;
-			continue;
-		}
-
-		const nextEntry: PersistedToolLogEntry = {
-			callId: part.callId,
-			name: part.name ?? 'tool',
-			input: {},
-			output: part.output
-		};
-		logsByCallId.set(part.callId, nextEntry);
-		orderedLogs.push(nextEntry);
-	}
-
-	return orderedLogs;
 }
 
 export function joinAssistantTextParts(parts: AssistantPart[]): string {

--- a/apps/web/src/convex/lib/assistantParts.ts
+++ b/apps/web/src/convex/lib/assistantParts.ts
@@ -1,7 +1,13 @@
 import type { Infer } from 'convex/values';
-import type { JsonValue } from '@convex/lib/json';
-import { vExecutorJobKind, vExecutorJobStatus } from '@convex/lib/validators';
-import type { ExecutorJobPayload, ExecutorJobResult } from '@convex/lib/validators';
+import { isJsonObject, type JsonValue } from '@convex/lib/json';
+import type {
+	AssistantToolResultErrorOutput,
+	AssistantToolResultErrorStatus,
+	ExecutorJobPayload,
+	ExecutorJobResult,
+	vExecutorJobKind,
+	vExecutorJobStatus
+} from '@convex/lib/validators';
 
 export type AssistantTextPart = {
 	type: 'text';
@@ -36,6 +42,27 @@ export type AssistantToolResultPart = {
 	output: JsonValue;
 };
 
+export type { AssistantToolResultErrorOutput, AssistantToolResultErrorStatus };
+
+export function assistantToolResultErrorOutput(
+	status: AssistantToolResultErrorStatus,
+	error: string
+): AssistantToolResultErrorOutput {
+	return { error, status };
+}
+
+/** Reads a tool-result error output. Legacy `{ error }` rows without `status` default to `failed`. */
+export function parseAssistantToolResultError(
+	output: JsonValue | undefined
+): AssistantToolResultErrorOutput | undefined {
+	if (!isJsonObject(output) || typeof output.error !== 'string') {
+		return undefined;
+	}
+	const status =
+		output.status === 'cancelled' || output.status === 'failed' ? output.status : 'failed';
+	return { error: output.error, status };
+}
+
 export type AssistantPart =
 	AssistantTextPart | AssistantReasoningPart | AssistantToolCallPart | AssistantToolResultPart;
 
@@ -55,6 +82,11 @@ export type PersistableExecutorToolJob = {
 	result?: ExecutorJobResult;
 	error?: string;
 };
+
+export type MatchableExecutorToolJob = Pick<
+	PersistableExecutorToolJob,
+	'id' | 'kind' | 'callId' | 'payload'
+>;
 
 export function cloneAssistantToolPayload<T>(value: T): T {
 	return value === undefined ? value : structuredClone(value);
@@ -178,6 +210,86 @@ export function joinAssistantTextParts(parts: AssistantPart[]): string {
 	return text;
 }
 
+export function resolveAssistantMessageText(streamedText: string, fallbackText: string): string {
+	return streamedText || fallbackText;
+}
+
+export function matchAssistantToolCallsToJobs(
+	calls: readonly AssistantToolCallPart[],
+	jobs: readonly MatchableExecutorToolJob[]
+): Map<string, string> {
+	const callIdByJobId = new Map<string, string>();
+	const usedCallIds = new Set<string>();
+	const unmatchedJobs = jobs.filter((job) => {
+		if (!job.callId) return true;
+		const call = calls.find(
+			(candidate) => candidate.callId === job.callId && !usedCallIds.has(candidate.callId)
+		);
+		if (!call) return false;
+		callIdByJobId.set(job.id, call.callId);
+		usedCallIds.add(call.callId);
+		return false;
+	});
+
+	const matchUnique = (
+		matches: (call: AssistantToolCallPart, job: MatchableExecutorToolJob) => boolean
+	): void => {
+		const availableCalls = calls.filter((call) => !usedCallIds.has(call.callId));
+		const candidatesByJob = new Map(
+			unmatchedJobs
+				.filter((job) => !callIdByJobId.has(job.id))
+				.map((job) => [job.id, availableCalls.filter((call) => matches(call, job))] as const)
+		);
+
+		for (const job of unmatchedJobs) {
+			if (callIdByJobId.has(job.id)) continue;
+			const candidates = candidatesByJob.get(job.id) ?? [];
+			if (candidates.length !== 1) continue;
+			const [call] = candidates;
+			const candidateJobs = unmatchedJobs.filter(
+				(candidate) =>
+					!callIdByJobId.has(candidate.id) &&
+					(candidatesByJob.get(candidate.id) ?? []).some(
+						(candidateCall) => candidateCall.callId === call.callId
+					)
+			);
+			if (candidateJobs.length !== 1) continue;
+			callIdByJobId.set(job.id, call.callId);
+			usedCallIds.add(call.callId);
+		}
+	};
+
+	matchUnique(
+		(call, job) => call.name === job.kind && assistantToolPayloadsEqual(call.input, job.payload)
+	);
+	matchUnique((call, job) => call.name === job.kind);
+
+	return callIdByJobId;
+}
+
+function assistantToolPayloadsEqual(left: JsonValue, right: JsonValue): boolean {
+	if (Object.is(left, right)) return true;
+	if (Array.isArray(left) || Array.isArray(right)) {
+		return (
+			Array.isArray(left) &&
+			Array.isArray(right) &&
+			left.length === right.length &&
+			left.every((value, index) => assistantToolPayloadsEqual(value, right[index]))
+		);
+	}
+	if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+		return false;
+	}
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	return (
+		leftKeys.length === rightKeys.length &&
+		leftKeys.every(
+			(key) => Object.hasOwn(right, key) && assistantToolPayloadsEqual(left[key], right[key])
+		)
+	);
+}
+
 export function ensureAssistantToolPartsFromJobs(
 	parts: AssistantPart[],
 	jobs: PersistableExecutorToolJob[]
@@ -196,20 +308,38 @@ export function ensureAssistantToolPartsFromJobs(
 	const unmatchedCalls = nextParts.filter(
 		(part): part is AssistantToolCallPart => part.type === 'tool-call'
 	);
+	const matchedCallIds = matchAssistantToolCallsToJobs(unmatchedCalls, jobs);
+	const matchedCallIdSet = new Set(matchedCallIds.values());
+	const ambiguousAnchors = unmatchedCalls.filter((call) => !matchedCallIdSet.has(call.callId));
+	const usedAnchorCallIds = new Set<string>();
+	const replacedAnchorCallIds = new Set<string>();
 	const usedCallIds = new Set<string>();
 
 	for (const job of jobs) {
-		const exactCall = unmatchedCalls.find((part) => {
-			if (usedCallIds.has(part.callId)) return false;
-			if (job.callId) return part.callId === job.callId;
-			return part.name === job.kind && JSON.stringify(part.input) === JSON.stringify(job.payload);
-		});
-		const streamedCall =
-			exactCall ??
-			(job.callId
-				? undefined
-				: unmatchedCalls.find((part) => !usedCallIds.has(part.callId) && part.name === job.kind));
+		const matchedCallId = matchedCallIds.get(job.id);
+		let streamedCall = matchedCallId
+			? unmatchedCalls.find((part) => part.callId === matchedCallId)
+			: undefined;
 		const callId = job.callId ?? streamedCall?.callId ?? `executor-job:${job.id}`;
+		if (!streamedCall && !job.callId) {
+			const anchor = ambiguousAnchors.find(
+				(call) => call.name === job.kind && !usedAnchorCallIds.has(call.callId)
+			);
+			if (anchor) {
+				usedAnchorCallIds.add(anchor.callId);
+				replacedAnchorCallIds.add(anchor.callId);
+				const anchorIndex = nextParts.indexOf(anchor);
+				const replacement: AssistantToolCallPart = {
+					type: 'tool-call',
+					callId,
+					name: job.kind,
+					input: cloneAssistantToolPayload(job.payload),
+					...(anchor.turnId ? { turnId: anchor.turnId } : {})
+				};
+				nextParts[anchorIndex] = replacement;
+				streamedCall = replacement;
+			}
+		}
 		usedCallIds.add(callId);
 		let insertAt: number;
 		if (streamedCall) {
@@ -246,9 +376,7 @@ export function ensureAssistantToolPartsFromJobs(
 				type: 'tool-result',
 				callId,
 				name: job.kind,
-				output: {
-					error: job.error ?? 'Executor job failed.'
-				}
+				output: assistantToolResultErrorOutput('failed', job.error ?? 'Executor job failed.')
 			});
 			resultCallIds.add(callId);
 			continue;
@@ -259,15 +387,22 @@ export function ensureAssistantToolPartsFromJobs(
 				type: 'tool-result',
 				callId,
 				name: job.kind,
-				output: {
-					error: job.error ?? 'Executor job cancelled before completion.'
-				}
+				output: assistantToolResultErrorOutput(
+					'cancelled',
+					job.error ?? 'Executor job cancelled before completion.'
+				)
 			});
 			resultCallIds.add(callId);
 		}
 	}
 
-	return removeAbandonedAssistantTurns(nextParts, new Set([...usedCallIds, ...resultCallIds]));
+	const reconciledParts = nextParts.filter(
+		(part) => part.type !== 'tool-result' || !replacedAnchorCallIds.has(part.callId)
+	);
+	return removeAbandonedAssistantTurns(
+		reconciledParts,
+		new Set([...usedCallIds, ...resultCallIds])
+	);
 }
 
 function removeAbandonedAssistantTurns(

--- a/apps/web/src/convex/lib/completionStream.ts
+++ b/apps/web/src/convex/lib/completionStream.ts
@@ -29,22 +29,32 @@ export const vCompletionStreamEvent = v.union(
 
 export type CompletionStreamEvent = Infer<typeof vCompletionStreamEvent>;
 
+export const COMPLETION_STREAM_SUPERSEDED = 'SPROCKET_COMPLETION_STREAM_SUPERSEDED';
+
+export type CompletionStreamBatchClassification = 'append' | 'duplicate' | 'superseded';
+
+export function isCompletionStreamSuperseded(error: unknown): boolean {
+	return String(error).includes(COMPLETION_STREAM_SUPERSEDED);
+}
+
+export function isCompletionStreamAttemptSuperseded(args: {
+	initialSequence: number;
+	observedSequence: number;
+	observedStreamId?: string;
+	streamId: string;
+}): boolean {
+	return args.observedSequence > args.initialSequence && args.observedStreamId !== args.streamId;
+}
+
 export function classifyCompletionStreamBatch(args: {
 	lastSequence: number;
 	lastStreamId?: string;
 	sequence: number;
 	streamId: string;
-}): 'append' | 'duplicate' {
-	if (args.sequence === args.lastSequence) {
+}): CompletionStreamBatchClassification {
+	if (args.sequence <= args.lastSequence) {
 		if (args.streamId === args.lastStreamId) return 'duplicate';
-		throw new Error(
-			`Assistant stream ${args.streamId} cannot reuse batch ${args.sequence} from stream ${args.lastStreamId ?? 'unknown'}.`
-		);
-	}
-	if (args.sequence < args.lastSequence) {
-		throw new Error(
-			`Assistant stream batch ${args.sequence} is stale; latest batch is ${args.lastSequence}.`
-		);
+		return 'superseded';
 	}
 	if (args.sequence !== args.lastSequence + 1) {
 		throw new Error(

--- a/apps/web/src/convex/lib/completionStream.ts
+++ b/apps/web/src/convex/lib/completionStream.ts
@@ -1,0 +1,123 @@
+import { v, type Infer } from 'convex/values';
+
+export const vCompletionStreamEvent = v.union(
+	v.object({
+		type: v.literal('text'),
+		id: v.string(),
+		text: v.string(),
+		turnId: v.optional(v.string()),
+		providerMetadata: v.optional(v.any())
+	}),
+	v.object({
+		type: v.literal('reasoning'),
+		id: v.string(),
+		text: v.string(),
+		turnId: v.optional(v.string()),
+		providerReasoningId: v.optional(v.string()),
+		providerMetadata: v.optional(v.any())
+	}),
+	v.object({
+		type: v.literal('toolCall'),
+		partId: v.string(),
+		callId: v.string(),
+		name: v.string(),
+		input: v.any(),
+		turnId: v.optional(v.string()),
+		providerMetadata: v.optional(v.any())
+	})
+);
+
+export type CompletionStreamEvent = Infer<typeof vCompletionStreamEvent>;
+
+export function classifyCompletionStreamBatch(args: {
+	lastSequence: number;
+	lastStreamId?: string;
+	sequence: number;
+	streamId: string;
+}): 'append' | 'duplicate' {
+	if (args.sequence === args.lastSequence) {
+		if (args.streamId === args.lastStreamId) return 'duplicate';
+		throw new Error(
+			`Assistant stream ${args.streamId} cannot reuse batch ${args.sequence} from stream ${args.lastStreamId ?? 'unknown'}.`
+		);
+	}
+	if (args.sequence < args.lastSequence) {
+		throw new Error(
+			`Assistant stream batch ${args.sequence} is stale; latest batch is ${args.lastSequence}.`
+		);
+	}
+	if (args.sequence !== args.lastSequence + 1) {
+		throw new Error(
+			`Assistant stream batch ${args.sequence} arrived after ${args.lastSequence}; expected ${args.lastSequence + 1}.`
+		);
+	}
+	return 'append';
+}
+
+export function appendCompletionStreamEvent(
+	events: CompletionStreamEvent[],
+	event: CompletionStreamEvent
+): void {
+	const previous = events.at(-1);
+	if (
+		previous &&
+		(previous.type === 'text' || previous.type === 'reasoning') &&
+		previous.type === event.type &&
+		(event.type === 'text' || event.type === 'reasoning') &&
+		previous.id === event.id
+	) {
+		previous.text += event.text;
+		if (event.turnId !== undefined) previous.turnId = event.turnId;
+		if (event.providerMetadata !== undefined) {
+			previous.providerMetadata = event.providerMetadata;
+		}
+		if (previous.type === 'reasoning' && event.type === 'reasoning') {
+			if (event.providerReasoningId !== undefined) {
+				previous.providerReasoningId = event.providerReasoningId;
+			}
+		}
+		return;
+	}
+	events.push({ ...event });
+}
+
+export function upsertCompletionTextEvent(
+	events: CompletionStreamEvent[],
+	event: Extract<CompletionStreamEvent, { type: 'text' }>
+): void {
+	const existing = events.find(
+		(candidate): candidate is Extract<CompletionStreamEvent, { type: 'text' }> =>
+			candidate.type === 'text' && candidate.id === event.id
+	);
+	if (!existing) {
+		events.push({ ...event });
+		return;
+	}
+	existing.text += event.text;
+	if (event.turnId !== undefined) existing.turnId = event.turnId;
+	if (event.providerMetadata !== undefined) {
+		existing.providerMetadata = event.providerMetadata;
+	}
+}
+
+export function upsertCompletionReasoningEvent(
+	events: CompletionStreamEvent[],
+	event: Extract<CompletionStreamEvent, { type: 'reasoning' }>
+): void {
+	const existing = events.find(
+		(candidate): candidate is Extract<CompletionStreamEvent, { type: 'reasoning' }> =>
+			candidate.type === 'reasoning' && candidate.id === event.id
+	);
+	if (!existing) {
+		events.push({ ...event });
+		return;
+	}
+	existing.text += event.text;
+	if (event.turnId !== undefined) existing.turnId = event.turnId;
+	if (event.providerReasoningId !== undefined) {
+		existing.providerReasoningId = event.providerReasoningId;
+	}
+	if (event.providerMetadata !== undefined) {
+		existing.providerMetadata = event.providerMetadata;
+	}
+}

--- a/apps/web/src/convex/lib/runs.ts
+++ b/apps/web/src/convex/lib/runs.ts
@@ -1,5 +1,14 @@
 import type { Infer } from 'convex/values';
-import { isRunFinalStatus, vRunStatus } from '@convex/lib/validators';
+import { isRunFinalStatus, type vExecutorJobStatus, type vRunStatus } from '@convex/lib/validators';
+
+type ExecutorJobState = {
+	status: Infer<typeof vExecutorJobStatus>;
+	error?: string;
+	completedAt?: number;
+};
+
+type FinalizedExecutorJob<T extends ExecutorJobState> = Omit<T, keyof ExecutorJobState> &
+	ExecutorJobState;
 
 export function assertThreadCanStartRun(status: Infer<typeof vRunStatus> | null | undefined) {
 	if (!status || isRunFinalStatus(status)) {
@@ -7,4 +16,47 @@ export function assertThreadCanStartRun(status: Infer<typeof vRunStatus> | null 
 	}
 
 	throw new Error('Finish or cancel the active run before sending another message.');
+}
+
+export function executorFailureRunPatch(args: {
+	runStatus: Infer<typeof vRunStatus>;
+	activeJobId?: string;
+	failedJobId: string;
+}): { status: 'running'; activeJobId: undefined } | undefined {
+	if (isRunFinalStatus(args.runStatus) || args.activeJobId !== args.failedJobId) {
+		return undefined;
+	}
+	return {
+		status: 'running',
+		activeJobId: undefined
+	};
+}
+
+export function cancelExecutorJobsForTerminalRun<T extends ExecutorJobState>(args: {
+	jobs: readonly T[];
+	runStatus: Infer<typeof vRunStatus>;
+	lastError?: string;
+	completedAt: number;
+}): FinalizedExecutorJob<T>[] {
+	if (!isRunFinalStatus(args.runStatus)) {
+		return args.jobs.map((job) => job as FinalizedExecutorJob<T>);
+	}
+	const error =
+		args.lastError ??
+		(args.runStatus === 'cancelled'
+			? 'Run was cancelled before executor job completed.'
+			: args.runStatus === 'failed'
+				? 'Run failed before executor job completed.'
+				: 'Run completed before executor job completed.');
+	return args.jobs.map((job) => {
+		if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+			return job as FinalizedExecutorJob<T>;
+		}
+		return {
+			...job,
+			status: 'cancelled',
+			error,
+			completedAt: args.completedAt
+		} as FinalizedExecutorJob<T>;
+	});
 }

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -149,6 +149,18 @@ export const vAssistantToolCallPart = v.object({
 	providerMetadata: v.optional(v.any())
 });
 
+export const assistantToolResultErrorStatuses = ['cancelled', 'failed'] as const;
+
+export const vAssistantToolResultErrorStatus = v.union(
+	...literals(assistantToolResultErrorStatuses)
+);
+
+/** Persisted tool-result error output. Older rows may omit `status`; readers default those to `failed`. */
+export const vAssistantToolResultErrorOutput = v.object({
+	error: v.string(),
+	status: vAssistantToolResultErrorStatus
+});
+
 export const vAssistantToolResultPart = v.object({
 	type: v.literal('tool-result'),
 	callId: v.string(),
@@ -240,4 +252,6 @@ export type CommandExecResult = Infer<typeof vCommandExecResult>;
 export type FileWriteResult = Infer<typeof vFileWriteResult>;
 export type FileEditResult = Infer<typeof vFileEditResult>;
 export type ExecutorJobResult = Infer<typeof vExecutorJobResult>;
+export type AssistantToolResultErrorStatus = Infer<typeof vAssistantToolResultErrorStatus>;
+export type AssistantToolResultErrorOutput = Infer<typeof vAssistantToolResultErrorOutput>;
 export type WorkspaceInstruction = Infer<typeof vWorkspaceInstruction>;

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -126,20 +126,27 @@ export type ThreadMessageType = Infer<typeof vThreadMessageType>;
 export const vAssistantTextPart = v.object({
 	type: v.literal('text'),
 	id: v.string(),
-	text: v.string()
+	text: v.string(),
+	turnId: v.optional(v.string()),
+	providerMetadata: v.optional(v.any())
 });
 
 export const vAssistantReasoningPart = v.object({
 	type: v.literal('reasoning'),
 	id: v.string(),
-	text: v.string()
+	text: v.string(),
+	turnId: v.optional(v.string()),
+	providerMetadata: v.optional(v.any())
 });
 
 export const vAssistantToolCallPart = v.object({
 	type: v.literal('tool-call'),
+	partId: v.optional(v.string()),
 	callId: v.string(),
 	name: v.string(),
-	input: v.any()
+	input: v.any(),
+	turnId: v.optional(v.string()),
+	providerMetadata: v.optional(v.any())
 });
 
 export const vAssistantToolResultPart = v.object({
@@ -176,7 +183,8 @@ export const vAgentHistoryToolResultItem = v.union(
 export const vAgentHistoryContent = v.union(
 	v.object({
 		type: v.literal('text'),
-		text: v.string()
+		text: v.string(),
+		additionalParamsJson: v.optional(v.string())
 	}),
 	v.object({
 		type: v.literal('reasoning'),

--- a/apps/web/src/convex/messages.ts
+++ b/apps/web/src/convex/messages.ts
@@ -22,6 +22,7 @@ export const listForThread = query({
 		const start: number = Math.max(0, endExclusive - requested);
 		const page: ThreadTranscriptMessage[] = allMessages.slice(start, endExclusive);
 		return {
+			threadId: args.threadId,
 			page,
 			isDone: start === 0,
 			continueCursor: start === 0 ? null : String(start),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -61,13 +61,16 @@ export default defineSchema({
 		userId: v.string(),
 		type: vThreadMessageType,
 		text: v.string(),
-		parts: v.optional(v.array(vAssistantMessagePart))
+		parts: v.optional(v.array(vAssistantMessagePart)),
+		streamSequence: v.optional(v.number()),
+		streamAttemptId: v.optional(v.string())
 	}),
 	executorJobs: defineTable({
 		workspaceSessionId: v.id('workspaceSessions'),
 		threadId: v.id('threadRecords'),
 		runId: v.id('runs'),
 		kind: vExecutorJobKind,
+		callId: v.optional(v.string()),
 		payload: vExecutorJobPayload,
 		hidden: v.optional(v.boolean()),
 		status: vExecutorJobStatus,

--- a/apps/web/src/lib/chat/agent-history.test.ts
+++ b/apps/web/src/lib/chat/agent-history.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildAgentHistoryFromAssistantParts,
+	buildCanonicalAgentHistory
+} from '$convex/lib/agentHistory';
+
+describe('canonical agent history', () => {
+	it('groups parallel calls from one model turn before their grouped results', () => {
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'tool-call',
+					callId: 'call-1',
+					name: 'exec_command',
+					input: { cmd: 'one' },
+					turnId: 'turn-1'
+				},
+				{ type: 'tool-result', callId: 'call-1', output: 'one' },
+				{
+					type: 'tool-call',
+					callId: 'call-2',
+					name: 'exec_command',
+					input: { cmd: 'two' },
+					turnId: 'turn-1'
+				},
+				{ type: 'tool-result', callId: 'call-2', output: 'two' }
+			],
+			jobs: [],
+			fallbackText: ''
+		});
+
+		expect(history.map((message) => message.role)).toEqual(['assistant', 'user']);
+		expect(history[0]?.contents).toMatchObject([
+			{ type: 'toolCall', callId: 'call-1' },
+			{ type: 'toolCall', callId: 'call-2' }
+		]);
+		expect(history[1]?.contents).toMatchObject([
+			{ type: 'toolResult', callId: 'call-1' },
+			{ type: 'toolResult', callId: 'call-2' }
+		]);
+	});
+
+	it('starts a new inferred turn for an untagged call after tool results', () => {
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'tool-call',
+					callId: 'call-1',
+					name: 'exec_command',
+					input: { cmd: 'one' }
+				},
+				{ type: 'tool-result', callId: 'call-1', output: 'one' },
+				{
+					type: 'tool-call',
+					callId: 'call-2',
+					name: 'exec_command',
+					input: { cmd: 'two' }
+				},
+				{ type: 'tool-result', callId: 'call-2', output: 'two' }
+			],
+			jobs: [],
+			fallbackText: ''
+		});
+
+		expect(history.map((message) => message.role)).toEqual([
+			'assistant',
+			'user',
+			'assistant',
+			'user'
+		]);
+		expect(history[0]?.contents).toMatchObject([{ type: 'toolCall', callId: 'call-1' }]);
+		expect(history[2]?.contents).toMatchObject([{ type: 'toolCall', callId: 'call-2' }]);
+	});
+
+	it('preserves assistant text provider metadata in the canonical wire format', () => {
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'text',
+					id: 'text-1',
+					text: 'Hello',
+					providerMetadata: { openai: { itemId: 'msg_123' } }
+				}
+			],
+			jobs: [],
+			fallbackText: ''
+		});
+
+		expect(history).toEqual([
+			{
+				role: 'assistant',
+				contents: [
+					{
+						type: 'text',
+						text: 'Hello',
+						additionalParamsJson: JSON.stringify({ openai: { itemId: 'msg_123' } })
+					}
+				]
+			}
+		]);
+	});
+
+	it.each(['failed', 'cancelled'] as const)(
+		'reconciles persisted tool parts for a %s run without losing metadata or order',
+		(runStatus) => {
+			const runId = `${runStatus}-run`;
+			const callId = `${runStatus}-call`;
+			const history = buildCanonicalAgentHistory({
+				messages: [
+					{
+						type: 'response',
+						runId,
+						runStatus,
+						text: '',
+						parts: [
+							{
+								type: 'tool-call',
+								callId,
+								name: 'exec_command',
+								input: { cmd: runStatus },
+								turnId: `${runStatus}-turn`,
+								providerMetadata: { openai: { itemId: `${runStatus}-item` } }
+							},
+							{ type: 'tool-result', callId, output: { persisted: runStatus } },
+							{
+								type: 'text',
+								id: `${runStatus}-text`,
+								text: 'after result',
+								turnId: `${runStatus}-next-turn`
+							}
+						]
+					}
+				] as unknown as Parameters<typeof buildCanonicalAgentHistory>[0]['messages'],
+				jobs: [
+					{
+						_id: `${runStatus}-job`,
+						runId,
+						callId,
+						kind: 'exec_command',
+						payload: { cmd: runStatus },
+						status: runStatus,
+						sequence: 0
+					}
+				] as unknown as Parameters<typeof buildCanonicalAgentHistory>[0]['jobs']
+			});
+
+			expect(history.map((message) => message.role)).toEqual(['assistant', 'user', 'assistant']);
+			expect(history[0]?.contents).toEqual([
+				{
+					type: 'toolCall',
+					id: callId,
+					callId,
+					name: 'exec_command',
+					argumentsJson: JSON.stringify({ cmd: runStatus }),
+					additionalParamsJson: JSON.stringify({
+						openai: { itemId: `${runStatus}-item` }
+					})
+				}
+			]);
+			expect(history[1]?.contents).toMatchObject([{ type: 'toolResult', callId }]);
+			expect(history[2]?.contents).toEqual([{ type: 'text', text: 'after result' }]);
+		}
+	);
+});

--- a/apps/web/src/lib/chat/agent-history.test.ts
+++ b/apps/web/src/lib/chat/agent-history.test.ts
@@ -3,6 +3,7 @@ import {
 	buildAgentHistoryFromAssistantParts,
 	buildCanonicalAgentHistory
 } from '$convex/lib/agentHistory';
+import { cancelExecutorJobsForTerminalRun } from '$convex/lib/runs';
 
 describe('canonical agent history', () => {
 	it('groups parallel calls from one model turn before their grouped results', () => {
@@ -70,6 +71,112 @@ describe('canonical agent history', () => {
 		]);
 		expect(history[0]?.contents).toMatchObject([{ type: 'toolCall', callId: 'call-1' }]);
 		expect(history[2]?.contents).toMatchObject([{ type: 'toolCall', callId: 'call-2' }]);
+	});
+
+	it('keeps ambiguous same-name jobs before text from the following model turn', () => {
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'tool-call',
+					callId: 'provider-call-1',
+					name: 'exec_command',
+					input: { cmd: 'same' },
+					turnId: 'tool-turn'
+				},
+				{
+					type: 'tool-call',
+					callId: 'provider-call-2',
+					name: 'exec_command',
+					input: { cmd: 'same' },
+					turnId: 'tool-turn'
+				},
+				{ type: 'text', id: 'answer', text: 'After tools', turnId: 'answer-turn' }
+			],
+			jobs: [
+				{
+					id: 'job-1',
+					kind: 'exec_command',
+					payload: { cmd: 'same' },
+					status: 'completed',
+					result: 'first'
+				},
+				{
+					id: 'job-2',
+					kind: 'exec_command',
+					payload: { cmd: 'same' },
+					status: 'completed',
+					result: 'second'
+				}
+			],
+			fallbackText: ''
+		});
+
+		expect(history.map((message) => message.role)).toEqual(['assistant', 'user', 'assistant']);
+		expect(history[0]?.contents).toMatchObject([
+			{ type: 'toolCall', callId: 'executor-job:job-1' },
+			{ type: 'toolCall', callId: 'executor-job:job-2' }
+		]);
+		expect(history[1]?.contents).toMatchObject([
+			{ type: 'toolResult', callId: 'executor-job:job-1' },
+			{ type: 'toolResult', callId: 'executor-job:job-2' }
+		]);
+		expect(history[2]?.contents).toEqual([{ type: 'text', text: 'After tools' }]);
+	});
+
+	it('replays cancelled sibling jobs as tool results after terminal reconciliation', () => {
+		const jobs = cancelExecutorJobsForTerminalRun({
+			jobs: [
+				{
+					id: 'job-1',
+					kind: 'exec_command' as const,
+					payload: { cmd: 'one' },
+					status: 'claimed' as const
+				},
+				{
+					id: 'job-2',
+					kind: 'exec_command' as const,
+					payload: { cmd: 'two' },
+					status: 'pending' as const
+				}
+			],
+			runStatus: 'failed',
+			lastError: 'model failed',
+			completedAt: 42
+		});
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'tool-call',
+					callId: 'call-1',
+					name: 'exec_command',
+					input: { cmd: 'one' },
+					turnId: 'tool-turn'
+				},
+				{
+					type: 'tool-call',
+					callId: 'call-2',
+					name: 'exec_command',
+					input: { cmd: 'two' },
+					turnId: 'tool-turn'
+				}
+			],
+			jobs,
+			fallbackText: ''
+		});
+
+		expect(history.map((message) => message.role)).toEqual(['assistant', 'user']);
+		expect(history[1]?.contents).toMatchObject([
+			{
+				type: 'toolResult',
+				callId: 'call-1',
+				items: [{ text: JSON.stringify({ error: 'model failed', status: 'cancelled' }) }]
+			},
+			{
+				type: 'toolResult',
+				callId: 'call-2',
+				items: [{ text: JSON.stringify({ error: 'model failed', status: 'cancelled' }) }]
+			}
+		]);
 	});
 
 	it('preserves assistant text provider metadata in the canonical wire format', () => {

--- a/apps/web/src/lib/chat/assistant-parts.test.ts
+++ b/apps/web/src/lib/chat/assistant-parts.test.ts
@@ -3,6 +3,7 @@ import {
 	buildPersistedToolLogs,
 	ensureAssistantToolPartsFromJobs,
 	joinAssistantTextParts,
+	resolveAssistantMessageText,
 	upsertAssistantToolCallPart,
 	upsertAssistantToolResultPart,
 	type AssistantPart
@@ -17,6 +18,26 @@ describe('assistant tool parts', () => {
 				{ type: 'text', id: 'text-3', text: 'Second turn.', turnId: 'turn-2' }
 			])
 		).toBe('First turn. Continued.\n\nSecond turn.');
+	});
+
+	it('preserves final text when reconciliation removes the only provisional tool call', () => {
+		const reconciledParts = ensureAssistantToolPartsFromJobs(
+			[
+				{
+					type: 'tool-call',
+					callId: 'provisional-call',
+					name: 'exec_command',
+					input: {},
+					turnId: 'provisional-turn'
+				}
+			],
+			[]
+		);
+
+		expect(reconciledParts).toEqual([]);
+		expect(
+			resolveAssistantMessageText(joinAssistantTextParts(reconciledParts), 'Final answer')
+		).toBe('Final answer');
 	});
 
 	it('keeps parallel tool calls distinct when stream ids collide', () => {
@@ -180,7 +201,33 @@ describe('assistant tool parts', () => {
 				type: 'tool-result',
 				callId: 'executed',
 				name: 'exec_command',
-				output: { error: 'failed' }
+				output: { error: 'failed', status: 'failed' }
+			}
+		]);
+	});
+
+	it('persists a cancelled discriminant on tool-result error output', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'sleep' } }],
+			[
+				{
+					id: 'job-1',
+					callId: 'call-1',
+					kind: 'exec_command',
+					payload: { cmd: 'sleep' },
+					status: 'cancelled',
+					error: 'stopped by user'
+				}
+			]
+		);
+
+		expect(hydrated).toEqual([
+			{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'sleep' } },
+			{
+				type: 'tool-result',
+				callId: 'call-1',
+				name: 'exec_command',
+				output: { error: 'stopped by user', status: 'cancelled' }
 			}
 		]);
 	});

--- a/apps/web/src/lib/chat/assistant-parts.test.ts
+++ b/apps/web/src/lib/chat/assistant-parts.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
-	buildPersistedToolLogs,
 	ensureAssistantToolPartsFromJobs,
 	joinAssistantTextParts,
 	resolveAssistantMessageText,
-	upsertAssistantToolCallPart,
-	upsertAssistantToolResultPart,
 	type AssistantPart
 } from '$convex/lib/assistantParts';
 
@@ -40,50 +37,7 @@ describe('assistant tool parts', () => {
 		).toBe('Final answer');
 	});
 
-	it('keeps parallel tool calls distinct when stream ids collide', () => {
-		const parts: AssistantPart[] = [];
-		const callIndex = new Map<string, number>();
-		const resultIndex = new Map<string, number>();
-
-		const sharedInput = { cmd: 'cat GEMINI.md' };
-		upsertAssistantToolCallPart(parts, callIndex, 'exec_command', 'call-1', sharedInput);
-		sharedInput.cmd = 'cat CLAUDE.md';
-		upsertAssistantToolCallPart(parts, callIndex, 'exec_command', 'call-2', sharedInput);
-		sharedInput.cmd = 'cat AGENTS.md';
-		upsertAssistantToolCallPart(parts, callIndex, 'exec_command', 'call-3', sharedInput);
-
-		const sharedOutput = { output: 'gemini' };
-		upsertAssistantToolResultPart(parts, resultIndex, 'call-1', {
-			name: 'exec_command',
-			output: sharedOutput
-		});
-		sharedOutput.output = 'claude';
-		upsertAssistantToolResultPart(parts, resultIndex, 'call-2', {
-			name: 'exec_command',
-			output: sharedOutput
-		});
-		sharedOutput.output = 'agents';
-		upsertAssistantToolResultPart(parts, resultIndex, 'call-3', {
-			name: 'exec_command',
-			output: sharedOutput
-		});
-
-		const logs = buildPersistedToolLogs(parts);
-
-		expect(logs).toHaveLength(3);
-		expect(logs.map((log) => (log.input as { cmd: string }).cmd)).toEqual([
-			'cat GEMINI.md',
-			'cat CLAUDE.md',
-			'cat AGENTS.md'
-		]);
-		expect(logs.map((log) => (log.output as { output: string }).output)).toEqual([
-			'gemini',
-			'claude',
-			'agents'
-		]);
-	});
-
-	it('backfills work-log parts from executor jobs when no streamed tool parts were persisted', () => {
+	it('backfills assistant timeline parts from executor jobs when no streamed tool parts were persisted', () => {
 		const parts: AssistantPart[] = [{ type: 'text', id: 'text-1', text: 'Done.' }];
 
 		const hydratedParts = ensureAssistantToolPartsFromJobs(parts, [
@@ -105,25 +59,31 @@ describe('assistant tool parts', () => {
 				}
 			}
 		]);
-		const logs = buildPersistedToolLogs(hydratedParts);
-
-		expect(logs).toHaveLength(1);
-		expect(logs[0]).toEqual({
-			callId: 'executor-job:job-1',
-			name: 'exec_command',
-			input: { cmd: 'cat AGENTS.md' },
-			output: {
-				command: 'cat AGENTS.md',
-				cwd: '.',
-				success: true,
-				timedOut: false,
-				stdout: 'instructions',
-				stderr: '',
-				output: 'instructions',
-				truncated: false,
-				exitCode: 0
+		expect(hydratedParts).toEqual([
+			parts[0],
+			{
+				type: 'tool-call',
+				callId: 'executor-job:job-1',
+				name: 'exec_command',
+				input: { cmd: 'cat AGENTS.md' }
+			},
+			{
+				type: 'tool-result',
+				callId: 'executor-job:job-1',
+				name: 'exec_command',
+				output: {
+					command: 'cat AGENTS.md',
+					cwd: '.',
+					success: true,
+					timedOut: false,
+					stdout: 'instructions',
+					stderr: '',
+					output: 'instructions',
+					truncated: false,
+					exitCode: 0
+				}
 			}
-		});
+		]);
 	});
 
 	it('adds executor results to streamed calls without duplicating the call', () => {

--- a/apps/web/src/lib/chat/assistant-parts.test.ts
+++ b/apps/web/src/lib/chat/assistant-parts.test.ts
@@ -2,12 +2,23 @@ import { describe, expect, it } from 'vitest';
 import {
 	buildPersistedToolLogs,
 	ensureAssistantToolPartsFromJobs,
+	joinAssistantTextParts,
 	upsertAssistantToolCallPart,
 	upsertAssistantToolResultPart,
 	type AssistantPart
 } from '$convex/lib/assistantParts';
 
 describe('assistant tool parts', () => {
+	it('joins text from distinct model turns with a blank line', () => {
+		expect(
+			joinAssistantTextParts([
+				{ type: 'text', id: 'text-1', text: 'First turn.', turnId: 'turn-1' },
+				{ type: 'text', id: 'text-2', text: ' Continued.', turnId: 'turn-1' },
+				{ type: 'text', id: 'text-3', text: 'Second turn.', turnId: 'turn-2' }
+			])
+		).toBe('First turn. Continued.\n\nSecond turn.');
+	});
+
 	it('keeps parallel tool calls distinct when stream ids collide', () => {
 		const parts: AssistantPart[] = [];
 		const callIndex = new Map<string, number>();
@@ -94,7 +105,7 @@ describe('assistant tool parts', () => {
 		});
 	});
 
-	it('does not duplicate executor jobs when tool parts are already persisted', () => {
+	it('adds executor results to streamed calls without duplicating the call', () => {
 		const parts: AssistantPart[] = [
 			{
 				type: 'tool-call',
@@ -124,6 +135,181 @@ describe('assistant tool parts', () => {
 			}
 		]);
 
-		expect(hydratedParts).toEqual(parts);
+		expect(hydratedParts).toEqual([
+			parts[0],
+			{
+				type: 'tool-result',
+				callId: 'call-1',
+				name: 'exec_command',
+				output: {
+					command: 'cat AGENTS.md',
+					cwd: '.',
+					success: true,
+					timedOut: false,
+					stdout: 'instructions',
+					stderr: '',
+					output: 'instructions',
+					truncated: false,
+					exitCode: 0
+				}
+			}
+		]);
+	});
+
+	it('correlates executor jobs by call id and removes unmatched provisional calls', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[
+				{ type: 'tool-call', callId: 'rejected', name: 'exec_command', input: {} },
+				{ type: 'tool-call', callId: 'executed', name: 'wrong_name', input: {} }
+			],
+			[
+				{
+					id: 'job-1',
+					callId: 'executed',
+					kind: 'exec_command',
+					payload: { cmd: 'pwd' },
+					status: 'failed',
+					error: 'failed'
+				}
+			]
+		);
+
+		expect(hydrated).toEqual([
+			{ type: 'tool-call', callId: 'executed', name: 'exec_command', input: { cmd: 'pwd' } },
+			{
+				type: 'tool-result',
+				callId: 'executed',
+				name: 'exec_command',
+				output: { error: 'failed' }
+			}
+		]);
+	});
+
+	it('places results beside their calls when job order differs from part order', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'one' } },
+				{ type: 'text', id: 'text-1', text: 'between' },
+				{ type: 'tool-call', callId: 'call-2', name: 'exec_command', input: { cmd: 'two' } }
+			],
+			[
+				{
+					id: 'job-2',
+					callId: 'call-2',
+					kind: 'exec_command',
+					payload: { cmd: 'two' },
+					status: 'completed',
+					result: 'two'
+				},
+				{
+					id: 'job-1',
+					callId: 'call-1',
+					kind: 'exec_command',
+					payload: { cmd: 'one' },
+					status: 'completed',
+					result: 'one'
+				}
+			]
+		);
+
+		expect(
+			hydrated.map((part) => `${part.type}:${'callId' in part ? part.callId : part.id}`)
+		).toEqual([
+			'tool-call:call-1',
+			'tool-result:call-1',
+			'text:text-1',
+			'tool-call:call-2',
+			'tool-result:call-2'
+		]);
+	});
+
+	it('removes every persisted part from a turn whose tool calls are all unmatched', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[
+				{ type: 'text', id: 'valid-text', text: 'Keep me', turnId: 'valid-turn' },
+				{
+					type: 'tool-call',
+					callId: 'valid-call',
+					name: 'exec_command',
+					input: {},
+					turnId: 'valid-turn'
+				},
+				{ type: 'tool-result', callId: 'valid-call', output: 'done' },
+				{ type: 'reasoning', id: 'abandoned-reasoning', text: 'Discard', turnId: 'bad-turn' },
+				{ type: 'text', id: 'abandoned-text', text: 'Discard', turnId: 'bad-turn' },
+				{
+					type: 'tool-call',
+					callId: 'abandoned-call',
+					name: 'exec_command',
+					input: {},
+					turnId: 'bad-turn'
+				}
+			],
+			[]
+		);
+
+		expect(hydrated.map((part) => part.type)).toEqual(['text', 'tool-call', 'tool-result']);
+		expect(hydrated).not.toContainEqual(expect.objectContaining({ turnId: 'bad-turn' }));
+	});
+
+	it('removes only unmatched calls from a turn that also contains a matched call', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[
+				{ type: 'reasoning', id: 'reasoning', text: 'Keep reasoning', turnId: 'mixed-turn' },
+				{ type: 'text', id: 'text', text: 'Keep prose', turnId: 'mixed-turn' },
+				{
+					type: 'tool-call',
+					callId: 'matched-call',
+					name: 'exec_command',
+					input: { cmd: 'pwd' },
+					turnId: 'mixed-turn'
+				},
+				{ type: 'tool-result', callId: 'matched-call', output: 'done' },
+				{
+					type: 'tool-call',
+					callId: 'unmatched-call',
+					name: 'exec_command',
+					input: { cmd: 'discard' },
+					turnId: 'mixed-turn'
+				}
+			],
+			[]
+		);
+
+		expect(hydrated).toEqual([
+			{ type: 'reasoning', id: 'reasoning', text: 'Keep reasoning', turnId: 'mixed-turn' },
+			{ type: 'text', id: 'text', text: 'Keep prose', turnId: 'mixed-turn' },
+			{
+				type: 'tool-call',
+				callId: 'matched-call',
+				name: 'exec_command',
+				input: { cmd: 'pwd' },
+				turnId: 'mixed-turn'
+			},
+			{ type: 'tool-result', callId: 'matched-call', output: 'done' }
+		]);
+	});
+
+	it('does not mutate caller-owned parts while reconciling jobs', () => {
+		const input = { cmd: 'old', nested: { value: 1 } };
+		const parts: AssistantPart[] = [
+			{ type: 'tool-call', callId: 'call-1', name: 'wrong_name', input }
+		];
+		const original = structuredClone(parts);
+
+		const hydrated = ensureAssistantToolPartsFromJobs(parts, [
+			{
+				id: 'job-1',
+				callId: 'call-1',
+				kind: 'exec_command',
+				payload: { cmd: 'new' },
+				status: 'completed',
+				result: 'done'
+			}
+		]);
+
+		expect(parts).toEqual(original);
+		expect(hydrated[0]).toMatchObject({ name: 'exec_command', input: { cmd: 'new' } });
+		expect(hydrated[0]).not.toBe(parts[0]);
 	});
 });

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { assistantTimelineToolError, buildAssistantTimeline } from '$lib/chat/assistant-timeline';
+import {
+	assistantTimelineToolError,
+	assistantTimelineToolFailureKind,
+	buildAssistantTimeline
+} from '$lib/chat/assistant-timeline';
 import type { ExecutorJob } from '$lib/types/sprocket';
 
 function executorJob(
@@ -46,9 +50,9 @@ describe('assistant timeline', () => {
 		});
 	});
 
-	it('correlates jobs without call ids positionally by tool name and keeps remaining jobs visible', () => {
-		const first = executorJob('job-1', 1);
-		const second = executorJob('job-2', 2);
+	it('correlates reversed same-name jobs by payload and keeps remaining jobs visible', () => {
+		const first = executorJob('job-1', 1, { payload: { cmd: 'one' } });
+		const second = executorJob('job-2', 2, { payload: { cmd: 'two' } });
 		const remaining = executorJob('job-3', 3, {
 			kind: 'create_file',
 			payload: { path: 'new.txt', content: 'content' }
@@ -58,13 +62,45 @@ describe('assistant timeline', () => {
 				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'one' } },
 				{ type: 'tool-call', callId: 'call-2', name: 'exec_command', input: { cmd: 'two' } }
 			],
-			[first, second, remaining]
+			[second, first, remaining]
 		);
 
 		expect(timeline).toHaveLength(3);
 		expect(timeline[0]).toMatchObject({ type: 'tool', job: { _id: first._id } });
 		expect(timeline[1]).toMatchObject({ type: 'tool', job: { _id: second._id } });
 		expect(timeline[2]).toMatchObject({ type: 'tool', job: { _id: remaining._id } });
+	});
+
+	it('keeps ambiguous same-name jobs separate from streamed calls', () => {
+		const first = executorJob('job-1', 1, { payload: { cmd: 'persisted-one' } });
+		const second = executorJob('job-2', 2, { payload: { cmd: 'persisted-two' } });
+		const timeline = buildAssistantTimeline(
+			[
+				{
+					type: 'tool-call',
+					callId: 'call-1',
+					name: 'exec_command',
+					input: { cmd: 'streamed-one' }
+				},
+				{
+					type: 'tool-call',
+					callId: 'call-2',
+					name: 'exec_command',
+					input: { cmd: 'streamed-two' }
+				}
+			],
+			[first, second]
+		);
+
+		expect(timeline).toHaveLength(4);
+		expect(timeline.slice(0, 2)).toEqual([
+			expect.not.objectContaining({ job: expect.anything() }),
+			expect.not.objectContaining({ job: expect.anything() })
+		]);
+		expect(timeline.slice(2)).toEqual([
+			expect.objectContaining({ job: expect.objectContaining({ _id: first._id }) }),
+			expect.objectContaining({ job: expect.objectContaining({ _id: second._id }) })
+		]);
 	});
 
 	it('exposes errors from older persisted tool results when no live job exists', () => {
@@ -97,6 +133,8 @@ describe('assistant timeline', () => {
 		}
 		expect(assistantTimelineToolError(cancelled)).toBe('Executor job cancelled before completion.');
 		expect(assistantTimelineToolError(cancelledWithError)).toBe('stopped by user');
+		expect(assistantTimelineToolFailureKind(cancelled)).toBe('cancelled');
+		expect(assistantTimelineToolFailureKind(cancelledWithError)).toBe('cancelled');
 	});
 
 	it('falls back to the failed state when a failed live job has no error', () => {
@@ -105,5 +143,50 @@ describe('assistant timeline', () => {
 		expect(failed).toMatchObject({ type: 'tool' });
 		if (failed?.type !== 'tool') throw new Error('Expected a tool timeline item.');
 		expect(assistantTimelineToolError(failed)).toBe('Executor job failed.');
+		expect(assistantTimelineToolFailureKind(failed)).toBe('failed');
+	});
+
+	it('labels persisted tool-result errors as failed, not cancelled', () => {
+		const [tool] = buildAssistantTimeline(
+			[
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'false' } },
+				{ type: 'tool-result', callId: 'call-1', output: { error: 'command failed' } }
+			],
+			[]
+		);
+
+		expect(tool).toMatchObject({ type: 'tool' });
+		if (tool?.type !== 'tool') throw new Error('Expected a tool timeline item.');
+		expect(assistantTimelineToolFailureKind(tool)).toBe('failed');
+	});
+
+	it('preserves cancelled vs failed from persisted tool-result status after jobs leave the timeline', () => {
+		const [cancelled, failed] = buildAssistantTimeline(
+			[
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'one' } },
+				{
+					type: 'tool-result',
+					callId: 'call-1',
+					output: { error: 'stopped by user', status: 'cancelled' }
+				},
+				{ type: 'tool-call', callId: 'call-2', name: 'exec_command', input: { cmd: 'two' } },
+				{
+					type: 'tool-result',
+					callId: 'call-2',
+					output: { error: 'command failed', status: 'failed' }
+				}
+			],
+			[]
+		);
+
+		expect(cancelled).toMatchObject({ type: 'tool' });
+		expect(failed).toMatchObject({ type: 'tool' });
+		if (cancelled?.type !== 'tool' || failed?.type !== 'tool') {
+			throw new Error('Expected tool timeline items.');
+		}
+		expect(assistantTimelineToolFailureKind(cancelled)).toBe('cancelled');
+		expect(assistantTimelineToolError(cancelled)).toBe('stopped by user');
+		expect(assistantTimelineToolFailureKind(failed)).toBe('failed');
+		expect(assistantTimelineToolError(failed)).toBe('command failed');
 	});
 });

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { assistantTimelineToolError, buildAssistantTimeline } from '$lib/chat/assistant-timeline';
+import type { ExecutorJob } from '$lib/types/sprocket';
+
+function executorJob(
+	id: string,
+	sequence: number,
+	overrides: Partial<ExecutorJob> = {}
+): ExecutorJob {
+	return {
+		_id: id as ExecutorJob['_id'],
+		workspaceSessionId: 'workspace' as ExecutorJob['workspaceSessionId'],
+		threadId: 'thread' as ExecutorJob['threadId'],
+		runId: 'run' as ExecutorJob['runId'],
+		kind: 'exec_command',
+		payload: { cmd: id },
+		status: 'pending',
+		enqueuedAt: sequence,
+		sequence,
+		...overrides
+	};
+}
+
+describe('assistant timeline', () => {
+	it('keeps tool calls between surrounding assistant parts and pairs results', () => {
+		const timeline = buildAssistantTimeline(
+			[
+				{ type: 'reasoning', id: 'r1', text: 'Thinking' },
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'pwd' } },
+				{
+					type: 'tool-result',
+					callId: 'call-1',
+					name: 'exec_command',
+					output: { output: '/workspace' }
+				},
+				{ type: 'text', id: 't1', text: 'Done' }
+			],
+			[]
+		);
+
+		expect(timeline.map((item) => item.type)).toEqual(['reasoning', 'tool', 'text']);
+		expect(timeline[1]).toMatchObject({
+			type: 'tool',
+			callId: 'call-1',
+			output: { output: '/workspace' }
+		});
+	});
+
+	it('correlates jobs without call ids positionally by tool name and keeps remaining jobs visible', () => {
+		const first = executorJob('job-1', 1);
+		const second = executorJob('job-2', 2);
+		const remaining = executorJob('job-3', 3, {
+			kind: 'create_file',
+			payload: { path: 'new.txt', content: 'content' }
+		});
+		const timeline = buildAssistantTimeline(
+			[
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'one' } },
+				{ type: 'tool-call', callId: 'call-2', name: 'exec_command', input: { cmd: 'two' } }
+			],
+			[first, second, remaining]
+		);
+
+		expect(timeline).toHaveLength(3);
+		expect(timeline[0]).toMatchObject({ type: 'tool', job: { _id: first._id } });
+		expect(timeline[1]).toMatchObject({ type: 'tool', job: { _id: second._id } });
+		expect(timeline[2]).toMatchObject({ type: 'tool', job: { _id: remaining._id } });
+	});
+
+	it('exposes errors from older persisted tool results when no live job exists', () => {
+		const [tool] = buildAssistantTimeline(
+			[
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'false' } },
+				{ type: 'tool-result', callId: 'call-1', output: { error: 'command failed' } }
+			],
+			[]
+		);
+
+		expect(tool).toMatchObject({ type: 'tool' });
+		if (tool?.type !== 'tool') throw new Error('Expected a tool timeline item.');
+		expect(assistantTimelineToolError(tool)).toBe('command failed');
+	});
+
+	it('exposes the error or cancelled state for live cancelled jobs', () => {
+		const [cancelled, cancelledWithError] = buildAssistantTimeline(
+			[],
+			[
+				executorJob('job-1', 1, { status: 'cancelled' }),
+				executorJob('job-2', 2, { status: 'cancelled', error: 'stopped by user' })
+			]
+		);
+
+		expect(cancelled).toMatchObject({ type: 'tool' });
+		expect(cancelledWithError).toMatchObject({ type: 'tool' });
+		if (cancelled?.type !== 'tool' || cancelledWithError?.type !== 'tool') {
+			throw new Error('Expected tool timeline items.');
+		}
+		expect(assistantTimelineToolError(cancelled)).toBe('Executor job cancelled before completion.');
+		expect(assistantTimelineToolError(cancelledWithError)).toBe('stopped by user');
+	});
+
+	it('falls back to the failed state when a failed live job has no error', () => {
+		const [failed] = buildAssistantTimeline([], [executorJob('job-1', 1, { status: 'failed' })]);
+
+		expect(failed).toMatchObject({ type: 'tool' });
+		if (failed?.type !== 'tool') throw new Error('Expected a tool timeline item.');
+		expect(assistantTimelineToolError(failed)).toBe('Executor job failed.');
+	});
+});

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -1,5 +1,10 @@
-import type { AssistantPart } from '$convex/lib/assistantParts';
-import { isJsonObject, type JsonValue } from '$convex/lib/json';
+import {
+	matchAssistantToolCallsToJobs,
+	parseAssistantToolResultError,
+	type AssistantPart,
+	type AssistantToolCallPart
+} from '$convex/lib/assistantParts';
+import type { JsonValue } from '$convex/lib/json';
 import type { ExecutorJob } from '$lib/types/sprocket';
 
 export type AssistantTimelineItem =
@@ -13,13 +18,25 @@ export type AssistantTimelineItem =
 			job?: ExecutorJob;
 	  };
 
+export type AssistantTimelineToolFailureKind = 'cancelled' | 'failed';
+
+export function assistantTimelineToolFailureKind(
+	item: Extract<AssistantTimelineItem, { type: 'tool' }>
+): AssistantTimelineToolFailureKind | undefined {
+	if (item.job?.status === 'cancelled') {
+		return 'cancelled';
+	}
+	if (item.job?.status === 'failed') {
+		return 'failed';
+	}
+
+	return parseAssistantToolResultError(item.output)?.status;
+}
+
 export function assistantTimelineToolError(
 	item: Extract<AssistantTimelineItem, { type: 'tool' }>
 ): string | undefined {
-	const outputError =
-		isJsonObject(item.output) && typeof item.output.error === 'string'
-			? item.output.error
-			: undefined;
+	const outputError = parseAssistantToolResultError(item.output)?.error;
 
 	if (item.job) {
 		if (item.job.status === 'cancelled') {
@@ -44,9 +61,22 @@ export function buildAssistantTimeline(
 			})
 			.map((part) => [part.callId, part] as const)
 	);
+	const toolCalls = parts.filter(
+		(part): part is AssistantToolCallPart => part.type === 'tool-call'
+	);
+	const matchedCallIds = matchAssistantToolCallsToJobs(
+		toolCalls,
+		jobs.map((job) => ({
+			id: job._id,
+			kind: job.kind,
+			...(job.callId ? { callId: job.callId } : {}),
+			payload: job.payload
+		}))
+	);
 	const jobsByCallId = new Map<string, ExecutorJob>();
 	for (const job of jobs) {
-		if (job.callId) jobsByCallId.set(job.callId, job);
+		const callId = matchedCallIds.get(job._id);
+		if (callId) jobsByCallId.set(callId, job);
 	}
 	const timeline: AssistantTimelineItem[] = [];
 	const usedJobIds = new Set<ExecutorJob['_id']>();
@@ -59,13 +89,7 @@ export function buildAssistantTimeline(
 		}
 
 		const result = resultsByCallId.get(part.callId);
-		const exactJob = jobsByCallId.get(part.callId);
-		const job =
-			exactJob ??
-			jobs.find(
-				(candidate) =>
-					!candidate.callId && !usedJobIds.has(candidate._id) && candidate.kind === part.name
-			);
+		const job = jobsByCallId.get(part.callId);
 		if (job) usedJobIds.add(job._id);
 		timeline.push({
 			type: 'tool',

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -1,0 +1,97 @@
+import type { AssistantPart } from '$convex/lib/assistantParts';
+import { isJsonObject, type JsonValue } from '$convex/lib/json';
+import type { ExecutorJob } from '$lib/types/sprocket';
+
+export type AssistantTimelineItem =
+	| Extract<AssistantPart, { type: 'text' | 'reasoning' }>
+	| {
+			type: 'tool';
+			callId: string;
+			name: string;
+			input: JsonValue;
+			output?: JsonValue;
+			job?: ExecutorJob;
+	  };
+
+export function assistantTimelineToolError(
+	item: Extract<AssistantTimelineItem, { type: 'tool' }>
+): string | undefined {
+	const outputError =
+		isJsonObject(item.output) && typeof item.output.error === 'string'
+			? item.output.error
+			: undefined;
+
+	if (item.job) {
+		if (item.job.status === 'cancelled') {
+			return item.job.error ?? outputError ?? 'Executor job cancelled before completion.';
+		}
+		if (item.job.status === 'failed') {
+			return item.job.error ?? outputError ?? 'Executor job failed.';
+		}
+		return undefined;
+	}
+	return outputError;
+}
+
+export function buildAssistantTimeline(
+	parts: AssistantPart[],
+	jobs: ExecutorJob[]
+): AssistantTimelineItem[] {
+	const resultsByCallId = new Map(
+		parts
+			.filter((part): part is Extract<AssistantPart, { type: 'tool-result' }> => {
+				return part.type === 'tool-result';
+			})
+			.map((part) => [part.callId, part] as const)
+	);
+	const jobsByCallId = new Map<string, ExecutorJob>();
+	for (const job of jobs) {
+		if (job.callId) jobsByCallId.set(job.callId, job);
+	}
+	const timeline: AssistantTimelineItem[] = [];
+	const usedJobIds = new Set<ExecutorJob['_id']>();
+
+	for (const part of parts) {
+		if (part.type === 'tool-result') continue;
+		if (part.type === 'text' || part.type === 'reasoning') {
+			if (part.text.trim().length > 0) timeline.push(part);
+			continue;
+		}
+
+		const result = resultsByCallId.get(part.callId);
+		const exactJob = jobsByCallId.get(part.callId);
+		const job =
+			exactJob ??
+			jobs.find(
+				(candidate) =>
+					!candidate.callId && !usedJobIds.has(candidate._id) && candidate.kind === part.name
+			);
+		if (job) usedJobIds.add(job._id);
+		timeline.push({
+			type: 'tool',
+			callId: part.callId,
+			name: part.name,
+			input: part.input,
+			...(result
+				? { output: result.output }
+				: job?.result !== undefined
+					? { output: job.result }
+					: {}),
+			...(job ? { job } : {})
+		});
+	}
+
+	for (const job of jobs) {
+		if (usedJobIds.has(job._id)) continue;
+		timeline.push({
+			type: 'tool',
+			callId: job.callId ?? `executor-job:${job._id}`,
+			name: job.kind,
+			input: job.payload,
+			...(job.result !== undefined ? { output: job.result } : {}),
+			job
+		});
+	}
+
+	return timeline;
+}

--- a/apps/web/src/lib/chat/completion-stream.test.ts
+++ b/apps/web/src/lib/chat/completion-stream.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	appendCompletionStreamEvent,
 	classifyCompletionStreamBatch,
+	COMPLETION_STREAM_SUPERSEDED,
 	type CompletionStreamEvent,
+	isCompletionStreamAttemptSuperseded,
+	isCompletionStreamSuperseded,
 	upsertCompletionReasoningEvent,
 	upsertCompletionTextEvent
 } from '$convex/lib/completionStream';
@@ -17,14 +20,22 @@ describe('completion stream reducer', () => {
 				streamId: 'attempt-a'
 			})
 		).toBe('duplicate');
-		expect(() =>
+		expect(
+			classifyCompletionStreamBatch({
+				lastSequence: 4,
+				lastStreamId: 'attempt-a',
+				sequence: 3,
+				streamId: 'attempt-a'
+			})
+		).toBe('duplicate');
+		expect(
 			classifyCompletionStreamBatch({
 				lastSequence: 4,
 				lastStreamId: 'attempt-a',
 				sequence: 4,
 				streamId: 'attempt-b'
 			})
-		).toThrow(/cannot reuse batch/);
+		).toBe('superseded');
 		expect(
 			classifyCompletionStreamBatch({
 				lastSequence: 4,
@@ -33,6 +44,64 @@ describe('completion stream reducer', () => {
 				streamId: 'attempt-b'
 			})
 		).toBe('append');
+	});
+
+	it('supersedes a different attempt behind the claimed sequence but keeps true gaps as errors', () => {
+		expect(
+			classifyCompletionStreamBatch({
+				lastSequence: 6,
+				lastStreamId: 'attempt-a',
+				sequence: 4,
+				streamId: 'attempt-b'
+			})
+		).toBe('superseded');
+		expect(() =>
+			classifyCompletionStreamBatch({
+				lastSequence: 6,
+				lastStreamId: 'attempt-a',
+				sequence: 8,
+				streamId: 'attempt-a'
+			})
+		).toThrow(/expected 7/);
+		expect(
+			isCompletionStreamSuperseded(
+				new Error(`Convex action failed: ${COMPLETION_STREAM_SUPERSEDED}`)
+			)
+		).toBe(true);
+	});
+
+	it('only supersedes a stream after another attempt advances its starting sequence', () => {
+		expect(
+			isCompletionStreamAttemptSuperseded({
+				initialSequence: 4,
+				observedSequence: 4,
+				observedStreamId: 'previous-attempt',
+				streamId: 'current-attempt'
+			})
+		).toBe(false);
+		expect(
+			isCompletionStreamAttemptSuperseded({
+				initialSequence: 4,
+				observedSequence: 5,
+				observedStreamId: 'current-attempt',
+				streamId: 'current-attempt'
+			})
+		).toBe(false);
+		expect(
+			isCompletionStreamAttemptSuperseded({
+				initialSequence: 4,
+				observedSequence: 5,
+				observedStreamId: 'replacement-attempt',
+				streamId: 'current-attempt'
+			})
+		).toBe(true);
+		expect(
+			isCompletionStreamAttemptSuperseded({
+				initialSequence: 4,
+				observedSequence: 5,
+				streamId: 'current-attempt'
+			})
+		).toBe(true);
 	});
 
 	it('coalesces text while retaining the newest metadata', () => {

--- a/apps/web/src/lib/chat/completion-stream.test.ts
+++ b/apps/web/src/lib/chat/completion-stream.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+	appendCompletionStreamEvent,
+	classifyCompletionStreamBatch,
+	type CompletionStreamEvent,
+	upsertCompletionReasoningEvent,
+	upsertCompletionTextEvent
+} from '$convex/lib/completionStream';
+
+describe('completion stream reducer', () => {
+	it('only accepts a retry when both its stream attempt and batch sequence match', () => {
+		expect(
+			classifyCompletionStreamBatch({
+				lastSequence: 4,
+				lastStreamId: 'attempt-a',
+				sequence: 4,
+				streamId: 'attempt-a'
+			})
+		).toBe('duplicate');
+		expect(() =>
+			classifyCompletionStreamBatch({
+				lastSequence: 4,
+				lastStreamId: 'attempt-a',
+				sequence: 4,
+				streamId: 'attempt-b'
+			})
+		).toThrow(/cannot reuse batch/);
+		expect(
+			classifyCompletionStreamBatch({
+				lastSequence: 4,
+				lastStreamId: 'attempt-a',
+				sequence: 5,
+				streamId: 'attempt-b'
+			})
+		).toBe('append');
+	});
+
+	it('coalesces text while retaining the newest metadata', () => {
+		const events: CompletionStreamEvent[] = [
+			{ type: 'reasoning', id: 'reasoning-1', text: 'first', turnId: 'old' }
+		];
+		appendCompletionStreamEvent(events, {
+			type: 'reasoning',
+			id: 'reasoning-1',
+			text: ' second',
+			turnId: 'new',
+			providerReasoningId: 'rs_123',
+			providerMetadata: { openai: { itemId: 'rs_123' } }
+		});
+
+		expect(events).toEqual([
+			{
+				type: 'reasoning',
+				id: 'reasoning-1',
+				text: 'first second',
+				turnId: 'new',
+				providerReasoningId: 'rs_123',
+				providerMetadata: { openai: { itemId: 'rs_123' } }
+			}
+		]);
+	});
+
+	it('retains turn and provider metadata on returned text events', () => {
+		const events: CompletionStreamEvent[] = [];
+		appendCompletionStreamEvent(events, {
+			type: 'text',
+			id: 'text-1',
+			text: 'Hello',
+			turnId: 'turn-1',
+			providerMetadata: { openai: { itemId: 'msg_123' } }
+		});
+
+		expect(events).toEqual([
+			{
+				type: 'text',
+				id: 'text-1',
+				text: 'Hello',
+				turnId: 'turn-1',
+				providerMetadata: { openai: { itemId: 'msg_123' } }
+			}
+		]);
+	});
+
+	it('updates a text placeholder in place with delta and boundary metadata', () => {
+		const events: CompletionStreamEvent[] = [];
+		upsertCompletionTextEvent(events, {
+			type: 'text',
+			id: 'text-1',
+			text: '',
+			turnId: 'turn-1',
+			providerMetadata: { openai: { itemId: 'start-item' } }
+		});
+		appendCompletionStreamEvent(events, {
+			type: 'toolCall',
+			partId: 'tool-1',
+			callId: 'call-1',
+			name: 'exec_command',
+			input: { cmd: 'pwd' }
+		});
+		upsertCompletionTextEvent(events, {
+			type: 'text',
+			id: 'text-1',
+			text: 'Hello'
+		});
+		upsertCompletionTextEvent(events, {
+			type: 'text',
+			id: 'text-1',
+			text: '',
+			providerMetadata: { openai: { itemId: 'end-item' } }
+		});
+
+		expect(events.map((event) => event.type)).toEqual(['text', 'toolCall']);
+		expect(events[0]).toEqual({
+			type: 'text',
+			id: 'text-1',
+			text: 'Hello',
+			turnId: 'turn-1',
+			providerMetadata: { openai: { itemId: 'end-item' } }
+		});
+	});
+
+	it('keeps reasoning before a tool call when reasoning metadata arrives later', () => {
+		const events: CompletionStreamEvent[] = [];
+		upsertCompletionReasoningEvent(events, {
+			type: 'reasoning',
+			id: 'reasoning-1',
+			text: 'Thinking'
+		});
+		appendCompletionStreamEvent(events, {
+			type: 'toolCall',
+			partId: 'tool-1',
+			callId: 'call-1',
+			name: 'exec_command',
+			input: { cmd: 'pwd' }
+		});
+		upsertCompletionReasoningEvent(events, {
+			type: 'reasoning',
+			id: 'reasoning-1',
+			text: '',
+			providerReasoningId: 'rs_123'
+		});
+
+		expect(events.map((event) => event.type)).toEqual(['reasoning', 'toolCall']);
+		expect(events[0]).toMatchObject({
+			text: 'Thinking',
+			providerReasoningId: 'rs_123'
+		});
+	});
+});

--- a/apps/web/src/lib/chat/executor-state.test.ts
+++ b/apps/web/src/lib/chat/executor-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { cancelExecutorJobsForTerminalRun, executorFailureRunPatch } from '$convex/lib/runs';
+
+describe('executor run state', () => {
+	it('releases the active run after a recoverable tool failure', () => {
+		expect(
+			executorFailureRunPatch({
+				runStatus: 'awaiting_executor',
+				activeJobId: 'job-1',
+				failedJobId: 'job-1'
+			})
+		).toEqual({ status: 'running', activeJobId: undefined });
+		expect(
+			executorFailureRunPatch({
+				runStatus: 'failed',
+				activeJobId: 'job-1',
+				failedJobId: 'job-1'
+			})
+		).toBeUndefined();
+	});
+
+	it('cancels every live sibling while preserving terminal jobs', () => {
+		const completedAt = 42;
+		const jobs = cancelExecutorJobsForTerminalRun({
+			jobs: [
+				{ id: 'pending', status: 'pending' as const },
+				{ id: 'claimed', status: 'claimed' as const },
+				{ id: 'completed', status: 'completed' as const, completedAt: 10 },
+				{ id: 'failed', status: 'failed' as const, error: 'tool failed', completedAt: 11 }
+			],
+			runStatus: 'cancelled',
+			lastError: 'stopped by user',
+			completedAt
+		});
+
+		expect(jobs).toEqual([
+			{ id: 'pending', status: 'cancelled', error: 'stopped by user', completedAt },
+			{ id: 'claimed', status: 'cancelled', error: 'stopped by user', completedAt },
+			{ id: 'completed', status: 'completed', completedAt: 10 },
+			{ id: 'failed', status: 'failed', error: 'tool failed', completedAt: 11 }
+		]);
+	});
+
+	it('cancels live siblings when a run completes', () => {
+		const completedAt = 42;
+		expect(
+			cancelExecutorJobsForTerminalRun({
+				jobs: [
+					{ id: 'pending', status: 'pending' as const },
+					{ id: 'claimed', status: 'claimed' as const },
+					{ id: 'completed', status: 'completed' as const, completedAt: 10 },
+					{ id: 'cancelled', status: 'cancelled' as const, error: 'already stopped' }
+				],
+				runStatus: 'completed',
+				completedAt
+			})
+		).toEqual([
+			{
+				id: 'pending',
+				status: 'cancelled',
+				error: 'Run completed before executor job completed.',
+				completedAt
+			},
+			{
+				id: 'claimed',
+				status: 'cancelled',
+				error: 'Run completed before executor job completed.',
+				completedAt
+			},
+			{ id: 'completed', status: 'completed', completedAt: 10 },
+			{ id: 'cancelled', status: 'cancelled', error: 'already stopped' }
+		]);
+	});
+});

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -4,6 +4,7 @@
 	import { isJsonObject, type JsonValue } from '$convex/lib/json';
 	import {
 		assistantTimelineToolError,
+		assistantTimelineToolFailureKind,
 		buildAssistantTimeline,
 		type AssistantTimelineItem
 	} from '$lib/chat/assistant-timeline';
@@ -223,18 +224,49 @@
 											</div>
 										{:else}
 											{@const toolError = assistantTimelineToolError(part)}
+											{@const toolFailureKind = assistantTimelineToolFailureKind(part)}
+											{@const toolSummary = part.job
+												? actionSummary(part.job)
+												: toolLogSummary(part)}
+											{@const isToolRunning =
+												part.job?.status === 'pending' || part.job?.status === 'claimed'}
 											<div
 												class="text-muted-foreground flex max-w-4xl items-start gap-3 rounded-xl border border-white/6 bg-black/15 px-3 py-2 text-sm"
 											>
 												<TerminalSquare class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
-												<p class="min-w-0 truncate" title={fullToolSummary(part)}>
-													{part.job ? actionSummary(part.job) : toolLogSummary(part)}
-													{#if part.job?.status === 'pending' || part.job?.status === 'claimed'}
-														<span> (running)</span>
-													{:else if toolError}
-														<span class="text-rose-200"> ({toolError})</span>
-													{/if}
-												</p>
+												{#if toolError && toolFailureKind}
+													<details class="min-w-0 flex-1">
+														<summary
+															class="min-w-0 cursor-pointer text-left"
+															title={fullToolSummary(part)}
+														>
+															<span class="truncate">{toolSummary}</span>
+															<span
+																class={toolFailureKind === 'cancelled'
+																	? 'text-amber-200'
+																	: 'text-rose-200'}
+															>
+																({toolFailureKind})
+															</span>
+														</summary>
+														<p
+															class="mt-1.5 whitespace-pre-wrap break-words text-xs leading-5 {toolFailureKind ===
+															'cancelled'
+																? 'text-amber-200'
+																: 'text-rose-200'}"
+															role="status"
+														>
+															{toolError}
+														</p>
+													</details>
+												{:else}
+													<p class="min-w-0 truncate" title={fullToolSummary(part)}>
+														{toolSummary}
+														{#if isToolRunning}
+															<span> (running)</span>
+														{/if}
+													</p>
+												{/if}
 											</div>
 										{/if}
 									{/each}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import { tick } from 'svelte';
 	import { TerminalSquare } from '@lucide/svelte';
-	import {
-		buildPersistedToolLogs,
-		type AssistantPart,
-		type PersistedToolLogEntry
-	} from '$convex/lib/assistantParts';
 	import { isJsonObject, type JsonValue } from '$convex/lib/json';
+	import {
+		assistantTimelineToolError,
+		buildAssistantTimeline,
+		type AssistantTimelineItem
+	} from '$lib/chat/assistant-timeline';
 	import ScrollArea from '$lib/components/ui/scroll-area/scroll-area.svelte';
 	import ChatMarkdown from '$lib/components/chat-markdown.svelte';
 	import type { ExecutorJob, ThreadMessage, WorkspaceSession } from '$lib/types/sprocket';
-	type AssistantDisplayPart = Extract<AssistantPart, { type: 'text' | 'reasoning' }>;
+	type AssistantTimelineTool = Extract<AssistantTimelineItem, { type: 'tool' }>;
 
 	type Props = {
 		currentError: string | null;
@@ -80,25 +80,6 @@
 		return details.length > 0 ? ` (${details.join(', ')})` : '';
 	}
 
-	function parseAssistantParts(message: ThreadMessage): AssistantDisplayPart[] {
-		if (!message.parts || message.parts.length === 0) {
-			return [];
-		}
-		return (message.parts as AssistantPart[]).filter((part) => {
-			if (part.type === 'text' || part.type === 'reasoning') {
-				return part.text.trim().length > 0;
-			}
-			return false;
-		}) as AssistantDisplayPart[];
-	}
-
-	function parseAssistantToolLogs(message: ThreadMessage): PersistedToolLogEntry[] {
-		if (!message.parts || message.parts.length === 0) {
-			return [];
-		}
-		return buildPersistedToolLogs(message.parts as AssistantPart[]);
-	}
-
 	function actionTitle(job: ExecutorJob) {
 		return toolDisplayName(job.kind);
 	}
@@ -119,7 +100,7 @@
 		}
 	}
 
-	function toolLogSummary(toolLog: PersistedToolLogEntry) {
+	function toolLogSummary(toolLog: AssistantTimelineTool) {
 		const input = isJsonObject(toolLog.input) ? toolLog.input : undefined;
 		const title = toolDisplayName(toolLog.name);
 
@@ -136,15 +117,14 @@
 		}
 	}
 
-	const latestAssistantMessageId = $derived.by(() => {
-		for (let index = messages.length - 1; index >= 0; index -= 1) {
-			const message = messages[index];
-			if (message?.type === 'response') {
-				return message._id;
-			}
+	function fullToolSummary(toolLog: AssistantTimelineTool) {
+		const summary = toolLog.job ? actionSummary(toolLog.job) : toolLogSummary(toolLog);
+		if (toolLog.job?.status === 'pending' || toolLog.job?.status === 'claimed') {
+			return `${summary} (running)`;
 		}
-		return null;
-	});
+		const error = assistantTimelineToolError(toolLog);
+		return error ? `${summary} (${error})` : summary;
+	}
 
 	const userMessageClass =
 		'w-full max-w-[56rem] rounded-[28px] border border-white/7 bg-[linear-gradient(180deg,rgba(39,39,42,0.96),rgba(28,28,30,0.96))] px-5 py-4 text-[15px] leading-8 text-slate-100 shadow-[0_16px_40px_rgba(0,0,0,0.22)]';
@@ -175,6 +155,7 @@
 		<div class="mx-auto flex min-h-full w-full max-w-336 flex-col px-8 py-8">
 			{#if currentError}
 				<div
+					role="alert"
 					class="mb-6 rounded-2xl border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100"
 				>
 					{currentError}
@@ -183,6 +164,7 @@
 
 			{#if runError}
 				<div
+					role="alert"
 					class="mb-6 rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-100"
 				>
 					{runError}
@@ -210,72 +192,53 @@
 								</div>
 							</div>
 						{:else}
-							{@const assistantParts = parseAssistantParts(message)}
-							{@const toolLogs = parseAssistantToolLogs(message)}
-							{@const showLiveActionsFallback =
-								message._id === latestAssistantMessageId &&
-								toolLogs.length === 0 &&
-								actions.length > 0}
-							<div class="max-w-4xl px-1">
-								{#if assistantParts.length > 0}
-									<div class="space-y-3">
-										{#each assistantParts as part, index (`${part.type}-${part.id}-${index}`)}
-											{#if part.type === 'text'}
-												<ChatMarkdown content={part.text || ' '} className="text-slate-200" />
-											{:else if part.type === 'reasoning'}
-												<div
-													class="rounded-xl border border-white/8 bg-black/20 px-3 py-2 text-xs text-slate-400"
-												>
-													<span class="mr-2 tracking-[0.12em] uppercase">Reasoning</span>{part.text}
-												</div>
-											{/if}
-										{/each}
-									</div>
-								{:else}
-									<ChatMarkdown
-										content={message.text || (message.runStatus === 'completed' ? ' ' : '...')}
-										className="text-slate-200"
-									/>
-								{/if}
-
-								{#if toolLogs.length > 0}
-									<div class="mt-4 max-w-4xl rounded-3xl border border-white/6 bg-black/15">
-										<div class="px-5 py-3 text-[11px] tracking-[0.22em] text-slate-500 uppercase">
-											Work Log ({toolLogs.length})
-										</div>
-										<div class="border-t border-white/6 px-5 py-3">
-											<div class="max-h-48 space-y-3 overflow-y-auto pr-1">
-												{#each toolLogs as toolLog (`persisted-tool-log-${toolLog.callId}`)}
-													<div class="text-muted-foreground flex items-start gap-3 text-sm">
-														<TerminalSquare class="mt-0.5 size-4 shrink-0" />
-														<p class="min-w-0 truncate">{toolLogSummary(toolLog)}</p>
-													</div>
-												{/each}
+							{@const messageActions = actions.filter((job) => job.runId === message.runId)}
+							{@const timeline = buildAssistantTimeline(message.parts ?? [], messageActions)}
+							{@const isStreaming =
+								message.runStatus !== 'completed' &&
+								message.runStatus !== 'failed' &&
+								message.runStatus !== 'cancelled'}
+							{@const hasPersistedAssistantContent = timeline.some(
+								(part) => part.type === 'text' || part.type === 'reasoning'
+							)}
+							<div
+								class="max-w-4xl px-1"
+								role={isStreaming ? 'log' : undefined}
+								aria-live={isStreaming ? 'polite' : undefined}
+								aria-atomic="false"
+								aria-relevant="additions text"
+							>
+								<div class="space-y-3">
+									{#if !hasPersistedAssistantContent && (message.text || (isStreaming && timeline.length === 0))}
+										<ChatMarkdown content={message.text || '...'} className="text-slate-200" />
+									{/if}
+									{#each timeline as part, index (`${part.type}-${part.type === 'tool' ? part.callId : part.id}-${index}`)}
+										{#if part.type === 'text'}
+											<ChatMarkdown content={part.text || ' '} className="text-slate-200" />
+										{:else if part.type === 'reasoning'}
+											<div
+												class="rounded-xl border border-white/8 bg-black/20 px-3 py-2 text-xs text-slate-400"
+											>
+												<span class="mr-2 tracking-[0.12em] uppercase">Reasoning</span>{part.text}
 											</div>
-										</div>
-									</div>
-								{:else if showLiveActionsFallback}
-									<div class="mt-4 max-w-4xl rounded-3xl border border-white/6 bg-black/15">
-										<div class="px-5 py-3 text-[11px] tracking-[0.22em] text-slate-500 uppercase">
-											Work Log ({actions.length})
-										</div>
-										<div class="border-t border-white/6 px-5 py-3">
-											<div class="max-h-48 space-y-3 overflow-y-auto pr-1">
-												{#each actions as job (job._id)}
-													<div class="text-muted-foreground flex items-start gap-3 text-sm">
-														<TerminalSquare class="mt-0.5 size-4 shrink-0" />
-														<p class="min-w-0 truncate">
-															{actionSummary(job)}
-															{#if job.status === 'failed' && job.error}
-																<span class="text-rose-200"> ({job.error})</span>
-															{/if}
-														</p>
-													</div>
-												{/each}
+										{:else}
+											{@const toolError = assistantTimelineToolError(part)}
+											<div
+												class="text-muted-foreground flex max-w-4xl items-start gap-3 rounded-xl border border-white/6 bg-black/15 px-3 py-2 text-sm"
+											>
+												<TerminalSquare class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+												<p class="min-w-0 truncate" title={fullToolSummary(part)}>
+													{part.job ? actionSummary(part.job) : toolLogSummary(part)}
+													{#if part.job?.status === 'pending' || part.job?.status === 'claimed'}
+														<span> (running)</span>
+													{:else if toolError}
+														<span class="text-rose-200"> ({toolError})</span>
+													{/if}
+												</p>
 											</div>
-										</div>
-									</div>
-								{/if}
+										{/if}
+									{/each}
+								</div>
 							</div>
 						{/if}
 					{/each}

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -1,4 +1,5 @@
 import type { Id } from '$convex/_generated/dataModel';
+import type { AssistantPart } from '$convex/lib/assistantParts';
 import type { Infer } from 'convex/values';
 import {
 	vExecutorJobKind,
@@ -92,6 +93,7 @@ export type ExecutorJob = {
 	threadId: Id<'threadRecords'>;
 	runId: Id<'runs'>;
 	kind: WorkspaceToolName;
+	callId?: string;
 	payload: ExecutorJobPayload;
 	hidden?: boolean;
 	status: Infer<typeof vExecutorJobStatus>;
@@ -127,12 +129,7 @@ export type ThreadMessage = {
 	userId: string;
 	type: Infer<typeof vThreadMessageType>;
 	text: string;
-	parts?: Array<
-		| { type: 'text'; id: string; text: string }
-		| { type: 'reasoning'; id: string; text: string }
-		| { type: 'tool-call'; callId: string; name: string; input: unknown }
-		| { type: 'tool-result'; callId: string; name?: string; output: unknown }
-	>;
+	parts?: AssistantPart[];
 	runStatus: Infer<typeof vRunStatus>;
 	runStartedAt: number;
 	runCompletedAt?: number;

--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+	dataForThread,
 	findWorkspaceSessionByName,
 	getAttachedWorkspaceSessionIds,
 	getWorkspaceThreadGroups,
+	isSelectionGenerationCurrent,
+	resolvePendingCreatedThreadId,
 	resolveWorkspaceThreadSelection
 } from '$lib/workspace/threads';
 import { defaultModelId, defaultReasoningEffort } from '$convex/lib/models';
@@ -129,5 +132,114 @@ describe('workspace thread helpers', () => {
 				draftWorkspaceName: 'Workspace'
 			})
 		).toBeNull();
+	});
+
+	it('preserves a newly created thread id before the reactive list includes it', () => {
+		const existing = makeThreadSummary({
+			_id: 'thread-record-old' as ThreadSummary['_id'],
+			threadId: 'thread-record-old' as ThreadSummary['threadId'],
+			lastMessageAt: 20
+		});
+		const pendingThreadId = 'thread-record-new' as ThreadSummary['threadId'];
+
+		expect(
+			resolveWorkspaceThreadSelection({
+				threads: [existing],
+				currentThreadId: pendingThreadId,
+				currentWorkspaceName: 'Workspace',
+				draftWorkspaceName: null,
+				pendingCreatedThreadId: pendingThreadId
+			})
+		).toBe(pendingThreadId);
+	});
+
+	it('falls back when an established thread disappears from the list', () => {
+		const newest = makeThreadSummary({
+			_id: 'thread-record-newest' as ThreadSummary['_id'],
+			threadId: 'thread-record-newest' as ThreadSummary['threadId'],
+			lastMessageAt: 30
+		});
+		const vanished = 'thread-record-vanished' as ThreadSummary['threadId'];
+
+		expect(
+			resolveWorkspaceThreadSelection({
+				threads: [newest],
+				currentThreadId: vanished,
+				currentWorkspaceName: 'Workspace',
+				draftWorkspaceName: null,
+				pendingCreatedThreadId: null
+			})
+		).toBe(newest.threadId);
+	});
+
+	it('falls back to the newest thread only after the current id is cleared', () => {
+		const newest = makeThreadSummary({
+			_id: 'thread-record-newest' as ThreadSummary['_id'],
+			threadId: 'thread-record-newest' as ThreadSummary['threadId'],
+			lastMessageAt: 30
+		});
+
+		expect(
+			resolveWorkspaceThreadSelection({
+				threads: [newest],
+				currentThreadId: null,
+				currentWorkspaceName: 'Workspace',
+				draftWorkspaceName: null
+			})
+		).toBe(newest.threadId);
+	});
+
+	it('clears pending created ids once the list catches up or create visibility fails', () => {
+		const existing = makeThreadSummary({
+			_id: 'thread-record-old' as ThreadSummary['_id'],
+			threadId: 'thread-record-old' as ThreadSummary['threadId']
+		});
+		const pendingThreadId = 'thread-record-new' as ThreadSummary['threadId'];
+		const created = makeThreadSummary({
+			_id: pendingThreadId,
+			threadId: pendingThreadId
+		});
+
+		expect(
+			resolvePendingCreatedThreadId({
+				pendingCreatedThreadId: pendingThreadId,
+				threads: [existing],
+				threadListChangedSinceCreate: false
+			})
+		).toBe(pendingThreadId);
+
+		expect(
+			resolvePendingCreatedThreadId({
+				pendingCreatedThreadId: pendingThreadId,
+				threads: [created, existing],
+				threadListChangedSinceCreate: true
+			})
+		).toBeNull();
+
+		expect(
+			resolvePendingCreatedThreadId({
+				pendingCreatedThreadId: pendingThreadId,
+				threads: [existing],
+				threadListChangedSinceCreate: true
+			})
+		).toBeNull();
+	});
+
+	it('rejects stale thread-scoped query data', () => {
+		const thread = makeThreadSummary();
+		const activeThreadRecord = {
+			_id: thread.threadId,
+			title: thread.title
+		};
+
+		expect(dataForThread(thread, thread.threadId)).toBe(thread);
+		expect(dataForThread(activeThreadRecord, thread.threadId)).toBe(activeThreadRecord);
+		expect(dataForThread(thread, 'thread-record-2' as ThreadSummary['threadId'])).toBeNull();
+		expect(dataForThread(undefined, thread.threadId)).toBeNull();
+	});
+
+	it('treats selection generations as current only when they match', () => {
+		expect(isSelectionGenerationCurrent(3, 3)).toBe(true);
+		expect(isSelectionGenerationCurrent(2, 3)).toBe(false);
 	});
 });

--- a/apps/web/src/lib/workspace/threads.ts
+++ b/apps/web/src/lib/workspace/threads.ts
@@ -112,20 +112,69 @@ export function findThreadById(
 	return threads.find((thread) => thread.threadId === threadId) ?? null;
 }
 
+export function dataForThread<
+	T extends { threadId?: Id<'threadRecords'>; _id?: Id<'threadRecords'> }
+>(data: T | null | undefined, threadId: Id<'threadRecords'> | null): T | null {
+	return threadId && (data?.threadId ?? data?._id) === threadId ? data! : null;
+}
+
+export function isSelectionGenerationCurrent(
+	startedGeneration: number,
+	currentGeneration: number
+): boolean {
+	return startedGeneration === currentGeneration;
+}
+
+export function resolvePendingCreatedThreadId(args: {
+	pendingCreatedThreadId: Id<'threadRecords'> | null;
+	threads: ThreadSummary[];
+	threadListChangedSinceCreate: boolean;
+}): Id<'threadRecords'> | null {
+	const { pendingCreatedThreadId, threads, threadListChangedSinceCreate } = args;
+	if (!pendingCreatedThreadId) {
+		return null;
+	}
+
+	if (threads.some((thread) => thread.threadId === pendingCreatedThreadId)) {
+		return null;
+	}
+
+	// Create/list catch-up window ended without the thread appearing — stop pinning.
+	if (threadListChangedSinceCreate) {
+		return null;
+	}
+
+	return pendingCreatedThreadId;
+}
+
 export function resolveWorkspaceThreadSelection(args: {
 	threads: ThreadSummary[];
 	currentThreadId: Id<'threadRecords'> | null;
 	currentWorkspaceName: string | null;
 	draftWorkspaceName: string | null;
+	pendingCreatedThreadId?: Id<'threadRecords'> | null;
 }) {
-	const { threads, currentThreadId, currentWorkspaceName, draftWorkspaceName } = args;
+	const {
+		threads,
+		currentThreadId,
+		currentWorkspaceName,
+		draftWorkspaceName,
+		pendingCreatedThreadId = null
+	} = args;
 
 	if (currentWorkspaceName && draftWorkspaceName === currentWorkspaceName) {
 		return null;
 	}
 
-	if (currentThreadId && threads.some((thread) => thread.threadId === currentThreadId)) {
-		return currentThreadId;
+	if (currentThreadId) {
+		if (threads.some((thread) => thread.threadId === currentThreadId)) {
+			return currentThreadId;
+		}
+
+		// Preserve an unknown ID only during the create → list catch-up window.
+		if (pendingCreatedThreadId && currentThreadId === pendingCreatedThreadId) {
+			return currentThreadId;
+		}
 	}
 
 	return threads[0]?.threadId ?? null;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -29,10 +29,13 @@
 		type SupportedReasoningEffort
 	} from '$convex/lib/models';
 	import {
+		dataForThread,
 		getAttachedWorkspaceSessionIds,
 		getWorkspaceThreadGroups,
 		findThreadById,
 		findWorkspaceSessionByName,
+		isSelectionGenerationCurrent,
+		resolvePendingCreatedThreadId,
 		resolveWorkspaceThreadSelection
 	} from '$lib/workspace/threads';
 	import { resolveDesktopApi } from '$lib/local/client';
@@ -51,7 +54,7 @@
 	const upsertWorkspaceSession = useMutation(api.workspaceSessions.upsertSelected);
 	const createThreadMutation = useMutation(api.threads.create);
 	const removeThread = useMutation(api.threads.remove);
-	const finishRun = useMutation(api.agentRuntime.finishRun);
+	const finalizeRun = useMutation(api.agentRuntime.finalizeRun);
 	const setLastThread = useMutation(api.uiPreferences.setLastThread);
 	const heartbeatAttached = useMutation(api.workspaceSessions.heartbeatAttached);
 	const localServerRequiredMessage = 'Connect to a running Sprocket server to use this workspace.';
@@ -74,6 +77,9 @@
 	let hasResolvedInitialSelection = $state(false);
 	let restoredWorkspaceSessionIdToAttach = $state<Id<'workspaceSessions'> | null>(null);
 	let lastSavedThreadId = $state<Id<'threadRecords'> | null>(null);
+	let workspaceSelectionGeneration = $state(0);
+	let pendingCreatedThreadId = $state<Id<'threadRecords'> | null>(null);
+	let threadsDataAtPendingCreate = $state<unknown>(undefined);
 	let desktopWorkspaceSessionsById = $state<Record<string, WorkspaceSessionLocation>>({});
 	let workspacePickerOpen = $state(false);
 	let workspacePickerMode = $state<'add' | 'reconnect'>('add');
@@ -147,6 +153,9 @@
 		})
 	);
 	const threads = $derived((threadsQuery.data ?? []) as ThreadSummary[]);
+	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
+	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
+	const currentMessagesData = $derived(dataForThread(messagesQuery.data, currentThreadId));
 
 	const currentWorkspaceSession = $derived.by<WorkspaceSessionState | null>(() => {
 		if (!currentWorkspaceName) {
@@ -172,8 +181,8 @@
 		getWorkspaceThreadGroups(workspaceSessions, threads)
 	);
 
-	const runState = $derived(latestRunQuery.data?.run);
-	const visibleActions = $derived((latestRunQuery.data?.jobs ?? []).slice(-60));
+	const runState = $derived(currentLatestRunData?.run ?? null);
+	const visibleActions = $derived((currentLatestRunData?.jobs ?? []).slice(-60));
 	const isRunning = $derived(
 		runState?.status === 'queued' ||
 			runState?.status === 'running' ||
@@ -219,7 +228,7 @@
 		desktopWorkspaceSessionsById = await refreshDesktopWorkspaceSessionsFromDesktop(desktopApi);
 	}
 
-	function setWorkspaceSelection(
+	function applyWorkspaceSelection(
 		workspaceName: string,
 		threadId: Id<'threadRecords'> | null = null,
 		draft: boolean = false
@@ -227,6 +236,19 @@
 		currentWorkspaceName = workspaceName;
 		currentThreadId = threadId;
 		draftWorkspaceName = draft ? workspaceName : null;
+		if (threadId !== pendingCreatedThreadId) {
+			pendingCreatedThreadId = null;
+			threadsDataAtPendingCreate = undefined;
+		}
+	}
+
+	function setWorkspaceSelection(
+		workspaceName: string,
+		threadId: Id<'threadRecords'> | null = null,
+		draft: boolean = false
+	) {
+		workspaceSelectionGeneration += 1;
+		applyWorkspaceSelection(workspaceName, threadId, draft);
 	}
 
 	async function attachLocalWorkspaceSession(
@@ -263,14 +285,29 @@
 		workspaceName: string,
 		selection: { threadId?: Id<'threadRecords'> | null; draft?: boolean } = {}
 	) {
+		const selectionGeneration = ++workspaceSelectionGeneration;
 		const workspaceSession = findWorkspaceSessionByName(workspaceSessions, workspaceName);
 		if (!workspaceSession) {
-			currentError = 'Choose a workspace first.';
+			if (isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
+				currentError = 'Choose a workspace first.';
+			}
 			return;
 		}
 
-		await attachWorkspaceSession(workspaceSession._id);
-		setWorkspaceSelection(workspaceName, selection.threadId, selection.draft);
+		try {
+			await attachWorkspaceSession(workspaceSession._id);
+		} catch (error) {
+			if (isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
+				currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
+			}
+			return;
+		}
+
+		if (!isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
+			return;
+		}
+
+		applyWorkspaceSelection(workspaceName, selection.threadId, selection.draft);
 		currentError = null;
 	}
 
@@ -364,6 +401,9 @@
 			selectedModel,
 			reasoningEffort: selectedReasoningEffort
 		});
+		pendingCreatedThreadId = result.threadId;
+		threadsDataAtPendingCreate = threadsQuery.data;
+		workspaceSelectionGeneration += 1;
 		currentThreadId = result.threadId;
 		draftWorkspaceName = null;
 		return result.threadId;
@@ -407,6 +447,9 @@
 			});
 			if (currentThreadId === thread.threadId) {
 				currentThreadId = null;
+				pendingCreatedThreadId = null;
+				threadsDataAtPendingCreate = undefined;
+				workspaceSelectionGeneration += 1;
 			}
 			if (lastSavedThreadId === thread.threadId) {
 				lastSavedThreadId = null;
@@ -489,9 +532,10 @@
 		}
 
 		try {
-			await finishRun({
+			await finalizeRun({
 				...getViewerArgs(),
 				runId: runState._id,
+				text: '',
 				status: 'cancelled'
 			});
 		} catch (error) {
@@ -500,13 +544,31 @@
 	}
 
 	$effect(() => {
-		const data = messagesQuery.data;
+		const data = currentMessagesData;
 		if (!data) {
 			visibleMessages = [];
 			return;
 		}
 
 		visibleMessages = [...(data.page ?? [])];
+	});
+
+	$effect(() => {
+		if (!pendingCreatedThreadId) {
+			return;
+		}
+
+		const nextPendingCreatedThreadId = resolvePendingCreatedThreadId({
+			pendingCreatedThreadId,
+			threads,
+			threadListChangedSinceCreate: threadsQuery.data !== threadsDataAtPendingCreate
+		});
+		if (nextPendingCreatedThreadId !== pendingCreatedThreadId) {
+			pendingCreatedThreadId = nextPendingCreatedThreadId;
+			if (!nextPendingCreatedThreadId) {
+				threadsDataAtPendingCreate = undefined;
+			}
+		}
 	});
 
 	$effect(() => {
@@ -583,13 +645,15 @@
 			threads,
 			currentThreadId,
 			currentWorkspaceName,
-			draftWorkspaceName
+			draftWorkspaceName,
+			pendingCreatedThreadId
 		});
 		if (nextThreadId === currentThreadId) {
 			return;
 		}
 
 		currentThreadId = nextThreadId;
+		workspaceSelectionGeneration += 1;
 	});
 
 	$effect(() => {
@@ -740,7 +804,7 @@
 				<header class="flex h-12 items-center justify-between border-b border-white/6 px-5">
 					<div class="flex min-w-0 items-center gap-3">
 						<h1 class="truncate text-[1rem] font-medium tracking-[-0.03em] text-white">
-							{activeThreadQuery.data?.title ?? 'New thread'}
+							{currentActiveThread?.title ?? 'New thread'}
 						</h1>
 						{#if currentWorkspaceSession}
 							<span

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -15,4 +15,4 @@ serde_json = "1.0.149"
 sprocket-convex-provider = { path = "../sprocket-convex-provider" }
 sprocket-workspace = { path = "../sprocket-workspace" }
 thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["sync"] }
+tokio = { version = "1.52.1", features = ["macros", "sync"] }

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 anyhow = "1.0.102"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 futures = "0.3.32"
-rig = { package = "rig-core", version = "0.39.0", default-features = false }
+rig = { package = "rig-core", version = "0.40.0", default-features = false }
 schemars = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, anyhow};
-use convex::{FunctionResult, Value};
+use convex::{FunctionResult, QuerySubscription, Value};
 use serde::Deserialize;
 use sprocket_convex_provider::Client as ConvexProviderClient;
 use std::collections::BTreeMap;
@@ -99,34 +99,38 @@ impl RuntimeClient {
             .await
     }
 
-    pub(crate) async fn finish_assistant_message(
-        &self,
-        run_id: &str,
-        text: &str,
-    ) -> anyhow::Result<()> {
-        let mut args = self.run_args(run_id);
-        args.insert("text".to_string(), text.to_string().into());
-        self.mutation_unit("agentRuntime:finishAssistantMessage", args)
-            .await
-    }
-
     pub(crate) async fn run_finished(&self, run_id: &str) -> anyhow::Result<bool> {
         self.query_json("agentRuntime:isFinished", self.run_args(run_id))
             .await
     }
 
-    pub(crate) async fn finish_run(
+    pub(crate) async fn run_finished_subscription(
         &self,
         run_id: &str,
+    ) -> anyhow::Result<QuerySubscription> {
+        self.client
+            .subscribe("agentRuntime:isFinished", self.run_args(run_id))
+            .await
+    }
+
+    pub(crate) fn decode_run_finished_update(result: FunctionResult) -> anyhow::Result<bool> {
+        decode_function_result(result, "agentRuntime:isFinished")
+    }
+
+    pub(crate) async fn finalize_run(
+        &self,
+        run_id: &str,
+        text: &str,
         status: &str,
         last_error: Option<&str>,
     ) -> anyhow::Result<()> {
         let mut args = self.run_args(run_id);
+        args.insert("text".to_string(), text.to_string().into());
         args.insert("status".to_string(), status.to_string().into());
         if let Some(last_error) = last_error {
             args.insert("lastError".to_string(), last_error.to_string().into());
         }
-        self.mutation_unit("agentRuntime:finishRun", args).await
+        self.mutation_unit("agentRuntime:finalizeRun", args).await
     }
 
     pub(crate) fn args_with_actor(&self) -> BTreeMap<String, Value> {

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -110,17 +110,6 @@ impl RuntimeClient {
             .await
     }
 
-    pub(crate) async fn update_assistant_message(
-        &self,
-        run_id: &str,
-        text: &str,
-    ) -> anyhow::Result<()> {
-        let mut args = self.run_args(run_id);
-        args.insert("text".to_string(), text.to_string().into());
-        self.mutation_unit("agentRuntime:updateAssistantMessage", args)
-            .await
-    }
-
     pub(crate) async fn run_finished(&self, run_id: &str) -> anyhow::Result<bool> {
         self.query_json("agentRuntime:isFinished", self.run_args(run_id))
             .await

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -33,11 +33,34 @@ impl ToolCallTracker {
 
     pub(crate) fn claim(&self, name: &str, args: &serde_json::Value) -> Option<String> {
         let mut calls = self.0.lock().ok()?;
-        let index = calls
+        let mut compatible = calls
             .iter()
-            .position(|call| call.name == name && call.args == *args)
-            .or_else(|| calls.iter().position(|call| call.name == name))?;
+            .enumerate()
+            .filter(|(_, call)| call.name == name && tool_payload_compatible(&call.args, args));
+        let (index, _) = compatible.next()?;
+        if compatible.next().is_some() {
+            return None;
+        }
         calls.remove(index)?.call_id
+    }
+}
+
+fn tool_payload_compatible(raw: &serde_json::Value, normalized: &serde_json::Value) -> bool {
+    match (raw, normalized) {
+        (serde_json::Value::Object(raw), serde_json::Value::Object(normalized)) => {
+            normalized.iter().all(|(key, value)| {
+                raw.get(key)
+                    .is_some_and(|raw| tool_payload_compatible(raw, value))
+            })
+        }
+        (serde_json::Value::Array(raw), serde_json::Value::Array(normalized)) => {
+            raw.len() == normalized.len()
+                && raw
+                    .iter()
+                    .zip(normalized)
+                    .all(|(raw, normalized)| tool_payload_compatible(raw, normalized))
+        }
+        _ => raw == normalized,
     }
 }
 
@@ -236,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn tracker_falls_back_to_same_name_call_order_when_typed_args_drop_fields() {
+    fn tracker_uniquely_matches_normalized_args_when_typed_args_drop_fields() {
         let tracker = ToolCallTracker::default();
         tracker.record(
             Some("call-1"),
@@ -252,6 +275,26 @@ mod tests {
         assert_eq!(
             tracker.claim("exec_command", &serde_json::json!({ "cmd": "ls" })),
             Some("call-2".to_string())
+        );
+    }
+
+    #[test]
+    fn tracker_does_not_claim_ambiguous_normalized_parallel_calls() {
+        let tracker = ToolCallTracker::default();
+        tracker.record(
+            Some("call-1"),
+            "exec_command",
+            r#"{"cmd":"pwd","workdir":null}"#,
+        );
+        tracker.record(
+            Some("call-2"),
+            "exec_command",
+            r#"{"cmd":"pwd","unknown":"first"}"#,
+        );
+
+        assert_eq!(
+            tracker.claim("exec_command", &serde_json::json!({ "cmd": "pwd" })),
+            None
         );
     }
 }

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -1,92 +1,106 @@
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use rig::agent::{
-    HookAction, InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
-};
+use rig::agent::{AgentHook, Flow, InvalidToolCallContext, StepEvent, StepEventKind};
 use rig::completion::CompletionModel;
-
-use crate::convex::RuntimeClient;
 
 pub(crate) const WORKSPACE_TOOL_NAMES: &[&str] =
     &["exec_command", "create_file", "replace_in_file"];
 
+#[derive(Clone, Debug)]
+struct TrackedToolCall {
+    call_id: Option<String>,
+    name: String,
+    args: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ToolCallTracker(Arc<Mutex<VecDeque<TrackedToolCall>>>);
+
+impl ToolCallTracker {
+    fn record(&self, call_id: Option<&str>, name: &str, args: &str) {
+        let Ok(args) = serde_json::from_str(args) else {
+            return;
+        };
+        if let Ok(mut calls) = self.0.lock() {
+            calls.push_back(TrackedToolCall {
+                call_id: call_id.map(str::to_owned),
+                name: name.to_owned(),
+                args,
+            });
+        }
+    }
+
+    pub(crate) fn claim(&self, name: &str, args: &serde_json::Value) -> Option<String> {
+        let mut calls = self.0.lock().ok()?;
+        let index = calls
+            .iter()
+            .position(|call| call.name == name && call.args == *args)
+            .or_else(|| calls.iter().position(|call| call.name == name))?;
+        calls.remove(index)?.call_id
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct AgentPromptHook {
-    runtime: RuntimeClient,
-    run_id: String,
-    aggregated_text: Arc<Mutex<String>>,
+    tracker: ToolCallTracker,
 }
 
 impl AgentPromptHook {
-    pub(crate) fn new(
-        runtime: RuntimeClient,
-        run_id: String,
-        aggregated_text: Arc<Mutex<String>>,
-    ) -> Self {
-        Self {
-            runtime,
-            run_id,
-            aggregated_text,
-        }
+    pub(crate) fn new(tracker: ToolCallTracker) -> Self {
+        Self { tracker }
     }
 }
 
-impl<M> PromptHook<M> for AgentPromptHook
+impl<M> AgentHook<M> for AgentPromptHook
 where
     M: CompletionModel,
 {
-    async fn on_text_delta(&self, _text_delta: &str, aggregated_text: &str) -> HookAction {
-        if let Ok(mut guard) = self.aggregated_text.lock() {
-            *guard = aggregated_text.to_string();
-        }
-
-        match self
-            .runtime
-            .update_assistant_message(&self.run_id, aggregated_text)
-            .await
-        {
-            Ok(()) => HookAction::cont(),
-            Err(error) => HookAction::terminate(error.to_string()),
+    async fn on_event(&self, _context: &rig::agent::HookContext, event: StepEvent<'_, M>) -> Flow {
+        match event {
+            StepEvent::InvalidToolCall(context) => resolve_invalid_tool_call(context),
+            StepEvent::ToolCall {
+                tool_name,
+                tool_call_id,
+                args,
+                ..
+            } => {
+                self.tracker.record(tool_call_id, tool_name, args);
+                Flow::cont()
+            }
+            _ => Flow::cont(),
         }
     }
 
-    async fn on_invalid_tool_call(
-        &self,
-        context: &InvalidToolCallContext,
-    ) -> InvalidToolCallHookAction {
-        resolve_invalid_tool_call(context)
-    }
-
-    async fn on_tool_call(
-        &self,
-        _tool_name: &str,
-        _tool_call_id: Option<String>,
-        _internal_call_id: &str,
-        _args: &str,
-    ) -> ToolCallHookAction {
-        ToolCallHookAction::cont()
+    fn observes(&self, kind: StepEventKind) -> bool {
+        matches!(
+            kind,
+            StepEventKind::InvalidToolCall | StepEventKind::ToolCall
+        )
     }
 }
 
-pub(crate) fn resolve_invalid_tool_call(
-    context: &InvalidToolCallContext,
-) -> InvalidToolCallHookAction {
-    let candidates = if context.available_tools.is_empty() {
+pub(crate) fn resolve_invalid_tool_call(context: &InvalidToolCallContext) -> Flow {
+    resolve_invalid_tool_name(&context.tool_name, &context.available_tools)
+}
+
+fn resolve_invalid_tool_name(tool_name: &str, available_tools: &[String]) -> Flow {
+    let candidates = if available_tools.is_empty() {
         WORKSPACE_TOOL_NAMES
             .iter()
             .map(|name| (*name).to_string())
             .collect()
     } else {
-        context.available_tools.clone()
+        available_tools.to_vec()
     };
 
-    if let Some(repaired) = repair_tool_name(&context.tool_name, &candidates) {
-        return InvalidToolCallHookAction::repair(repaired);
+    if let Some(repaired) = repair_tool_name(tool_name, &candidates) {
+        return Flow::repair(repaired);
     }
 
-    InvalidToolCallHookAction::retry(format!(
+    Flow::retry(format!(
         "Unknown or disallowed tool `{}`. Use one of: {}.",
-        context.tool_name,
+        tool_name,
         candidates.join(", ")
     ))
 }
@@ -168,39 +182,25 @@ fn levenshtein(left: &str, right: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rig::agent::InvalidToolCallContext;
 
-    fn context(tool_name: &str) -> InvalidToolCallContext {
-        InvalidToolCallContext {
-            tool_name: tool_name.to_string(),
-            tool_call_id: None,
-            internal_call_id: None,
-            args: None,
-            available_tools: WORKSPACE_TOOL_NAMES
-                .iter()
-                .map(|name| (*name).to_string())
-                .collect(),
-            allowed_tools: WORKSPACE_TOOL_NAMES
-                .iter()
-                .map(|name| (*name).to_string())
-                .collect(),
-            tool_choice: None,
-            chat_history: Vec::new(),
-            is_streaming: true,
-        }
+    fn tools() -> Vec<String> {
+        WORKSPACE_TOOL_NAMES
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect()
     }
 
     #[test]
     fn repairs_near_miss_tool_names() {
-        match resolve_invalid_tool_call(&context("exec-command")) {
-            InvalidToolCallHookAction::Repair { tool_name } => {
+        match resolve_invalid_tool_name("exec-command", &tools()) {
+            Flow::Repair { tool_name } => {
                 assert_eq!(tool_name, "exec_command");
             }
             other => panic!("expected repair, got {other:?}"),
         }
 
-        match resolve_invalid_tool_call(&context("createfile")) {
-            InvalidToolCallHookAction::Repair { tool_name } => {
+        match resolve_invalid_tool_name("createfile", &tools()) {
+            Flow::Repair { tool_name } => {
                 assert_eq!(tool_name, "create_file");
             }
             other => panic!("expected repair, got {other:?}"),
@@ -209,13 +209,49 @@ mod tests {
 
     #[test]
     fn retries_unknown_tool_names() {
-        match resolve_invalid_tool_call(&context("launch_missiles")) {
-            InvalidToolCallHookAction::Retry { feedback } => {
+        match resolve_invalid_tool_name("launch_missiles", &tools()) {
+            Flow::Retry { feedback } => {
                 assert!(feedback.contains("exec_command"));
                 assert!(feedback.contains("create_file"));
                 assert!(feedback.contains("replace_in_file"));
             }
             other => panic!("expected retry, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn tracker_claims_only_the_matching_executed_call() {
+        let tracker = ToolCallTracker::default();
+        tracker.record(Some("call-1"), "exec_command", r#"{"cmd":"pwd"}"#);
+        tracker.record(Some("call-2"), "exec_command", r#"{"cmd":"ls"}"#);
+
+        assert_eq!(
+            tracker.claim("exec_command", &serde_json::json!({ "cmd": "ls" })),
+            Some("call-2".to_string())
+        );
+        assert_eq!(
+            tracker.claim("exec_command", &serde_json::json!({ "cmd": "pwd" })),
+            Some("call-1".to_string())
+        );
+    }
+
+    #[test]
+    fn tracker_falls_back_to_same_name_call_order_when_typed_args_drop_fields() {
+        let tracker = ToolCallTracker::default();
+        tracker.record(
+            Some("call-1"),
+            "exec_command",
+            r#"{"cmd":"pwd","workdir":null,"unknown":"ignored"}"#,
+        );
+        tracker.record(Some("call-2"), "exec_command", r#"{"cmd":"ls"}"#);
+
+        assert_eq!(
+            tracker.claim("exec_command", &serde_json::json!({ "cmd": "pwd" })),
+            Some("call-1".to_string())
+        );
+        assert_eq!(
+            tracker.claim("exec_command", &serde_json::json!({ "cmd": "ls" })),
+            Some("call-2".to_string())
+        );
     }
 }

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::{CompletionModel, Message};
 use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
-use sprocket_convex_provider::Client as ConvexProviderClient;
+use sprocket_convex_provider::{Client as ConvexProviderClient, is_completion_stream_superseded};
 
 use crate::convex::RuntimeClient;
 use crate::hooks::{AgentPromptHook, ToolCallTracker};
@@ -19,6 +19,24 @@ const MAX_INVALID_TOOL_CALL_RETRIES: usize = 3;
 const RUN_CANCELLED_BY_USER: &str = "Run is cancelled.";
 /// Must match `RUN_NO_LONGER_ACTIVE` in `apps/web/src/convex/lib/agentErrors.ts`.
 const RUN_NO_LONGER_ACTIVE: &str = "Run is no longer active.";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderErrorDisposition {
+    Cancelled,
+    Superseded,
+    Failed,
+}
+
+fn classify_provider_error(error: &(impl std::fmt::Display + ?Sized)) -> ProviderErrorDisposition {
+    if is_completion_stream_superseded(error) {
+        return ProviderErrorDisposition::Superseded;
+    }
+    let error_text = error.to_string();
+    if error_text.contains(RUN_CANCELLED_BY_USER) || error_text.contains(RUN_NO_LONGER_ACTIVE) {
+        return ProviderErrorDisposition::Cancelled;
+    }
+    ProviderErrorDisposition::Failed
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ProviderKind {
@@ -50,6 +68,7 @@ pub(crate) struct AgentProviderRequest {
 pub(crate) enum AgentProviderResult {
     Completed { text: String },
     Cancelled { text: String },
+    Superseded,
     Failed { text: String, error: anyhow::Error },
 }
 
@@ -155,11 +174,14 @@ where
                 } else {
                     final_text
                 };
-                let error_text = error.to_string();
-                if error_text.contains(RUN_CANCELLED_BY_USER)
-                    || error_text.contains(RUN_NO_LONGER_ACTIVE)
-                {
-                    return AgentProviderResult::Cancelled { text };
+                match classify_provider_error(&error) {
+                    ProviderErrorDisposition::Superseded => {
+                        return AgentProviderResult::Superseded;
+                    }
+                    ProviderErrorDisposition::Cancelled => {
+                        return AgentProviderResult::Cancelled { text };
+                    }
+                    ProviderErrorDisposition::Failed => {}
                 }
                 return AgentProviderResult::Failed {
                     text,
@@ -174,4 +196,30 @@ where
     }
 
     AgentProviderResult::Completed { text: final_text }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProviderErrorDisposition, RUN_NO_LONGER_ACTIVE, classify_provider_error};
+    use sprocket_convex_provider::COMPLETION_STREAM_SUPERSEDED;
+
+    #[test]
+    fn classifies_superseded_completion_without_treating_it_as_failure() {
+        let error = anyhow::anyhow!("completion provider failed: {COMPLETION_STREAM_SUPERSEDED}");
+
+        assert_eq!(
+            classify_provider_error(&error),
+            ProviderErrorDisposition::Superseded
+        );
+    }
+
+    #[test]
+    fn classifies_stopped_workspace_tool_as_cancellation() {
+        let error = anyhow::anyhow!("tool execution failed: {RUN_NO_LONGER_ACTIVE}");
+
+        assert_eq!(
+            classify_provider_error(&error),
+            ProviderErrorDisposition::Cancelled
+        );
+    }
 }

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -1,15 +1,14 @@
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::{CompletionModel, Message};
-use rig::streaming::StreamingPrompt;
+use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
 use sprocket_convex_provider::Client as ConvexProviderClient;
 
 use crate::convex::RuntimeClient;
-use crate::hooks::AgentPromptHook;
+use crate::hooks::{AgentPromptHook, ToolCallTracker};
 use crate::tools::workspace_tools;
 use crate::types::{RunAgentRequest, RunContextResponse};
 
@@ -30,20 +29,14 @@ impl ProviderKind {
     pub(crate) const DEFAULT: Self = Self::ConvexCompletion;
 
     pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::ConvexCompletion => "convex-completion",
-        }
+        "convex-completion"
     }
 }
 
 pub(crate) struct AgentProvider {
     kind: ProviderKind,
-    completion: ProviderCompletion,
+    completion: ConvexProviderClient,
     model: String,
-}
-
-enum ProviderCompletion {
-    Convex(ConvexProviderClient),
 }
 
 pub(crate) struct AgentProviderRequest {
@@ -69,13 +62,11 @@ impl AgentProvider {
     ) -> Self {
         Self {
             kind: ProviderKind::DEFAULT,
-            completion: ProviderCompletion::Convex(
-                runtime
-                    .completion_client()
-                    .clone()
-                    .with_reasoning_effort(context.run.reasoning_effort.clone())
-                    .with_stream_target(Some(run_id.to_string()), request.guest_id.clone()),
-            ),
+            completion: runtime
+                .completion_client()
+                .clone()
+                .with_reasoning_effort(context.run.reasoning_effort.clone())
+                .with_stream_target(Some(run_id.to_string()), request.guest_id.clone()),
             model: context.run.selected_model.clone(),
         }
     }
@@ -89,11 +80,7 @@ impl AgentProvider {
         runtime: RuntimeClient,
         request: AgentProviderRequest,
     ) -> AgentProviderResult {
-        match self.completion {
-            ProviderCompletion::Convex(client) => {
-                run_with_completion_client(client, self.model, runtime, request).await
-            }
-        }
+        run_with_completion_client(self.completion, self.model, runtime, request).await
     }
 }
 
@@ -108,10 +95,12 @@ where
     C::CompletionModel: CompletionModel<Client = C> + 'static,
     <C::CompletionModel as CompletionModel>::StreamingResponse: 'static,
 {
+    let tool_call_tracker = ToolCallTracker::default();
     let tools = workspace_tools(
         runtime.clone(),
         request.run_id.clone(),
         request.workspace_root.clone(),
+        tool_call_tracker.clone(),
     );
     let agent = completion_client
         .agent(model)
@@ -124,34 +113,45 @@ where
     eprintln!("sprocket-agent: built agent {}", request.run_id);
     eprintln!("sprocket-agent: prompting model {}", request.run_id);
 
-    let aggregated_text = Arc::new(Mutex::new(String::new()));
-    let hook = AgentPromptHook::new(
-        runtime,
-        request.run_id.clone(),
-        Arc::clone(&aggregated_text),
-    );
+    let hook = AgentPromptHook::new(tool_call_tracker);
 
     let mut stream = agent
         .stream_prompt(request.prompt)
-        .with_history(request.prior_history)
-        .multi_turn(AGENT_MAX_TURNS)
-        .with_hook(hook)
+        .history(request.prior_history)
+        .max_turns(AGENT_MAX_TURNS)
+        .add_hook(hook)
         .max_invalid_tool_call_retries(MAX_INVALID_TOOL_CALL_RETRIES)
         .await;
     let mut final_text = String::new();
+    let mut streamed_text = String::new();
 
     while let Some(item) = stream.next().await {
         match item {
             Ok(rig::agent::MultiTurnStreamItem::FinalResponse(response)) => {
-                final_text = response.response().to_string();
+                final_text = response.output().to_string();
             }
+            Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::Text(text),
+            )) => {
+                streamed_text.push_str(&text.text);
+            }
+            // Model tool calls are persisted by the Convex completion action. Tool execution
+            // and results are persisted by executor jobs and correlated during finalization.
+            Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::ToolCall { .. }
+                | StreamedAssistantContent::ToolCallDelta { .. }
+                | StreamedAssistantContent::Reasoning(_)
+                | StreamedAssistantContent::ReasoningDelta { .. }
+                | StreamedAssistantContent::Final(_)
+                | StreamedAssistantContent::Unknown(_),
+            ))
+            | Ok(rig::agent::MultiTurnStreamItem::ToolExecutionStart { .. })
+            | Ok(rig::agent::MultiTurnStreamItem::StreamUserItem(_))
+            | Ok(rig::agent::MultiTurnStreamItem::CompletionCall(_)) => {}
             Ok(_) => {}
             Err(error) => {
                 let text = if final_text.is_empty() {
-                    aggregated_text
-                        .lock()
-                        .map(|guard| guard.clone())
-                        .unwrap_or_default()
+                    streamed_text
                 } else {
                     final_text
                 };
@@ -170,10 +170,7 @@ where
     }
 
     if final_text.is_empty() {
-        final_text = aggregated_text
-            .lock()
-            .map(|guard| guard.clone())
-            .unwrap_or_default();
+        final_text = streamed_text;
     }
 
     AgentProviderResult::Completed { text: final_text }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -101,10 +101,10 @@ async fn finalize_run(
     error_message: Option<&str>,
 ) -> anyhow::Result<()> {
     let status_text = status.as_str();
+    let finish_error = runtime.finish_run(run_id, status_text, error_message).await;
     let assistant_error = runtime
         .finish_assistant_message(run_id, assistant_text)
         .await;
-    let finish_error = runtime.finish_run(run_id, status_text, error_message).await;
 
     match (assistant_error, finish_error) {
         (Ok(()), Ok(())) => Ok(()),

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -83,9 +83,11 @@ async fn fail_run_early(
     run_id: &str,
     error: &anyhow::Error,
 ) -> anyhow::Result<()> {
+    let message = format!("Run failed before the model started: {error}");
     runtime
-        .finish_run(
+        .finalize_run(
             run_id,
+            &message,
             RunFinalStatus::Failed.as_str(),
             Some(&error.to_string()),
         )
@@ -101,23 +103,10 @@ async fn finalize_run(
     error_message: Option<&str>,
 ) -> anyhow::Result<()> {
     let status_text = status.as_str();
-    let finish_error = runtime.finish_run(run_id, status_text, error_message).await;
-    let assistant_error = runtime
-        .finish_assistant_message(run_id, assistant_text)
-        .await;
-
-    match (assistant_error, finish_error) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(assistant_error), Ok(())) => Err(anyhow!(
-            "failed to finish assistant message for {status_text} run: {assistant_error}"
-        )),
-        (Ok(()), Err(finish_error)) => Err(anyhow!(
-            "failed to mark run as {status_text}: {finish_error}"
-        )),
-        (Err(assistant_error), Err(finish_error)) => Err(anyhow!(
-            "failed to finalize {status_text} run: assistant message update failed: {assistant_error}; run status update failed: {finish_error}"
-        )),
-    }
+    runtime
+        .finalize_run(run_id, assistant_text, status_text, error_message)
+        .await
+        .map_err(|error| anyhow!("failed to finalize {status_text} run: {error}"))
 }
 
 async fn fail_run_setup(
@@ -150,6 +139,10 @@ async fn finalize_provider_result(
         AgentProviderResult::Cancelled { text } => {
             eprintln!("sprocket-agent: run cancelled {}", run_id);
             finalize_run(runtime, run_id, &text, RunFinalStatus::Cancelled, None).await
+        }
+        AgentProviderResult::Superseded => {
+            eprintln!("sprocket-agent: provider attempt superseded {}", run_id);
+            Ok(())
         }
         AgentProviderResult::Failed { text, error } => {
             let error_text = error.to_string();

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -1,16 +1,21 @@
 use std::path::PathBuf;
 
 use convex::Value;
+use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sprocket_workspace::{create_workspace_file, exec_workspace_command, replace_workspace_file};
+use sprocket_workspace::{
+    WorkspaceCancellation, create_workspace_file, exec_workspace_command, replace_workspace_file,
+};
 
 use crate::convex::RuntimeClient;
 use crate::hooks::ToolCallTracker;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AgentToolError {
+    #[error("Run is no longer active.")]
+    Cancelled,
     #[error("{0}")]
     Message(String),
 }
@@ -133,9 +138,10 @@ impl rig::tool::Tool for ExecCommandTool {
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
-            async {
+            |cancellation| async {
                 let output = exec_workspace_command(
                     self.0.workspace_root.clone(),
+                    cancellation,
                     &args.cmd,
                     args.workdir.as_deref(),
                     args.shell.as_deref(),
@@ -173,11 +179,15 @@ impl rig::tool::Tool for CreateFileTool {
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
-            async {
-                let output =
-                    create_workspace_file(self.0.workspace_root.clone(), &args.path, &args.content)
-                        .await
-                        .map_err(tool_error)?;
+            |cancellation| async {
+                let output = create_workspace_file(
+                    self.0.workspace_root.clone(),
+                    cancellation,
+                    &args.path,
+                    &args.content,
+                )
+                .await
+                .map_err(tool_error)?;
                 Ok(serde_json::json!({
                     "path": output.path,
                     "bytesWritten": output.bytes_written,
@@ -209,9 +219,10 @@ impl rig::tool::Tool for ReplaceInFileTool {
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
-            async {
+            |cancellation| async {
                 let output = replace_workspace_file(
                     self.0.workspace_root.clone(),
+                    cancellation,
                     &args.path,
                     &args.old_text,
                     &args.new_text,
@@ -230,18 +241,33 @@ impl rig::tool::Tool for ReplaceInFileTool {
     }
 }
 
-async fn execute_tool_job<F>(
+async fn execute_tool_job<F, Fut>(
     runtime: &RuntimeClient,
     run_id: &str,
     kind: &str,
     tool_call_tracker: &ToolCallTracker,
     payload: serde_json::Value,
-    future: F,
+    operation: F,
 ) -> Result<serde_json::Value, AgentToolError>
 where
-    F: std::future::Future<Output = Result<serde_json::Value, AgentToolError>>,
+    F: FnOnce(WorkspaceCancellation) -> Fut,
+    Fut: std::future::Future<Output = Result<serde_json::Value, AgentToolError>>,
 {
     eprintln!("sprocket-agent: starting tool {} for run {}", kind, run_id);
+    let mut run_updates = runtime
+        .run_finished_subscription(run_id)
+        .await
+        .map_err(tool_error)?;
+    let initial_update = run_updates
+        .next()
+        .await
+        .ok_or_else(|| AgentToolError::Message("run status subscription closed".to_string()))?;
+    let initial_run_finished =
+        RuntimeClient::decode_run_finished_update(initial_update).map_err(tool_error)?;
+    if initial_run_finished {
+        return Err(AgentToolError::Cancelled);
+    }
+
     let mut begin_args = runtime.args_with_actor();
     begin_args.insert("runId".to_string(), run_id.to_string().into());
     begin_args.insert("kind".to_string(), kind.to_string().into());
@@ -262,7 +288,38 @@ where
         .ok_or_else(|| AgentToolError::Message("beginToolJob did not return a jobId".to_string()))?
         .to_string();
 
-    match future.await {
+    let cancellation = WorkspaceCancellation::new();
+    let operation = operation(cancellation.clone());
+    tokio::pin!(operation);
+    let operation_result = loop {
+        tokio::select! {
+            biased;
+            update = run_updates.next() => {
+                let Some(update) = update else {
+                    cancellation.cancel();
+                    let _ = operation.await;
+                    break Err(AgentToolError::Message("run status subscription closed".to_string()));
+                };
+                match RuntimeClient::decode_run_finished_update(update) {
+                    Ok(false) => {}
+                    Ok(true) => {
+                        cancellation.cancel();
+                        let _ = operation.await;
+                        eprintln!("sprocket-agent: cancelled tool {} for run {}", kind, run_id);
+                        return Err(AgentToolError::Cancelled);
+                    }
+                    Err(error) => {
+                        cancellation.cancel();
+                        let _ = operation.await;
+                        break Err(tool_error(format!("run status subscription failed: {error}")));
+                    }
+                }
+            },
+            result = &mut operation => break result,
+        }
+    };
+
+    match operation_result {
         Ok(output) => {
             eprintln!("sprocket-agent: completed tool {} for run {}", kind, run_id);
             let mut complete_args = runtime.args_with_actor();
@@ -271,11 +328,15 @@ where
                 "result".to_string(),
                 Value::try_from(output.clone()).map_err(tool_error)?,
             );
-            runtime
-                .mutation_unit("executor:complete", complete_args)
+            let accepted: bool = runtime
+                .mutation_json("executor:complete", complete_args)
                 .await
                 .map_err(tool_error)?;
-            Ok(output)
+            if accepted {
+                Ok(output)
+            } else {
+                Err(AgentToolError::Cancelled)
+            }
         }
         Err(error) => {
             eprintln!(
@@ -285,11 +346,15 @@ where
             let mut fail_args = runtime.args_with_actor();
             fail_args.insert("jobId".to_string(), job_id.into());
             fail_args.insert("error".to_string(), error.to_string().into());
-            runtime
-                .mutation_unit("executor:fail", fail_args)
+            let accepted: bool = runtime
+                .mutation_json("executor:fail", fail_args)
                 .await
                 .map_err(tool_error)?;
-            Err(error)
+            if accepted {
+                Err(error)
+            } else {
+                Err(AgentToolError::Cancelled)
+            }
         }
     }
 }

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use convex::Value;
-use rig::completion::ToolDefinition;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sprocket_workspace::{create_workspace_file, exec_workspace_command, replace_workspace_file};
 
 use crate::convex::RuntimeClient;
+use crate::hooks::ToolCallTracker;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AgentToolError {
@@ -20,14 +20,21 @@ struct WorkspaceToolContext {
     runtime: RuntimeClient,
     run_id: String,
     workspace_root: PathBuf,
+    tool_call_tracker: ToolCallTracker,
 }
 
 impl WorkspaceToolContext {
-    fn new(runtime: RuntimeClient, run_id: String, workspace_root: PathBuf) -> Self {
+    fn new(
+        runtime: RuntimeClient,
+        run_id: String,
+        workspace_root: PathBuf,
+        tool_call_tracker: ToolCallTracker,
+    ) -> Self {
         Self {
             runtime,
             run_id,
             workspace_root,
+            tool_call_tracker,
         }
     }
 }
@@ -51,8 +58,9 @@ pub(crate) fn workspace_tools(
     runtime: RuntimeClient,
     run_id: String,
     workspace_root: PathBuf,
+    tool_call_tracker: ToolCallTracker,
 ) -> WorkspaceToolSet {
-    let context = WorkspaceToolContext::new(runtime, run_id, workspace_root);
+    let context = WorkspaceToolContext::new(runtime, run_id, workspace_root, tool_call_tracker);
     WorkspaceToolSet {
         exec_command: ExecCommandTool(context.clone()),
         create_file: CreateFileTool(context.clone()),
@@ -110,13 +118,12 @@ impl rig::tool::Tool for ExecCommandTool {
     type Args = ExecCommandArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Runs a shell command inside the workspace and returns its output."
-                .to_string(),
-            parameters: json!(schemars::schema_for!(ExecCommandArgs)),
-        }
+    fn description(&self) -> String {
+        "Runs a shell command inside the workspace and returns its output.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schemars::schema_for!(ExecCommandArgs))
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -124,6 +131,7 @@ impl rig::tool::Tool for ExecCommandTool {
             &self.0.runtime,
             &self.0.run_id,
             Self::NAME,
+            &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
             async {
                 let output = exec_workspace_command(
@@ -150,13 +158,12 @@ impl rig::tool::Tool for CreateFileTool {
     type Args = CreateFileArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Create a new UTF-8 text file. Fails if the file already exists."
-                .to_string(),
-            parameters: json!(schemars::schema_for!(CreateFileArgs)),
-        }
+    fn description(&self) -> String {
+        "Create a new UTF-8 text file. Fails if the file already exists.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schemars::schema_for!(CreateFileArgs))
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -164,6 +171,7 @@ impl rig::tool::Tool for CreateFileTool {
             &self.0.runtime,
             &self.0.run_id,
             Self::NAME,
+            &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
             async {
                 let output =
@@ -186,13 +194,12 @@ impl rig::tool::Tool for ReplaceInFileTool {
     type Args = ReplaceInFileArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Apply an exact text replacement inside an existing UTF-8 file."
-                .to_string(),
-            parameters: json!(schemars::schema_for!(ReplaceInFileArgs)),
-        }
+    fn description(&self) -> String {
+        "Apply an exact text replacement inside an existing UTF-8 file.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schemars::schema_for!(ReplaceInFileArgs))
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -200,6 +207,7 @@ impl rig::tool::Tool for ReplaceInFileTool {
             &self.0.runtime,
             &self.0.run_id,
             Self::NAME,
+            &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
             async {
                 let output = replace_workspace_file(
@@ -226,6 +234,7 @@ async fn execute_tool_job<F>(
     runtime: &RuntimeClient,
     run_id: &str,
     kind: &str,
+    tool_call_tracker: &ToolCallTracker,
     payload: serde_json::Value,
     future: F,
 ) -> Result<serde_json::Value, AgentToolError>
@@ -236,6 +245,9 @@ where
     let mut begin_args = runtime.args_with_actor();
     begin_args.insert("runId".to_string(), run_id.to_string().into());
     begin_args.insert("kind".to_string(), kind.to_string().into());
+    if let Some(call_id) = tool_call_tracker.claim(kind, &payload) {
+        begin_args.insert("callId".to_string(), call_id.into());
+    }
     begin_args.insert(
         "payload".to_string(),
         Value::try_from(payload.clone()).map_err(tool_error)?,

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -62,6 +62,8 @@ pub enum AgentHistoryRole {
 pub enum AgentHistoryContent {
     Text {
         text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        additional_params_json: Option<String>,
     },
     Reasoning {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -149,7 +151,7 @@ fn from_json_string<T: for<'de> Deserialize<'de>>(value: &str, what: &str) -> an
 impl AgentHistoryContent {
     fn into_user_content(self) -> anyhow::Result<UserContent> {
         match self {
-            Self::Text { text } => Ok(UserContent::Text(Text::new(text))),
+            Self::Text { text, .. } => Ok(UserContent::Text(Text::new(text))),
             Self::ToolResult { id, call_id, items } => Ok(UserContent::ToolResult(ToolResult {
                 id,
                 call_id,
@@ -185,7 +187,16 @@ impl AgentHistoryContent {
 
     fn into_assistant_content(self) -> anyhow::Result<AssistantContent> {
         match self {
-            Self::Text { text } => Ok(AssistantContent::Text(Text::new(text))),
+            Self::Text {
+                text,
+                additional_params_json,
+            } => Ok(AssistantContent::Text(Text {
+                text,
+                additional_params: additional_params_json
+                    .as_deref()
+                    .map(|json| from_json_string(json, "text additional params"))
+                    .transpose()?,
+            })),
             Self::Reasoning { id, blocks_json } => Ok(AssistantContent::Reasoning(
                 serde_json::from_value(serde_json::json!({
                     "id": id,
@@ -252,7 +263,7 @@ impl TryFrom<AgentHistoryMessage> for Message {
                     .contents
                     .into_iter()
                     .find_map(|content| match content {
-                        AgentHistoryContent::Text { text } => Some(text),
+                        AgentHistoryContent::Text { text, .. } => Some(text),
                         _ => None,
                     })
                     .ok_or_else(|| anyhow!("system history message is missing text content"))?;
@@ -349,6 +360,51 @@ mod tests {
                 other => panic!("expected user tool result, got {other:?}"),
             },
             other => panic!("expected user message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn restores_assistant_text_metadata_while_accepting_plain_user_text() {
+        let history: Vec<AgentHistoryMessage> = serde_json::from_value(serde_json::json!([
+            {
+                "role": "user",
+                "contents": [{ "type": "text", "text": "hello" }]
+            },
+            {
+                "role": "assistant",
+                "contents": [{
+                    "type": "text",
+                    "text": "hi",
+                    "additionalParamsJson": "{\"openai\":{\"itemId\":\"msg_123\"}}"
+                }]
+            }
+        ]))
+        .expect("history wire format");
+
+        let messages = deserialize_agent_history(history).expect("messages");
+
+        match &messages[0] {
+            Message::User { content } => match content.iter().next() {
+                Some(UserContent::Text(text)) => {
+                    assert_eq!(text.text, "hello");
+                    assert!(text.additional_params.is_none());
+                }
+                other => panic!("expected user text, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
+        match &messages[1] {
+            Message::Assistant { content, .. } => match content.iter().next() {
+                Some(AssistantContent::Text(text)) => {
+                    assert_eq!(text.text, "hi");
+                    assert_eq!(
+                        text.additional_params.as_ref().unwrap()["openai"]["itemId"],
+                        "msg_123"
+                    );
+                }
+                other => panic!("expected assistant text, got {other:?}"),
+            },
+            other => panic!("expected assistant message, got {other:?}"),
         }
     }
 }

--- a/crates/sprocket-convex-provider/Cargo.toml
+++ b/crates/sprocket-convex-provider/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 anyhow = "1.0.102"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 futures = "0.3.32"
-rig = { package = "rig-core", version = "0.39.0", default-features = false }
+rig = { package = "rig-core", version = "0.40.0", default-features = false }
 rustls = { version = "0.23.40", features = ["ring"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -11,7 +11,7 @@ use rig::completion::{
     AssistantContent, CompletionError, CompletionModel as RigCompletionModel, CompletionRequest,
     CompletionResponse, GetTokenUsage, ToolDefinition, Usage as RigUsage,
 };
-use rig::message::{ToolCall as RigToolCall, ToolChoice, ToolFunction};
+use rig::message::{ReasoningContent, ToolCall as RigToolCall, ToolChoice, ToolFunction};
 use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
 use rustls::crypto::ring::default_provider;
 use serde::{Deserialize, Serialize};
@@ -127,6 +127,41 @@ pub struct CompletionOutput {
     pub message_id: Option<String>,
     #[serde(default)]
     pub tool_calls: Vec<ToolCall>,
+    #[serde(default)]
+    pub stream_events: Vec<CompletionStreamEvent>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum CompletionStreamEvent {
+    Text {
+        id: String,
+        text: String,
+        #[serde(default)]
+        turn_id: Option<String>,
+        #[serde(default)]
+        provider_metadata: Option<serde_json::Value>,
+    },
+    Reasoning {
+        id: String,
+        text: String,
+        #[serde(default)]
+        provider_reasoning_id: Option<String>,
+        #[serde(default)]
+        provider_metadata: Option<serde_json::Value>,
+    },
+    ToolCall {
+        part_id: String,
+        call_id: String,
+        name: String,
+        input: serde_json::Value,
+        #[serde(default)]
+        provider_metadata: Option<serde_json::Value>,
+    },
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -190,6 +225,8 @@ pub struct ToolCall {
     pub id: String,
     pub name: String,
     pub arguments: serde_json::Value,
+    #[serde(default)]
+    pub provider_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -255,17 +292,83 @@ impl RigCompletionModel for CompletionModel {
         let completion = self.completion(request).await?;
         let mut chunks: Vec<Result<RawStreamingChoice<CompletionOutput>, CompletionError>> =
             Vec::new();
-        if !completion.raw_response.text.is_empty() {
-            chunks.push(Ok(RawStreamingChoice::Message(
-                completion.raw_response.text.clone(),
-            )));
-        }
-        for tool_call in &completion.raw_response.tool_calls {
-            chunks.push(Ok(RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
-                tool_call.id.clone(),
-                tool_call.name.clone(),
-                tool_call.arguments.clone(),
-            ))));
+        if completion.raw_response.stream_events.is_empty() {
+            if !completion.raw_response.text.is_empty() {
+                chunks.push(Ok(RawStreamingChoice::Message(
+                    completion.raw_response.text.clone(),
+                )));
+            }
+            for tool_call in &completion.raw_response.tool_calls {
+                chunks.push(Ok(RawStreamingChoice::ToolCall(
+                    RawStreamingToolCall::new(
+                        tool_call.id.clone(),
+                        tool_call.name.clone(),
+                        tool_call.arguments.clone(),
+                    )
+                    .with_call_id(tool_call.id.clone())
+                    .with_additional_params(tool_call.provider_metadata.clone()),
+                )));
+            }
+        } else {
+            for event in &completion.raw_response.stream_events {
+                match event {
+                    CompletionStreamEvent::Text {
+                        text,
+                        provider_metadata,
+                        ..
+                    } => chunks.extend(
+                        text_stream_choices(text, provider_metadata)
+                            .into_iter()
+                            .map(Ok),
+                    ),
+                    CompletionStreamEvent::Reasoning {
+                        text,
+                        provider_reasoning_id,
+                        provider_metadata,
+                        ..
+                    } => {
+                        let id = provider_reasoning_id.clone().or_else(|| {
+                            provider_metadata
+                                .as_ref()
+                                .and_then(|metadata| metadata.pointer("/openai/itemId"))
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_owned)
+                        });
+                        if !text.is_empty() {
+                            chunks.push(Ok(RawStreamingChoice::Reasoning {
+                                id: id.clone(),
+                                content: ReasoningContent::Text {
+                                    text: text.clone(),
+                                    signature: None,
+                                },
+                            }));
+                        }
+                        if let Some(encrypted) = provider_metadata
+                            .as_ref()
+                            .and_then(|metadata| {
+                                metadata.pointer("/openai/reasoningEncryptedContent")
+                            })
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            chunks.push(Ok(RawStreamingChoice::Reasoning {
+                                id,
+                                content: ReasoningContent::Encrypted(encrypted.to_owned()),
+                            }));
+                        }
+                    }
+                    CompletionStreamEvent::ToolCall {
+                        call_id,
+                        name,
+                        input,
+                        provider_metadata,
+                        ..
+                    } => chunks.push(Ok(RawStreamingChoice::ToolCall(
+                        RawStreamingToolCall::new(call_id.clone(), name.clone(), input.clone())
+                            .with_call_id(call_id.clone())
+                            .with_additional_params(provider_metadata.clone()),
+                    ))),
+                }
+            }
         }
         chunks.push(Ok(RawStreamingChoice::FinalResponse(
             completion.raw_response.clone(),
@@ -273,6 +376,18 @@ impl RigCompletionModel for CompletionModel {
         let stream = stream::iter(chunks);
         Ok(StreamingCompletionResponse::stream(Box::pin(stream)))
     }
+}
+
+fn text_stream_choices(
+    text: &str,
+    provider_metadata: &Option<serde_json::Value>,
+) -> [RawStreamingChoice<CompletionOutput>; 2] {
+    [
+        RawStreamingChoice::TextStart {
+            additional_params: provider_metadata.clone(),
+        },
+        RawStreamingChoice::Message(text.to_owned()),
+    ]
 }
 
 async fn call_completion_action(
@@ -372,6 +487,11 @@ fn parse_completion_output(value: Value) -> Result<CompletionOutput, CompletionE
     for tool_call in &mut output.tool_calls {
         normalize_convex_json_numbers(&mut tool_call.arguments);
     }
+    for event in &mut output.stream_events {
+        if let CompletionStreamEvent::ToolCall { input, .. } = event {
+            normalize_convex_json_numbers(input);
+        }
+    }
 
     eprintln!(
         "sprocket-convex-provider: completion output text_len={} tool_calls={}",
@@ -396,10 +516,13 @@ fn completion_choice(output: &CompletionOutput) -> OneOrMany<AssistantContent> {
         parts.push(AssistantContent::text(output.text.clone()));
     }
     parts.extend(output.tool_calls.iter().map(|tool_call| {
-        AssistantContent::ToolCall(RigToolCall::new(
-            tool_call.id.clone(),
-            ToolFunction::new(tool_call.name.clone(), tool_call.arguments.clone()),
-        ))
+        AssistantContent::ToolCall(RigToolCall {
+            id: tool_call.id.clone(),
+            call_id: Some(tool_call.id.clone()),
+            function: ToolFunction::new(tool_call.name.clone(), tool_call.arguments.clone()),
+            signature: None,
+            additional_params: tool_call.provider_metadata.clone(),
+        })
     }));
 
     OneOrMany::many(parts).unwrap_or_else(|_| OneOrMany::one(AssistantContent::text(String::new())))
@@ -436,4 +559,98 @@ where
     }
 
     Ok(value as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompletionOutput, CompletionStreamEvent, ToolCall, Usage, completion_choice,
+        text_stream_choices,
+    };
+    use rig::message::AssistantContent;
+    use rig::streaming::RawStreamingChoice;
+
+    #[test]
+    fn deserializes_and_streams_typescript_text_metadata() {
+        let event: CompletionStreamEvent = serde_json::from_value(serde_json::json!({
+            "type": "text",
+            "id": "turn-1:text:output-1",
+            "text": "hello",
+            "turnId": "turn-1",
+            "providerMetadata": { "openai": { "itemId": "msg_123" } }
+        }))
+        .expect("TypeScript text stream event should deserialize");
+
+        let CompletionStreamEvent::Text {
+            text,
+            turn_id,
+            provider_metadata,
+            ..
+        } = event
+        else {
+            panic!("expected text event");
+        };
+        assert_eq!(turn_id.as_deref(), Some("turn-1"));
+
+        let choices = text_stream_choices(&text, &provider_metadata);
+        let RawStreamingChoice::TextStart { additional_params } = &choices[0] else {
+            panic!("expected text-start event before text");
+        };
+        assert_eq!(
+            additional_params.as_ref().unwrap()["openai"]["itemId"],
+            "msg_123"
+        );
+        assert!(matches!(&choices[1], RawStreamingChoice::Message(value) if value == "hello"));
+    }
+
+    #[test]
+    fn deserializes_typescript_tool_call_stream_event() {
+        let event: CompletionStreamEvent = serde_json::from_value(serde_json::json!({
+            "type": "toolCall",
+            "partId": "turn-1:tool:call_123",
+            "callId": "call_123",
+            "name": "exec_command",
+            "input": { "cmd": "pwd" },
+            "turnId": "turn-1",
+            "providerMetadata": { "openai": { "itemId": "fc_123" } }
+        }))
+        .expect("TypeScript stream event should deserialize");
+
+        match event {
+            CompletionStreamEvent::ToolCall {
+                part_id,
+                call_id,
+                provider_metadata,
+                ..
+            } => {
+                assert_eq!(part_id, "turn-1:tool:call_123");
+                assert_eq!(call_id, "call_123");
+                assert_eq!(provider_metadata.unwrap()["openai"]["itemId"], "fc_123");
+            }
+            other => panic!("expected tool-call event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completion_choice_preserves_provider_call_id() {
+        let output = CompletionOutput {
+            text: String::new(),
+            usage: Usage::default(),
+            message_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_123".to_string(),
+                name: "exec_command".to_string(),
+                arguments: serde_json::json!({ "cmd": "pwd" }),
+                provider_metadata: None,
+            }],
+            stream_events: Vec::new(),
+        };
+
+        let choice = completion_choice(&output);
+        let AssistantContent::ToolCall(tool_call) = choice.first() else {
+            panic!("expected tool call");
+        };
+        assert_eq!(tool_call.id, "call_123");
+        assert_eq!(tool_call.call_id.as_deref(), Some("call_123"));
+    }
 }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use convex::{ConvexClient, FunctionResult, Value};
+use convex::{ConvexClient, FunctionResult, QuerySubscription, Value};
 use futures::stream;
 use rig::OneOrMany;
 use rig::client::{CompletionClient, ProviderClient};
@@ -21,6 +21,12 @@ use tokio::time::timeout;
 use crate::messages::{build_model_messages, instructions_text, normalize_convex_json_numbers};
 
 const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+
+pub const COMPLETION_STREAM_SUPERSEDED: &str = "SPROCKET_COMPLETION_STREAM_SUPERSEDED";
+
+pub fn is_completion_stream_superseded(error: &(impl std::fmt::Display + ?Sized)) -> bool {
+    error.to_string().contains(COMPLETION_STREAM_SUPERSEDED)
+}
 
 #[derive(Clone)]
 pub struct Client {
@@ -62,6 +68,18 @@ impl Client {
         timeout(CONVEX_RPC_TIMEOUT, convex.query(function, args))
             .await
             .with_context(|| format!("query timed out for {function}"))?
+            .map_err(Into::into)
+    }
+
+    pub async fn subscribe(
+        &self,
+        function: &str,
+        args: BTreeMap<String, Value>,
+    ) -> anyhow::Result<QuerySubscription> {
+        let mut convex = self.inner.lock().await;
+        timeout(CONVEX_RPC_TIMEOUT, convex.subscribe(function, args))
+            .await
+            .with_context(|| format!("subscription timed out for {function}"))?
             .map_err(Into::into)
     }
 
@@ -564,9 +582,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        CompletionOutput, CompletionStreamEvent, ToolCall, Usage, completion_choice,
-        text_stream_choices,
+        COMPLETION_STREAM_SUPERSEDED, CompletionOutput, CompletionStreamEvent, ToolCall, Usage,
+        completion_choice, is_completion_stream_superseded, text_stream_choices,
     };
+    use rig::completion::CompletionError;
     use rig::message::AssistantContent;
     use rig::streaming::RawStreamingChoice;
 
@@ -652,5 +671,14 @@ mod tests {
         };
         assert_eq!(tool_call.id, "call_123");
         assert_eq!(tool_call.call_id.as_deref(), Some("call_123"));
+    }
+
+    #[test]
+    fn recognizes_superseded_stream_signal_inside_provider_errors() {
+        let error = CompletionError::ProviderError(format!(
+            "completion:complete failed: {COMPLETION_STREAM_SUPERSEDED}"
+        ));
+
+        assert!(is_completion_stream_superseded(&error));
     }
 }

--- a/crates/sprocket-convex-provider/src/lib.rs
+++ b/crates/sprocket-convex-provider/src/lib.rs
@@ -2,6 +2,6 @@ mod client;
 mod messages;
 
 pub use client::{
-    Client, CompletionModel, CompletionOutput, InputTokenDetails, OutputTokenDetails, ToolCall,
-    Usage,
+    COMPLETION_STREAM_SUPERSEDED, Client, CompletionModel, CompletionOutput, InputTokenDetails,
+    OutputTokenDetails, ToolCall, Usage, is_completion_stream_superseded,
 };

--- a/crates/sprocket-convex-provider/src/messages.rs
+++ b/crates/sprocket-convex-provider/src/messages.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use rig::completion::{CompletionError, CompletionRequest, Message};
-use rig::message::{AssistantContent, ToolResultContent, UserContent};
+use rig::message::{AssistantContent, ReasoningContent, ToolResultContent, UserContent};
 
 pub(crate) fn build_model_messages(
     request: &CompletionRequest,
@@ -68,30 +68,60 @@ pub(crate) fn build_model_messages(
                 for item in content.iter() {
                     match item {
                         AssistantContent::Text(text) => {
-                            parts.push(serde_json::json!({
+                            let mut part = serde_json::json!({
                                 "type": "text",
                                 "text": text.text.clone()
-                            }));
+                            });
+                            if let Some(provider_options) = &text.additional_params {
+                                part["providerOptions"] = provider_options.clone();
+                            }
+                            parts.push(part);
                         }
                         AssistantContent::Reasoning(reasoning) => {
-                            let text: String = reasoning.display_text();
-                            if !text.is_empty() {
-                                parts.push(serde_json::json!({
-                                    "type": "text",
+                            let encrypted = reasoning.content.iter().find_map(|content| {
+                                if let ReasoningContent::Encrypted(value) = content {
+                                    Some(value.clone())
+                                } else {
+                                    None
+                                }
+                            });
+                            let mut openai = serde_json::Map::new();
+                            if let Some(id) = &reasoning.id {
+                                openai.insert("itemId".to_string(), id.clone().into());
+                            }
+                            if let Some(encrypted) = encrypted {
+                                openai.insert(
+                                    "reasoningEncryptedContent".to_string(),
+                                    encrypted.into(),
+                                );
+                            }
+                            let text = reasoning.display_text();
+                            if !text.is_empty() || !openai.is_empty() {
+                                let mut part = serde_json::json!({
+                                    "type": "reasoning",
                                     "text": text
-                                }));
+                                });
+                                if !openai.is_empty() {
+                                    part["providerOptions"] =
+                                        serde_json::json!({ "openai": openai });
+                                }
+                                parts.push(part);
                             }
                         }
                         AssistantContent::ToolCall(tool_call) => {
                             let tool_call_id: String = tool_call.id.clone();
                             tool_names_by_call_id
                                 .insert(tool_call_id.clone(), tool_call.function.name.clone());
-                            parts.push(serde_json::json!({
+                            let mut part = serde_json::json!({
                                 "type": "tool-call",
                                 "toolCallId": tool_call_id,
                                 "toolName": tool_call.function.name.clone(),
                                 "input": tool_call.function.arguments.clone()
-                            }));
+                            });
+                            if let Some(provider_options) = &tool_call.additional_params {
+                                part["providerOptions"] = provider_options.clone();
+                            }
+                            parts.push(part);
                         }
                         _ => {
                             return Err(CompletionError::ProviderError(
@@ -168,7 +198,7 @@ pub(crate) fn instructions_text(request: &CompletionRequest) -> Option<String> {
 mod tests {
     use rig::OneOrMany;
     use rig::completion::{CompletionRequest, Message};
-    use rig::message::{AssistantContent, UserContent};
+    use rig::message::{AssistantContent, Text, UserContent};
 
     use super::{build_model_messages, instructions_text, normalize_convex_json_numbers};
 
@@ -279,6 +309,38 @@ mod tests {
         assert_eq!(
             array[2]["content"][0]["output"]["value"]["contents"],
             "fn main() {}"
+        );
+    }
+
+    #[test]
+    fn preserves_assistant_text_provider_options() {
+        let messages = OneOrMany::one(Message::Assistant {
+            id: None,
+            content: OneOrMany::one(AssistantContent::Text(Text {
+                text: "Grounded answer".to_string(),
+                additional_params: Some(serde_json::json!({
+                    "openai": { "itemId": "msg_123" }
+                })),
+            })),
+        });
+
+        let structured = build_model_messages(&CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: messages,
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        })
+        .expect("structured");
+
+        assert_eq!(
+            structured[0]["content"][0]["providerOptions"],
+            serde_json::json!({ "openai": { "itemId": "msg_123" } })
         );
     }
 

--- a/crates/sprocket-workspace/Cargo.toml
+++ b/crates/sprocket-workspace/Cargo.toml
@@ -7,8 +7,10 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.102"
 gix = { version = "0.85.0", default-features = false, features = ["sha1", "status"] }
+libc = "0.2.186"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full"] }
+tokio-util = "0.7.18"
 walkdir = "2.5.0"

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -11,8 +11,9 @@ pub use browse::{
     resolve_or_create_workspace_root,
 };
 pub use tools::{
-    CommandExecOutput, FileEditOutput, FileWriteOutput, create_workspace_file,
-    exec_workspace_command, replace_workspace_file,
+    CommandExecOutput, FileEditOutput, FileWriteOutput, WorkspaceCancellation,
+    WorkspaceOperationCancelled, create_workspace_file, exec_workspace_command,
+    replace_workspace_file,
 };
 pub use workspace::{WorkspaceEntry, WorkspaceOverview};
 pub use workspace::{build_workspace_overview, resolve_workspace_root};

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -419,16 +419,23 @@ pub async fn replace_workspace_file(
 mod tests {
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{WorkspaceCancellation, WorkspaceOperationCancelled, WorkspaceTools};
 
+    static TEMP_WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     fn temp_workspace() -> PathBuf {
-        let unique = SystemTime::now()
+        let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock should be after unix epoch")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("sprocket-workspace-tests-{unique}"));
+        let counter = TEMP_WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "sprocket-workspace-tests-{timestamp}-{}-{counter}",
+            std::process::id()
+        ));
         fs::create_dir_all(&path).expect("temp dir should be created");
         path
     }

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 use crate::text::limit_chars;
@@ -7,20 +7,54 @@ use crate::workspace::{relative_to_root, resolve_workspace_path};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
+use tokio_util::sync::CancellationToken;
 
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_COMMAND_MAX_OUTPUT_CHARS: usize = 20_000;
 const MAX_COMMAND_MAX_OUTPUT_CHARS: usize = 80_000;
 
+#[derive(Clone, Debug, Default)]
+pub struct WorkspaceCancellation(CancellationToken);
+
+impl WorkspaceCancellation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.0.cancel();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.is_cancelled()
+    }
+
+    async fn cancelled(&self) {
+        self.0.cancelled().await;
+    }
+
+    fn ensure_active(&self) -> Result<()> {
+        if self.is_cancelled() {
+            return Err(WorkspaceOperationCancelled.into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("workspace operation was cancelled")]
+pub struct WorkspaceOperationCancelled;
+
 #[derive(Clone)]
 pub(crate) struct WorkspaceTools {
     root: PathBuf,
+    cancellation: WorkspaceCancellation,
 }
 
 impl WorkspaceTools {
-    pub(crate) fn new(root: PathBuf) -> Self {
-        Self { root }
+    pub(crate) fn new(root: PathBuf, cancellation: WorkspaceCancellation) -> Self {
+        Self { root, cancellation }
     }
 
     fn root(&self) -> &PathBuf {
@@ -36,6 +70,7 @@ impl WorkspaceTools {
         timeout_ms: Option<u64>,
         max_output_chars: Option<usize>,
     ) -> Result<CommandExecOutput> {
+        self.cancellation.ensure_active()?;
         if command.trim().is_empty() {
             bail!("command cannot be empty");
         }
@@ -50,28 +85,68 @@ impl WorkspaceTools {
             .current_dir(&cwd)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        process.process_group(0);
 
+        self.cancellation.ensure_active()?;
         let mut child = process
             .spawn()
             .with_context(|| format!("failed to start command in {}", cwd.display()))?;
+        let process_id = child.id();
         let stdout_task = tokio::spawn(read_pipe(child.stdout.take()));
         let stderr_task = tokio::spawn(read_pipe(child.stderr.take()));
 
         let timeout =
             Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_COMMAND_TIMEOUT_MS).max(1));
-        let (status, timed_out) = match tokio::time::timeout(timeout, child.wait()).await {
-            Ok(status) => (
-                status
-                    .with_context(|| format!("failed to wait for command in {}", cwd.display()))?,
-                false,
+        let wait = tokio::time::sleep(timeout);
+        tokio::pin!(wait);
+        let outcome = tokio::select! {
+            biased;
+            _ = self.cancellation.cancelled() => CommandWaitOutcome::Cancelled,
+            status = child.wait() => CommandWaitOutcome::Exited(status),
+            _ = &mut wait => CommandWaitOutcome::TimedOut,
+        };
+        let (status, timed_out) = match outcome {
+            CommandWaitOutcome::Exited(Ok(status)) => {
+                if let Err(error) = stop_processes_after_shell_exit(process_id) {
+                    stdout_task.abort();
+                    stderr_task.abort();
+                    let _ = stdout_task.await;
+                    let _ = stderr_task.await;
+                    return Err(error).with_context(|| {
+                        format!("failed to stop command descendants in {}", cwd.display())
+                    });
+                }
+                (status, false)
+            }
+            CommandWaitOutcome::Exited(Err(error)) => {
+                let _ = terminate_child(&mut child, process_id).await;
+                return Err(error)
+                    .with_context(|| format!("failed to wait for command in {}", cwd.display()));
+            }
+            CommandWaitOutcome::TimedOut => (
+                terminate_child(&mut child, process_id)
+                    .await
+                    .with_context(|| {
+                        format!("failed to stop timed out command in {}", cwd.display())
+                    })?,
+                true,
             ),
-            Err(_) => {
-                let _ = child.kill().await;
-                let status = child.wait().await.with_context(|| {
-                    format!("failed to stop timed out command in {}", cwd.display())
-                })?;
-                (status, true)
+            CommandWaitOutcome::Cancelled => {
+                let termination =
+                    terminate_child(&mut child, process_id)
+                        .await
+                        .with_context(|| {
+                            format!("failed to stop cancelled command in {}", cwd.display())
+                        });
+                stdout_task.abort();
+                stderr_task.abort();
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+                termination?;
+                return Err(WorkspaceOperationCancelled.into());
             }
         };
 
@@ -94,6 +169,7 @@ impl WorkspaceTools {
     }
 
     async fn create_file(&self, relative_path: &str, content: &str) -> Result<FileWriteOutput> {
+        self.cancellation.ensure_active()?;
         let path = resolve_workspace_path(self.root(), relative_path, true)?;
         if tokio::fs::try_exists(&path)
             .await
@@ -103,11 +179,13 @@ impl WorkspaceTools {
         }
 
         if let Some(parent) = path.parent() {
+            self.cancellation.ensure_active()?;
             tokio::fs::create_dir_all(parent)
                 .await
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
 
+        self.cancellation.ensure_active()?;
         tokio::fs::write(&path, content.as_bytes())
             .await
             .with_context(|| format!("failed to write {}", path.display()))?;
@@ -125,6 +203,7 @@ impl WorkspaceTools {
         new_text: &str,
         replace_all: bool,
     ) -> Result<FileEditOutput> {
+        self.cancellation.ensure_active()?;
         if old_text.is_empty() {
             bail!("old_text cannot be empty");
         }
@@ -153,6 +232,7 @@ impl WorkspaceTools {
             contents.replacen(old_text, new_text, 1)
         };
 
+        self.cancellation.ensure_active()?;
         tokio::fs::write(&path, next_contents.as_bytes())
             .await
             .with_context(|| format!("failed to write {}", path.display()))?;
@@ -163,6 +243,62 @@ impl WorkspaceTools {
             bytes_written: next_contents.len(),
         })
     }
+}
+
+enum CommandWaitOutcome {
+    Exited(std::io::Result<ExitStatus>),
+    TimedOut,
+    Cancelled,
+}
+
+async fn terminate_child(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
+    let tree_result = stop_remaining_processes(process_id);
+    let _ = child.start_kill();
+    let wait_result = child.wait().await;
+    tree_result?;
+    wait_result.map_err(Into::into)
+}
+
+#[cfg(unix)]
+fn stop_remaining_processes(process_id: Option<u32>) -> Result<()> {
+    if let Some(pid) = process_id {
+        // The shell is started as the leader of a new process group, so signalling the
+        // negative pid also stops commands spawned by that shell.
+        let result = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error.into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn stop_processes_after_shell_exit(process_id: Option<u32>) -> Result<()> {
+    stop_remaining_processes(process_id)
+}
+
+#[cfg(windows)]
+fn stop_remaining_processes(process_id: Option<u32>) -> Result<()> {
+    if let Some(pid) = process_id {
+        std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .context("failed to start taskkill")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn stop_processes_after_shell_exit(_process_id: Option<u32>) -> Result<()> {
+    Ok(())
 }
 
 #[cfg(not(windows))]
@@ -242,6 +378,7 @@ pub struct FileEditOutput {
 
 pub async fn exec_workspace_command(
     workspace_root: PathBuf,
+    cancellation: WorkspaceCancellation,
     command: &str,
     workdir: Option<&str>,
     shell: Option<&str>,
@@ -249,29 +386,31 @@ pub async fn exec_workspace_command(
     timeout_ms: Option<u64>,
     max_output_chars: Option<usize>,
 ) -> Result<CommandExecOutput> {
-    WorkspaceTools::new(workspace_root)
+    WorkspaceTools::new(workspace_root, cancellation)
         .exec_command(command, workdir, shell, login, timeout_ms, max_output_chars)
         .await
 }
 
 pub async fn create_workspace_file(
     workspace_root: PathBuf,
+    cancellation: WorkspaceCancellation,
     path: &str,
     content: &str,
 ) -> Result<FileWriteOutput> {
-    WorkspaceTools::new(workspace_root)
+    WorkspaceTools::new(workspace_root, cancellation)
         .create_file(path, content)
         .await
 }
 
 pub async fn replace_workspace_file(
     workspace_root: PathBuf,
+    cancellation: WorkspaceCancellation,
     path: &str,
     old_text: &str,
     new_text: &str,
     replace_all: bool,
 ) -> Result<FileEditOutput> {
-    WorkspaceTools::new(workspace_root)
+    WorkspaceTools::new(workspace_root, cancellation)
         .replace_in_file(path, old_text, new_text, replace_all)
         .await
 }
@@ -280,9 +419,9 @@ pub async fn replace_workspace_file(
 mod tests {
     use std::fs;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use super::WorkspaceTools;
+    use super::{WorkspaceCancellation, WorkspaceOperationCancelled, WorkspaceTools};
 
     fn temp_workspace() -> PathBuf {
         let unique = SystemTime::now()
@@ -297,7 +436,7 @@ mod tests {
     #[tokio::test]
     async fn exec_command_runs_inside_workspace_root() {
         let root = temp_workspace();
-        let tools = WorkspaceTools::new(root.clone());
+        let tools = WorkspaceTools::new(root.clone(), WorkspaceCancellation::new());
 
         let output = tools
             .exec_command("pwd", None, None, Some(false), Some(5_000), None)
@@ -316,7 +455,7 @@ mod tests {
     #[tokio::test]
     async fn exec_command_rejects_workdir_outside_workspace() {
         let root = temp_workspace();
-        let tools = WorkspaceTools::new(root.clone());
+        let tools = WorkspaceTools::new(root.clone(), WorkspaceCancellation::new());
 
         let result = tools
             .exec_command("pwd", Some("../"), None, Some(false), Some(5_000), None)
@@ -333,12 +472,66 @@ mod tests {
         let path = root.join("src.txt");
         fs::write(&path, "alpha\nalpha\n").expect("fixture should be written");
 
-        let tools = WorkspaceTools::new(root.clone());
+        let tools = WorkspaceTools::new(root.clone(), WorkspaceCancellation::new());
         let result = tools
             .replace_in_file("src.txt", "alpha", "beta", false)
             .await;
 
         assert!(result.is_err());
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[tokio::test]
+    async fn cancelled_create_and_replace_do_not_mutate_files() {
+        let root = temp_workspace();
+        let existing = root.join("existing.txt");
+        fs::write(&existing, "before").expect("fixture should be written");
+        let cancellation = WorkspaceCancellation::new();
+        cancellation.cancel();
+        let tools = WorkspaceTools::new(root.clone(), cancellation);
+
+        let create_error = tools
+            .create_file("created.txt", "content")
+            .await
+            .expect_err("cancelled create should fail");
+        let replace_error = tools
+            .replace_in_file("existing.txt", "before", "after", false)
+            .await
+            .expect_err("cancelled replace should fail");
+
+        assert!(create_error.is::<WorkspaceOperationCancelled>());
+        assert!(replace_error.is::<WorkspaceOperationCancelled>());
+        assert!(!root.join("created.txt").exists());
+        assert_eq!(fs::read_to_string(existing).unwrap(), "before");
+
+        fs::remove_dir_all(root).expect("temp dir should be removed");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelling_command_stops_spawned_descendants() {
+        let root = temp_workspace();
+        let cancellation = WorkspaceCancellation::new();
+        let tools = WorkspaceTools::new(root.clone(), cancellation.clone());
+        let command = tools.exec_command(
+            "sh -c 'sleep 0.2; touch leaked.txt' & wait",
+            None,
+            None,
+            Some(false),
+            Some(5_000),
+            None,
+        );
+        tokio::pin!(command);
+
+        tokio::select! {
+            result = &mut command => panic!("command exited before cancellation: {result:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(25)) => cancellation.cancel(),
+        }
+        let error = command.await.expect_err("cancelled command should fail");
+        assert!(error.is::<WorkspaceOperationCancelled>());
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(!root.join("leaked.txt").exists());
 
         fs::remove_dir_all(root).expect("temp dir should be removed");
     }


### PR DESCRIPTION
## What changed

- Persist assistant text, reasoning, tool calls, results, turn identity, and provider metadata in streaming order.
- Make Convex stream batches retry-safe with bounded attempt/sequence deduplication.
- Preserve OpenAI text/reasoning metadata through Convex, Rig, and canonical follow-up history.
- Correlate executor jobs with provider tool-call IDs and keep parallel calls/results protocol-correct.
- Remove abandoned retry turns without discarding valid siblings.
- Render a chronological, accessible assistant timeline with durable tool failure/cancellation state.
- Upgrade `rig-core` to 0.40 and migrate the agent hook/stream integration.
- Update the repository agent instructions included in the original worktree.

## Why

The previous flow repeatedly replaced a flattened assistant message while Rig separately reconstructed tool execution. That lost provider metadata and ordering, made ambiguous retries capable of duplicating content, and could replay tool calls/results in an invalid protocol shape on later model turns.

## Impact

Streaming transcripts now remain stable during retries and failures, tool activity appears in the correct chronological position, and subsequent agent turns receive faithful text, reasoning, and tool history across completed, failed, and cancelled runs.

## Validation

- `cargo test`
- `bun run test` (58 tests)
- `bun convex dev --once` from `apps/web`
- `bun run build`
- `prek run -a`
- Independent overall reliability review and UI/API-quality review, followed by fix/review loops until clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves streamed assistant responses as ordered, durable agent parts. The main changes are:

- Streaming text, reasoning, tool calls, and metadata are stored in sequence.
- Completion stream batches get attempt and sequence fencing.
- Executor jobs are correlated with provider tool-call IDs.
- Assistant history and timeline rendering now use structured parts.
- Rig is upgraded and the agent hook integration is migrated.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The structured streaming flow is close, with one remaining correctness issue in legacy tool-job reconciliation.

Superseded stream attempts now exit without failing the shared run, finalized assistant text is preserved when provisional tool calls are removed, and legacy jobs without provider call IDs can still swap results when parallel same-name calls finish in a different order.

apps/web/src/convex/lib/assistantParts.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The harness reproduced ambiguous reattachment of two same-name legacy jobs by name using two streaming tool calls and two persisted jobs, demonstrating the swapped association.
- The harness assertions passed and logged the streamed order, job order, returned part order, replacement callIds, payloads, and tool-result outputs, confirming the swapped mapping.
- Validation runs completed: the cargo test suite finished with exit code 0, the web tests finished with 75 passed and exit code 0, and the build completed with 3 tasks successful and exit code 0.

<a href="https://app.greptile.com/trex/runs/14257518/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/completionStream.ts | Adds stream attempt and sequence classification for duplicate and superseded batches. |
| apps/web/src/convex/agentRuntime.ts | Merges streamed assistant events and reconciles final run state with executor jobs. |
| apps/web/src/convex/lib/assistantParts.ts | Builds assistant part reconciliation and tool-job matching, with one remaining ambiguous legacy-job pairing issue. |
| apps/web/src/lib/chat/assistant-timeline.ts | Renders assistant text, reasoning, tool calls, and tool results as a chronological timeline. |
| crates/sprocket-agent/src/hooks.rs | Tracks provider tool-call IDs through Rig hook events and avoids claiming ambiguous normalized calls. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FassistantParts.ts%3A223-226%0A**Ambiguous%20Jobs%20Reattach%20By%20Name**%0A%0AWhen%20two%20legacy%20same-name%20tool%20jobs%20have%20no%20%60callId%60%2C%20this%20fallback%20can%20assign%20them%20to%20streamed%20calls%20by%20part%20order%20instead%20of%20the%20job's%20real%20provider%20call.%20If%20the%20jobs%20are%20persisted%20in%20the%20opposite%20order%20from%20the%20streamed%20calls%2C%20finalization%20writes%20each%20job%20result%20next%20to%20the%20wrong%20tool%20input%2C%20and%20later%20history%20can%20replay%20swapped%20tool%20outputs.%0A%0A&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FassistantParts.ts%3A223-226%0A**Ambiguous%20Jobs%20Reattach%20By%20Name**%0A%0AWhen%20two%20legacy%20same-name%20tool%20jobs%20have%20no%20%60callId%60%2C%20this%20fallback%20can%20assign%20them%20to%20streamed%20calls%20by%20part%20order%20instead%20of%20the%20job's%20real%20provider%20call.%20If%20the%20jobs%20are%20persisted%20in%20the%20opposite%20order%20from%20the%20streamed%20calls%2C%20finalization%20writes%20each%20job%20result%20next%20to%20the%20wrong%20tool%20input%2C%20and%20later%20history%20can%20replay%20swapped%20tool%20outputs.%0A%0A&repo=spikonado%2Fsprocket&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FassistantParts.ts%3A223-226%0A**Ambiguous%20Jobs%20Reattach%20By%20Name**%0A%0AWhen%20two%20legacy%20same-name%20tool%20jobs%20have%20no%20%60callId%60%2C%20this%20fallback%20can%20assign%20them%20to%20streamed%20calls%20by%20part%20order%20instead%20of%20the%20job's%20real%20provider%20call.%20If%20the%20jobs%20are%20persisted%20in%20the%20opposite%20order%20from%20the%20streamed%20calls%2C%20finalization%20writes%20each%20job%20result%20next%20to%20the%20wrong%20tool%20input%2C%20and%20later%20history%20can%20replay%20swapped%20tool%20outputs.%0A%0A&repo=spikonado%2Fsprocket&pr=49&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fstreaming%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstreaming%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FassistantParts.ts%3A223-226%0A**Ambiguous%20Jobs%20Reattach%20By%20Name**%0A%0AWhen%20two%20legacy%20same-name%20tool%20jobs%20have%20no%20%60callId%60%2C%20this%20fallback%20can%20assign%20them%20to%20streamed%20calls%20by%20part%20order%20instead%20of%20the%20job's%20real%20provider%20call.%20If%20the%20jobs%20are%20persisted%20in%20the%20opposite%20order%20from%20the%20streamed%20calls%2C%20finalization%20writes%20each%20job%20result%20next%20to%20the%20wrong%20tool%20input%2C%20and%20later%20history%20can%20replay%20swapped%20tool%20outputs.%0A%0A&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/convex/lib/assistantParts.ts:223-226
**Ambiguous Jobs Reattach By Name**

When two legacy same-name tool jobs have no `callId`, this fallback can assign them to streamed calls by part order instead of the job's real provider call. If the jobs are persisted in the opposite order from the streamed calls, finalization writes each job result next to the wrong tool input, and later history can replay swapped tool outputs.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["restore useful fixes and harden workspac..."](https://github.com/spikonado/sprocket/commit/2dfc2f078fbe0fd02e374119204404cdcdf351c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43816135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->