### PR TITLE
fix(agent): Prevent premature completion

### DIFF
--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -81,6 +81,7 @@ fn build_workspace_preamble(
     [
         "You are a coding agent operating in the user’s real local workspace.",
         "Persist until the task is handled end-to-end. Do not stop at analysis if the user is asking for implementation.",
+        "A response without a tool call ends the run. Before sending one, reread the user request and continue with the next tool call if any work remains, including work requested after an explanation or update.",
         "Behave like a careful senior software engineer.",
         "Do not guess about repo state or file contents. Always inspect before editing.",
         "Fix the root-cause of problems.",


### PR DESCRIPTION
## Summary

- Clarify that a text-only model response terminates an agent run.
- Tell the model to continue with a tool call whenever requested work remains, including work scheduled after an explanation or update.

## Root cause

The agent loop correctly finalized after GPT-5.4 returned a text response with no tool calls. The system prompt did not explicitly connect that protocol-level terminal response to the requirement to finish later requested actions.

## Impact

Multi-part prompts are less likely to terminate after an intermediate explanation while later command or validation work remains.

## Validation

- nix develop -c prek run -a

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR clarifies when an agent response ends the run. The main change is:

- Adds preamble guidance to continue with a tool call while requested work remains.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The new instruction applies only when requested work remains. Completed and analysis-only requests can still end with a text response. No blocking issues were found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The baseline workspace preamble log shows the exact instruction was missing and the focused assertion failed with exit code 101.
- After changes, the workspace preamble test passes the same focused assertion with one test passing and exit code 0.
- The focused test source workspace-preamble-focused-test.rs was preserved for continued validation.
- Targeted crate compilation and all package tests completed successfully, validating the changes across the codebase.
- The unavailable lint-command blocker is acknowledged and captured separately for tracking.

<a href="https://app.greptile.com/trex/runs/14532205/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/run.rs | Adds prompt guidance connecting text-only responses to run completion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Prevent premature completion"](https://github.com/spikonado/sprocket/commit/283a5b14f7e824dcc749554f3c8662dfe72be6c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44437187)</sub>

<!-- /greptile_comment -->