### PR TITLE
 fix: Make thread launches responsive and idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 - Do the deep dives and figure out what needs to be done and delegate the rest accordingly to subagents.
 - Always use subagents to write the code.
 - For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents must have >=8 intelligence and review the code overall, the other must have >=7 taste and review the UI/UX, API design, and code quality parts.
-- When getting code reviewed by subagents in a loop, use gpt-5.6-sol for a max of 3 reviews. After this, rely on some other model.
+- When getting code reviewed by subagents in a loop, use gpt-5.6-sol as the review subagent for a max of 3 reviews. After this, rely on some other model for the review subagent.
 
 #### PR Workflow
 
@@ -90,9 +90,9 @@ To subagents:
 
 | model         | cost | intelligence | taste | reasoning to use | CLI to use                  |
 | ------------- | ---- | ------------ | ----- | ---------------- | --------------------------- |
-| gpt-5.6-sol   | 8    | 9            | 6     | high             | codex or cursor-agent       |
+| gpt-5.6-sol   | 8    | 9            | 6     | high             | codex                       |
 | fable-5       | 5    | 8            | 9     | high             | claude-code or cursor-agent |
-| gpt-5.6-terra | 9    | 7            | 5     | high             | codex or cursor-agent       |
+| gpt-5.6-terra | 9    | 7            | 5     | high             | codex                       |
 | grok-4.5      | 10   | 6            | 7     | high, fast       | cursor-agent                |
 
 How to apply:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,7 @@ dependencies = [
  "sprocket-workspace",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -26,6 +26,7 @@ import type * as lib_json from "../lib/json.js";
 import type * as lib_modelRegistry from "../lib/modelRegistry.js";
 import type * as lib_models from "../lib/models.js";
 import type * as lib_rateLimits from "../lib/rateLimits.js";
+import type * as lib_runLease from "../lib/runLease.js";
 import type * as lib_runs from "../lib/runs.js";
 import type * as lib_threadMessages from "../lib/threadMessages.js";
 import type * as lib_threadTranscript from "../lib/threadTranscript.js";
@@ -61,6 +62,7 @@ declare const fullApi: ApiFromModules<{
   "lib/modelRegistry": typeof lib_modelRegistry;
   "lib/models": typeof lib_models;
   "lib/rateLimits": typeof lib_rateLimits;
+  "lib/runLease": typeof lib_runLease;
   "lib/runs": typeof lib_runs;
   "lib/threadMessages": typeof lib_threadMessages;
   "lib/threadTranscript": typeof lib_threadTranscript;

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -33,6 +33,7 @@ import {
 export const createRun = mutation({
 	args: {
 		guestId: v.optional(v.string()),
+		submissionId: v.string(),
 		threadId: v.id('threadRecords'),
 		prompt: v.string(),
 		selectedModel: vModelId,
@@ -42,6 +43,7 @@ export const createRun = mutation({
 		ctx,
 		args
 	): Promise<{
+		created: boolean;
 		runId: Id<'runs'>;
 		promptMessageId: Id<'threadMessages'>;
 	}> => {
@@ -51,6 +53,37 @@ export const createRun = mutation({
 			userId,
 			args.threadId
 		);
+		const prompt: string = args.prompt.trim();
+		if (!prompt) {
+			throw new Error('Prompt cannot be empty.');
+		}
+
+		const existingRun: Doc<'runs'> | null = await ctx.db
+			.query('runs')
+			.withIndex('by_userId_submissionId', (query) =>
+				query.eq('userId', userId).eq('submissionId', args.submissionId)
+			)
+			.unique();
+		if (existingRun) {
+			if (
+				existingRun.threadId !== args.threadId ||
+				existingRun.selectedModel !== args.selectedModel ||
+				existingRun.reasoningEffort !== args.reasoningEffort ||
+				!existingRun.promptMessageId
+			) {
+				throw new Error('Submission belongs to a different or incomplete run.');
+			}
+			const existingPrompt = await ctx.db.get(existingRun.promptMessageId);
+			if (!existingPrompt || existingPrompt.text !== prompt) {
+				throw new Error('Submission prompt does not match the existing run.');
+			}
+
+			return {
+				created: false,
+				runId: existingRun._id,
+				promptMessageId: existingRun.promptMessageId
+			};
+		}
 		const latestRun: Doc<'runs'> | null = await ctx.db
 			.query('runs')
 			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', args.threadId))
@@ -58,14 +91,10 @@ export const createRun = mutation({
 			.first();
 		assertThreadCanStartRun(latestRun?.status);
 
-		const prompt: string = args.prompt.trim();
-		if (!prompt) {
-			throw new Error('Prompt cannot be empty.');
-		}
-
 		const runId: Id<'runs'> = await ctx.db.insert('runs', {
 			threadId: args.threadId,
 			userId,
+			submissionId: args.submissionId,
 			workspaceSessionId: threadRecord.workspaceSessionId,
 			status: 'queued',
 			selectedModel: args.selectedModel,
@@ -89,6 +118,7 @@ export const createRun = mutation({
 		});
 
 		return {
+			created: true,
 			runId,
 			promptMessageId
 		};
@@ -98,25 +128,26 @@ export const createRun = mutation({
 export const start = mutation({
 	args: {
 		guestId: v.optional(v.string()),
+		claimId: v.string(),
 		runId: v.id('runs')
 	},
-	handler: async (ctx, args): Promise<Doc<'runs'>> => {
+	handler: async (ctx, args): Promise<{ claimed: boolean }> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (isRunFinalStatus(run.status) || run.status !== 'queued') {
-			return run;
+		if (run.status === 'running') {
+			return { claimed: run.claimId === args.claimId };
+		}
+		if (run.status !== 'queued') {
+			return { claimed: false };
 		}
 
 		await ctx.db.patch(args.runId, {
+			claimId: args.claimId,
 			status: 'running',
 			lastError: undefined
 		});
 
-		return {
-			...run,
-			status: 'running',
-			lastError: undefined
-		};
+		return { claimed: true };
 	}
 });
 

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -9,6 +9,12 @@ import { buildThreadTranscript, type ThreadTranscriptMessage } from '@convex/lib
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 import {
+	canStartRunWithClaim,
+	claimExpiresAt,
+	isClaimedRunStatus,
+	isRunClaimLeaseActive
+} from '@convex/lib/runLease';
+import {
 	ensureAssistantToolPartsFromJobs,
 	joinAssistantTextParts,
 	resolveAssistantMessageText,
@@ -131,23 +137,57 @@ export const start = mutation({
 		claimId: v.string(),
 		runId: v.id('runs')
 	},
-	handler: async (ctx, args): Promise<{ claimed: boolean }> => {
+	handler: async (ctx, args): Promise<{ claimed: boolean; claimExpiresAt?: number }> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (run.status === 'running') {
-			return { claimed: run.claimId === args.claimId };
-		}
-		if (run.status !== 'queued') {
+		const now = Date.now();
+		if (!canStartRunWithClaim(run, args.claimId, now)) {
 			return { claimed: false };
 		}
 
+		const isTakeover = isClaimedRunStatus(run.status) && run.claimId !== args.claimId;
+		const isSameClaimRenewal = isClaimedRunStatus(run.status) && run.claimId === args.claimId;
+		if (isTakeover && run.activeJobId) {
+			const activeJob = await ctx.db.get(run.activeJobId);
+			if (activeJob && (activeJob.status === 'pending' || activeJob.status === 'claimed')) {
+				await ctx.db.patch(activeJob._id, {
+					status: 'cancelled',
+					error: 'The agent worker claim expired.',
+					completedAt: now
+				});
+			}
+		}
+
+		const nextClaimExpiresAt = claimExpiresAt(now);
+
 		await ctx.db.patch(args.runId, {
 			claimId: args.claimId,
-			status: 'running',
-			lastError: undefined
+			claimExpiresAt: nextClaimExpiresAt,
+			status: isSameClaimRenewal ? run.status : 'running',
+			lastError: undefined,
+			...(isTakeover ? { activeJobId: undefined } : {})
 		});
 
-		return { claimed: true };
+		return { claimed: true, claimExpiresAt: nextClaimExpiresAt };
+	}
+});
+
+export const renewClaim = mutation({
+	args: {
+		guestId: v.optional(v.string()),
+		claimId: v.string(),
+		runId: v.id('runs')
+	},
+	handler: async (ctx, args): Promise<{ renewed: boolean; claimExpiresAt?: number }> => {
+		const userId: string = await getUserId(ctx, args.guestId);
+		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		if (!isClaimedRunStatus(run.status) || run.claimId !== args.claimId) {
+			return { renewed: false };
+		}
+
+		const nextClaimExpiresAt = claimExpiresAt(Date.now());
+		await ctx.db.patch(run._id, { claimExpiresAt: nextClaimExpiresAt });
+		return { renewed: true, claimExpiresAt: nextClaimExpiresAt };
 	}
 });
 
@@ -382,6 +422,7 @@ export const mergeAssistantStreamEvents = mutation({
 export const finalizeRun = mutation({
 	args: {
 		expectedStatus: v.optional(vRunStatus),
+		expectedClaimId: v.optional(v.string()),
 		guestId: v.optional(v.string()),
 		runId: v.id('runs'),
 		text: v.string(),
@@ -392,6 +433,12 @@ export const finalizeRun = mutation({
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		if (args.expectedStatus && run.status !== args.expectedStatus) {
+			return false;
+		}
+		if (
+			args.expectedClaimId &&
+			(run.claimId !== args.expectedClaimId || !isRunClaimLeaseActive(run, Date.now()))
+		) {
 			return false;
 		}
 		const alreadyFinal = isRunFinalStatus(run.status);
@@ -459,6 +506,7 @@ export const finalizeRun = mutation({
 		});
 		await ctx.db.patch(run._id, {
 			status: finalStatus,
+			claimExpiresAt: undefined,
 			lastError: args.lastError,
 			activeJobId: undefined,
 			completedAt,
@@ -471,6 +519,7 @@ export const finalizeRun = mutation({
 export const beginToolJob = mutation({
 	args: {
 		guestId: v.optional(v.string()),
+		claimId: v.string(),
 		runId: v.id('runs'),
 		kind: vExecutorJobKind,
 		callId: v.optional(v.string()),
@@ -487,6 +536,9 @@ export const beginToolJob = mutation({
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		assertRunAcceptsModelCompletion(run.status);
+		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+			throw new Error('Run is no longer active.');
+		}
 		const workspaceSession: Doc<'workspaceSessions'> = await getOwnedWorkspaceSession(
 			ctx.db,
 			userId,

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -381,15 +381,19 @@ export const mergeAssistantStreamEvents = mutation({
 
 export const finalizeRun = mutation({
 	args: {
+		expectedStatus: v.optional(vRunStatus),
 		guestId: v.optional(v.string()),
 		runId: v.id('runs'),
 		text: v.string(),
 		status: vRunFinalStatus,
 		lastError: v.optional(v.string())
 	},
-	handler: async (ctx, args): Promise<void> => {
+	handler: async (ctx, args): Promise<boolean> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		if (args.expectedStatus && run.status !== args.expectedStatus) {
+			return false;
+		}
 		const alreadyFinal = isRunFinalStatus(run.status);
 		const finalStatus = alreadyFinal ? run.status : args.status;
 		const completedAt = run.completedAt ?? Date.now();
@@ -416,7 +420,7 @@ export const finalizeRun = mutation({
 			if (run.activeJobId) {
 				await ctx.db.patch(run._id, { activeJobId: undefined });
 			}
-			return;
+			return true;
 		}
 
 		const responseMessageId =
@@ -460,6 +464,7 @@ export const finalizeRun = mutation({
 			completedAt,
 			responseMessageId
 		});
+		return true;
 	}
 });
 

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -16,6 +16,8 @@ export const latestRunForThread = query({
 		threadId: typeof args.threadId;
 		run: Doc<'runs'> | null;
 		jobs: Doc<'executorJobs'>[];
+		prompt?: string;
+		serverNow: number;
 	}> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
@@ -29,7 +31,8 @@ export const latestRunForThread = query({
 			return {
 				threadId: args.threadId,
 				run: null,
-				jobs: []
+				jobs: [],
+				serverNow: Date.now()
 			};
 		}
 
@@ -37,11 +40,16 @@ export const latestRunForThread = query({
 			.query('executorJobs')
 			.withIndex('by_runId_sequence', (query) => query.eq('runId', latestRun._id))
 			.collect();
+		const promptMessage = latestRun.promptMessageId
+			? await ctx.db.get(latestRun.promptMessageId)
+			: null;
 
 		return {
 			threadId: args.threadId,
 			run: latestRun,
-			jobs: jobs.filter((job) => !job.hidden).sort((left, right) => left.sequence - right.sequence)
+			jobs: jobs.filter((job) => !job.hidden).sort((left, right) => left.sequence - right.sequence),
+			...(promptMessage?.type === 'prompt' ? { prompt: promptMessage.text } : {}),
+			serverNow: Date.now()
 		};
 	}
 });

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -25,14 +25,12 @@ describe('run claim leases', () => {
 		expect(canStartRunWithClaim(run, 'claim-b', 200)).toBe(true);
 	});
 
-	it('recovers legacy active rows without lease metadata', () => {
-		expect(canStartRunWithClaim({ status: 'running', claimId: 'old-claim' }, 'claim-b', 100)).toBe(
-			true
-		);
-		expect(
-			canStartRunWithClaim({ status: 'awaiting_executor', claimId: 'old-claim' }, 'claim-b', 100)
-		).toBe(true);
-	});
+	it.each(['running', 'awaiting_executor'] as const)(
+		'recovers legacy %s rows without lease metadata',
+		(status) => {
+			expect(canStartRunWithClaim({ status, claimId: 'old-claim' }, 'claim-b', 100)).toBe(true);
+		}
+	);
 
 	it('only reports an unexpired active-state lease as active', () => {
 		expect(isRunClaimLeaseActive({ status: 'running', claimExpiresAt: 101 }, 100)).toBe(true);

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+	RUN_CLAIM_LEASE_DURATION_MS,
+	canStartRunWithClaim,
+	claimExpiresAt,
+	isRunClaimLeaseActive
+} from '@convex/lib/runLease';
+
+describe('run claim leases', () => {
+	it('claims queued runs and renews the current claim', () => {
+		expect(canStartRunWithClaim({ status: 'queued' }, 'claim-a', 100)).toBe(true);
+		expect(
+			canStartRunWithClaim(
+				{ status: 'running', claimId: 'claim-a', claimExpiresAt: 200 },
+				'claim-a',
+				200
+			)
+		).toBe(true);
+		expect(claimExpiresAt(100)).toBe(100 + RUN_CLAIM_LEASE_DURATION_MS);
+	});
+
+	it('excludes a different claim until the lease expires', () => {
+		const run = { status: 'running', claimId: 'claim-a', claimExpiresAt: 200 };
+		expect(canStartRunWithClaim(run, 'claim-b', 199)).toBe(false);
+		expect(canStartRunWithClaim(run, 'claim-b', 200)).toBe(true);
+	});
+
+	it('recovers legacy active rows without lease metadata', () => {
+		expect(canStartRunWithClaim({ status: 'running', claimId: 'old-claim' }, 'claim-b', 100)).toBe(
+			true
+		);
+		expect(
+			canStartRunWithClaim({ status: 'awaiting_executor', claimId: 'old-claim' }, 'claim-b', 100)
+		).toBe(true);
+	});
+
+	it('only reports an unexpired active-state lease as active', () => {
+		expect(isRunClaimLeaseActive({ status: 'running', claimExpiresAt: 101 }, 100)).toBe(true);
+		expect(isRunClaimLeaseActive({ status: 'running', claimExpiresAt: 100 }, 100)).toBe(false);
+		expect(isRunClaimLeaseActive({ status: 'completed', claimExpiresAt: 200 }, 100)).toBe(false);
+	});
+});

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -1,0 +1,29 @@
+export const RUN_CLAIM_LEASE_DURATION_MS = 60_000;
+export const RUN_CLAIM_RENEW_INTERVAL_MS = 20_000;
+
+type ClaimableRun = {
+	status: string;
+	claimId?: string;
+	claimExpiresAt?: number;
+};
+
+export function isClaimedRunStatus(status: string): boolean {
+	return status === 'running' || status === 'awaiting_executor';
+}
+
+export function isRunClaimLeaseActive(run: ClaimableRun, now: number): boolean {
+	return (
+		isClaimedRunStatus(run.status) && run.claimExpiresAt !== undefined && run.claimExpiresAt > now
+	);
+}
+
+export function canStartRunWithClaim(run: ClaimableRun, claimId: string, now: number): boolean {
+	if (run.status === 'queued') return true;
+	if (!isClaimedRunStatus(run.status)) return false;
+	if (run.claimId === claimId) return true;
+	return !isRunClaimLeaseActive(run, now);
+}
+
+export function claimExpiresAt(now: number): number {
+	return now + RUN_CLAIM_LEASE_DURATION_MS;
+}

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -30,6 +30,7 @@ export default defineSchema({
 		.index('by_user_workspaceName', ['userId', 'workspaceName']),
 	threadRecords: defineTable({
 		userId: v.string(),
+		submissionId: v.optional(v.string()),
 		workspaceSessionId: v.id('workspaceSessions'),
 		title: v.optional(v.string()),
 		selectedModel: vModelId,
@@ -37,12 +38,15 @@ export default defineSchema({
 		lastMessageAt: v.number()
 	})
 		.index('by_userId_lastMessageAt', ['userId', 'lastMessageAt'])
+		.index('by_userId_submissionId', ['userId', 'submissionId'])
 		.index('by_workspaceSessionId', ['workspaceSessionId']),
 	runs: defineTable({
 		threadId: v.id('threadRecords'),
 		userId: v.string(),
+		submissionId: v.optional(v.string()),
 		workspaceSessionId: v.id('workspaceSessions'),
 		status: vRunStatus,
+		claimId: v.optional(v.string()),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		startedAt: v.number(),
@@ -53,6 +57,7 @@ export default defineSchema({
 		responseMessageId: v.optional(v.id('threadMessages'))
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
+		.index('by_userId_submissionId', ['userId', 'submissionId'])
 		.index('by_workspaceSessionId', ['workspaceSessionId'])
 		.index('by_userId_startedAt', ['userId', 'startedAt']),
 	threadMessages: defineTable({

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -47,6 +47,7 @@ export default defineSchema({
 		workspaceSessionId: v.id('workspaceSessions'),
 		status: vRunStatus,
 		claimId: v.optional(v.string()),
+		claimExpiresAt: v.optional(v.number()),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		startedAt: v.number(),

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -1,3 +1,4 @@
+import type { Doc, Id } from '@convex/_generated/dataModel';
 import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
@@ -12,7 +13,13 @@ export const create = mutation({
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort
 	},
-	handler: async (ctx, args) => {
+	handler: async (
+		ctx,
+		args
+	): Promise<{
+		threadId: Id<'threadRecords'>;
+		submissionRunStatus: Doc<'runs'>['status'] | null;
+	}> => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		await getOwnedWorkspaceSession(ctx.db, userId, args.workspaceSessionId);
 		const existingRecord = await ctx.db
@@ -30,7 +37,17 @@ export const create = mutation({
 				throw new Error('Submission settings do not match the existing thread.');
 			}
 
-			return { threadId: existingRecord._id };
+			const submissionRun = await ctx.db
+				.query('runs')
+				.withIndex('by_userId_submissionId', (query) =>
+					query.eq('userId', userId).eq('submissionId', args.submissionId)
+				)
+				.unique();
+
+			return {
+				threadId: existingRecord._id,
+				submissionRunStatus: submissionRun?.status ?? null
+			};
 		}
 
 		const now = Date.now();
@@ -44,7 +61,8 @@ export const create = mutation({
 		});
 
 		return {
-			threadId: recordId
+			threadId: recordId,
+			submissionRunStatus: null
 		};
 	}
 });

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -85,6 +85,7 @@ export const listMine = query({
 					latestRunStatus: latestRun?.status ?? null,
 					latestRunId: latestRun?._id ?? null,
 					latestRunStartedAt: latestRun?.startedAt,
+					latestRunClaimExpiresAt: latestRun?.claimExpiresAt,
 					hasActiveRun: latestRun ? !isRunFinalStatus(latestRun.status) : false
 				};
 			})

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -7,6 +7,7 @@ import { isRunFinalStatus, vModelId, vReasoningEffort } from '@convex/lib/valida
 export const create = mutation({
 	args: {
 		guestId: v.optional(v.string()),
+		submissionId: v.string(),
 		workspaceSessionId: v.id('workspaceSessions'),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort
@@ -14,10 +15,28 @@ export const create = mutation({
 	handler: async (ctx, args) => {
 		const userId: string = await getUserId(ctx, args.guestId);
 		await getOwnedWorkspaceSession(ctx.db, userId, args.workspaceSessionId);
+		const existingRecord = await ctx.db
+			.query('threadRecords')
+			.withIndex('by_userId_submissionId', (query) =>
+				query.eq('userId', userId).eq('submissionId', args.submissionId)
+			)
+			.unique();
+		if (existingRecord) {
+			if (
+				existingRecord.workspaceSessionId !== args.workspaceSessionId ||
+				existingRecord.selectedModel !== args.selectedModel ||
+				existingRecord.reasoningEffort !== args.reasoningEffort
+			) {
+				throw new Error('Submission settings do not match the existing thread.');
+			}
+
+			return { threadId: existingRecord._id };
+		}
 
 		const now = Date.now();
 		const recordId = await ctx.db.insert('threadRecords', {
 			userId: userId,
+			submissionId: args.submissionId,
 			workspaceSessionId: args.workspaceSessionId,
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
@@ -64,6 +83,7 @@ export const listMine = query({
 					threadStatus: 'active',
 					workspaceName: workspaceSession?.workspaceName ?? 'Unknown workspace',
 					latestRunStatus: latestRun?.status ?? null,
+					latestRunId: latestRun?._id ?? null,
 					latestRunStartedAt: latestRun?.startedAt,
 					hasActiveRun: latestRun ? !isRunFinalStatus(latestRun.status) : false
 				};

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -13,6 +13,7 @@
 		selectedReasoningEffort?: SupportedReasoningEffort;
 		canSend: boolean;
 		isSubmitting: boolean;
+		isStarting: boolean;
 		isRunning: boolean;
 		elapsedLabel: string | null;
 		onSubmit: () => void;
@@ -25,6 +26,7 @@
 		selectedReasoningEffort = $bindable(defaultReasoningEffort),
 		canSend,
 		isSubmitting,
+		isStarting,
 		isRunning,
 		elapsedLabel,
 		onSubmit,
@@ -93,6 +95,15 @@
 					></span>
 				</span>
 				<span>Working for {elapsedLabel}</span>
+			</div>
+		{:else if isSubmitting}
+			<div
+				class="mb-3 flex items-center gap-2 px-4 text-[11px] text-slate-400"
+				role="status"
+				aria-live="polite"
+			>
+				<span class="size-1.5 animate-pulse rounded-full bg-white/28"></span>
+				<span>{isStarting ? 'Starting agent…' : 'Sending request…'}</span>
 			</div>
 		{/if}
 

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -19,6 +19,7 @@
 		currentWorkspaceName: string | null;
 		currentThreadId: Id<'threadRecords'> | null;
 		groups: WorkspaceThreadGroup[];
+		pendingAgentLaunchThreadIds?: Id<'threadRecords'>[];
 		onChooseWorkspace: () => void;
 		onReconnectWorkspace: (workspaceSessionId: Id<'workspaceSessions'>) => void;
 		onAccountAction: () => void;
@@ -33,6 +34,7 @@
 		currentWorkspaceName,
 		currentThreadId,
 		groups,
+		pendingAgentLaunchThreadIds = [],
 		onChooseWorkspace,
 		onReconnectWorkspace,
 		onAccountAction,
@@ -79,6 +81,10 @@
 		}
 
 		return null;
+	}
+
+	function hasPendingAgentLaunch(threadId: Id<'threadRecords'>) {
+		return pendingAgentLaunchThreadIds.includes(threadId);
 	}
 </script>
 
@@ -233,6 +239,7 @@
 										{@const hasHiddenThreads = group.threads.length > DEFAULT_VISIBLE_THREAD_COUNT}
 										<div class="space-y-1">
 											{#each visibleThreads as thread (thread.threadId)}
+												{@const isStartingAgent = hasPendingAgentLaunch(thread.threadId)}
 												<div class="group flex items-start gap-1">
 													<button
 														type="button"
@@ -247,7 +254,12 @@
 													>
 														<div class="min-w-0 flex-1">
 															<div class="flex items-center gap-1.5">
-																{#if thread.hasActiveRun}
+																{#if isStartingAgent}
+																	<span
+																		class="shrink-0 rounded-full border border-amber-400/20 bg-amber-400/10 px-1.5 py-0.5 text-[9px] text-amber-200"
+																		aria-label="Starting agent">Starting</span
+																	>
+																{:else if thread.hasActiveRun}
 																	<span
 																		class="mt-px size-2 shrink-0 animate-pulse rounded-full bg-emerald-400"
 																		aria-label="Thread has an active run"
@@ -268,13 +280,19 @@
 																: 'opacity-0 group-hover:opacity-100 hover:border-rose-400/40 hover:bg-rose-400/10 hover:text-rose-200 focus-visible:opacity-100'
 														} disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/3 disabled:text-slate-600 disabled:opacity-40`}
 														onclick={() => {
+															if (thread.hasActiveRun || isStartingAgent) {
+																return;
+															}
+
 															onDeleteThread(thread);
 														}}
-														disabled={thread.hasActiveRun}
+														disabled={thread.hasActiveRun || isStartingAgent}
 														aria-label={`Delete ${thread.title}`}
-														title={thread.hasActiveRun
-															? 'Finish or cancel the active run before deleting.'
-															: `Delete ${thread.title}`}
+														title={isStartingAgent
+															? 'Wait for the local agent to start before deleting.'
+															: thread.hasActiveRun
+																? 'Finish or cancel the active run before deleting.'
+																: `Delete ${thread.title}`}
 													>
 														<Trash2 class="size-3" />
 													</button>

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -12,6 +12,11 @@
 	import { formatRelativeTime } from '$lib/format';
 	import type { Id } from '$convex/_generated/dataModel';
 	import type { ThreadSummary, WorkspaceThreadGroup } from '$lib/types/sprocket';
+	import {
+		getThreadDeletionBlockMessage,
+		isAgentLaunchPending,
+		type PendingAgentLaunches
+	} from '$lib/workspace/threads';
 
 	type Props = {
 		isAuthenticated: boolean;
@@ -19,7 +24,7 @@
 		currentWorkspaceName: string | null;
 		currentThreadId: Id<'threadRecords'> | null;
 		groups: WorkspaceThreadGroup[];
-		pendingAgentLaunchThreadIds?: Id<'threadRecords'>[];
+		pendingAgentLaunches?: PendingAgentLaunches;
 		onChooseWorkspace: () => void;
 		onReconnectWorkspace: (workspaceSessionId: Id<'workspaceSessions'>) => void;
 		onAccountAction: () => void;
@@ -34,7 +39,7 @@
 		currentWorkspaceName,
 		currentThreadId,
 		groups,
-		pendingAgentLaunchThreadIds = [],
+		pendingAgentLaunches = {},
 		onChooseWorkspace,
 		onReconnectWorkspace,
 		onAccountAction,
@@ -81,10 +86,6 @@
 		}
 
 		return null;
-	}
-
-	function hasPendingAgentLaunch(threadId: Id<'threadRecords'>) {
-		return pendingAgentLaunchThreadIds.includes(threadId);
 	}
 </script>
 
@@ -239,7 +240,14 @@
 										{@const hasHiddenThreads = group.threads.length > DEFAULT_VISIBLE_THREAD_COUNT}
 										<div class="space-y-1">
 											{#each visibleThreads as thread (thread.threadId)}
-												{@const isStartingAgent = hasPendingAgentLaunch(thread.threadId)}
+												{@const isStartingAgent = isAgentLaunchPending(
+													pendingAgentLaunches,
+													thread.threadId
+												)}
+												{@const deletionBlockMessage = getThreadDeletionBlockMessage(
+													pendingAgentLaunches,
+													thread
+												)}
 												<div class="group flex items-start gap-1">
 													<button
 														type="button"
@@ -280,19 +288,15 @@
 																: 'opacity-0 group-hover:opacity-100 hover:border-rose-400/40 hover:bg-rose-400/10 hover:text-rose-200 focus-visible:opacity-100'
 														} disabled:cursor-not-allowed disabled:border-white/8 disabled:bg-white/3 disabled:text-slate-600 disabled:opacity-40`}
 														onclick={() => {
-															if (thread.hasActiveRun || isStartingAgent) {
+															if (deletionBlockMessage) {
 																return;
 															}
 
 															onDeleteThread(thread);
 														}}
-														disabled={thread.hasActiveRun || isStartingAgent}
+														disabled={Boolean(deletionBlockMessage)}
 														aria-label={`Delete ${thread.title}`}
-														title={isStartingAgent
-															? 'Wait for the local agent to start before deleting.'
-															: thread.hasActiveRun
-																? 'Finish or cancel the active run before deleting.'
-																: `Delete ${thread.title}`}
+														title={deletionBlockMessage ?? `Delete ${thread.title}`}
 													>
 														<Trash2 class="size-3" />
 													</button>

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -9,7 +9,14 @@ import {
 	resolveDraftRunSubmissionId,
 	resolveSubmissionId
 } from '$lib/home/desktop';
-import type { DesktopApi, WorkspaceSessionLocation } from '$lib/types/sprocket';
+import type { DesktopApi, RunState, WorkspaceSessionLocation } from '$lib/types/sprocket';
+
+const recoveredSubmission = {
+	prompt: 'Inspect the robot',
+	reasoningEffort: 'medium' as const,
+	selectedModel: 'gpt-5.4' as const,
+	submissionId: 'recovered-id'
+};
 
 function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 	return {
@@ -22,23 +29,57 @@ function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 	} as unknown as DesktopApi;
 }
 
+function launchArgs(
+	overrides: Partial<Parameters<typeof launchAgentRun>[0]> &
+		Pick<Parameters<typeof launchAgentRun>[0], 'desktopApi' | 'onError'>
+): Parameters<typeof launchAgentRun>[0] {
+	return {
+		threadId: 'thread-1' as never,
+		prompt: 'Inspect src/lib.rs',
+		selectedModel: 'gpt-5.4',
+		reasoningEffort: 'medium',
+		submissionId: 'submission-1',
+		viewerArgs: {},
+		workspaceSessionId: 'workspace-1' as never,
+		...overrides
+	};
+}
+
+function resolveRecoveredSubmission(
+	overrides: Partial<Parameters<typeof resolveSubmissionId>[0]> = {}
+) {
+	return resolveSubmissionId({
+		latestRun: null,
+		newSubmissionId: 'new-id',
+		prompt: recoveredSubmission.prompt,
+		reasoningEffort: recoveredSubmission.reasoningEffort,
+		recoveredSubmission,
+		selectedModel: recoveredSubmission.selectedModel,
+		...overrides
+	});
+}
+
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((settle) => {
+		resolve = settle;
+	});
+	return { promise, resolve: () => resolve() };
+}
+
 describe('launchAgentRun', () => {
 	it('starts a desktop run with viewer args and auth token', () => {
 		const runAgent = vi.fn().mockResolvedValue(undefined);
 		const desktopApi = createDesktopApi(runAgent);
 
-		launchAgentRun({
-			authToken: 'token-1',
-			desktopApi,
-			onError: vi.fn(),
-			threadId: 'thread-1' as never,
-			prompt: 'Inspect src/lib.rs',
-			selectedModel: 'gpt-5.4',
-			reasoningEffort: 'medium',
-			submissionId: 'submission-1',
-			viewerArgs: { guestId: 'guest-1' },
-			workspaceSessionId: 'workspace-1' as never
-		});
+		launchAgentRun(
+			launchArgs({
+				authToken: 'token-1',
+				desktopApi,
+				onError: vi.fn(),
+				viewerArgs: { guestId: 'guest-1' }
+			})
+		);
 
 		expect(runAgent).toHaveBeenCalledWith({
 			authToken: 'token-1',
@@ -57,22 +98,11 @@ describe('launchAgentRun', () => {
 		const onError = vi.fn();
 		const desktopApi = createDesktopApi(vi.fn().mockRejectedValue(launchError));
 
-		launchAgentRun({
-			desktopApi,
-			onError,
-			threadId: 'thread-1' as never,
-			prompt: 'Inspect src/lib.rs',
-			selectedModel: 'gpt-5.4',
-			reasoningEffort: 'medium',
-			submissionId: 'submission-1',
-			viewerArgs: {},
-			workspaceSessionId: 'workspace-1' as never
+		launchAgentRun(launchArgs({ desktopApi, onError }));
+
+		await vi.waitFor(() => {
+			expect(onError).toHaveBeenCalledWith(launchError);
 		});
-
-		await Promise.resolve();
-		await Promise.resolve();
-
-		expect(onError).toHaveBeenCalledWith(launchError);
 	});
 });
 
@@ -86,81 +116,25 @@ describe('getViewerIdentity', () => {
 
 describe('resolveSubmissionId', () => {
 	it('reuses an uncertain submission only when its restored prompt is unchanged', () => {
-		const recoveredSubmission = {
-			prompt: 'Inspect the robot',
-			reasoningEffort: 'medium' as const,
-			selectedModel: 'gpt-5.4' as const,
-			submissionId: 'recovered-id'
-		};
-
-		expect(
-			resolveSubmissionId({
-				latestRun: null,
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect the robot',
-				reasoningEffort: 'medium',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
-			})
-		).toBe('recovered-id');
-		expect(
-			resolveSubmissionId({
-				latestRun: null,
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect and fix the robot',
-				reasoningEffort: 'medium',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
-			})
-		).toBe('new-id');
-		expect(
-			resolveSubmissionId({
-				latestRun: null,
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect the robot',
-				reasoningEffort: 'high',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
-			})
-		).toBe('new-id');
+		expect(resolveRecoveredSubmission()).toBe('recovered-id');
+		expect(resolveRecoveredSubmission({ prompt: 'Inspect and fix the robot' })).toBe('new-id');
+		expect(resolveRecoveredSubmission({ reasoningEffort: 'high' })).toBe('new-id');
 	});
 
 	it('uses a fresh id when the visible latest submission has finished or supersedes recovery', () => {
-		const recoveredSubmission = {
-			prompt: 'Inspect the robot',
-			reasoningEffort: 'medium' as const,
-			selectedModel: 'gpt-5.4' as const,
-			submissionId: 'recovered-id'
-		};
-
 		expect(
-			resolveSubmissionId({
-				latestRun: { status: 'failed', submissionId: 'recovered-id' },
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect the robot',
-				reasoningEffort: 'medium',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
+			resolveRecoveredSubmission({
+				latestRun: { status: 'failed', submissionId: 'recovered-id' }
 			})
 		).toBe('new-id');
 		expect(
-			resolveSubmissionId({
-				latestRun: { status: 'queued', submissionId: 'recovered-id' },
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect the robot',
-				reasoningEffort: 'medium',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
+			resolveRecoveredSubmission({
+				latestRun: { status: 'queued', submissionId: 'recovered-id' }
 			})
 		).toBe('recovered-id');
 		expect(
-			resolveSubmissionId({
-				latestRun: { status: 'queued', submissionId: 'newer-id' },
-				newSubmissionId: 'new-id',
-				prompt: 'Inspect the robot',
-				reasoningEffort: 'medium',
-				recoveredSubmission,
-				selectedModel: 'gpt-5.4'
+			resolveRecoveredSubmission({
+				latestRun: { status: 'queued', submissionId: 'newer-id' }
 			})
 		).toBe('new-id');
 	});
@@ -196,14 +170,18 @@ describe('resolveDraftRunSubmissionId', () => {
 
 describe('isRunBlockingAgentLaunch', () => {
 	it('blocks queued and actively leased runs but permits stale claimed runs', () => {
-		expect(isRunBlockingAgentLaunch({ status: 'queued' } as never, 100)).toBe(true);
-		expect(isRunBlockingAgentLaunch({ status: 'running', claimExpiresAt: 101 } as never, 100)).toBe(
-			true
-		);
-		expect(
-			isRunBlockingAgentLaunch({ status: 'awaiting_executor', claimExpiresAt: 100 } as never, 100)
-		).toBe(false);
-		expect(isRunBlockingAgentLaunch({ status: 'running' } as never, 100)).toBe(false);
+		const run = (
+			status: RunState['status'],
+			claimExpiresAt?: number
+		): Pick<RunState, 'status' | 'claimExpiresAt'> => ({
+			status,
+			...(claimExpiresAt === undefined ? {} : { claimExpiresAt })
+		});
+
+		expect(isRunBlockingAgentLaunch(run('queued'), 100)).toBe(true);
+		expect(isRunBlockingAgentLaunch(run('running', 101), 100)).toBe(true);
+		expect(isRunBlockingAgentLaunch(run('awaiting_executor', 100), 100)).toBe(false);
+		expect(isRunBlockingAgentLaunch(run('running'), 100)).toBe(false);
 	});
 });
 
@@ -278,15 +256,13 @@ describe('createLatestTaskQueue', () => {
 	});
 
 	it('rejects every coalesced request when the retained latest write fails', async () => {
-		let releaseFirst: (() => void) | undefined;
+		const firstGate = deferred();
 		const writeError = new Error('offline');
 		const values: string[] = [];
 		const queue = createLatestTaskQueue(async (value: string) => {
 			values.push(value);
 			if (value === 'first') {
-				await new Promise<void>((resolve) => {
-					releaseFirst = resolve;
-				});
+				await firstGate.promise;
 				return;
 			}
 
@@ -298,21 +274,19 @@ describe('createLatestTaskQueue', () => {
 		const supersededFailure = expect(superseded).rejects.toBe(writeError);
 		const latestFailure = expect(latest).rejects.toBe(writeError);
 
-		releaseFirst?.();
+		firstGate.resolve();
 		await first;
 		await Promise.all([supersededFailure, latestFailure]);
 		expect(values).toEqual(['first', 'latest']);
 	});
 
 	it('cancels pending requests without affecting an in-flight write', async () => {
-		let releaseFirst: (() => void) | undefined;
+		const firstGate = deferred();
 		const values: string[] = [];
 		const queue = createLatestTaskQueue(async (value: string) => {
 			values.push(value);
 			if (value === 'first') {
-				await new Promise<void>((resolve) => {
-					releaseFirst = resolve;
-				});
+				await firstGate.promise;
 			}
 		});
 		const first = queue.enqueue('first');
@@ -325,7 +299,7 @@ describe('createLatestTaskQueue', () => {
 		await Promise.all([supersededCancellation, latestCancellation]);
 		expect(values).toEqual(['first']);
 		const replacement = queue.enqueue('replacement');
-		releaseFirst?.();
+		firstGate.resolve();
 		await Promise.all([first, replacement]);
 		expect(values).toEqual(['first', 'replacement']);
 	});

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -4,6 +4,7 @@ import {
 	getDesiredAttachedWorkspaceSessionIds,
 	getViewerIdentity,
 	getViewerQueryArgs,
+	isRunBlockingAgentLaunch,
 	launchAgentRun,
 	resolveSubmissionId
 } from '$lib/home/desktop';
@@ -161,6 +162,19 @@ describe('resolveSubmissionId', () => {
 				selectedModel: 'gpt-5.4'
 			})
 		).toBe('recovered-id');
+	});
+});
+
+describe('isRunBlockingAgentLaunch', () => {
+	it('blocks queued and actively leased runs but permits stale claimed runs', () => {
+		expect(isRunBlockingAgentLaunch({ status: 'queued' } as never, 100)).toBe(true);
+		expect(isRunBlockingAgentLaunch({ status: 'running', claimExpiresAt: 101 } as never, 100)).toBe(
+			true
+		);
+		expect(
+			isRunBlockingAgentLaunch({ status: 'awaiting_executor', claimExpiresAt: 100 } as never, 100)
+		).toBe(false);
+		expect(isRunBlockingAgentLaunch({ status: 'running' } as never, 100)).toBe(false);
 	});
 });
 

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -125,7 +125,7 @@ describe('resolveSubmissionId', () => {
 		).toBe('new-id');
 	});
 
-	it('only uses a fresh id when the recovered submission itself is observed as final', () => {
+	it('uses a fresh id when the visible latest submission has finished or supersedes recovery', () => {
 		const recoveredSubmission = {
 			prompt: 'Inspect the robot',
 			reasoningEffort: 'medium' as const,
@@ -155,14 +155,14 @@ describe('resolveSubmissionId', () => {
 		).toBe('recovered-id');
 		expect(
 			resolveSubmissionId({
-				latestRun: { status: 'completed', submissionId: 'older-id' },
+				latestRun: { status: 'queued', submissionId: 'newer-id' },
 				newSubmissionId: 'new-id',
 				prompt: 'Inspect the robot',
 				reasoningEffort: 'medium',
 				recoveredSubmission,
 				selectedModel: 'gpt-5.4'
 			})
-		).toBe('recovered-id');
+		).toBe('new-id');
 	});
 });
 

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -6,6 +6,7 @@ import {
 	getViewerQueryArgs,
 	isRunBlockingAgentLaunch,
 	launchAgentRun,
+	resolveDraftRunSubmissionId,
 	resolveSubmissionId
 } from '$lib/home/desktop';
 import type { DesktopApi, WorkspaceSessionLocation } from '$lib/types/sprocket';
@@ -163,6 +164,34 @@ describe('resolveSubmissionId', () => {
 			})
 		).toBe('recovered-id');
 	});
+});
+
+describe('resolveDraftRunSubmissionId', () => {
+	it.each(['completed', 'failed', 'cancelled'] as const)(
+		'uses a fresh run submission after draft creation reveals a %s run',
+		(submissionRunStatus) => {
+			expect(
+				resolveDraftRunSubmissionId({
+					freshSubmissionId: 'fresh-id',
+					submissionRunStatus,
+					threadSubmissionId: 'recovered-id'
+				})
+			).toBe('fresh-id');
+		}
+	);
+
+	it.each([null, 'queued', 'running', 'awaiting_executor'] as const)(
+		'reuses the draft submission when its run is %s',
+		(submissionRunStatus) => {
+			expect(
+				resolveDraftRunSubmissionId({
+					freshSubmissionId: 'fresh-id',
+					submissionRunStatus,
+					threadSubmissionId: 'recovered-id'
+				})
+			).toBe('recovered-id');
+		}
+	);
 });
 
 describe('isRunBlockingAgentLaunch', () => {

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	createLatestTaskQueue,
+	getDesiredAttachedWorkspaceSessionIds,
+	getViewerIdentity,
 	getViewerQueryArgs,
 	launchAgentRun,
-	syncAttachedWorkspaceSessions
+	resolveSubmissionId
 } from '$lib/home/desktop';
-import type { DesktopApi } from '$lib/types/sprocket';
+import type { DesktopApi, WorkspaceSessionLocation } from '$lib/types/sprocket';
 
 function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 	return {
@@ -25,12 +28,13 @@ describe('launchAgentRun', () => {
 		launchAgentRun({
 			authToken: 'token-1',
 			desktopApi,
-			getViewerArgs: () => ({ guestId: 'guest-1' }),
 			onError: vi.fn(),
 			threadId: 'thread-1' as never,
 			prompt: 'Inspect src/lib.rs',
 			selectedModel: 'gpt-5.4',
 			reasoningEffort: 'medium',
+			submissionId: 'submission-1',
+			viewerArgs: { guestId: 'guest-1' },
 			workspaceSessionId: 'workspace-1' as never
 		});
 
@@ -40,6 +44,7 @@ describe('launchAgentRun', () => {
 			threadId: 'thread-1',
 			prompt: 'Inspect src/lib.rs',
 			selectedModel: 'gpt-5.4',
+			submissionId: 'submission-1',
 			reasoningEffort: 'medium',
 			workspaceSessionId: 'workspace-1'
 		});
@@ -52,12 +57,13 @@ describe('launchAgentRun', () => {
 
 		launchAgentRun({
 			desktopApi,
-			getViewerArgs: () => ({}),
 			onError,
 			threadId: 'thread-1' as never,
 			prompt: 'Inspect src/lib.rs',
 			selectedModel: 'gpt-5.4',
 			reasoningEffort: 'medium',
+			submissionId: 'submission-1',
+			viewerArgs: {},
 			workspaceSessionId: 'workspace-1' as never
 		});
 
@@ -65,6 +71,53 @@ describe('launchAgentRun', () => {
 		await Promise.resolve();
 
 		expect(onError).toHaveBeenCalledWith(launchError);
+	});
+});
+
+describe('getViewerIdentity', () => {
+	it('derives a stable identity from the authenticated user or guest', () => {
+		expect(getViewerIdentity({ id: 'user-1' }, 'guest-1')).toBe('user:user-1');
+		expect(getViewerIdentity(null, 'guest-1')).toBe('guest:guest-1');
+		expect(getViewerIdentity(null, null)).toBeNull();
+	});
+});
+
+describe('resolveSubmissionId', () => {
+	it('reuses an uncertain submission only when its restored prompt is unchanged', () => {
+		const recoveredSubmission = {
+			prompt: 'Inspect the robot',
+			reasoningEffort: 'medium' as const,
+			selectedModel: 'gpt-5.4' as const,
+			submissionId: 'recovered-id'
+		};
+
+		expect(
+			resolveSubmissionId({
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect the robot',
+				reasoningEffort: 'medium',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('recovered-id');
+		expect(
+			resolveSubmissionId({
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect and fix the robot',
+				reasoningEffort: 'medium',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('new-id');
+		expect(
+			resolveSubmissionId({
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect the robot',
+				reasoningEffort: 'high',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('new-id');
 	});
 });
 
@@ -110,22 +163,106 @@ describe('getViewerQueryArgs', () => {
 	});
 });
 
-describe('syncAttachedWorkspaceSessions', () => {
-	it('combines existing and newly attached sessions through the injected mutation', async () => {
-		const heartbeatAttached = vi.fn().mockResolvedValue(undefined);
-
-		await syncAttachedWorkspaceSessions({
-			attachedWorkspaceSessionIds: ['workspace-1' as never],
-			executorClientId: 'client-1',
-			getViewerArgs: () => ({ guestId: 'guest-1' }),
-			heartbeatAttached,
-			workspaceSessionIds: ['workspace-1' as never, 'workspace-2' as never]
+describe('createLatestTaskQueue', () => {
+	it('settles coalesced requests with the retained latest write', async () => {
+		const releases: Array<() => void> = [];
+		const values: string[] = [];
+		const queue = createLatestTaskQueue(async (value: string) => {
+			values.push(value);
+			await new Promise<void>((resolve) => releases.push(resolve));
 		});
 
-		expect(heartbeatAttached).toHaveBeenCalledWith({
-			guestId: 'guest-1',
-			clientId: 'client-1',
-			workspaceSessionIds: ['workspace-1', 'workspace-2']
+		const first = queue.enqueue('old-viewer');
+		const superseded = queue.enqueue('superseded');
+		const latest = queue.enqueue('new-viewer');
+		expect(superseded).toBe(latest);
+		let coalescedSettled = false;
+		void superseded.then(() => {
+			coalescedSettled = true;
 		});
+
+		expect(values).toEqual(['old-viewer']);
+		releases.shift()?.();
+		await first;
+		expect(values).toEqual(['old-viewer', 'new-viewer']);
+		expect(coalescedSettled).toBe(false);
+		releases.shift()?.();
+		await Promise.all([superseded, latest]);
+		expect(coalescedSettled).toBe(true);
+	});
+
+	it('rejects every coalesced request when the retained latest write fails', async () => {
+		let releaseFirst: (() => void) | undefined;
+		const writeError = new Error('offline');
+		const values: string[] = [];
+		const queue = createLatestTaskQueue(async (value: string) => {
+			values.push(value);
+			if (value === 'first') {
+				await new Promise<void>((resolve) => {
+					releaseFirst = resolve;
+				});
+				return;
+			}
+
+			throw writeError;
+		});
+		const first = queue.enqueue('first');
+		const superseded = queue.enqueue('superseded');
+		const latest = queue.enqueue('latest');
+		const supersededFailure = expect(superseded).rejects.toBe(writeError);
+		const latestFailure = expect(latest).rejects.toBe(writeError);
+
+		releaseFirst?.();
+		await first;
+		await Promise.all([supersededFailure, latestFailure]);
+		expect(values).toEqual(['first', 'latest']);
+	});
+
+	it('cancels pending requests without affecting an in-flight write', async () => {
+		let releaseFirst: (() => void) | undefined;
+		const values: string[] = [];
+		const queue = createLatestTaskQueue(async (value: string) => {
+			values.push(value);
+			if (value === 'first') {
+				await new Promise<void>((resolve) => {
+					releaseFirst = resolve;
+				});
+			}
+		});
+		const first = queue.enqueue('first');
+		const superseded = queue.enqueue('superseded');
+		const latest = queue.enqueue('latest');
+		const supersededCancellation = expect(superseded).rejects.toThrow('Pending task was canceled.');
+		const latestCancellation = expect(latest).rejects.toThrow('Pending task was canceled.');
+
+		queue.cancelPending();
+		await Promise.all([supersededCancellation, latestCancellation]);
+		expect(values).toEqual(['first']);
+		const replacement = queue.enqueue('replacement');
+		releaseFirst?.();
+		await Promise.all([first, replacement]);
+		expect(values).toEqual(['first', 'replacement']);
+	});
+});
+
+describe('getDesiredAttachedWorkspaceSessionIds', () => {
+	it('includes only locally available sessions belonging to the current viewer', () => {
+		const location = (
+			workspaceSessionId: string,
+			availability: WorkspaceSessionLocation['availability'] = 'available'
+		): WorkspaceSessionLocation => ({
+			workspaceSessionId: workspaceSessionId as never,
+			workspacePath: `/workspaces/${workspaceSessionId}`,
+			availability,
+			lastValidatedAt: 1,
+			lastUsedAt: 1
+		});
+
+		expect(
+			getDesiredAttachedWorkspaceSessionIds(
+				[location('local'), location('old-viewer'), location('confirmed', 'unavailable')],
+				['local' as never, 'confirmed' as never]
+			)
+		).toEqual(['local']);
 	});
 });

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -93,6 +93,7 @@ describe('resolveSubmissionId', () => {
 
 		expect(
 			resolveSubmissionId({
+				latestRun: null,
 				newSubmissionId: 'new-id',
 				prompt: 'Inspect the robot',
 				reasoningEffort: 'medium',
@@ -102,6 +103,7 @@ describe('resolveSubmissionId', () => {
 		).toBe('recovered-id');
 		expect(
 			resolveSubmissionId({
+				latestRun: null,
 				newSubmissionId: 'new-id',
 				prompt: 'Inspect and fix the robot',
 				reasoningEffort: 'medium',
@@ -111,6 +113,7 @@ describe('resolveSubmissionId', () => {
 		).toBe('new-id');
 		expect(
 			resolveSubmissionId({
+				latestRun: null,
 				newSubmissionId: 'new-id',
 				prompt: 'Inspect the robot',
 				reasoningEffort: 'high',
@@ -118,6 +121,46 @@ describe('resolveSubmissionId', () => {
 				selectedModel: 'gpt-5.4'
 			})
 		).toBe('new-id');
+	});
+
+	it('only uses a fresh id when the recovered submission itself is observed as final', () => {
+		const recoveredSubmission = {
+			prompt: 'Inspect the robot',
+			reasoningEffort: 'medium' as const,
+			selectedModel: 'gpt-5.4' as const,
+			submissionId: 'recovered-id'
+		};
+
+		expect(
+			resolveSubmissionId({
+				latestRun: { status: 'failed', submissionId: 'recovered-id' },
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect the robot',
+				reasoningEffort: 'medium',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('new-id');
+		expect(
+			resolveSubmissionId({
+				latestRun: { status: 'queued', submissionId: 'recovered-id' },
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect the robot',
+				reasoningEffort: 'medium',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('recovered-id');
+		expect(
+			resolveSubmissionId({
+				latestRun: { status: 'completed', submissionId: 'older-id' },
+				newSubmissionId: 'new-id',
+				prompt: 'Inspect the robot',
+				reasoningEffort: 'medium',
+				recoveredSubmission,
+				selectedModel: 'gpt-5.4'
+			})
+		).toBe('recovered-id');
 	});
 });
 

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -55,11 +55,11 @@ export function resolveSubmissionId(args: {
 }) {
 	const recoveredSubmission = args.recoveredSubmission;
 	const latestRun = args.latestRun;
-	const recoveredSubmissionIsFinal =
-		recoveredSubmission !== undefined &&
-		latestRun?.submissionId === recoveredSubmission.submissionId &&
-		isRunFinalStatus(latestRun.status);
-	return !recoveredSubmissionIsFinal &&
+	const canReuseRecoveredSubmission =
+		latestRun === null ||
+		(latestRun.submissionId === recoveredSubmission?.submissionId &&
+			!isRunFinalStatus(latestRun.status));
+	return canReuseRecoveredSubmission &&
 		recoveredSubmission?.prompt === args.prompt &&
 		recoveredSubmission.selectedModel === args.selectedModel &&
 		recoveredSubmission.reasoningEffort === args.reasoningEffort

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -1,6 +1,4 @@
-import { api } from '$convex/_generated/api';
 import type { Id } from '$convex/_generated/dataModel';
-import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server';
 import type {
 	AgentRunRequest,
 	DesktopApi,
@@ -9,12 +7,6 @@ import type {
 	WorkspaceSessionAttachment,
 	WorkspaceSessionLocation
 } from '$lib/types/sprocket';
-
-type MutationFunction<Mutation extends FunctionReference<'mutation'>> = (
-	args: FunctionArgs<Mutation>
-) => Promise<FunctionReturnType<Mutation>>;
-
-type HeartbeatAttachedMutation = MutationFunction<typeof api.workspaceSessions.heartbeatAttached>;
 
 export type ViewerArgs = {
 	guestId?: string;
@@ -29,6 +21,36 @@ export function getViewerArgs(
 	guestSessionId: string | null
 ): ViewerArgs {
 	return !authenticatedUser && guestSessionId ? { guestId: guestSessionId } : {};
+}
+
+export function getViewerIdentity(
+	authenticatedUser: { id: string } | null | undefined,
+	guestSessionId: string | null
+): string | null {
+	if (authenticatedUser) {
+		return `user:${authenticatedUser.id}`;
+	}
+
+	return guestSessionId ? `guest:${guestSessionId}` : null;
+}
+
+export function resolveSubmissionId(args: {
+	newSubmissionId: string;
+	prompt: string;
+	reasoningEffort: AgentRunRequest['reasoningEffort'];
+	recoveredSubmission?: {
+		prompt: string;
+		reasoningEffort: AgentRunRequest['reasoningEffort'];
+		selectedModel: AgentRunRequest['selectedModel'];
+		submissionId: string;
+	};
+	selectedModel: AgentRunRequest['selectedModel'];
+}) {
+	return args.recoveredSubmission?.prompt === args.prompt &&
+		args.recoveredSubmission.selectedModel === args.selectedModel &&
+		args.recoveredSubmission.reasoningEffort === args.reasoningEffort
+		? args.recoveredSubmission.submissionId
+		: args.newSubmissionId;
 }
 
 export function getViewerQueryArgs(args: {
@@ -51,22 +73,24 @@ export function getViewerQueryArgs(args: {
 export function launchAgentRun(args: {
 	authToken?: string;
 	desktopApi: DesktopApi;
-	getViewerArgs: () => ViewerArgs;
 	onError: (error: unknown) => void;
 	threadId: Id<'threadRecords'>;
 	prompt: string;
 	selectedModel: AgentRunRequest['selectedModel'];
 	reasoningEffort: AgentRunRequest['reasoningEffort'];
+	submissionId: string;
+	viewerArgs: ViewerArgs;
 	workspaceSessionId: Id<'workspaceSessions'>;
 }) {
 	void args.desktopApi
 		.runAgent({
 			...(args.authToken ? { authToken: args.authToken } : {}),
-			...args.getViewerArgs(),
+			...args.viewerArgs,
 			threadId: args.threadId,
 			prompt: args.prompt,
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
+			submissionId: args.submissionId,
 			workspaceSessionId: args.workspaceSessionId
 		})
 		.catch((error) => {
@@ -105,51 +129,104 @@ export async function attachLocalWorkspaceSession(args: {
 	} satisfies WorkspaceSessionAttachment);
 }
 
-export async function syncAttachedWorkspaceSessions(args: {
-	attachedWorkspaceSessionIds: Id<'workspaceSessions'>[];
-	executorClientId: string | null;
-	getViewerArgs: () => ViewerArgs;
-	heartbeatAttached: HeartbeatAttachedMutation;
-	workspaceSessionIds: Id<'workspaceSessions'>[];
-}) {
-	if (!args.executorClientId) {
-		return;
-	}
-
-	const attachedSessionIds = [
-		...new Set([...args.attachedWorkspaceSessionIds, ...args.workspaceSessionIds])
-	];
-
-	await args.heartbeatAttached({
-		...args.getViewerArgs(),
-		clientId: args.executorClientId,
-		workspaceSessionIds: attachedSessionIds
-	});
+export function getDesiredAttachedWorkspaceSessionIds(
+	desktopWorkspaceSessions: WorkspaceSessionLocation[],
+	backendWorkspaceSessionIds: Id<'workspaceSessions'>[]
+): Id<'workspaceSessions'>[] {
+	const backendWorkspaceSessionIdSet = new Set(backendWorkspaceSessionIds);
+	return desktopWorkspaceSessions
+		.filter(
+			(workspaceSession) =>
+				workspaceSession.availability === 'available' &&
+				backendWorkspaceSessionIdSet.has(workspaceSession.workspaceSessionId)
+		)
+		.map((workspaceSession) => workspaceSession.workspaceSessionId);
 }
 
-export async function attachWorkspaceSession(args: {
-	attachedWorkspaceSessionIds: Id<'workspaceSessions'>[];
+type PendingLatestTask<T> = {
+	value: T;
+	promise: Promise<void>;
+	resolve: () => void;
+	reject: (error: unknown) => void;
+};
+
+export class LatestTaskQueueCancelledError extends Error {
+	constructor() {
+		super('Pending task was canceled.');
+		this.name = 'LatestTaskQueueCancelledError';
+	}
+}
+
+export function createLatestTaskQueue<T>(run: (value: T) => Promise<void>) {
+	let pending: PendingLatestTask<T> | null = null;
+	let isRunning = false;
+
+	async function drain() {
+		if (isRunning) {
+			return;
+		}
+
+		isRunning = true;
+		try {
+			while (pending) {
+				const task = pending;
+				pending = null;
+				try {
+					await run(task.value);
+					task.resolve();
+				} catch (error) {
+					task.reject(error);
+				}
+			}
+		} finally {
+			isRunning = false;
+			if (pending) {
+				void drain();
+			}
+		}
+	}
+
+	return {
+		enqueue(value: T): Promise<void> {
+			if (pending) {
+				pending.value = value;
+				return pending.promise;
+			}
+
+			let resolveTask!: () => void;
+			let rejectTask!: (error: unknown) => void;
+			const promise = new Promise<void>((resolve, reject) => {
+				resolveTask = resolve;
+				rejectTask = reject;
+			});
+			pending = { value, promise, resolve: resolveTask, reject: rejectTask };
+			void drain();
+			return promise;
+		},
+		cancelPending() {
+			if (!pending) {
+				return;
+			}
+
+			const task = pending;
+			pending = null;
+			task.reject(new LatestTaskQueueCancelledError());
+		}
+	};
+}
+
+export async function verifyWorkspaceSession(args: {
 	desktopApi: DesktopApi | null;
-	executorClientId: string | null;
-	getViewerArgs: () => ViewerArgs;
-	heartbeatAttached: HeartbeatAttachedMutation;
 	refreshDesktopWorkspaceSessions: () => Promise<void>;
 	workspaceSessionId: Id<'workspaceSessions'>;
 }) {
-	if (!args.desktopApi || !args.executorClientId) {
+	if (!args.desktopApi) {
 		return;
 	}
 
 	try {
 		await args.desktopApi.getWorkspaceSessionOverview(args.workspaceSessionId);
 		await args.refreshDesktopWorkspaceSessions();
-		await syncAttachedWorkspaceSessions({
-			attachedWorkspaceSessionIds: args.attachedWorkspaceSessionIds,
-			executorClientId: args.executorClientId,
-			getViewerArgs: args.getViewerArgs,
-			heartbeatAttached: args.heartbeatAttached,
-			workspaceSessionIds: [args.workspaceSessionId]
-		});
 	} catch (error) {
 		await args.refreshDesktopWorkspaceSessions();
 		throw error;

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -183,7 +183,7 @@ type PendingLatestTask<T> = {
 	reject: (error: unknown) => void;
 };
 
-export class LatestTaskQueueCancelledError extends Error {
+class LatestTaskQueueCancelledError extends Error {
 	constructor() {
 		super('Pending task was canceled.');
 		this.name = 'LatestTaskQueueCancelledError';

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -3,6 +3,7 @@ import type {
 	AgentRunRequest,
 	DesktopApi,
 	LocalWorkspaceAvailability,
+	RunState,
 	WorkspaceSession,
 	WorkspaceSessionAttachment,
 	WorkspaceSessionLocation
@@ -44,12 +45,25 @@ export function resolveSubmissionId(args: {
 		selectedModel: AgentRunRequest['selectedModel'];
 		submissionId: string;
 	};
+	latestRun: {
+		status: RunState['status'];
+		submissionId?: string;
+	} | null;
 	selectedModel: AgentRunRequest['selectedModel'];
 }) {
-	return args.recoveredSubmission?.prompt === args.prompt &&
-		args.recoveredSubmission.selectedModel === args.selectedModel &&
-		args.recoveredSubmission.reasoningEffort === args.reasoningEffort
-		? args.recoveredSubmission.submissionId
+	const recoveredSubmission = args.recoveredSubmission;
+	const latestRun = args.latestRun;
+	const recoveredSubmissionIsFinal =
+		recoveredSubmission !== undefined &&
+		latestRun?.submissionId === recoveredSubmission.submissionId &&
+		(latestRun.status === 'completed' ||
+			latestRun.status === 'failed' ||
+			latestRun.status === 'cancelled');
+	return !recoveredSubmissionIsFinal &&
+		recoveredSubmission?.prompt === args.prompt &&
+		recoveredSubmission.selectedModel === args.selectedModel &&
+		recoveredSubmission.reasoningEffort === args.reasoningEffort
+		? recoveredSubmission.submissionId
 		: args.newSubmissionId;
 }
 

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -9,6 +9,7 @@ import type {
 	WorkspaceSessionLocation
 } from '$lib/types/sprocket';
 import { isRunClaimLeaseActive } from '$convex/lib/runLease';
+import { isRunFinalStatus } from '$convex/lib/validators';
 
 export type ViewerArgs = {
 	guestId?: string;
@@ -57,15 +58,23 @@ export function resolveSubmissionId(args: {
 	const recoveredSubmissionIsFinal =
 		recoveredSubmission !== undefined &&
 		latestRun?.submissionId === recoveredSubmission.submissionId &&
-		(latestRun.status === 'completed' ||
-			latestRun.status === 'failed' ||
-			latestRun.status === 'cancelled');
+		isRunFinalStatus(latestRun.status);
 	return !recoveredSubmissionIsFinal &&
 		recoveredSubmission?.prompt === args.prompt &&
 		recoveredSubmission.selectedModel === args.selectedModel &&
 		recoveredSubmission.reasoningEffort === args.reasoningEffort
 		? recoveredSubmission.submissionId
 		: args.newSubmissionId;
+}
+
+export function resolveDraftRunSubmissionId(args: {
+	freshSubmissionId: string;
+	submissionRunStatus: RunState['status'] | null;
+	threadSubmissionId: string;
+}) {
+	return args.submissionRunStatus && isRunFinalStatus(args.submissionRunStatus)
+		? args.freshSubmissionId
+		: args.threadSubmissionId;
 }
 
 export function isRunBlockingAgentLaunch(

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -8,6 +8,7 @@ import type {
 	WorkspaceSessionAttachment,
 	WorkspaceSessionLocation
 } from '$lib/types/sprocket';
+import { isRunClaimLeaseActive } from '$convex/lib/runLease';
 
 export type ViewerArgs = {
 	guestId?: string;
@@ -65,6 +66,15 @@ export function resolveSubmissionId(args: {
 		recoveredSubmission.reasoningEffort === args.reasoningEffort
 		? recoveredSubmission.submissionId
 		: args.newSubmissionId;
+}
+
+export function isRunBlockingAgentLaunch(
+	run: Pick<RunState, 'status' | 'claimExpiresAt'> | null,
+	now: number
+): boolean {
+	if (!run) return false;
+	if (run.status === 'queued') return true;
+	return isRunClaimLeaseActive(run, now);
 }
 
 export function getViewerQueryArgs(args: {

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -71,6 +71,7 @@ export type ThreadSummary = {
 	latestRunStatus: RunState['status'] | null;
 	latestRunId: Id<'runs'> | null;
 	latestRunStartedAt?: number;
+	latestRunClaimExpiresAt?: number;
 	hasActiveRun: boolean;
 };
 
@@ -112,6 +113,8 @@ export type RunState = {
 	userId: string;
 	workspaceSessionId: Id<'workspaceSessions'>;
 	status: Infer<typeof vRunStatus>;
+	submissionId?: string;
+	claimExpiresAt?: number;
 	selectedModel: Infer<typeof vModelId>;
 	reasoningEffort: Infer<typeof vReasoningEffort>;
 	startedAt: number;

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -69,6 +69,7 @@ export type ThreadSummary = {
 	lastMessageAt: number;
 	threadStatus: 'active' | 'archived';
 	latestRunStatus: RunState['status'] | null;
+	latestRunId: Id<'runs'> | null;
 	latestRunStartedAt?: number;
 	hasActiveRun: boolean;
 };
@@ -138,6 +139,7 @@ export type ThreadMessage = {
 export type AgentRunRequest = {
 	authToken?: string;
 	guestId?: string;
+	submissionId: string;
 	threadId: Id<'threadRecords'>;
 	prompt: string;
 	selectedModel: Infer<typeof vModelId>;

--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -48,6 +48,7 @@ function makeThreadSummary(overrides: Partial<ThreadSummary> = {}): ThreadSummar
 		latestRunStatus: null,
 		latestRunId: null,
 		latestRunStartedAt: undefined,
+		latestRunClaimExpiresAt: undefined,
 		hasActiveRun: false,
 		...overrides
 	};
@@ -305,6 +306,25 @@ describe('workspace thread helpers', () => {
 
 		expect(isAgentLaunchPending(result.pendingLaunches, threadId)).toBe(false);
 		expect(result.shouldRecover).toBe(false);
+	});
+
+	it('reconciles a retry when the existing run receives a new claim lease', () => {
+		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
+		const runId = 'run-a-1' as never;
+		const pendingLaunches = beginPendingAgentLaunch({}, threadId, {
+			expiresAt: 100,
+			launchId: 1,
+			previousClaimExpiresAt: 50,
+			previousRunId: runId
+		});
+
+		expect(resolvePendingAgentLaunch(pendingLaunches, threadId, runId, 50)).toBe(pendingLaunches);
+		expect(
+			isAgentLaunchPending(
+				resolvePendingAgentLaunch(pendingLaunches, threadId, runId, 150),
+				threadId
+			)
+		).toBe(false);
 	});
 
 	it('reconciles background launches by run id even when timestamps collide', () => {

--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+	beginPendingAgentLaunch,
+	clearPendingAgentLaunch,
 	dataForThread,
 	findWorkspaceSessionByName,
 	getAttachedWorkspaceSessionIds,
 	getWorkspaceThreadGroups,
+	isAgentLaunchPending,
+	isLatestRunReadyForThread,
 	isSelectionGenerationCurrent,
+	resolveExpiredAgentLaunch,
+	resolvePendingAgentLaunch,
+	resolvePendingAgentLaunchesFromThreads,
 	resolvePendingCreatedThreadId,
 	resolveWorkspaceThreadSelection
 } from '$lib/workspace/threads';
@@ -39,6 +46,7 @@ function makeThreadSummary(overrides: Partial<ThreadSummary> = {}): ThreadSummar
 		lastMessageAt: 0,
 		threadStatus: 'active',
 		latestRunStatus: null,
+		latestRunId: null,
 		latestRunStartedAt: undefined,
 		hasActiveRun: false,
 		...overrides
@@ -189,7 +197,7 @@ describe('workspace thread helpers', () => {
 		).toBe(newest.threadId);
 	});
 
-	it('clears pending created ids once the list catches up or create visibility fails', () => {
+	it('keeps a created id pinned through unrelated list updates until the thread appears', () => {
 		const existing = makeThreadSummary({
 			_id: 'thread-record-old' as ThreadSummary['_id'],
 			threadId: 'thread-record-old' as ThreadSummary['threadId']
@@ -199,30 +207,190 @@ describe('workspace thread helpers', () => {
 			_id: pendingThreadId,
 			threadId: pendingThreadId
 		});
+		const unrelated = makeThreadSummary({
+			_id: 'thread-record-unrelated' as ThreadSummary['_id'],
+			threadId: 'thread-record-unrelated' as ThreadSummary['threadId'],
+			lastMessageAt: 10
+		});
 
 		expect(
 			resolvePendingCreatedThreadId({
 				pendingCreatedThreadId: pendingThreadId,
-				threads: [existing],
-				threadListChangedSinceCreate: false
+				threads: [existing]
 			})
 		).toBe(pendingThreadId);
 
 		expect(
 			resolvePendingCreatedThreadId({
 				pendingCreatedThreadId: pendingThreadId,
-				threads: [created, existing],
-				threadListChangedSinceCreate: true
+				threads: [unrelated, existing]
 			})
-		).toBeNull();
+		).toBe(pendingThreadId);
 
 		expect(
 			resolvePendingCreatedThreadId({
 				pendingCreatedThreadId: pendingThreadId,
-				threads: [existing],
-				threadListChangedSinceCreate: true
+				threads: [created, existing]
 			})
 		).toBeNull();
+	});
+
+	it('tracks pending launches independently by thread', () => {
+		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
+		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
+		const previousRunA = 'run-a-1' as never;
+		const previousRunB = 'run-b-1' as never;
+		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
+			expiresAt: 100,
+			launchId: 1,
+			previousRunId: previousRunA
+		});
+		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
+			expiresAt: 100,
+			launchId: 2,
+			previousRunId: previousRunB
+		});
+
+		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
+		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
+
+		pendingLaunches = resolvePendingAgentLaunch(pendingLaunches, threadA, previousRunA);
+		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
+
+		pendingLaunches = resolvePendingAgentLaunch(pendingLaunches, threadA, 'run-a-2' as never);
+		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(false);
+		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
+	});
+
+	it('expires only the matching pending launch after its deadline', () => {
+		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
+		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
+		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
+			expiresAt: 100,
+			launchId: 1,
+			previousRunId: null
+		});
+		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
+			expiresAt: 100,
+			launchId: 2,
+			previousRunId: null
+		});
+
+		expect(resolveExpiredAgentLaunch(pendingLaunches, threadA, 1, 99, null)).toEqual({
+			pendingLaunches,
+			shouldRecover: false
+		});
+		expect(resolveExpiredAgentLaunch(pendingLaunches, threadA, 3, 100, null)).toEqual({
+			pendingLaunches,
+			shouldRecover: false
+		});
+
+		const expired = resolveExpiredAgentLaunch(pendingLaunches, threadA, 1, 100, null);
+		pendingLaunches = expired.pendingLaunches;
+		expect(expired.shouldRecover).toBe(true);
+		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(false);
+		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
+	});
+
+	it('does not recover an expired launch after its run becomes visible', () => {
+		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
+		const previousRunId = 'run-a-1' as never;
+		const pendingLaunches = beginPendingAgentLaunch({}, threadId, {
+			expiresAt: 100,
+			launchId: 1,
+			previousRunId
+		});
+
+		const result = resolveExpiredAgentLaunch(pendingLaunches, threadId, 1, 100, 'run-a-2' as never);
+
+		expect(isAgentLaunchPending(result.pendingLaunches, threadId)).toBe(false);
+		expect(result.shouldRecover).toBe(false);
+	});
+
+	it('reconciles background launches by run id even when timestamps collide', () => {
+		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
+		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
+		const previousRunA = 'run-a-1' as never;
+		const previousRunB = 'run-b-1' as never;
+		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
+			expiresAt: 100,
+			launchId: 1,
+			previousRunId: previousRunA
+		});
+		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
+			expiresAt: 100,
+			launchId: 2,
+			previousRunId: previousRunB
+		});
+
+		pendingLaunches = resolvePendingAgentLaunchesFromThreads(pendingLaunches, [
+			makeThreadSummary({
+				threadId: threadA,
+				latestRunId: previousRunA,
+				latestRunStartedAt: 10
+			}),
+			makeThreadSummary({
+				threadId: threadB,
+				latestRunId: 'run-b-2' as never,
+				latestRunStartedAt: 10
+			})
+		]);
+
+		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
+		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(false);
+	});
+
+	it('waits for an established thread latest-run query but permits a newly created thread', () => {
+		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
+
+		expect(
+			isLatestRunReadyForThread({
+				threadId,
+				pendingCreatedThreadId: null,
+				hasLatestRunData: false
+			})
+		).toBe(false);
+		expect(
+			isLatestRunReadyForThread({
+				threadId,
+				pendingCreatedThreadId: threadId,
+				hasLatestRunData: false
+			})
+		).toBe(true);
+		expect(
+			isLatestRunReadyForThread({
+				threadId,
+				pendingCreatedThreadId: null,
+				hasLatestRunData: true
+			})
+		).toBe(true);
+	});
+
+	it('scopes error cleanup to the matching thread and launch', () => {
+		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
+		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
+		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
+			expiresAt: 100,
+			launchId: 1,
+			previousRunId: null
+		});
+		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadA, {
+			expiresAt: 100,
+			launchId: 2,
+			previousRunId: 'run-a-1' as never
+		});
+		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
+			expiresAt: 100,
+			launchId: 3,
+			previousRunId: null
+		});
+
+		const unchanged = clearPendingAgentLaunch(pendingLaunches, threadA, 1);
+		expect(unchanged).toBe(pendingLaunches);
+
+		const afterThreadAError = clearPendingAgentLaunch(unchanged, threadA, 2);
+		expect(isAgentLaunchPending(afterThreadAError, threadA)).toBe(false);
+		expect(isAgentLaunchPending(afterThreadAError, threadB)).toBe(true);
 	});
 
 	it('rejects stale thread-scoped query data', () => {

--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -4,7 +4,7 @@ import {
 	clearPendingAgentLaunch,
 	dataForThread,
 	findWorkspaceSessionByName,
-	getAttachedWorkspaceSessionIds,
+	getThreadDeletionBlockMessage,
 	getWorkspaceThreadGroups,
 	isAgentLaunchPending,
 	isLatestRunReadyForThread,
@@ -13,10 +13,21 @@ import {
 	resolvePendingAgentLaunch,
 	resolvePendingAgentLaunchesFromThreads,
 	resolvePendingCreatedThreadId,
-	resolveWorkspaceThreadSelection
+	resolveWorkspaceThreadSelection,
+	type PendingAgentLaunch,
+	type PendingAgentLaunches
 } from '$lib/workspace/threads';
 import { defaultModelId, defaultReasoningEffort } from '$convex/lib/models';
 import type { ThreadSummary, WorkspaceSession } from '$lib/types/sprocket';
+
+type RunId = NonNullable<ThreadSummary['latestRunId']>;
+
+const threadA = 'thread-record-a' as ThreadSummary['threadId'];
+const threadB = 'thread-record-b' as ThreadSummary['threadId'];
+const runA1 = 'run-a-1' as RunId;
+const runA2 = 'run-a-2' as RunId;
+const runB1 = 'run-b-1' as RunId;
+const runB2 = 'run-b-2' as RunId;
 
 function makeWorkspaceSession(overrides: Partial<WorkspaceSession> = {}): WorkspaceSession {
 	return {
@@ -54,32 +65,22 @@ function makeThreadSummary(overrides: Partial<ThreadSummary> = {}): ThreadSummar
 	};
 }
 
-describe('workspace thread helpers', () => {
-	it('returns attached workspaces for the current executor client only', () => {
-		const attached = getAttachedWorkspaceSessionIds(
-			[
-				makeWorkspaceSession({
-					_id: 'ws-1' as WorkspaceSession['_id'],
-					connectedClientId: 'client-1',
-					executorStatus: 'connected'
-				}),
-				makeWorkspaceSession({
-					_id: 'ws-2' as WorkspaceSession['_id'],
-					connectedClientId: 'client-1',
-					executorStatus: 'disconnected'
-				}),
-				makeWorkspaceSession({
-					_id: 'ws-3' as WorkspaceSession['_id'],
-					connectedClientId: 'client-2',
-					executorStatus: 'connected'
-				})
-			],
-			'client-1'
-		);
-
-		expect(attached).toEqual(['ws-1']);
+function beginLaunch(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: ThreadSummary['threadId'],
+	launchId: number,
+	previousRunId: RunId | null = null,
+	extras: Partial<PendingAgentLaunch> = {}
+): PendingAgentLaunches {
+	return beginPendingAgentLaunch(pendingLaunches, threadId, {
+		expiresAt: 100,
+		launchId,
+		previousRunId,
+		...extras
 	});
+}
 
+describe('workspace thread helpers', () => {
 	it('groups threads by exact workspace name', () => {
 		const groups = getWorkspaceThreadGroups(
 			[
@@ -131,11 +132,9 @@ describe('workspace thread helpers', () => {
 	});
 
 	it('preserves a blank draft selection for the current workspace', () => {
-		const threads = [makeThreadSummary()];
-
 		expect(
 			resolveWorkspaceThreadSelection({
-				threads,
+				threads: [makeThreadSummary()],
 				currentThreadId: null,
 				currentWorkspaceName: 'Workspace',
 				draftWorkspaceName: 'Workspace'
@@ -168,12 +167,11 @@ describe('workspace thread helpers', () => {
 			threadId: 'thread-record-newest' as ThreadSummary['threadId'],
 			lastMessageAt: 30
 		});
-		const vanished = 'thread-record-vanished' as ThreadSummary['threadId'];
 
 		expect(
 			resolveWorkspaceThreadSelection({
 				threads: [newest],
-				currentThreadId: vanished,
+				currentThreadId: 'thread-record-vanished' as ThreadSummary['threadId'],
 				currentWorkspaceName: 'Workspace',
 				draftWorkspaceName: null,
 				pendingCreatedThreadId: null
@@ -220,14 +218,12 @@ describe('workspace thread helpers', () => {
 				threads: [existing]
 			})
 		).toBe(pendingThreadId);
-
 		expect(
 			resolvePendingCreatedThreadId({
 				pendingCreatedThreadId: pendingThreadId,
 				threads: [unrelated, existing]
 			})
 		).toBe(pendingThreadId);
-
 		expect(
 			resolvePendingCreatedThreadId({
 				pendingCreatedThreadId: pendingThreadId,
@@ -236,46 +232,30 @@ describe('workspace thread helpers', () => {
 		).toBeNull();
 	});
 
-	it('tracks pending launches independently by thread', () => {
-		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
-		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
-		const previousRunA = 'run-a-1' as never;
-		const previousRunB = 'run-b-1' as never;
-		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
-			expiresAt: 100,
-			launchId: 1,
-			previousRunId: previousRunA
-		});
-		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
-			expiresAt: 100,
-			launchId: 2,
-			previousRunId: previousRunB
-		});
+	it('tracks pending launches independently by thread and clears only progressed ones', () => {
+		let pendingLaunches = beginLaunch({}, threadA, 1, runA1);
+		pendingLaunches = beginLaunch(pendingLaunches, threadB, 2, runB1);
 
 		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
 		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
+		expect(
+			isAgentLaunchPending(resolvePendingAgentLaunch(pendingLaunches, threadA, runA1), threadA)
+		).toBe(true);
 
-		pendingLaunches = resolvePendingAgentLaunch(pendingLaunches, threadA, previousRunA);
+		pendingLaunches = resolvePendingAgentLaunchesFromThreads(pendingLaunches, [
+			makeThreadSummary({ threadId: threadA, latestRunId: runA1, latestRunStartedAt: 10 }),
+			makeThreadSummary({ threadId: threadB, latestRunId: runB2, latestRunStartedAt: 10 })
+		]);
 		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
+		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(false);
 
-		pendingLaunches = resolvePendingAgentLaunch(pendingLaunches, threadA, 'run-a-2' as never);
+		pendingLaunches = resolvePendingAgentLaunch(pendingLaunches, threadA, runA2);
 		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(false);
-		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
 	});
 
-	it('expires only the matching pending launch after its deadline', () => {
-		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
-		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
-		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
-			expiresAt: 100,
-			launchId: 1,
-			previousRunId: null
-		});
-		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
-			expiresAt: 100,
-			launchId: 2,
-			previousRunId: null
-		});
+	it('expires only the matching pending launch and recovers only when the run is unchanged', () => {
+		let pendingLaunches = beginLaunch({}, threadA, 1);
+		pendingLaunches = beginLaunch(pendingLaunches, threadB, 2);
 
 		expect(resolveExpiredAgentLaunch(pendingLaunches, threadA, 1, 99, null)).toEqual({
 			pendingLaunches,
@@ -287,99 +267,50 @@ describe('workspace thread helpers', () => {
 		});
 
 		const expired = resolveExpiredAgentLaunch(pendingLaunches, threadA, 1, 100, null);
-		pendingLaunches = expired.pendingLaunches;
 		expect(expired.shouldRecover).toBe(true);
-		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(false);
-		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(true);
-	});
+		expect(isAgentLaunchPending(expired.pendingLaunches, threadA)).toBe(false);
+		expect(isAgentLaunchPending(expired.pendingLaunches, threadB)).toBe(true);
 
-	it('does not recover an expired launch after its run becomes visible', () => {
-		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
-		const previousRunId = 'run-a-1' as never;
-		const pendingLaunches = beginPendingAgentLaunch({}, threadId, {
-			expiresAt: 100,
-			launchId: 1,
-			previousRunId
-		});
-
-		const result = resolveExpiredAgentLaunch(pendingLaunches, threadId, 1, 100, 'run-a-2' as never);
-
-		expect(isAgentLaunchPending(result.pendingLaunches, threadId)).toBe(false);
-		expect(result.shouldRecover).toBe(false);
+		const visibleRun = resolveExpiredAgentLaunch(
+			beginLaunch({}, threadA, 1, runA1),
+			threadA,
+			1,
+			100,
+			runA2
+		);
+		expect(isAgentLaunchPending(visibleRun.pendingLaunches, threadA)).toBe(false);
+		expect(visibleRun.shouldRecover).toBe(false);
 	});
 
 	it('reconciles a retry when the existing run receives a new claim lease', () => {
-		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
-		const runId = 'run-a-1' as never;
-		const pendingLaunches = beginPendingAgentLaunch({}, threadId, {
-			expiresAt: 100,
-			launchId: 1,
-			previousClaimExpiresAt: 50,
-			previousRunId: runId
+		const pendingLaunches = beginLaunch({}, threadA, 1, runA1, {
+			previousClaimExpiresAt: 50
 		});
 
-		expect(resolvePendingAgentLaunch(pendingLaunches, threadId, runId, 50)).toBe(pendingLaunches);
+		expect(resolvePendingAgentLaunch(pendingLaunches, threadA, runA1, 50)).toBe(pendingLaunches);
 		expect(
-			isAgentLaunchPending(
-				resolvePendingAgentLaunch(pendingLaunches, threadId, runId, 150),
-				threadId
-			)
+			isAgentLaunchPending(resolvePendingAgentLaunch(pendingLaunches, threadA, runA1, 150), threadA)
 		).toBe(false);
 	});
 
-	it('reconciles background launches by run id even when timestamps collide', () => {
-		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
-		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
-		const previousRunA = 'run-a-1' as never;
-		const previousRunB = 'run-b-1' as never;
-		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
-			expiresAt: 100,
-			launchId: 1,
-			previousRunId: previousRunA
-		});
-		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
-			expiresAt: 100,
-			launchId: 2,
-			previousRunId: previousRunB
-		});
-
-		pendingLaunches = resolvePendingAgentLaunchesFromThreads(pendingLaunches, [
-			makeThreadSummary({
-				threadId: threadA,
-				latestRunId: previousRunA,
-				latestRunStartedAt: 10
-			}),
-			makeThreadSummary({
-				threadId: threadB,
-				latestRunId: 'run-b-2' as never,
-				latestRunStartedAt: 10
-			})
-		]);
-
-		expect(isAgentLaunchPending(pendingLaunches, threadA)).toBe(true);
-		expect(isAgentLaunchPending(pendingLaunches, threadB)).toBe(false);
-	});
-
 	it('waits for an established thread latest-run query but permits a newly created thread', () => {
-		const threadId = 'thread-record-a' as ThreadSummary['threadId'];
-
 		expect(
 			isLatestRunReadyForThread({
-				threadId,
+				threadId: threadA,
 				pendingCreatedThreadId: null,
 				hasLatestRunData: false
 			})
 		).toBe(false);
 		expect(
 			isLatestRunReadyForThread({
-				threadId,
-				pendingCreatedThreadId: threadId,
+				threadId: threadA,
+				pendingCreatedThreadId: threadA,
 				hasLatestRunData: false
 			})
 		).toBe(true);
 		expect(
 			isLatestRunReadyForThread({
-				threadId,
+				threadId: threadA,
 				pendingCreatedThreadId: null,
 				hasLatestRunData: true
 			})
@@ -387,28 +318,13 @@ describe('workspace thread helpers', () => {
 	});
 
 	it('scopes error cleanup to the matching thread and launch', () => {
-		const threadA = 'thread-record-a' as ThreadSummary['threadId'];
-		const threadB = 'thread-record-b' as ThreadSummary['threadId'];
-		let pendingLaunches = beginPendingAgentLaunch({}, threadA, {
-			expiresAt: 100,
-			launchId: 1,
-			previousRunId: null
-		});
-		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadA, {
-			expiresAt: 100,
-			launchId: 2,
-			previousRunId: 'run-a-1' as never
-		});
-		pendingLaunches = beginPendingAgentLaunch(pendingLaunches, threadB, {
-			expiresAt: 100,
-			launchId: 3,
-			previousRunId: null
-		});
+		let pendingLaunches = beginLaunch({}, threadA, 1);
+		pendingLaunches = beginLaunch(pendingLaunches, threadA, 2, runA1);
+		pendingLaunches = beginLaunch(pendingLaunches, threadB, 3);
 
-		const unchanged = clearPendingAgentLaunch(pendingLaunches, threadA, 1);
-		expect(unchanged).toBe(pendingLaunches);
+		expect(clearPendingAgentLaunch(pendingLaunches, threadA, 1)).toBe(pendingLaunches);
 
-		const afterThreadAError = clearPendingAgentLaunch(unchanged, threadA, 2);
+		const afterThreadAError = clearPendingAgentLaunch(pendingLaunches, threadA, 2);
 		expect(isAgentLaunchPending(afterThreadAError, threadA)).toBe(false);
 		expect(isAgentLaunchPending(afterThreadAError, threadB)).toBe(true);
 	});
@@ -429,5 +345,32 @@ describe('workspace thread helpers', () => {
 	it('treats selection generations as current only when they match', () => {
 		expect(isSelectionGenerationCurrent(3, 3)).toBe(true);
 		expect(isSelectionGenerationCurrent(2, 3)).toBe(false);
+	});
+
+	it('blocks thread deletion while a launch is pending or a run is active', () => {
+		expect(
+			getThreadDeletionBlockMessage(beginLaunch({}, threadA, 1), {
+				threadId: threadA,
+				hasActiveRun: false
+			})
+		).toBe('Wait for the local agent to start before deleting this thread.');
+		expect(
+			getThreadDeletionBlockMessage(
+				{},
+				{
+					threadId: threadA,
+					hasActiveRun: true
+				}
+			)
+		).toBe('Finish or cancel the active run before deleting this thread.');
+		expect(
+			getThreadDeletionBlockMessage(
+				{},
+				{
+					threadId: threadA,
+					hasActiveRun: false
+				}
+			)
+		).toBeNull();
 	});
 });

--- a/apps/web/src/lib/workspace/threads.ts
+++ b/apps/web/src/lib/workspace/threads.ts
@@ -1,23 +1,6 @@
 import type { Id } from '$convex/_generated/dataModel';
 import type { ThreadSummary, WorkspaceSession, WorkspaceThreadGroup } from '$lib/types/sprocket';
 
-export function getAttachedWorkspaceSessionIds(
-	workspaceSessions: WorkspaceSession[],
-	clientId: string | null
-) {
-	if (!clientId) {
-		return [];
-	}
-
-	return workspaceSessions
-		.filter(
-			(workspaceSession) =>
-				workspaceSession.connectedClientId === clientId &&
-				workspaceSession.executorStatus === 'connected'
-		)
-		.map((workspaceSession) => workspaceSession._id);
-}
-
 export function findWorkspaceSessionByName<T extends Pick<WorkspaceSession, 'workspaceName'>>(
 	workspaceSessions: T[],
 	workspaceName: string
@@ -188,6 +171,18 @@ export function clearPendingAgentLaunch(
 	return nextPendingLaunches;
 }
 
+function hasAgentLaunchProgressed(
+	pendingLaunch: PendingAgentLaunch,
+	observedRunId: Id<'runs'> | null,
+	observedClaimExpiresAt?: number
+): boolean {
+	return Boolean(
+		observedRunId &&
+		(observedRunId !== pendingLaunch.previousRunId ||
+			observedClaimExpiresAt !== pendingLaunch.previousClaimExpiresAt)
+	);
+}
+
 export function resolvePendingAgentLaunch(
 	pendingLaunches: PendingAgentLaunches,
 	threadId: Id<'threadRecords'>,
@@ -195,12 +190,9 @@ export function resolvePendingAgentLaunch(
 	observedClaimExpiresAt?: number
 ): PendingAgentLaunches {
 	const pendingLaunch = pendingLaunches[threadId];
-	if (!pendingLaunch || !observedRunId) {
-		return pendingLaunches;
-	}
 	if (
-		observedRunId === pendingLaunch.previousRunId &&
-		observedClaimExpiresAt === pendingLaunch.previousClaimExpiresAt
+		!pendingLaunch ||
+		!hasAgentLaunchProgressed(pendingLaunch, observedRunId, observedClaimExpiresAt)
 	) {
 		return pendingLaunches;
 	}
@@ -215,20 +207,11 @@ export function resolvePendingAgentLaunchesFromThreads(
 	let nextPendingLaunches = pendingLaunches;
 
 	for (const thread of threads) {
-		const pendingLaunch = nextPendingLaunches[thread.threadId];
-		if (
-			!pendingLaunch ||
-			!thread.latestRunId ||
-			(thread.latestRunId === pendingLaunch.previousRunId &&
-				thread.latestRunClaimExpiresAt === pendingLaunch.previousClaimExpiresAt)
-		) {
-			continue;
-		}
-
-		nextPendingLaunches = clearPendingAgentLaunch(
+		nextPendingLaunches = resolvePendingAgentLaunch(
 			nextPendingLaunches,
 			thread.threadId,
-			pendingLaunch.launchId
+			thread.latestRunId,
+			thread.latestRunClaimExpiresAt
 		);
 	}
 
@@ -250,11 +233,21 @@ export function resolveExpiredAgentLaunch(
 
 	return {
 		pendingLaunches: clearPendingAgentLaunch(pendingLaunches, threadId, launchId),
-		shouldRecover:
-			!latestRunId ||
-			(latestRunId === pendingLaunch.previousRunId &&
-				latestClaimExpiresAt === pendingLaunch.previousClaimExpiresAt)
+		shouldRecover: !hasAgentLaunchProgressed(pendingLaunch, latestRunId, latestClaimExpiresAt)
 	};
+}
+
+export function getThreadDeletionBlockMessage(
+	pendingLaunches: PendingAgentLaunches,
+	thread: Pick<ThreadSummary, 'threadId' | 'hasActiveRun'>
+): string | null {
+	if (isAgentLaunchPending(pendingLaunches, thread.threadId)) {
+		return 'Wait for the local agent to start before deleting this thread.';
+	}
+
+	return thread.hasActiveRun
+		? 'Finish or cancel the active run before deleting this thread.'
+		: null;
 }
 
 export function resolveWorkspaceThreadSelection(args: {

--- a/apps/web/src/lib/workspace/threads.ts
+++ b/apps/web/src/lib/workspace/threads.ts
@@ -128,9 +128,8 @@ export function isSelectionGenerationCurrent(
 export function resolvePendingCreatedThreadId(args: {
 	pendingCreatedThreadId: Id<'threadRecords'> | null;
 	threads: ThreadSummary[];
-	threadListChangedSinceCreate: boolean;
 }): Id<'threadRecords'> | null {
-	const { pendingCreatedThreadId, threads, threadListChangedSinceCreate } = args;
+	const { pendingCreatedThreadId, threads } = args;
 	if (!pendingCreatedThreadId) {
 		return null;
 	}
@@ -139,12 +138,110 @@ export function resolvePendingCreatedThreadId(args: {
 		return null;
 	}
 
-	// Create/list catch-up window ended without the thread appearing — stop pinning.
-	if (threadListChangedSinceCreate) {
-		return null;
+	return pendingCreatedThreadId;
+}
+
+export function isLatestRunReadyForThread(args: {
+	threadId: Id<'threadRecords'> | null;
+	pendingCreatedThreadId: Id<'threadRecords'> | null;
+	hasLatestRunData: boolean;
+}): boolean {
+	return !args.threadId || args.threadId === args.pendingCreatedThreadId || args.hasLatestRunData;
+}
+
+export type PendingAgentLaunch = {
+	expiresAt: number;
+	launchId: number;
+	previousRunId: Id<'runs'> | null;
+};
+
+export type PendingAgentLaunches = Readonly<Partial<Record<string, PendingAgentLaunch>>>;
+
+export function isAgentLaunchPending(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: Id<'threadRecords'> | null
+): boolean {
+	return Boolean(threadId && pendingLaunches[threadId]);
+}
+
+export function beginPendingAgentLaunch(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: Id<'threadRecords'>,
+	launch: PendingAgentLaunch
+): PendingAgentLaunches {
+	return { ...pendingLaunches, [threadId]: launch };
+}
+
+export function clearPendingAgentLaunch(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: Id<'threadRecords'>,
+	launchId?: number
+): PendingAgentLaunches {
+	const pendingLaunch = pendingLaunches[threadId];
+	if (!pendingLaunch || (launchId !== undefined && pendingLaunch.launchId !== launchId)) {
+		return pendingLaunches;
 	}
 
-	return pendingCreatedThreadId;
+	const nextPendingLaunches = { ...pendingLaunches };
+	delete nextPendingLaunches[threadId];
+	return nextPendingLaunches;
+}
+
+export function resolvePendingAgentLaunch(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: Id<'threadRecords'>,
+	observedRunId: Id<'runs'> | null
+): PendingAgentLaunches {
+	const pendingLaunch = pendingLaunches[threadId];
+	if (!pendingLaunch || !observedRunId || observedRunId === pendingLaunch.previousRunId) {
+		return pendingLaunches;
+	}
+
+	return clearPendingAgentLaunch(pendingLaunches, threadId, pendingLaunch.launchId);
+}
+
+export function resolvePendingAgentLaunchesFromThreads(
+	pendingLaunches: PendingAgentLaunches,
+	threads: ThreadSummary[]
+): PendingAgentLaunches {
+	let nextPendingLaunches = pendingLaunches;
+
+	for (const thread of threads) {
+		const pendingLaunch = nextPendingLaunches[thread.threadId];
+		if (
+			!pendingLaunch ||
+			!thread.latestRunId ||
+			thread.latestRunId === pendingLaunch.previousRunId
+		) {
+			continue;
+		}
+
+		nextPendingLaunches = clearPendingAgentLaunch(
+			nextPendingLaunches,
+			thread.threadId,
+			pendingLaunch.launchId
+		);
+	}
+
+	return nextPendingLaunches;
+}
+
+export function resolveExpiredAgentLaunch(
+	pendingLaunches: PendingAgentLaunches,
+	threadId: Id<'threadRecords'>,
+	launchId: number,
+	now: number,
+	latestRunId: Id<'runs'> | null
+): { pendingLaunches: PendingAgentLaunches; shouldRecover: boolean } {
+	const pendingLaunch = pendingLaunches[threadId];
+	if (!pendingLaunch || pendingLaunch.launchId !== launchId || pendingLaunch.expiresAt > now) {
+		return { pendingLaunches, shouldRecover: false };
+	}
+
+	return {
+		pendingLaunches: clearPendingAgentLaunch(pendingLaunches, threadId, launchId),
+		shouldRecover: !latestRunId || latestRunId === pendingLaunch.previousRunId
+	};
 }
 
 export function resolveWorkspaceThreadSelection(args: {

--- a/apps/web/src/lib/workspace/threads.ts
+++ b/apps/web/src/lib/workspace/threads.ts
@@ -152,6 +152,7 @@ export function isLatestRunReadyForThread(args: {
 export type PendingAgentLaunch = {
 	expiresAt: number;
 	launchId: number;
+	previousClaimExpiresAt?: number;
 	previousRunId: Id<'runs'> | null;
 };
 
@@ -190,10 +191,17 @@ export function clearPendingAgentLaunch(
 export function resolvePendingAgentLaunch(
 	pendingLaunches: PendingAgentLaunches,
 	threadId: Id<'threadRecords'>,
-	observedRunId: Id<'runs'> | null
+	observedRunId: Id<'runs'> | null,
+	observedClaimExpiresAt?: number
 ): PendingAgentLaunches {
 	const pendingLaunch = pendingLaunches[threadId];
-	if (!pendingLaunch || !observedRunId || observedRunId === pendingLaunch.previousRunId) {
+	if (!pendingLaunch || !observedRunId) {
+		return pendingLaunches;
+	}
+	if (
+		observedRunId === pendingLaunch.previousRunId &&
+		observedClaimExpiresAt === pendingLaunch.previousClaimExpiresAt
+	) {
 		return pendingLaunches;
 	}
 
@@ -211,7 +219,8 @@ export function resolvePendingAgentLaunchesFromThreads(
 		if (
 			!pendingLaunch ||
 			!thread.latestRunId ||
-			thread.latestRunId === pendingLaunch.previousRunId
+			(thread.latestRunId === pendingLaunch.previousRunId &&
+				thread.latestRunClaimExpiresAt === pendingLaunch.previousClaimExpiresAt)
 		) {
 			continue;
 		}
@@ -231,7 +240,8 @@ export function resolveExpiredAgentLaunch(
 	threadId: Id<'threadRecords'>,
 	launchId: number,
 	now: number,
-	latestRunId: Id<'runs'> | null
+	latestRunId: Id<'runs'> | null,
+	latestClaimExpiresAt?: number
 ): { pendingLaunches: PendingAgentLaunches; shouldRecover: boolean } {
 	const pendingLaunch = pendingLaunches[threadId];
 	if (!pendingLaunch || pendingLaunch.launchId !== launchId || pendingLaunch.expiresAt > now) {
@@ -240,7 +250,10 @@ export function resolveExpiredAgentLaunch(
 
 	return {
 		pendingLaunches: clearPendingAgentLaunch(pendingLaunches, threadId, launchId),
-		shouldRecover: !latestRunId || latestRunId === pendingLaunch.previousRunId
+		shouldRecover:
+			!latestRunId ||
+			(latestRunId === pendingLaunch.previousRunId &&
+				latestClaimExpiresAt === pendingLaunch.previousClaimExpiresAt)
 	};
 }
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -33,12 +33,14 @@
 		type SupportedModelId,
 		type SupportedReasoningEffort
 	} from '$convex/lib/models';
+	import { isClaimedRunStatus } from '$convex/lib/runLease';
 	import {
 		beginPendingAgentLaunch,
 		clearPendingAgentLaunch,
 		dataForThread,
 		findThreadById,
 		findWorkspaceSessionByName,
+		getThreadDeletionBlockMessage,
 		getWorkspaceThreadGroups,
 		isAgentLaunchPending,
 		isLatestRunReadyForThread,
@@ -304,9 +306,6 @@
 	);
 	const hasPendingAgentLaunch = $derived(
 		isAgentLaunchPending(pendingAgentLaunches, currentThreadId)
-	);
-	const pendingAgentLaunchThreadIds = $derived(
-		Object.keys(pendingAgentLaunches) as Id<'threadRecords'>[]
 	);
 	const isLatestRunReady = $derived(
 		isLatestRunReadyForThread({
@@ -616,18 +615,8 @@
 		openWorkspaceSession(thread.workspaceName, { threadId: thread.threadId });
 	}
 
-	function getThreadDeletionBlockMessage(thread: ThreadSummary) {
-		if (isAgentLaunchPending(pendingAgentLaunches, thread.threadId)) {
-			return 'Wait for the local agent to start before deleting this thread.';
-		}
-
-		return thread.hasActiveRun
-			? 'Finish or cancel the active run before deleting this thread.'
-			: null;
-	}
-
 	async function deleteThread(thread: ThreadSummary) {
-		const initialBlockMessage = getThreadDeletionBlockMessage(thread);
+		const initialBlockMessage = getThreadDeletionBlockMessage(pendingAgentLaunches, thread);
 		if (initialBlockMessage) {
 			currentError = initialBlockMessage;
 			return;
@@ -638,7 +627,7 @@
 		if (!confirmed) {
 			return;
 		}
-		const currentBlockMessage = getThreadDeletionBlockMessage(thread);
+		const currentBlockMessage = getThreadDeletionBlockMessage(pendingAgentLaunches, thread);
 		if (currentBlockMessage) {
 			currentError = currentBlockMessage;
 			return;
@@ -985,7 +974,7 @@
 	});
 
 	$effect(() => {
-		if (runState?.status !== 'running' && runState?.status !== 'awaiting_executor') {
+		if (!runState || !isClaimedRunStatus(runState.status)) {
 			return;
 		}
 		const updateClock = () => {
@@ -1004,7 +993,7 @@
 			!viewerIdentity ||
 			!recoveryScope ||
 			!staleRun ||
-			(staleRun.status !== 'running' && staleRun.status !== 'awaiting_executor') ||
+			!isClaimedRunStatus(staleRun.status) ||
 			isRunning ||
 			isSubmittingPrompt ||
 			hasPendingAgentLaunch ||
@@ -1222,26 +1211,20 @@
 	});
 
 	$effect(() => {
-		const nextPendingAgentLaunches = resolvePendingAgentLaunchesFromThreads(
+		let nextPendingAgentLaunches = resolvePendingAgentLaunchesFromThreads(
 			pendingAgentLaunches,
 			threads
 		);
-		if (nextPendingAgentLaunches !== pendingAgentLaunches) {
-			pendingAgentLaunches = nextPendingAgentLaunches;
-		}
-	});
-
-	$effect(() => {
 		if (currentThreadId && runState?._id) {
-			const nextPendingAgentLaunches = resolvePendingAgentLaunch(
-				pendingAgentLaunches,
+			nextPendingAgentLaunches = resolvePendingAgentLaunch(
+				nextPendingAgentLaunches,
 				currentThreadId,
 				runState._id,
 				runState.claimExpiresAt
 			);
-			if (nextPendingAgentLaunches !== pendingAgentLaunches) {
-				pendingAgentLaunches = nextPendingAgentLaunches;
-			}
+		}
+		if (nextPendingAgentLaunches !== pendingAgentLaunches) {
+			pendingAgentLaunches = nextPendingAgentLaunches;
 		}
 	});
 
@@ -1348,7 +1331,7 @@
 				{currentWorkspaceName}
 				{currentThreadId}
 				groups={groupedWorkspaceThreads}
-				{pendingAgentLaunchThreadIds}
+				{pendingAgentLaunches}
 				onChooseWorkspace={() => {
 					openWorkspacePicker('add');
 				}}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -21,6 +21,7 @@
 		isRunBlockingAgentLaunch,
 		launchAgentRun,
 		refreshDesktopWorkspaceSessions as refreshDesktopWorkspaceSessionsFromDesktop,
+		resolveDraftRunSubmissionId,
 		resolveSubmissionId,
 		verifyWorkspaceSession as verifyWorkspaceSessionForExecution,
 		type WorkspaceSessionState
@@ -604,7 +605,7 @@
 			});
 		}
 
-		return result.threadId;
+		return result;
 	}
 
 	function startThreadDraftForWorkspace(workspaceName: string) {
@@ -735,14 +736,16 @@
 			originatingRecoveryScope
 		);
 		const recoveredSubmission = recoveredSubmissionIds.get(originatingRecoveryKey);
-		const submissionRequestId = resolveSubmissionId({
+		const freshSubmissionId = crypto.randomUUID();
+		const threadSubmissionId = resolveSubmissionId({
 			latestRun: selectedThreadId ? runState : null,
-			newSubmissionId: crypto.randomUUID(),
+			newSubmissionId: freshSubmissionId,
 			prompt: submittedPrompt,
 			reasoningEffort: submittedReasoningEffort,
 			recoveredSubmission,
 			selectedModel: submittedModel
 		});
+		let runSubmissionId = threadSubmissionId;
 		clearComposerRecovery(submittedViewerIdentity, originatingRecoveryScope);
 		let launchedThreadId: Id<'threadRecords'> | null = null;
 		let agentLaunchId: number | null = null;
@@ -765,7 +768,10 @@
 				reasoningEffort: submittedReasoningEffort,
 				selectedModel: submittedModel,
 				scope: recoveryScope,
-				submissionId: submissionRequestId,
+				submissionId:
+					!selectedThreadId && recoveryScope === originatingRecoveryScope
+						? threadSubmissionId
+						: runSubmissionId,
 				viewerIdentity: submittedViewerIdentity
 			});
 		};
@@ -794,22 +800,30 @@
 		submittingPromptScopes.set(submissionScope, submissionSequence);
 
 		try {
-			const threadId =
-				selectedThreadId ??
-				(await createThread({
-					isSubmissionCurrent,
-					prompt: submittedPrompt,
-					selectionGeneration,
-					selectedModel: submittedModel,
-					selectedReasoningEffort: submittedReasoningEffort,
-					submissionId: submissionRequestId,
-					viewerArgs: submittedViewerArgs,
-					viewerIdentity: submittedViewerIdentity,
-					workspaceName: submittedWorkspaceName,
-					workspaceSessionId
-				}));
+			const threadCreation = selectedThreadId
+				? null
+				: await createThread({
+						isSubmissionCurrent,
+						prompt: submittedPrompt,
+						selectionGeneration,
+						selectedModel: submittedModel,
+						selectedReasoningEffort: submittedReasoningEffort,
+						submissionId: threadSubmissionId,
+						viewerArgs: submittedViewerArgs,
+						viewerIdentity: submittedViewerIdentity,
+						workspaceName: submittedWorkspaceName,
+						workspaceSessionId
+					});
+			const threadId = selectedThreadId ?? threadCreation?.threadId ?? null;
 			if (!threadId || !isSubmissionCurrent()) {
 				return;
+			}
+			if (threadCreation) {
+				runSubmissionId = resolveDraftRunSubmissionId({
+					freshSubmissionId,
+					submissionRunStatus: threadCreation.submissionRunStatus,
+					threadSubmissionId
+				});
 			}
 			if (!isSubmittedViewerCurrent()) {
 				recoverSubmission(sessionChangedMessage);
@@ -900,7 +914,7 @@
 				threadId,
 				prompt: submittedPrompt,
 				selectedModel: submittedModel,
-				submissionId: submissionRequestId,
+				submissionId: runSubmissionId,
 				reasoningEffort: submittedReasoningEffort,
 				viewerArgs: submittedViewerArgs,
 				workspaceSessionId

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -18,6 +18,7 @@
 		getViewerArgs as getViewerArgsForUser,
 		getViewerIdentity,
 		getViewerQueryArgs as getViewerQueryArgsForUser,
+		isRunBlockingAgentLaunch,
 		launchAgentRun,
 		refreshDesktopWorkspaceSessions as refreshDesktopWorkspaceSessionsFromDesktop,
 		resolveSubmissionId,
@@ -115,7 +116,14 @@
 		}
 	>();
 	const latestSubmissionSequencesByRecoveryScope = new SvelteMap<string, number>();
+	const recoveredStaleClaims = new SvelteSet<string>();
 	let pendingAgentLaunches = $state<PendingAgentLaunches>({});
+	let leaseClockNow = $state(0);
+	let latestRunServerClock = $state<{
+		localObservedAt: number;
+		runId: Id<'runs'> | null;
+		serverNow: number;
+	} | null>(null);
 	let nextAgentLaunchId = 0;
 	let nextSubmissionSequence = 0;
 	let hasResolvedInitialSelection = $state(false);
@@ -271,10 +279,27 @@
 
 	const runState = $derived(currentLatestRunData?.run ?? null);
 	const visibleActions = $derived((currentLatestRunData?.jobs ?? []).slice(-60));
+	const currentComposerScope = $derived(
+		getComposerScope(currentThreadId, currentWorkspaceSessionId)
+	);
+	const estimatedServerNow = $derived(
+		latestRunServerClock && latestRunServerClock.runId === (runState?._id ?? null)
+			? latestRunServerClock.serverNow +
+					Math.max(0, leaseClockNow - latestRunServerClock.localObservedAt)
+			: (currentLatestRunData?.serverNow ?? Date.now())
+	);
+	const currentRecoveredSubmission = $derived.by(() => {
+		const viewerIdentity = getCurrentViewerIdentity();
+		if (!viewerIdentity || !currentComposerScope) return undefined;
+		return recoveredSubmissionIds.get(getComposerRecoveryKey(viewerIdentity, currentComposerScope));
+	});
+	const isRetryableQueuedRun = $derived(
+		runState?.status === 'queued' &&
+			runState.submissionId !== undefined &&
+			currentRecoveredSubmission?.submissionId === runState.submissionId
+	);
 	const isRunning = $derived(
-		runState?.status === 'queued' ||
-			runState?.status === 'running' ||
-			runState?.status === 'awaiting_executor'
+		isRunBlockingAgentLaunch(runState, estimatedServerNow) && !isRetryableQueuedRun
 	);
 	const hasPendingAgentLaunch = $derived(
 		isAgentLaunchPending(pendingAgentLaunches, currentThreadId)
@@ -288,9 +313,6 @@
 			pendingCreatedThreadId,
 			hasLatestRunData: Boolean(currentLatestRunData)
 		})
-	);
-	const currentComposerScope = $derived(
-		getComposerScope(currentThreadId, currentWorkspaceSessionId)
 	);
 	const isSubmittingPrompt = $derived(
 		Boolean(currentComposerScope && submittingPromptScopes.has(currentComposerScope))
@@ -824,6 +846,7 @@
 			pendingAgentLaunches = beginPendingAgentLaunch(pendingAgentLaunches, threadId, {
 				expiresAt: Date.now() + agentLaunchTimeoutMs,
 				launchId,
+				...(runState?.claimExpiresAt ? { previousClaimExpiresAt: runState.claimExpiresAt } : {}),
 				previousRunId
 			});
 			window.setTimeout(() => {
@@ -834,12 +857,17 @@
 					[threadLatestRunId, selectedRunId].find((runId) => runId && runId !== previousRunId) ??
 					threadLatestRunId ??
 					selectedRunId;
+				const latestClaimExpiresAt =
+					currentThreadId === threadId && runState?._id === latestRunId
+						? runState.claimExpiresAt
+						: threads.find((thread) => thread.threadId === threadId)?.latestRunClaimExpiresAt;
 				const recovery = resolveExpiredAgentLaunch(
 					pendingAgentLaunches,
 					threadId,
 					launchId,
 					Date.now(),
-					latestRunId
+					latestRunId,
+					latestClaimExpiresAt
 				);
 				if (recovery.pendingLaunches === pendingAgentLaunches) {
 					return;
@@ -854,16 +882,17 @@
 				authToken,
 				desktopApi,
 				onError: (error) => {
+					if (!isSubmissionCurrent() || !isSubmittedViewerCurrent()) {
+						return;
+					}
 					const nextPendingAgentLaunches = clearPendingAgentLaunch(
 						pendingAgentLaunches,
 						threadId,
 						launchId
 					);
-					if (nextPendingAgentLaunches === pendingAgentLaunches) {
-						return;
+					if (nextPendingAgentLaunches !== pendingAgentLaunches) {
+						pendingAgentLaunches = nextPendingAgentLaunches;
 					}
-
-					pendingAgentLaunches = nextPendingAgentLaunches;
 					recoverSubmission(
 						error instanceof Error ? error.message : 'Failed to start the local agent run.'
 					);
@@ -897,6 +926,7 @@
 			window.clearTimeout(submissionTimeoutId);
 			clearSubmittingPrompt(submissionScope, submissionSequence);
 			if (
+				agentLaunchId === null &&
 				latestSubmissionSequencesByRecoveryScope.get(submissionTrackingKey) === submissionSequence
 			) {
 				latestSubmissionSequencesByRecoveryScope.delete(submissionTrackingKey);
@@ -920,6 +950,72 @@
 			currentError = error instanceof Error ? error.message : 'Failed to cancel run.';
 		}
 	}
+
+	$effect(() => {
+		const data = currentLatestRunData;
+		if (!data) {
+			latestRunServerClock = null;
+			return;
+		}
+		if (
+			latestRunServerClock?.serverNow === data.serverNow &&
+			latestRunServerClock.runId === (data.run?._id ?? null)
+		) {
+			return;
+		}
+		latestRunServerClock = {
+			localObservedAt: window.performance.now(),
+			runId: data.run?._id ?? null,
+			serverNow: data.serverNow
+		};
+	});
+
+	$effect(() => {
+		if (runState?.status !== 'running' && runState?.status !== 'awaiting_executor') {
+			return;
+		}
+		const updateClock = () => {
+			leaseClockNow = window.performance.now();
+		};
+		updateClock();
+		const intervalId = window.setInterval(updateClock, 1_000);
+		return () => window.clearInterval(intervalId);
+	});
+
+	$effect(() => {
+		const viewerIdentity = getCurrentViewerIdentity();
+		const recoveryScope = getComposerScope(currentThreadId, currentWorkspaceSessionId);
+		const staleRun = runState;
+		if (
+			!viewerIdentity ||
+			!recoveryScope ||
+			!staleRun ||
+			(staleRun.status !== 'running' && staleRun.status !== 'awaiting_executor') ||
+			isRunning ||
+			isSubmittingPrompt ||
+			hasPendingAgentLaunch ||
+			prompt !== '' ||
+			!staleRun.submissionId ||
+			!currentLatestRunData?.prompt
+		) {
+			return;
+		}
+
+		const staleClaimKey = `${viewerIdentity}\0${staleRun._id}\0${staleRun.claimExpiresAt ?? 'legacy'}`;
+		if (recoveredStaleClaims.has(staleClaimKey)) {
+			return;
+		}
+		recoveredStaleClaims.add(staleClaimKey);
+		storeComposerRecovery({
+			message: 'The previous agent stopped responding. Retry to continue this submission.',
+			prompt: currentLatestRunData.prompt,
+			reasoningEffort: staleRun.reasoningEffort,
+			selectedModel: staleRun.selectedModel,
+			scope: recoveryScope,
+			submissionId: staleRun.submissionId,
+			viewerIdentity
+		});
+	});
 
 	$effect(() => {
 		const viewerIdentity = getCurrentViewerIdentity();
@@ -1126,7 +1222,8 @@
 			const nextPendingAgentLaunches = resolvePendingAgentLaunch(
 				pendingAgentLaunches,
 				currentThreadId,
-				runState._id
+				runState._id,
+				runState.claimExpiresAt
 			);
 			if (nextPendingAgentLaunches !== pendingAgentLaunches) {
 				pendingAgentLaunches = nextPendingAgentLaunches;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { useAuth, useMutation, useQuery } from 'convex-svelte';
 	import type { Id } from '$convex/_generated/dataModel';
 	import { api } from '$convex/_generated/api';
@@ -13,12 +13,15 @@
 	import WorkspaceSidebar from '$lib/components/home/workspace-sidebar.svelte';
 	import {
 		attachLocalWorkspaceSession as attachLocalWorkspaceSessionForPath,
-		attachWorkspaceSession as attachWorkspaceSessionForExecution,
+		createLatestTaskQueue,
+		getDesiredAttachedWorkspaceSessionIds,
 		getViewerArgs as getViewerArgsForUser,
+		getViewerIdentity,
 		getViewerQueryArgs as getViewerQueryArgsForUser,
 		launchAgentRun,
 		refreshDesktopWorkspaceSessions as refreshDesktopWorkspaceSessionsFromDesktop,
-		syncAttachedWorkspaceSessions as syncAttachedWorkspaceSessionsForClient,
+		resolveSubmissionId,
+		verifyWorkspaceSession as verifyWorkspaceSessionForExecution,
 		type WorkspaceSessionState
 	} from '$lib/home/desktop';
 	import { formatElapsedDuration } from '$lib/format';
@@ -29,14 +32,21 @@
 		type SupportedReasoningEffort
 	} from '$convex/lib/models';
 	import {
+		beginPendingAgentLaunch,
+		clearPendingAgentLaunch,
 		dataForThread,
-		getAttachedWorkspaceSessionIds,
-		getWorkspaceThreadGroups,
 		findThreadById,
 		findWorkspaceSessionByName,
+		getWorkspaceThreadGroups,
+		isAgentLaunchPending,
+		isLatestRunReadyForThread,
 		isSelectionGenerationCurrent,
+		resolveExpiredAgentLaunch,
+		resolvePendingAgentLaunch,
+		resolvePendingAgentLaunchesFromThreads,
 		resolvePendingCreatedThreadId,
-		resolveWorkspaceThreadSelection
+		resolveWorkspaceThreadSelection,
+		type PendingAgentLaunches
 	} from '$lib/workspace/threads';
 	import { resolveDesktopApi } from '$lib/local/client';
 	import { resolve } from '$app/paths';
@@ -58,6 +68,28 @@
 	const setLastThread = useMutation(api.uiPreferences.setLastThread);
 	const heartbeatAttached = useMutation(api.workspaceSessions.heartbeatAttached);
 	const localServerRequiredMessage = 'Connect to a running Sprocket server to use this workspace.';
+	const agentLaunchTimeoutMs = 30_000;
+	type ComposerRecovery = {
+		message: string;
+		prompt: string;
+		reasoningEffort?: SupportedReasoningEffort;
+		selectedModel?: SupportedModelId;
+		submissionId?: string;
+		viewerIdentity: string;
+	};
+	const workspaceAttachmentHeartbeatQueue = createLatestTaskQueue(
+		async (request: {
+			clientId: string;
+			viewerArgs: ReturnType<typeof getViewerArgsForUser>;
+			workspaceSessionIds: Id<'workspaceSessions'>[];
+		}) => {
+			await heartbeatAttached({
+				...request.viewerArgs,
+				clientId: request.clientId,
+				workspaceSessionIds: request.workspaceSessionIds
+			});
+		}
+	);
 
 	let desktopApi = $state<DesktopApi | null>(null);
 	let currentWorkspaceName = $state<string | null>(null);
@@ -71,22 +103,78 @@
 	let visibleMessages = $state<ThreadMessage[]>([]);
 	let elapsedSeconds = $state(0);
 	let guestSessionId = $state<string | null>(null);
-	let isSubmittingPrompt = $state(false);
-	let hasPendingAgentLaunch = $state(false);
-	let pendingLaunchPreviousRunId = $state<Id<'runs'> | null>(null);
+	const submittingPromptScopes = new SvelteMap<string, number>();
+	const composerRecoveries = new SvelteMap<string, ComposerRecovery>();
+	const recoveredSubmissionIds = new SvelteMap<
+		string,
+		{
+			prompt: string;
+			reasoningEffort: SupportedReasoningEffort;
+			selectedModel: SupportedModelId;
+			submissionId: string;
+		}
+	>();
+	const latestSubmissionSequencesByRecoveryScope = new SvelteMap<string, number>();
+	let pendingAgentLaunches = $state<PendingAgentLaunches>({});
+	let nextAgentLaunchId = 0;
+	let nextSubmissionSequence = 0;
 	let hasResolvedInitialSelection = $state(false);
 	let restoredWorkspaceSessionIdToAttach = $state<Id<'workspaceSessions'> | null>(null);
 	let lastSavedThreadId = $state<Id<'threadRecords'> | null>(null);
 	let workspaceSelectionGeneration = $state(0);
 	let pendingCreatedThreadId = $state<Id<'threadRecords'> | null>(null);
-	let threadsDataAtPendingCreate = $state<unknown>(undefined);
 	let desktopWorkspaceSessionsById = $state<Record<string, WorkspaceSessionLocation>>({});
+	let hasLoadedDesktopWorkspaceSessions = $state(false);
+	let desktopWorkspaceSessionsGeneration = 0;
+	let selectionViewerIdentity = $state<string | null>(null);
 	let workspacePickerOpen = $state(false);
 	let workspacePickerMode = $state<'add' | 'reconnect'>('add');
 	let workspacePickerExpectedName = $state<string | undefined>(undefined);
 	let workspacePickerReconnectSessionId = $state<Id<'workspaceSessions'> | null>(null);
 	function getViewerArgs() {
 		return getViewerArgsForUser($authState.user, guestSessionId);
+	}
+
+	function getCurrentViewerIdentity() {
+		return getViewerIdentity($authState.user, guestSessionId);
+	}
+
+	function getComposerScope(
+		threadId: Id<'threadRecords'> | null,
+		workspaceSessionId: Id<'workspaceSessions'> | null
+	) {
+		return threadId
+			? `thread:${threadId}`
+			: workspaceSessionId
+				? `draft:${workspaceSessionId}`
+				: null;
+	}
+
+	function clearSubmittingPrompt(scope: string, submissionSequence: number) {
+		if (submittingPromptScopes.get(scope) === submissionSequence) {
+			submittingPromptScopes.delete(scope);
+		}
+	}
+
+	function getComposerRecoveryKey(viewerIdentity: string, scope: string) {
+		return `${viewerIdentity}\0${scope}`;
+	}
+
+	function storeComposerRecovery(args: ComposerRecovery & { scope: string }) {
+		composerRecoveries.set(getComposerRecoveryKey(args.viewerIdentity, args.scope), {
+			message: args.message,
+			prompt: args.prompt,
+			...(args.reasoningEffort ? { reasoningEffort: args.reasoningEffort } : {}),
+			...(args.selectedModel ? { selectedModel: args.selectedModel } : {}),
+			...(args.submissionId ? { submissionId: args.submissionId } : {}),
+			viewerIdentity: args.viewerIdentity
+		});
+	}
+
+	function clearComposerRecovery(viewerIdentity: string, scope: string) {
+		const recoveryKey = getComposerRecoveryKey(viewerIdentity, scope);
+		composerRecoveries.delete(recoveryKey);
+		recoveredSubmissionIds.delete(recoveryKey);
 	}
 
 	function getViewerQueryArgs() {
@@ -188,20 +276,43 @@
 			runState?.status === 'running' ||
 			runState?.status === 'awaiting_executor'
 	);
+	const hasPendingAgentLaunch = $derived(
+		isAgentLaunchPending(pendingAgentLaunches, currentThreadId)
+	);
+	const pendingAgentLaunchThreadIds = $derived(
+		Object.keys(pendingAgentLaunches) as Id<'threadRecords'>[]
+	);
+	const isLatestRunReady = $derived(
+		isLatestRunReadyForThread({
+			threadId: currentThreadId,
+			pendingCreatedThreadId,
+			hasLatestRunData: Boolean(currentLatestRunData)
+		})
+	);
+	const currentComposerScope = $derived(
+		getComposerScope(currentThreadId, currentWorkspaceSessionId)
+	);
+	const isSubmittingPrompt = $derived(
+		Boolean(currentComposerScope && submittingPromptScopes.has(currentComposerScope))
+	);
 	const canSend = $derived(
 		Boolean(
 			currentWorkspaceSessionId &&
 			currentWorkspaceSession?.localWorkspaceAvailability === 'available' &&
 			!isRunning &&
 			!isSubmittingPrompt &&
-			!hasPendingAgentLaunch
+			!hasPendingAgentLaunch &&
+			isLatestRunReady
 		)
 	);
-	const attachedWorkspaceSessionIds = $derived.by<Id<'workspaceSessions'>[]>(() =>
-		getAttachedWorkspaceSessionIds(workspaceSessions, executorClientId)
+	const desiredAttachedWorkspaceSessionIds = $derived.by<Id<'workspaceSessions'>[]>(() =>
+		getDesiredAttachedWorkspaceSessionIds(
+			Object.values(desktopWorkspaceSessionsById),
+			workspaceSessions.map((workspaceSession) => workspaceSession._id)
+		)
 	);
-	const attachedWorkspaceSessionIdsKey = $derived.by(() =>
-		[...attachedWorkspaceSessionIds].sort().join('\0')
+	const desiredAttachedWorkspaceSessionIdsKey = $derived.by(() =>
+		[...desiredAttachedWorkspaceSessionIds].sort().join('\0')
 	);
 	const recentWorkspaceDirectories = $derived.by(() => {
 		const seen = new SvelteSet<string>();
@@ -225,7 +336,14 @@
 	});
 
 	async function refreshDesktopWorkspaceSessions() {
-		desktopWorkspaceSessionsById = await refreshDesktopWorkspaceSessionsFromDesktop(desktopApi);
+		const refreshGeneration = ++desktopWorkspaceSessionsGeneration;
+		const nextWorkspaceSessions = await refreshDesktopWorkspaceSessionsFromDesktop(desktopApi);
+		if (refreshGeneration !== desktopWorkspaceSessionsGeneration) {
+			return;
+		}
+
+		desktopWorkspaceSessionsById = nextWorkspaceSessions;
+		hasLoadedDesktopWorkspaceSessions = true;
 	}
 
 	function applyWorkspaceSelection(
@@ -238,16 +356,19 @@
 		draftWorkspaceName = draft ? workspaceName : null;
 		if (threadId !== pendingCreatedThreadId) {
 			pendingCreatedThreadId = null;
-			threadsDataAtPendingCreate = undefined;
 		}
 	}
 
 	function setWorkspaceSelection(
 		workspaceName: string,
 		threadId: Id<'threadRecords'> | null = null,
-		draft: boolean = false
+		draft: boolean = false,
+		preserveError: boolean = false
 	) {
 		workspaceSelectionGeneration += 1;
+		if (!preserveError) {
+			currentError = null;
+		}
 		applyWorkspaceSelection(workspaceName, threadId, draft);
 	}
 
@@ -264,51 +385,32 @@
 			workspaceSessionId,
 			workspacePath
 		});
+		desktopWorkspaceSessionsGeneration += 1;
 		desktopWorkspaceSessionsById = {
 			...desktopWorkspaceSessionsById,
 			[session.workspaceSessionId]: session
 		};
+		hasLoadedDesktopWorkspaceSessions = true;
 		return session;
 	}
 
-	async function syncAttachedWorkspaceSessions(workspaceSessionIds: Id<'workspaceSessions'>[]) {
-		await syncAttachedWorkspaceSessionsForClient({
-			attachedWorkspaceSessionIds,
-			executorClientId,
-			getViewerArgs,
-			heartbeatAttached,
-			workspaceSessionIds
-		});
-	}
-
-	async function openWorkspaceSession(
+	function openWorkspaceSession(
 		workspaceName: string,
 		selection: { threadId?: Id<'threadRecords'> | null; draft?: boolean } = {}
 	) {
-		const selectionGeneration = ++workspaceSelectionGeneration;
 		const workspaceSession = findWorkspaceSessionByName(workspaceSessions, workspaceName);
 		if (!workspaceSession) {
-			if (isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
-				currentError = 'Choose a workspace first.';
-			}
+			currentError = 'Choose a workspace first.';
 			return;
 		}
 
-		try {
-			await attachWorkspaceSession(workspaceSession._id);
-		} catch (error) {
+		setWorkspaceSelection(workspaceName, selection.threadId, selection.draft);
+		const selectionGeneration = workspaceSelectionGeneration;
+		void verifyWorkspaceSession(workspaceSession._id).catch((error) => {
 			if (isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
 				currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
 			}
-			return;
-		}
-
-		if (!isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
-			return;
-		}
-
-		applyWorkspaceSelection(workspaceName, selection.threadId, selection.draft);
-		currentError = null;
+		});
 	}
 
 	function openWorkspacePicker(
@@ -335,6 +437,11 @@
 			currentError = localServerRequiredMessage;
 			return;
 		}
+		const pickerViewerIdentity = getCurrentViewerIdentity();
+		if (!pickerViewerIdentity) {
+			currentError = 'Viewer session is not ready.';
+			return;
+		}
 
 		try {
 			if (workspacePickerMode === 'reconnect' && workspacePickerReconnectSessionId) {
@@ -347,7 +454,9 @@
 				}
 
 				await attachLocalWorkspaceSession(workspacePickerReconnectSessionId, overview.rootPath);
-				await attachWorkspaceSession(workspacePickerReconnectSessionId);
+				if (getCurrentViewerIdentity() !== pickerViewerIdentity) {
+					return;
+				}
 				setWorkspaceSelection(reconnectSession.workspaceName, currentThreadId);
 				currentError = null;
 				return;
@@ -361,24 +470,28 @@
 			if (!session) {
 				throw new Error('Failed to create or update the workspace session.');
 			}
+			if (getCurrentViewerIdentity() !== pickerViewerIdentity) {
+				return;
+			}
 
 			await attachLocalWorkspaceSession(session._id, overview.rootPath);
-			await syncAttachedWorkspaceSessions([session._id]);
+			if (getCurrentViewerIdentity() !== pickerViewerIdentity) {
+				return;
+			}
 			setWorkspaceSelection(overview.name, null, true);
 			currentError = null;
 		} catch (error) {
+			if (getCurrentViewerIdentity() !== pickerViewerIdentity) {
+				return;
+			}
 			currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
 			throw error;
 		}
 	}
 
-	async function attachWorkspaceSession(workspaceSessionId: Id<'workspaceSessions'>) {
-		await attachWorkspaceSessionForExecution({
-			attachedWorkspaceSessionIds,
+	async function verifyWorkspaceSession(workspaceSessionId: Id<'workspaceSessions'>) {
+		await verifyWorkspaceSessionForExecution({
 			desktopApi,
-			executorClientId,
-			getViewerArgs,
-			heartbeatAttached,
 			refreshDesktopWorkspaceSessions,
 			workspaceSessionId
 		});
@@ -388,74 +501,150 @@
 		openWorkspacePicker('reconnect', workspaceSessionId);
 	}
 
-	async function createThread() {
-		const workspaceSessionId = currentWorkspaceSessionId;
-		if (!workspaceSessionId) {
-			currentError = 'Choose a workspace first.';
+	function schedulePendingCreatedThreadExpiration(args: {
+		prompt: string;
+		reasoningEffort: SupportedReasoningEffort;
+		selectedModel: SupportedModelId;
+		submissionId: string;
+		threadId: Id<'threadRecords'>;
+		viewerIdentity: string;
+		workspaceName: string;
+		workspaceSessionId: Id<'workspaceSessions'>;
+	}) {
+		window.setTimeout(() => {
+			if (
+				getCurrentViewerIdentity() !== args.viewerIdentity ||
+				pendingCreatedThreadId !== args.threadId ||
+				currentThreadId !== args.threadId ||
+				currentWorkspaceName !== args.workspaceName ||
+				threads.some((thread) => thread.threadId === args.threadId)
+			) {
+				return;
+			}
+
+			pendingCreatedThreadId = null;
+			setWorkspaceSelection(args.workspaceName, null, true);
+			const recoveryScope = getComposerScope(null, args.workspaceSessionId);
+			if (recoveryScope) {
+				storeComposerRecovery({
+					message: 'The new thread did not appear. Review your prompt and try sending it again.',
+					prompt: args.prompt,
+					reasoningEffort: args.reasoningEffort,
+					selectedModel: args.selectedModel,
+					scope: recoveryScope,
+					submissionId: args.submissionId,
+					viewerIdentity: args.viewerIdentity
+				});
+			}
+		}, agentLaunchTimeoutMs);
+	}
+
+	async function createThread(args: {
+		isSubmissionCurrent: () => boolean;
+		prompt: string;
+		selectionGeneration: number;
+		selectedModel: SupportedModelId;
+		selectedReasoningEffort: SupportedReasoningEffort;
+		submissionId: string;
+		viewerArgs: ReturnType<typeof getViewerArgs>;
+		viewerIdentity: string;
+		workspaceName: string;
+		workspaceSessionId: Id<'workspaceSessions'>;
+	}) {
+		const result = await createThreadMutation({
+			...args.viewerArgs,
+			submissionId: args.submissionId,
+			workspaceSessionId: args.workspaceSessionId,
+			selectedModel: args.selectedModel,
+			reasoningEffort: args.selectedReasoningEffort
+		});
+		if (!args.isSubmissionCurrent()) {
 			return null;
 		}
 
-		const result = await createThreadMutation({
-			...getViewerArgs(),
-			workspaceSessionId,
-			selectedModel,
-			reasoningEffort: selectedReasoningEffort
-		});
-		pendingCreatedThreadId = result.threadId;
-		threadsDataAtPendingCreate = threadsQuery.data;
-		workspaceSelectionGeneration += 1;
-		currentThreadId = result.threadId;
-		draftWorkspaceName = null;
+		if (
+			args.viewerIdentity === getCurrentViewerIdentity() &&
+			isSelectionGenerationCurrent(args.selectionGeneration, workspaceSelectionGeneration)
+		) {
+			pendingCreatedThreadId = result.threadId;
+			workspaceSelectionGeneration += 1;
+			currentThreadId = result.threadId;
+			draftWorkspaceName = null;
+			schedulePendingCreatedThreadExpiration({
+				prompt: args.prompt,
+				reasoningEffort: args.selectedReasoningEffort,
+				selectedModel: args.selectedModel,
+				submissionId: args.submissionId,
+				threadId: result.threadId,
+				viewerIdentity: args.viewerIdentity,
+				workspaceName: args.workspaceName,
+				workspaceSessionId: args.workspaceSessionId
+			});
+		}
+
 		return result.threadId;
 	}
 
-	async function startThreadDraftForWorkspace(workspaceName: string) {
-		try {
-			await openWorkspaceSession(workspaceName, { draft: true });
-			return null;
-		} catch (error) {
-			currentError = error instanceof Error ? error.message : 'Failed to open thread draft.';
-			return null;
-		}
+	function startThreadDraftForWorkspace(workspaceName: string) {
+		openWorkspaceSession(workspaceName, { draft: true });
 	}
 
-	async function selectThread(thread: ThreadSummary) {
-		try {
-			await openWorkspaceSession(thread.workspaceName, { threadId: thread.threadId });
-		} catch (error) {
-			currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
+	function selectThread(thread: ThreadSummary) {
+		openWorkspaceSession(thread.workspaceName, { threadId: thread.threadId });
+	}
+
+	function getThreadDeletionBlockMessage(thread: ThreadSummary) {
+		if (isAgentLaunchPending(pendingAgentLaunches, thread.threadId)) {
+			return 'Wait for the local agent to start before deleting this thread.';
 		}
+
+		return thread.hasActiveRun
+			? 'Finish or cancel the active run before deleting this thread.'
+			: null;
 	}
 
 	async function deleteThread(thread: ThreadSummary) {
-		if (thread.hasActiveRun) {
-			currentError = 'Finish or cancel the active run before deleting this thread.';
+		const initialBlockMessage = getThreadDeletionBlockMessage(thread);
+		if (initialBlockMessage) {
+			currentError = initialBlockMessage;
 			return;
 		}
-
 		const confirmed = window.confirm(
 			`Delete "${thread.title}"? This permanently removes the thread, messages, and run history.`
 		);
 		if (!confirmed) {
 			return;
 		}
+		const currentBlockMessage = getThreadDeletionBlockMessage(thread);
+		if (currentBlockMessage) {
+			currentError = currentBlockMessage;
+			return;
+		}
+		const deletionViewerIdentity = getCurrentViewerIdentity();
 
 		try {
 			await removeThread({
 				...getViewerArgs(),
 				threadId: thread.threadId
 			});
-			if (currentThreadId === thread.threadId) {
-				currentThreadId = null;
-				pendingCreatedThreadId = null;
-				threadsDataAtPendingCreate = undefined;
-				workspaceSelectionGeneration += 1;
+			if (deletionViewerIdentity) {
+				clearComposerRecovery(deletionViewerIdentity, `thread:${thread.threadId}`);
 			}
-			if (lastSavedThreadId === thread.threadId) {
-				lastSavedThreadId = null;
+			if (getCurrentViewerIdentity() === deletionViewerIdentity) {
+				if (currentThreadId === thread.threadId) {
+					currentThreadId = null;
+					pendingCreatedThreadId = null;
+					workspaceSelectionGeneration += 1;
+				}
+				if (lastSavedThreadId === thread.threadId) {
+					lastSavedThreadId = null;
+				}
+				currentError = null;
 			}
-			currentError = null;
 		} catch (error) {
+			if (getCurrentViewerIdentity() !== deletionViewerIdentity) {
+				return;
+			}
 			currentError = error instanceof Error ? error.message : 'Failed to delete thread.';
 		}
 	}
@@ -469,7 +658,8 @@
 			return;
 		}
 
-		if (!currentWorkspaceSessionId) {
+		const workspaceSessionId = currentWorkspaceSessionId;
+		if (!workspaceSessionId) {
 			currentError = 'Choose a workspace first.';
 			return;
 		}
@@ -479,50 +669,237 @@
 			return;
 		}
 
-		if (!canSend) {
-			currentError =
-				currentWorkspaceSession?.localWorkspaceAvailability === 'available'
-					? 'You need an active workspace session before sending.'
-					: 'This workspace needs to be attached before sending.';
+		if (currentThreadId && !isLatestRunReady) {
+			currentError = 'Loading thread state before sending.';
 			return;
 		}
 
-		isSubmittingPrompt = true;
+		if (!canSend) {
+			currentError =
+				isRunning || hasPendingAgentLaunch || isSubmittingPrompt
+					? 'Wait for the current agent launch or run to finish.'
+					: currentWorkspaceSession?.localWorkspaceAvailability === 'available'
+						? 'You need an active workspace session before sending.'
+						: 'This workspace needs to be attached before sending.';
+			return;
+		}
 
-		try {
-			await attachWorkspaceSession(currentWorkspaceSessionId);
-			const threadId = currentThreadId ?? (await createThread());
-			if (!threadId) {
+		const selectionGeneration = workspaceSelectionGeneration;
+		const selectedThreadId = currentThreadId;
+		const submittedWorkspaceName = currentWorkspaceName;
+		if (!submittedWorkspaceName) {
+			currentError = 'Choose a workspace first.';
+			return;
+		}
+		const submittedViewerIdentity = getCurrentViewerIdentity();
+		if (!submittedViewerIdentity) {
+			currentError = 'Viewer session is not ready.';
+			return;
+		}
+		const submittedViewerArgs = getViewerArgs();
+		const submittedAuthenticatedUserId = $authState.user?.id ?? null;
+		const isSubmittedViewerCurrent = () => getCurrentViewerIdentity() === submittedViewerIdentity;
+		const submittedPrompt = prompt.trim();
+		const submittedModel = selectedModel;
+		const submittedReasoningEffort = selectedReasoningEffort;
+		const previousRunId = selectedThreadId ? (runState?._id ?? null) : null;
+		let submissionScope = selectedThreadId
+			? `thread:${selectedThreadId}`
+			: `draft:${workspaceSessionId}`;
+		const originatingRecoveryScope = submissionScope;
+		let recoveryScope = originatingRecoveryScope;
+		const originatingRecoveryKey = getComposerRecoveryKey(
+			submittedViewerIdentity,
+			originatingRecoveryScope
+		);
+		const recoveredSubmission = recoveredSubmissionIds.get(originatingRecoveryKey);
+		const submissionRequestId = resolveSubmissionId({
+			newSubmissionId: crypto.randomUUID(),
+			prompt: submittedPrompt,
+			reasoningEffort: submittedReasoningEffort,
+			recoveredSubmission,
+			selectedModel: submittedModel
+		});
+		clearComposerRecovery(submittedViewerIdentity, originatingRecoveryScope);
+		let launchedThreadId: Id<'threadRecords'> | null = null;
+		let agentLaunchId: number | null = null;
+		const submissionSequence = ++nextSubmissionSequence;
+		let submissionTrackingKey = getComposerRecoveryKey(
+			submittedViewerIdentity,
+			originatingRecoveryScope
+		);
+		latestSubmissionSequencesByRecoveryScope.set(submissionTrackingKey, submissionSequence);
+		const isSubmissionCurrent = () =>
+			latestSubmissionSequencesByRecoveryScope.get(submissionTrackingKey) === submissionSequence;
+		const sessionChangedMessage =
+			'Your session changed before the agent started. Return to this account and send the prompt again.';
+		const submissionDelayMessage =
+			'This request is still preparing. Wait for it to finish before trying again.';
+		const recoverSubmission = (message: string) => {
+			storeComposerRecovery({
+				message,
+				prompt: submittedPrompt,
+				reasoningEffort: submittedReasoningEffort,
+				selectedModel: submittedModel,
+				scope: recoveryScope,
+				submissionId: submissionRequestId,
+				viewerIdentity: submittedViewerIdentity
+			});
+		};
+		const clearSubmissionDelay = () => {
+			clearComposerRecovery(submittedViewerIdentity, recoveryScope);
+			if (isSubmittedViewerCurrent() && currentError === submissionDelayMessage) {
+				currentError = null;
+			}
+		};
+		const submissionTimeoutId = window.setTimeout(() => {
+			if (
+				latestSubmissionSequencesByRecoveryScope.get(submissionTrackingKey) !== submissionSequence
+			) {
 				return;
 			}
 
-			const nextPrompt = prompt.trim();
-			prompt = '';
-			currentError = null;
-			const authToken = $authState.user ? ((await getAccessToken()) ?? undefined) : undefined;
-			hasPendingAgentLaunch = true;
-			pendingLaunchPreviousRunId = runState?._id ?? null;
+			storeComposerRecovery({
+				message: submissionDelayMessage,
+				prompt: '',
+				scope: recoveryScope,
+				viewerIdentity: submittedViewerIdentity
+			});
+		}, agentLaunchTimeoutMs);
+		prompt = '';
+		currentError = null;
+		submittingPromptScopes.set(submissionScope, submissionSequence);
+
+		try {
+			const threadId =
+				selectedThreadId ??
+				(await createThread({
+					isSubmissionCurrent,
+					prompt: submittedPrompt,
+					selectionGeneration,
+					selectedModel: submittedModel,
+					selectedReasoningEffort: submittedReasoningEffort,
+					submissionId: submissionRequestId,
+					viewerArgs: submittedViewerArgs,
+					viewerIdentity: submittedViewerIdentity,
+					workspaceName: submittedWorkspaceName,
+					workspaceSessionId
+				}));
+			if (!threadId || !isSubmissionCurrent()) {
+				return;
+			}
+			if (!isSubmittedViewerCurrent()) {
+				recoverSubmission(sessionChangedMessage);
+				return;
+			}
+			launchedThreadId = threadId;
+			if (!selectedThreadId) {
+				clearSubmittingPrompt(submissionScope, submissionSequence);
+				submissionScope = `thread:${threadId}`;
+				submittingPromptScopes.set(submissionScope, submissionSequence);
+				clearSubmissionDelay();
+				if (
+					latestSubmissionSequencesByRecoveryScope.get(submissionTrackingKey) === submissionSequence
+				) {
+					latestSubmissionSequencesByRecoveryScope.delete(submissionTrackingKey);
+				}
+				recoveryScope = `thread:${threadId}`;
+				submissionTrackingKey = getComposerRecoveryKey(submittedViewerIdentity, recoveryScope);
+				latestSubmissionSequencesByRecoveryScope.set(submissionTrackingKey, submissionSequence);
+			}
+			const authToken = submittedAuthenticatedUserId
+				? ((await getAccessToken()) ?? undefined)
+				: undefined;
+			if (!isSubmissionCurrent()) {
+				return;
+			}
+			if (!isSubmittedViewerCurrent()) {
+				recoverSubmission(sessionChangedMessage);
+				return;
+			}
+			clearSubmissionDelay();
+			const launchId = ++nextAgentLaunchId;
+			agentLaunchId = launchId;
+			pendingAgentLaunches = beginPendingAgentLaunch(pendingAgentLaunches, threadId, {
+				expiresAt: Date.now() + agentLaunchTimeoutMs,
+				launchId,
+				previousRunId
+			});
+			window.setTimeout(() => {
+				const threadLatestRunId =
+					threads.find((thread) => thread.threadId === threadId)?.latestRunId ?? null;
+				const selectedRunId = currentThreadId === threadId ? (runState?._id ?? null) : null;
+				const latestRunId =
+					[threadLatestRunId, selectedRunId].find((runId) => runId && runId !== previousRunId) ??
+					threadLatestRunId ??
+					selectedRunId;
+				const recovery = resolveExpiredAgentLaunch(
+					pendingAgentLaunches,
+					threadId,
+					launchId,
+					Date.now(),
+					latestRunId
+				);
+				if (recovery.pendingLaunches === pendingAgentLaunches) {
+					return;
+				}
+
+				pendingAgentLaunches = recovery.pendingLaunches;
+				if (recovery.shouldRecover) {
+					recoverSubmission('The local agent did not start. Please try again.');
+				}
+			}, agentLaunchTimeoutMs);
 			launchAgentRun({
 				authToken,
 				desktopApi,
-				getViewerArgs,
 				onError: (error) => {
-					hasPendingAgentLaunch = false;
-					pendingLaunchPreviousRunId = null;
-					currentError =
-						error instanceof Error ? error.message : 'Failed to start the local agent run.';
+					const nextPendingAgentLaunches = clearPendingAgentLaunch(
+						pendingAgentLaunches,
+						threadId,
+						launchId
+					);
+					if (nextPendingAgentLaunches === pendingAgentLaunches) {
+						return;
+					}
+
+					pendingAgentLaunches = nextPendingAgentLaunches;
+					recoverSubmission(
+						error instanceof Error ? error.message : 'Failed to start the local agent run.'
+					);
 				},
 				threadId,
-				prompt: nextPrompt,
-				selectedModel,
-				reasoningEffort: selectedReasoningEffort,
-				workspaceSessionId: currentWorkspaceSessionId
+				prompt: submittedPrompt,
+				selectedModel: submittedModel,
+				submissionId: submissionRequestId,
+				reasoningEffort: submittedReasoningEffort,
+				viewerArgs: submittedViewerArgs,
+				workspaceSessionId
 			});
 		} catch (error) {
-			await refreshDesktopWorkspaceSessions();
-			currentError = error instanceof Error ? error.message : 'Failed to send prompt.';
+			if (launchedThreadId && agentLaunchId !== null) {
+				pendingAgentLaunches = clearPendingAgentLaunch(
+					pendingAgentLaunches,
+					launchedThreadId,
+					agentLaunchId
+				);
+			}
+			if (!isSubmissionCurrent()) {
+				return;
+			}
+			if (!isSubmittedViewerCurrent()) {
+				recoverSubmission(sessionChangedMessage);
+				return;
+			}
+			recoverSubmission(error instanceof Error ? error.message : 'Failed to send prompt.');
+			void refreshDesktopWorkspaceSessions().catch(() => {});
 		} finally {
-			isSubmittingPrompt = false;
+			window.clearTimeout(submissionTimeoutId);
+			clearSubmittingPrompt(submissionScope, submissionSequence);
+			if (
+				latestSubmissionSequencesByRecoveryScope.get(submissionTrackingKey) === submissionSequence
+			) {
+				latestSubmissionSequencesByRecoveryScope.delete(submissionTrackingKey);
+			}
 		}
 	}
 
@@ -544,6 +921,33 @@
 	}
 
 	$effect(() => {
+		const viewerIdentity = getCurrentViewerIdentity();
+		if (selectionViewerIdentity === viewerIdentity) {
+			return;
+		}
+
+		selectionViewerIdentity = viewerIdentity;
+		hasResolvedInitialSelection = false;
+		currentWorkspaceName = null;
+		currentThreadId = null;
+		draftWorkspaceName = null;
+		pendingCreatedThreadId = null;
+		pendingAgentLaunches = {};
+		restoredWorkspaceSessionIdToAttach = null;
+		lastSavedThreadId = null;
+		workspaceSelectionGeneration += 1;
+		prompt = '';
+		currentError = null;
+		visibleMessages = [];
+		elapsedSeconds = 0;
+		selectedModel = defaultModelId;
+		selectedReasoningEffort = defaultReasoningEffort;
+		workspacePickerOpen = false;
+		workspacePickerReconnectSessionId = null;
+		workspacePickerExpectedName = undefined;
+	});
+
+	$effect(() => {
 		const data = currentMessagesData;
 		if (!data) {
 			visibleMessages = [];
@@ -554,20 +958,50 @@
 	});
 
 	$effect(() => {
+		const viewerIdentity = getCurrentViewerIdentity();
+		const recoveryScope = getComposerScope(currentThreadId, currentWorkspaceSessionId);
+		if (!viewerIdentity || !recoveryScope) {
+			return;
+		}
+
+		const recoveryKey = getComposerRecoveryKey(viewerIdentity, recoveryScope);
+		const recovery = composerRecoveries.get(recoveryKey);
+		if (!recovery || recovery.viewerIdentity !== viewerIdentity) {
+			return;
+		}
+
+		composerRecoveries.delete(recoveryKey);
+		if (prompt === '') {
+			prompt = recovery.prompt;
+			if (
+				recovery.submissionId &&
+				recovery.prompt &&
+				recovery.reasoningEffort &&
+				recovery.selectedModel
+			) {
+				recoveredSubmissionIds.set(recoveryKey, {
+					prompt: recovery.prompt,
+					reasoningEffort: recovery.reasoningEffort,
+					selectedModel: recovery.selectedModel,
+					submissionId: recovery.submissionId
+				});
+			}
+		}
+
+		currentError = recovery.message;
+	});
+
+	$effect(() => {
 		if (!pendingCreatedThreadId) {
 			return;
 		}
 
 		const nextPendingCreatedThreadId = resolvePendingCreatedThreadId({
 			pendingCreatedThreadId,
-			threads,
-			threadListChangedSinceCreate: threadsQuery.data !== threadsDataAtPendingCreate
+			threads
 		});
 		if (nextPendingCreatedThreadId !== pendingCreatedThreadId) {
 			pendingCreatedThreadId = nextPendingCreatedThreadId;
-			if (!nextPendingCreatedThreadId) {
-				threadsDataAtPendingCreate = undefined;
-			}
 		}
 	});
 
@@ -594,30 +1028,30 @@
 
 		if (workspaceSessions[0]) {
 			setWorkspaceSelection(workspaceSessions[0].workspaceName, null, false);
+			restoredWorkspaceSessionIdToAttach = workspaceSessions[0]._id;
 		}
 	});
 
 	$effect(() => {
 		const workspaceSessionId = restoredWorkspaceSessionIdToAttach;
-		if (!workspaceSessionId || !desktopApi || !executorClientId) {
+		if (!workspaceSessionId || !desktopApi || !hasLoadedDesktopWorkspaceSessions) {
 			return;
 		}
 
 		const workspaceSession = workspaceSessions.find(
 			(session) => session._id === workspaceSessionId
 		);
-		if (!workspaceSession || workspaceSession.localWorkspaceAvailability !== 'available') {
+		if (!workspaceSession) {
 			restoredWorkspaceSessionIdToAttach = null;
-			if (workspaceSession?.localWorkspaceError) {
-				currentError = workspaceSession.localWorkspaceError;
-			}
 			return;
 		}
 
 		restoredWorkspaceSessionIdToAttach = null;
-		void attachWorkspaceSession(workspaceSessionId).catch((error) => {
-			void refreshDesktopWorkspaceSessions();
-			currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
+		const selectionGeneration = workspaceSelectionGeneration;
+		void verifyWorkspaceSession(workspaceSessionId).catch((error) => {
+			if (isSelectionGenerationCurrent(selectionGeneration, workspaceSelectionGeneration)) {
+				currentError = error instanceof Error ? error.message : 'Failed to attach workspace.';
+			}
 		});
 	});
 
@@ -652,8 +1086,12 @@
 			return;
 		}
 
-		currentThreadId = nextThreadId;
-		workspaceSelectionGeneration += 1;
+		setWorkspaceSelection(
+			currentWorkspaceName,
+			nextThreadId,
+			draftWorkspaceName === currentWorkspaceName,
+			true
+		);
 	});
 
 	$effect(() => {
@@ -673,11 +1111,30 @@
 	});
 
 	$effect(() => {
-		const startedAt = runState?.startedAt;
-		if (hasPendingAgentLaunch && runState?._id && runState._id !== pendingLaunchPreviousRunId) {
-			hasPendingAgentLaunch = false;
-			pendingLaunchPreviousRunId = null;
+		const nextPendingAgentLaunches = resolvePendingAgentLaunchesFromThreads(
+			pendingAgentLaunches,
+			threads
+		);
+		if (nextPendingAgentLaunches !== pendingAgentLaunches) {
+			pendingAgentLaunches = nextPendingAgentLaunches;
 		}
+	});
+
+	$effect(() => {
+		if (currentThreadId && runState?._id) {
+			const nextPendingAgentLaunches = resolvePendingAgentLaunch(
+				pendingAgentLaunches,
+				currentThreadId,
+				runState._id
+			);
+			if (nextPendingAgentLaunches !== pendingAgentLaunches) {
+				pendingAgentLaunches = nextPendingAgentLaunches;
+			}
+		}
+	});
+
+	$effect(() => {
+		const startedAt = runState?.startedAt;
 		if (!isRunning || !startedAt) {
 			elapsedSeconds = 0;
 			return;
@@ -697,31 +1154,34 @@
 
 	$effect(() => {
 		const clientId = executorClientId;
-		const workspaceSessionIdsKey = attachedWorkspaceSessionIdsKey;
-		const workspaceSessionIds = workspaceSessionIdsKey
-			? (workspaceSessionIdsKey.split('\0') as Id<'workspaceSessions'>[])
-			: [];
+		const workspaceSessionIdsKey = desiredAttachedWorkspaceSessionIdsKey;
 		const viewerArgs = getViewerQueryArgs();
-		if (!clientId || !desktopApi || workspaceSessionIds.length === 0 || viewerArgs === 'skip') {
+		if (
+			!clientId ||
+			!desktopApi ||
+			!hasLoadedDesktopWorkspaceSessions ||
+			workspaceSessionsQuery.data === undefined ||
+			viewerArgs === 'skip'
+		) {
 			return;
 		}
-
-		void heartbeatAttached({
-			...viewerArgs,
+		const request = {
 			clientId,
-			workspaceSessionIds
-		});
+			viewerArgs,
+			workspaceSessionIds: workspaceSessionIdsKey
+				? (workspaceSessionIdsKey.split('\0') as Id<'workspaceSessions'>[])
+				: []
+		};
+
+		void workspaceAttachmentHeartbeatQueue.enqueue(request).catch(() => {});
 
 		const intervalId = window.setInterval(() => {
-			void heartbeatAttached({
-				...viewerArgs,
-				clientId,
-				workspaceSessionIds
-			});
+			void workspaceAttachmentHeartbeatQueue.enqueue(request).catch(() => {});
 		}, EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS);
 
 		return () => {
 			window.clearInterval(intervalId);
+			workspaceAttachmentHeartbeatQueue.cancelPending();
 		};
 	});
 
@@ -776,6 +1236,7 @@
 				{currentWorkspaceName}
 				{currentThreadId}
 				groups={groupedWorkspaceThreads}
+				{pendingAgentLaunchThreadIds}
 				onChooseWorkspace={() => {
 					openWorkspacePicker('add');
 				}}
@@ -857,7 +1318,8 @@
 					bind:selectedModel
 					bind:selectedReasoningEffort
 					{canSend}
-					isSubmitting={isSubmittingPrompt}
+					isSubmitting={isSubmittingPrompt || hasPendingAgentLaunch}
+					isStarting={hasPendingAgentLaunch}
 					{isRunning}
 					elapsedLabel={isRunning ? formatElapsedDuration(elapsedSeconds) : null}
 					onSubmit={() => {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -714,6 +714,7 @@
 		);
 		const recoveredSubmission = recoveredSubmissionIds.get(originatingRecoveryKey);
 		const submissionRequestId = resolveSubmissionId({
+			latestRun: selectedThreadId ? runState : null,
 			newSubmissionId: crypto.randomUUID(),
 			prompt: submittedPrompt,
 			reasoningEffort: submittedReasoningEffort,

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -15,5 +15,5 @@ serde_json = "1.0.149"
 sprocket-convex-provider = { path = "../sprocket-convex-provider" }
 sprocket-workspace = { path = "../sprocket-workspace" }
 thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "sync"] }
+tokio = { version = "1.52.1", features = ["macros", "sync", "time"] }
 uuid = { version = "1.21.0", features = ["v4"] }

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -16,3 +16,4 @@ sprocket-convex-provider = { path = "../sprocket-convex-provider" }
 sprocket-workspace = { path = "../sprocket-workspace" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["macros", "sync"] }
+uuid = { version = "1.21.0", features = ["v4"] }

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -142,6 +142,23 @@ impl RuntimeClient {
         self.mutation_unit("agentRuntime:finalizeRun", args).await
     }
 
+    pub(crate) async fn finalize_queued_run(
+        &self,
+        run_id: &str,
+        text: &str,
+        status: &str,
+        last_error: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        let mut args = self.run_args(run_id);
+        args.insert("expectedStatus".to_string(), "queued".to_string().into());
+        args.insert("text".to_string(), text.to_string().into());
+        args.insert("status".to_string(), status.to_string().into());
+        if let Some(last_error) = last_error {
+            args.insert("lastError".to_string(), last_error.to_string().into());
+        }
+        self.mutation_json("agentRuntime:finalizeRun", args).await
+    }
+
     pub(crate) fn args_with_actor(&self) -> BTreeMap<String, Value> {
         let mut args = BTreeMap::new();
         if let Some(guest_id) = &self.guest_id {

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -100,9 +100,11 @@ impl RuntimeClient {
         run_id: &str,
         claim_id: &str,
     ) -> anyhow::Result<StartRunResponse> {
-        let mut args = self.run_args(run_id);
-        args.insert("claimId".to_string(), claim_id.to_string().into());
-        self.mutation_json("agentRuntime:start", args).await
+        self.mutation_json(
+            "agentRuntime:start",
+            self.run_args_with_claim(run_id, claim_id),
+        )
+        .await
     }
 
     pub(crate) async fn renew_claim(
@@ -110,9 +112,11 @@ impl RuntimeClient {
         run_id: &str,
         claim_id: &str,
     ) -> anyhow::Result<RenewClaimResponse> {
-        let mut args = self.run_args(run_id);
-        args.insert("claimId".to_string(), claim_id.to_string().into());
-        self.mutation_json("agentRuntime:renewClaim", args).await
+        self.mutation_json(
+            "agentRuntime:renewClaim",
+            self.run_args_with_claim(run_id, claim_id),
+        )
+        .await
     }
 
     pub(crate) async fn begin_assistant_message(&self, run_id: &str) -> anyhow::Result<()> {
@@ -146,14 +150,8 @@ impl RuntimeClient {
         status: &str,
         last_error: Option<&str>,
     ) -> anyhow::Result<bool> {
-        let mut args = self.run_args(run_id);
-        args.insert("expectedClaimId".to_string(), claim_id.to_string().into());
-        args.insert("text".to_string(), text.to_string().into());
-        args.insert("status".to_string(), status.to_string().into());
-        if let Some(last_error) = last_error {
-            args.insert("lastError".to_string(), last_error.to_string().into());
-        }
-        self.mutation_json("agentRuntime:finalizeRun", args).await
+        self.finalize_run_with_expectations(run_id, text, status, last_error, Some(claim_id), None)
+            .await
     }
 
     pub(crate) async fn finalize_queued_run(
@@ -163,8 +161,32 @@ impl RuntimeClient {
         status: &str,
         last_error: Option<&str>,
     ) -> anyhow::Result<bool> {
+        self.finalize_run_with_expectations(run_id, text, status, last_error, None, Some("queued"))
+            .await
+    }
+
+    async fn finalize_run_with_expectations(
+        &self,
+        run_id: &str,
+        text: &str,
+        status: &str,
+        last_error: Option<&str>,
+        expected_claim_id: Option<&str>,
+        expected_status: Option<&str>,
+    ) -> anyhow::Result<bool> {
         let mut args = self.run_args(run_id);
-        args.insert("expectedStatus".to_string(), "queued".to_string().into());
+        if let Some(expected_claim_id) = expected_claim_id {
+            args.insert(
+                "expectedClaimId".to_string(),
+                expected_claim_id.to_string().into(),
+            );
+        }
+        if let Some(expected_status) = expected_status {
+            args.insert(
+                "expectedStatus".to_string(),
+                expected_status.to_string().into(),
+            );
+        }
         args.insert("text".to_string(), text.to_string().into());
         args.insert("status".to_string(), status.to_string().into());
         if let Some(last_error) = last_error {
@@ -184,6 +206,12 @@ impl RuntimeClient {
     fn run_args(&self, run_id: &str) -> BTreeMap<String, Value> {
         let mut args = self.args_with_actor();
         args.insert("runId".to_string(), run_id.to_string().into());
+        args
+    }
+
+    fn run_args_with_claim(&self, run_id: &str, claim_id: &str) -> BTreeMap<String, Value> {
+        let mut args = self.run_args(run_id);
+        args.insert("claimId".to_string(), claim_id.to_string().into());
         args
     }
 }

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -4,7 +4,9 @@ use serde::Deserialize;
 use sprocket_convex_provider::Client as ConvexProviderClient;
 use std::collections::BTreeMap;
 
-use crate::types::{CreateRunResponse, RunAgentRequest, RunContextResponse, StartRunResponse};
+use crate::types::{
+    CreateRunResponse, RenewClaimResponse, RunAgentRequest, RunContextResponse, StartRunResponse,
+};
 
 #[derive(Clone)]
 pub(crate) struct RuntimeClient {
@@ -103,6 +105,16 @@ impl RuntimeClient {
         self.mutation_json("agentRuntime:start", args).await
     }
 
+    pub(crate) async fn renew_claim(
+        &self,
+        run_id: &str,
+        claim_id: &str,
+    ) -> anyhow::Result<RenewClaimResponse> {
+        let mut args = self.run_args(run_id);
+        args.insert("claimId".to_string(), claim_id.to_string().into());
+        self.mutation_json("agentRuntime:renewClaim", args).await
+    }
+
     pub(crate) async fn begin_assistant_message(&self, run_id: &str) -> anyhow::Result<()> {
         self.mutation_unit("agentRuntime:beginAssistantMessage", self.run_args(run_id))
             .await
@@ -129,17 +141,19 @@ impl RuntimeClient {
     pub(crate) async fn finalize_run(
         &self,
         run_id: &str,
+        claim_id: &str,
         text: &str,
         status: &str,
         last_error: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let mut args = self.run_args(run_id);
+        args.insert("expectedClaimId".to_string(), claim_id.to_string().into());
         args.insert("text".to_string(), text.to_string().into());
         args.insert("status".to_string(), status.to_string().into());
         if let Some(last_error) = last_error {
             args.insert("lastError".to_string(), last_error.to_string().into());
         }
-        self.mutation_unit("agentRuntime:finalizeRun", args).await
+        self.mutation_json("agentRuntime:finalizeRun", args).await
     }
 
     pub(crate) async fn finalize_queued_run(

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use sprocket_convex_provider::Client as ConvexProviderClient;
 use std::collections::BTreeMap;
 
-use crate::types::{CreateRunResponse, RunAgentRequest, RunContextResponse};
+use crate::types::{CreateRunResponse, RunAgentRequest, RunContextResponse, StartRunResponse};
 
 #[derive(Clone)]
 pub(crate) struct RuntimeClient {
@@ -76,6 +76,10 @@ impl RuntimeClient {
         request: &RunAgentRequest,
     ) -> anyhow::Result<CreateRunResponse> {
         let mut args = self.args_with_actor();
+        args.insert(
+            "submissionId".to_string(),
+            request.submission_id.clone().into(),
+        );
         args.insert("threadId".to_string(), request.thread_id.clone().into());
         args.insert("prompt".to_string(), request.prompt.clone().into());
         args.insert(
@@ -89,9 +93,14 @@ impl RuntimeClient {
         self.mutation_json("agentRuntime:createRun", args).await
     }
 
-    pub(crate) async fn start_run(&self, run_id: &str) -> anyhow::Result<()> {
-        self.mutation_unit("agentRuntime:start", self.run_args(run_id))
-            .await
+    pub(crate) async fn start_run(
+        &self,
+        run_id: &str,
+        claim_id: &str,
+    ) -> anyhow::Result<StartRunResponse> {
+        let mut args = self.run_args(run_id);
+        args.insert("claimId".to_string(), claim_id.to_string().into());
+        self.mutation_json("agentRuntime:start", args).await
     }
 
     pub(crate) async fn begin_assistant_message(&self, run_id: &str) -> anyhow::Result<()> {

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -59,6 +59,7 @@ pub(crate) struct AgentProvider {
 
 pub(crate) struct AgentProviderRequest {
     pub(crate) run_id: String,
+    pub(crate) claim_id: String,
     pub(crate) prompt: String,
     pub(crate) preamble: String,
     pub(crate) prior_history: Vec<Message>,
@@ -118,6 +119,7 @@ where
     let tools = workspace_tools(
         runtime.clone(),
         request.run_id.clone(),
+        request.claim_id.clone(),
         request.workspace_root.clone(),
         tool_call_tracker.clone(),
     );

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -3,12 +3,21 @@ use sprocket_workspace::{
     WorkspaceInstruction, WorkspaceOverview, build_workspace_overview, load_workspace_instructions,
     resolve_workspace_root,
 };
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::{Instant, MissedTickBehavior};
 use uuid::Uuid;
 
 use crate::RunContextResponse;
 use crate::convex::RuntimeClient;
 use crate::provider::{AgentProvider, AgentProviderRequest, AgentProviderResult};
 use crate::types::{RunAgentRequest, deserialize_agent_history};
+
+// Keep these synchronized with apps/web/src/convex/lib/runLease.ts.
+const RUN_CLAIM_LEASE_DURATION: Duration = Duration::from_secs(60);
+const RUN_CLAIM_RENEW_INTERVAL: Duration = Duration::from_secs(20);
+const RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(8);
+const RUN_CLAIM_EXPIRY_SAFETY_MARGIN: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy)]
 enum RunFinalStatus {
@@ -98,30 +107,54 @@ async fn fail_run_before_start(
 async fn finalize_run(
     runtime: &RuntimeClient,
     run_id: &str,
+    claim_id: &str,
     assistant_text: &str,
     status: RunFinalStatus,
     error_message: Option<&str>,
 ) -> anyhow::Result<()> {
     let status_text = status.as_str();
-    runtime
-        .finalize_run(run_id, assistant_text, status_text, error_message)
+    let accepted = runtime
+        .finalize_run(run_id, claim_id, assistant_text, status_text, error_message)
         .await
-        .map_err(|error| anyhow!("failed to finalize {status_text} run: {error}"))
+        .map_err(|error| anyhow!("failed to finalize {status_text} run: {error}"))?;
+    if !accepted {
+        return Err(anyhow!(
+            "failed to finalize {status_text} run because claim ownership was lost"
+        ));
+    }
+    Ok(())
 }
 
 async fn finalize_provider_result(
     runtime: &RuntimeClient,
     run_id: &str,
+    claim_id: &str,
     provider_result: AgentProviderResult,
 ) -> anyhow::Result<()> {
     match provider_result {
         AgentProviderResult::Completed { text } => {
             eprintln!("sprocket-agent: model completed {}", run_id);
-            finalize_run(runtime, run_id, &text, RunFinalStatus::Completed, None).await
+            finalize_run(
+                runtime,
+                run_id,
+                claim_id,
+                &text,
+                RunFinalStatus::Completed,
+                None,
+            )
+            .await
         }
         AgentProviderResult::Cancelled { text } => {
             eprintln!("sprocket-agent: run cancelled {}", run_id);
-            finalize_run(runtime, run_id, &text, RunFinalStatus::Cancelled, None).await
+            finalize_run(
+                runtime,
+                run_id,
+                claim_id,
+                &text,
+                RunFinalStatus::Cancelled,
+                None,
+            )
+            .await
         }
         AgentProviderResult::Superseded => {
             eprintln!("sprocket-agent: provider attempt superseded {}", run_id);
@@ -134,6 +167,7 @@ async fn finalize_provider_result(
             match finalize_run(
                 runtime,
                 run_id,
+                claim_id,
                 &text,
                 RunFinalStatus::Failed,
                 Some(&error_text),
@@ -149,7 +183,12 @@ async fn finalize_provider_result(
     }
 }
 
-async fn claim_run(runtime: &RuntimeClient, run_id: &str, claim_id: &str) -> anyhow::Result<bool> {
+async fn claim_run(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+) -> anyhow::Result<Option<Instant>> {
+    let mut request_started_at = Instant::now();
     let start = match runtime.start_run(run_id, claim_id).await {
         Ok(start) => start,
         Err(first_error) => {
@@ -157,6 +196,7 @@ async fn claim_run(runtime: &RuntimeClient, run_id: &str, claim_id: &str) -> any
                 "sprocket-agent: claim attempt failed for run {}; retrying with the same claim: {}",
                 run_id, first_error
             );
+            request_started_at = Instant::now();
             runtime
                 .start_run(run_id, claim_id)
                 .await
@@ -169,11 +209,94 @@ async fn claim_run(runtime: &RuntimeClient, run_id: &str, claim_id: &str) -> any
     };
     if !start.claimed {
         eprintln!("sprocket-agent: run {} already claimed or finished", run_id);
-        return Ok(false);
+        return Ok(None);
     }
 
     eprintln!("sprocket-agent: marked run running {}", run_id);
-    Ok(true)
+    Ok(Some(request_started_at))
+}
+
+async fn renew_claim_once(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+) -> anyhow::Result<(bool, Instant)> {
+    let request_started_at = Instant::now();
+    tokio::time::timeout(
+        RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT,
+        runtime.renew_claim(run_id, claim_id),
+    )
+    .await
+    .map_err(|_| anyhow!("claim renewal timed out"))?
+    .map(|response| (response.renewed, request_started_at))
+}
+
+async fn renew_claim(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+) -> anyhow::Result<(bool, Instant)> {
+    match renew_claim_once(runtime, run_id, claim_id).await {
+        Ok(outcome) => Ok(outcome),
+        Err(first_error) => {
+            eprintln!(
+                "sprocket-agent: claim renewal failed for run {}; retrying: {}",
+                run_id, first_error
+            );
+            renew_claim_once(runtime, run_id, claim_id)
+                .await
+                .map_err(|retry_error| {
+                    anyhow!(
+                        "failed to renew claim for run {run_id} after retry: {retry_error}; initial attempt failed: {first_error}"
+                    )
+                })
+        }
+    }
+}
+
+async fn run_with_claim_lease<F, T>(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+    lease_started_at: Instant,
+    operation: F,
+) -> anyhow::Result<T>
+where
+    F: Future<Output = anyhow::Result<T>>,
+{
+    let mut lease_deadline = lease_started_at + RUN_CLAIM_LEASE_DURATION;
+    let mut renewals = tokio::time::interval_at(
+        Instant::now() + RUN_CLAIM_RENEW_INTERVAL,
+        RUN_CLAIM_RENEW_INTERVAL,
+    );
+    renewals.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    tokio::pin!(operation);
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = renewals.tick() => {
+                let renewal_budget = RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT * 2
+                    + RUN_CLAIM_EXPIRY_SAFETY_MARGIN;
+                if Instant::now() + renewal_budget >= lease_deadline {
+                    return Err(anyhow!("claim lease for run {run_id} cannot be renewed safely before expiry"));
+                }
+                match renew_claim(runtime, run_id, claim_id).await {
+                    Ok((true, renewal_started_at)) => {
+                        if Instant::now() + RUN_CLAIM_EXPIRY_SAFETY_MARGIN >= lease_deadline {
+                            return Err(anyhow!("claim renewal for run {run_id} was not confirmed safely before expiry"));
+                        }
+                        lease_deadline = renewal_started_at + RUN_CLAIM_LEASE_DURATION;
+                    }
+                    Ok((false, _)) => {
+                        return Err(anyhow!("claim lease for run {run_id} was lost"));
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            result = &mut operation => return result,
+        }
+    }
 }
 
 pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
@@ -249,9 +372,9 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     }
     eprintln!("sprocket-agent: prepared assistant response {}", run_id);
 
-    if !claim_run(&runtime, &run_id, &claim_id).await? {
+    let Some(lease_started_at) = claim_run(&runtime, &run_id, &claim_id).await? else {
         return Ok(());
-    }
+    };
 
     eprintln!(
         "sprocket-agent: selected provider {} for run {}",
@@ -259,22 +382,26 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
         run_id
     );
 
-    if runtime.run_finished(&run_id).await? {
-        return Ok(());
-    }
+    run_with_claim_lease(&runtime, &run_id, &claim_id, lease_started_at, async {
+        if runtime.run_finished(&run_id).await? {
+            return Ok(());
+        }
 
-    let provider_result = provider
-        .run(
-            runtime.clone(),
-            AgentProviderRequest {
-                run_id: run_id.clone(),
-                prompt,
-                preamble,
-                prior_history,
-                workspace_root,
-            },
-        )
-        .await;
+        let provider_result = provider
+            .run(
+                runtime.clone(),
+                AgentProviderRequest {
+                    run_id: run_id.clone(),
+                    claim_id: claim_id.clone(),
+                    prompt,
+                    preamble,
+                    prior_history,
+                    workspace_root,
+                },
+            )
+            .await;
 
-    finalize_provider_result(&runtime, &run_id, provider_result).await
+        finalize_provider_result(&runtime, &run_id, &claim_id, provider_result).await
+    })
+    .await
 }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -79,21 +79,20 @@ fn build_workspace_preamble(
     .join("\n")
 }
 
-async fn fail_run_early(
+async fn fail_run_before_start(
     runtime: &RuntimeClient,
     run_id: &str,
     error: &anyhow::Error,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let message = format!("Run failed before the model started: {error}");
     runtime
-        .finalize_run(
+        .finalize_queued_run(
             run_id,
             &message,
             RunFinalStatus::Failed.as_str(),
             Some(&error.to_string()),
         )
-        .await?;
-    Ok(())
+        .await
 }
 
 async fn finalize_run(
@@ -108,23 +107,6 @@ async fn finalize_run(
         .finalize_run(run_id, assistant_text, status_text, error_message)
         .await
         .map_err(|error| anyhow!("failed to finalize {status_text} run: {error}"))
-}
-
-async fn fail_run_setup(
-    runtime: &RuntimeClient,
-    run_id: &str,
-    error: &anyhow::Error,
-) -> anyhow::Result<()> {
-    let _ = runtime.begin_assistant_message(run_id).await;
-    let message = format!("Run failed before the model started: {error}");
-    finalize_run(
-        runtime,
-        run_id,
-        &message,
-        RunFinalStatus::Failed,
-        Some(&error.to_string()),
-    )
-    .await
 }
 
 async fn finalize_provider_result(
@@ -214,19 +196,10 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     let context: RunContextResponse = match runtime.run_context(&run_id).await {
         Ok(context) => context,
         Err(error) => {
-            return match claim_run(&runtime, &run_id, &claim_id).await {
-                Ok(true) => {
-                    fail_run_early(&runtime, &run_id, &error).await?;
-                    Err(error)
-                }
-                Ok(false) => Ok(()),
-                Err(start_error) => {
-                    eprintln!(
-                        "sprocket-agent: failed to load context for run {}; claim outcome is uncertain: {}",
-                        run_id, start_error
-                    );
-                    Err(start_error)
-                }
+            return if fail_run_before_start(&runtime, &run_id, &error).await? {
+                Err(error)
+            } else {
+                Ok(())
             };
         }
     };
@@ -259,22 +232,22 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     let (_, _, prompt, provider, prior_history, preamble) = match prepared {
         Ok(values) => values,
         Err(error) => {
-            return match claim_run(&runtime, &run_id, &claim_id).await {
-                Ok(true) => {
-                    fail_run_setup(&runtime, &run_id, &error).await?;
-                    Err(error)
-                }
-                Ok(false) => Ok(()),
-                Err(start_error) => {
-                    eprintln!(
-                        "sprocket-agent: failed to prepare run {}; claim outcome is uncertain: {}",
-                        run_id, start_error
-                    );
-                    Err(start_error)
-                }
+            return if fail_run_before_start(&runtime, &run_id, &error).await? {
+                Err(error)
+            } else {
+                Ok(())
             };
         }
     };
+
+    if let Err(error) = runtime.begin_assistant_message(&run_id).await {
+        return if fail_run_before_start(&runtime, &run_id, &error).await? {
+            Err(error)
+        } else {
+            Ok(())
+        };
+    }
+    eprintln!("sprocket-agent: prepared assistant response {}", run_id);
 
     if !claim_run(&runtime, &run_id, &claim_id).await? {
         return Ok(());
@@ -289,12 +262,6 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     if runtime.run_finished(&run_id).await? {
         return Ok(());
     }
-
-    if let Err(error) = runtime.begin_assistant_message(&run_id).await {
-        fail_run_setup(&runtime, &run_id, &error).await?;
-        return Err(error);
-    }
-    eprintln!("sprocket-agent: prepared assistant response {}", run_id);
 
     let provider_result = provider
         .run(

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -3,6 +3,7 @@ use sprocket_workspace::{
     WorkspaceInstruction, WorkspaceOverview, build_workspace_overview, load_workspace_instructions,
     resolve_workspace_root,
 };
+use uuid::Uuid;
 
 use crate::RunContextResponse;
 use crate::convex::RuntimeClient;
@@ -166,29 +167,70 @@ async fn finalize_provider_result(
     }
 }
 
+async fn claim_run(runtime: &RuntimeClient, run_id: &str, claim_id: &str) -> anyhow::Result<bool> {
+    let start = match runtime.start_run(run_id, claim_id).await {
+        Ok(start) => start,
+        Err(first_error) => {
+            eprintln!(
+                "sprocket-agent: claim attempt failed for run {}; retrying with the same claim: {}",
+                run_id, first_error
+            );
+            runtime
+                .start_run(run_id, claim_id)
+                .await
+                .map_err(|retry_error| {
+                    anyhow!(
+                        "failed to claim run {run_id} after retry: {retry_error}; initial attempt failed: {first_error}"
+                    )
+                })?
+        }
+    };
+    if !start.claimed {
+        eprintln!("sprocket-agent: run {} already claimed or finished", run_id);
+        return Ok(false);
+    }
+
+    eprintln!("sprocket-agent: marked run running {}", run_id);
+    Ok(true)
+}
+
 pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     eprintln!("sprocket-agent: starting thread {}", request.thread_id);
+    let claim_id = Uuid::new_v4().to_string();
     let runtime: RuntimeClient = RuntimeClient::from_request(&request).await?;
     let workspace_root = resolve_workspace_root(&request.workspace_path)?;
 
     let created_run = runtime.create_run(&request).await?;
+    if created_run.created {
+        eprintln!("sprocket-agent: created run {}", created_run.run_id);
+    } else {
+        eprintln!(
+            "sprocket-agent: resuming submission {} as run {}",
+            request.submission_id, created_run.run_id
+        );
+    }
     let run_id = created_run.run_id;
-    eprintln!("sprocket-agent: created run {}", run_id);
 
     let context: RunContextResponse = match runtime.run_context(&run_id).await {
         Ok(context) => context,
         Err(error) => {
-            fail_run_early(&runtime, &run_id, &error).await?;
-            return Err(error);
+            return match claim_run(&runtime, &run_id, &claim_id).await {
+                Ok(true) => {
+                    fail_run_early(&runtime, &run_id, &error).await?;
+                    Err(error)
+                }
+                Ok(false) => Ok(()),
+                Err(start_error) => {
+                    eprintln!(
+                        "sprocket-agent: failed to load context for run {}; claim outcome is uncertain: {}",
+                        run_id, start_error
+                    );
+                    Err(start_error)
+                }
+            };
         }
     };
     eprintln!("sprocket-agent: loaded run context {}", run_id);
-
-    if let Err(error) = runtime.start_run(&run_id).await {
-        fail_run_early(&runtime, &run_id, &error).await?;
-        return Err(error);
-    }
-    eprintln!("sprocket-agent: marked run running {}", run_id);
 
     let prepared = (|| {
         let workspace_overview = build_workspace_overview(&workspace_root)?;
@@ -217,10 +259,26 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
     let (_, _, prompt, provider, prior_history, preamble) = match prepared {
         Ok(values) => values,
         Err(error) => {
-            fail_run_setup(&runtime, &run_id, &error).await?;
-            return Err(error);
+            return match claim_run(&runtime, &run_id, &claim_id).await {
+                Ok(true) => {
+                    fail_run_setup(&runtime, &run_id, &error).await?;
+                    Err(error)
+                }
+                Ok(false) => Ok(()),
+                Err(start_error) => {
+                    eprintln!(
+                        "sprocket-agent: failed to prepare run {}; claim outcome is uncertain: {}",
+                        run_id, start_error
+                    );
+                    Err(start_error)
+                }
+            };
         }
     };
+
+    if !claim_run(&runtime, &run_id, &claim_id).await? {
+        return Ok(());
+    }
 
     eprintln!(
         "sprocket-agent: selected provider {} for run {}",

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -104,6 +104,18 @@ async fn fail_run_before_start(
         .await
 }
 
+async fn abort_before_start(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    error: anyhow::Error,
+) -> anyhow::Result<()> {
+    if fail_run_before_start(runtime, run_id, &error).await? {
+        Err(error)
+    } else {
+        Ok(())
+    }
+}
+
 async fn finalize_run(
     runtime: &RuntimeClient,
     run_id: &str,
@@ -318,13 +330,7 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
 
     let context: RunContextResponse = match runtime.run_context(&run_id).await {
         Ok(context) => context,
-        Err(error) => {
-            return if fail_run_before_start(&runtime, &run_id, &error).await? {
-                Err(error)
-            } else {
-                Ok(())
-            };
-        }
+        Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };
     eprintln!("sprocket-agent: loaded run context {}", run_id);
 
@@ -354,21 +360,11 @@ pub async fn run_agent(request: RunAgentRequest) -> anyhow::Result<()> {
 
     let (_, _, prompt, provider, prior_history, preamble) = match prepared {
         Ok(values) => values,
-        Err(error) => {
-            return if fail_run_before_start(&runtime, &run_id, &error).await? {
-                Err(error)
-            } else {
-                Ok(())
-            };
-        }
+        Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };
 
     if let Err(error) = runtime.begin_assistant_message(&run_id).await {
-        return if fail_run_before_start(&runtime, &run_id, &error).await? {
-            Err(error)
-        } else {
-            Ok(())
-        };
+        return abort_before_start(&runtime, &run_id, error).await;
     }
     eprintln!("sprocket-agent: prepared assistant response {}", run_id);
 

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -24,6 +24,7 @@ pub(crate) enum AgentToolError {
 struct WorkspaceToolContext {
     runtime: RuntimeClient,
     run_id: String,
+    claim_id: String,
     workspace_root: PathBuf,
     tool_call_tracker: ToolCallTracker,
 }
@@ -32,12 +33,14 @@ impl WorkspaceToolContext {
     fn new(
         runtime: RuntimeClient,
         run_id: String,
+        claim_id: String,
         workspace_root: PathBuf,
         tool_call_tracker: ToolCallTracker,
     ) -> Self {
         Self {
             runtime,
             run_id,
+            claim_id,
             workspace_root,
             tool_call_tracker,
         }
@@ -62,10 +65,12 @@ pub(crate) struct WorkspaceToolSet {
 pub(crate) fn workspace_tools(
     runtime: RuntimeClient,
     run_id: String,
+    claim_id: String,
     workspace_root: PathBuf,
     tool_call_tracker: ToolCallTracker,
 ) -> WorkspaceToolSet {
-    let context = WorkspaceToolContext::new(runtime, run_id, workspace_root, tool_call_tracker);
+    let context =
+        WorkspaceToolContext::new(runtime, run_id, claim_id, workspace_root, tool_call_tracker);
     WorkspaceToolSet {
         exec_command: ExecCommandTool(context.clone()),
         create_file: CreateFileTool(context.clone()),
@@ -135,6 +140,7 @@ impl rig::tool::Tool for ExecCommandTool {
         execute_tool_job(
             &self.0.runtime,
             &self.0.run_id,
+            &self.0.claim_id,
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
@@ -176,6 +182,7 @@ impl rig::tool::Tool for CreateFileTool {
         execute_tool_job(
             &self.0.runtime,
             &self.0.run_id,
+            &self.0.claim_id,
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
@@ -216,6 +223,7 @@ impl rig::tool::Tool for ReplaceInFileTool {
         execute_tool_job(
             &self.0.runtime,
             &self.0.run_id,
+            &self.0.claim_id,
             Self::NAME,
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
@@ -244,6 +252,7 @@ impl rig::tool::Tool for ReplaceInFileTool {
 async fn execute_tool_job<F, Fut>(
     runtime: &RuntimeClient,
     run_id: &str,
+    claim_id: &str,
     kind: &str,
     tool_call_tracker: &ToolCallTracker,
     payload: serde_json::Value,
@@ -270,6 +279,7 @@ where
 
     let mut begin_args = runtime.args_with_actor();
     begin_args.insert("runId".to_string(), run_id.to_string().into());
+    begin_args.insert("claimId".to_string(), claim_id.to_string().into());
     begin_args.insert("kind".to_string(), kind.to_string().into());
     if let Some(call_id) = tool_call_tracker.claim(kind, &payload) {
         begin_args.insert("callId".to_string(), call_id.into());

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -36,6 +36,12 @@ pub struct StartRunResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RenewClaimResponse {
+    pub renewed: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RunContextResponse {
     pub run: RunSnapshot,
     pub thread_record: ThreadRecordSnapshot,

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -12,6 +12,7 @@ pub struct RunAgentRequest {
     pub deployment_url: String,
     pub auth_token: Option<String>,
     pub guest_id: Option<String>,
+    pub submission_id: String,
     pub thread_id: String,
     pub prompt: String,
     pub selected_model: String,
@@ -22,8 +23,15 @@ pub struct RunAgentRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRunResponse {
+    pub created: bool,
     pub run_id: String,
     pub prompt_message_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRunResponse {
+    pub claimed: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -15,6 +15,7 @@ use crate::auth::require_session;
 struct RunAgentApiRequest {
     auth_token: Option<String>,
     guest_id: Option<String>,
+    submission_id: String,
     thread_id: String,
     prompt: String,
     selected_model: String,
@@ -52,6 +53,7 @@ async fn run_agent_handler(
         deployment_url: state.convex_deployment_url.clone(),
         auth_token: payload.auth_token,
         guest_id: payload.guest_id,
+        submission_id: payload.submission_id,
         thread_id: payload.thread_id,
         prompt: payload.prompt,
         selected_model: payload.selected_model,


### PR DESCRIPTION
## What changed

- make new thread and run submissions idempotent with stable submission IDs
- claim queued runs in the Rust agent so duplicate launch requests cannot execute the same run twice
- keep the composer and thread UI responsive while Convex catches up, with recovery for timed-out desktop launches
- coalesce desktop workspace attachment heartbeats and avoid blocking launches on attachment synchronization
- update unit coverage for launch, recovery, queueing, and selection behavior

## Why

Thread launches waited on avoidable synchronization work and could be retried across the desktop/Convex boundary without a shared idempotency key. This made the UI feel slow and allowed ambiguous duplicate execution during transient failures.

## Impact

Thread creation and agent launch feedback now appear immediately, retries resolve to the original thread/run, and only the agent holding the run claim proceeds with execution.

## Validation

- `nix develop -c cargo test`
- `nix develop -c bun run test`
- `nix develop -c bun convex dev --once` from `apps/web`
- `nix develop -c bun run build`
- `nix develop -c prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes thread and agent launches more responsive and idempotent. The main changes are:

- Stable submission IDs for thread and run creation.
- Claim leases and renewal for Rust agent run ownership.
- Recovery flows for timed-out or stale desktop launches.
- Pending-launch UI state in the composer and sidebar.
- Coalesced workspace attachment heartbeats.
- Tests for launch recovery, queueing, and selection behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Bun-based targeted web test suite, covering runLease, desktop, and threads tests, was executed and completed with exit code 0; see the web-targeted-tests log.
- The Rust cargo tests for the sprocket-agent crate were run with --locked and completed with exit code 0; see the rust-agent-tests log.

<a href="https://app.greptile.com/trex/runs/14378528/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/run.rs | Adds claim IDs, lease renewal, guarded finalization, and queued-run failure handling before ownership is claimed. |
| apps/web/src/convex/agentRuntime.ts | Adds idempotent run creation plus claim-aware start, renewal, finalization, and tool-job checks. |
| apps/web/src/lib/home/desktop.ts | Adds submission ID selection, stale-run blocking, and coalesced workspace attachment helpers. |
| apps/web/src/routes/+page.svelte | Tracks prompt submissions, pending launches, recovery messages, and draft-to-thread launch transitions. |
| apps/web/src/convex/threads.ts | Makes thread creation idempotent by submission ID and returns the matching run state. |

</details>

<sub>Reviews (6): Last reviewed commit: ["refactor: dedupe thread launch helpers a..."](https://github.com/spikonado/sprocket/commit/50989919574c7ef28470aaddc4a421381fd12557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44027600)</sub>

<!-- /greptile_comment -->