### PR TITLE
fix(agent): Preserve OpenAI reasoning references

### DIFF
--- a/apps/web/src/convex/lib/agentHistory.test.ts
+++ b/apps/web/src/convex/lib/agentHistory.test.ts
@@ -207,6 +207,45 @@ describe('canonical agent history', () => {
 		]);
 	});
 
+	it('preserves id-only reasoning before its OpenAI message', () => {
+		const history = buildAgentHistoryFromAssistantParts({
+			parts: [
+				{
+					type: 'reasoning',
+					id: 'reasoning-1',
+					text: '',
+					turnId: 'turn-1',
+					providerMetadata: {
+						openai: { itemId: 'rs_123', reasoningEncryptedContent: null }
+					}
+				},
+				{
+					type: 'text',
+					id: 'text-1',
+					text: 'Continuing',
+					turnId: 'turn-1',
+					providerMetadata: { openai: { itemId: 'msg_123' } }
+				}
+			],
+			jobs: [],
+			fallbackText: ''
+		});
+
+		expect(history).toEqual([
+			{
+				role: 'assistant',
+				contents: [
+					{ type: 'reasoning', id: 'rs_123', blocksJson: '[]' },
+					{
+						type: 'text',
+						text: 'Continuing',
+						additionalParamsJson: JSON.stringify({ openai: { itemId: 'msg_123' } })
+					}
+				]
+			}
+		]);
+	});
+
 	it.each(['failed', 'cancelled'] as const)(
 		'reconciles persisted tool parts for a %s run without losing metadata or order',
 		(runStatus) => {

--- a/apps/web/src/convex/lib/agentHistory.ts
+++ b/apps/web/src/convex/lib/agentHistory.ts
@@ -97,6 +97,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 
 		if (part.type === 'reasoning') {
 			const openai = openAiMetadata(part.providerMetadata);
+			const itemId = typeof openai?.itemId === 'string' ? openai.itemId : undefined;
 			const blocks: unknown[] = [];
 			if (part.text.length > 0) {
 				blocks.push({ type: 'text', content: { text: part.text } });
@@ -104,10 +105,10 @@ export function buildAgentHistoryFromAssistantParts(args: {
 			if (typeof openai?.reasoningEncryptedContent === 'string') {
 				blocks.push({ type: 'encrypted', content: openai.reasoningEncryptedContent });
 			}
-			if (blocks.length > 0) {
+			if (blocks.length > 0 || itemId !== undefined) {
 				turn.assistant.push({
 					type: 'reasoning',
-					...(typeof openai?.itemId === 'string' ? { id: openai.itemId } : {}),
+					...(itemId !== undefined ? { id: itemId } : {}),
 					blocksJson: JSON.stringify(blocks)
 				});
 			}

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -348,36 +348,15 @@ impl RigCompletionModel for CompletionModel {
                         provider_reasoning_id,
                         provider_metadata,
                         ..
-                    } => {
-                        let id = provider_reasoning_id.clone().or_else(|| {
-                            provider_metadata
-                                .as_ref()
-                                .and_then(|metadata| metadata.pointer("/openai/itemId"))
-                                .and_then(serde_json::Value::as_str)
-                                .map(str::to_owned)
-                        });
-                        if !text.is_empty() {
-                            chunks.push(Ok(RawStreamingChoice::Reasoning {
-                                id: id.clone(),
-                                content: ReasoningContent::Text {
-                                    text: text.clone(),
-                                    signature: None,
-                                },
-                            }));
-                        }
-                        if let Some(encrypted) = provider_metadata
-                            .as_ref()
-                            .and_then(|metadata| {
-                                metadata.pointer("/openai/reasoningEncryptedContent")
-                            })
-                            .and_then(serde_json::Value::as_str)
-                        {
-                            chunks.push(Ok(RawStreamingChoice::Reasoning {
-                                id,
-                                content: ReasoningContent::Encrypted(encrypted.to_owned()),
-                            }));
-                        }
-                    }
+                    } => chunks.extend(
+                        reasoning_stream_choices(
+                            text,
+                            provider_reasoning_id.as_deref(),
+                            provider_metadata,
+                        )
+                        .into_iter()
+                        .map(Ok),
+                    ),
                     CompletionStreamEvent::ToolCall {
                         call_id,
                         name,
@@ -410,6 +389,44 @@ fn text_stream_choices(
         },
         RawStreamingChoice::Message(text.to_owned()),
     ]
+}
+
+fn reasoning_stream_choices(
+    text: &str,
+    provider_reasoning_id: Option<&str>,
+    provider_metadata: &Option<serde_json::Value>,
+) -> Vec<RawStreamingChoice<CompletionOutput>> {
+    let id = provider_reasoning_id.map(str::to_owned).or_else(|| {
+        provider_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.pointer("/openai/itemId"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    });
+    let encrypted = provider_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.pointer("/openai/reasoningEncryptedContent"))
+        .and_then(serde_json::Value::as_str);
+    let mut choices = Vec::new();
+
+    // ID-only stored reasoning still needs a chunk so Rig retains its replay reference.
+    if !text.is_empty() || (id.is_some() && encrypted.is_none()) {
+        choices.push(RawStreamingChoice::Reasoning {
+            id: id.clone(),
+            content: ReasoningContent::Text {
+                text: text.to_owned(),
+                signature: None,
+            },
+        });
+    }
+    if let Some(encrypted) = encrypted {
+        choices.push(RawStreamingChoice::Reasoning {
+            id,
+            content: ReasoningContent::Encrypted(encrypted.to_owned()),
+        });
+    }
+
+    choices
 }
 
 /// Clone `T` under a brief mutex hold so callers can await work on the clone
@@ -590,7 +607,8 @@ where
 mod tests {
     use super::{
         COMPLETION_STREAM_SUPERSEDED, CompletionOutput, CompletionStreamEvent, ToolCall, Usage,
-        clone_locked, completion_choice, is_completion_stream_superseded, text_stream_choices,
+        clone_locked, completion_choice, is_completion_stream_superseded, reasoning_stream_choices,
+        text_stream_choices,
     };
     use rig::completion::CompletionError;
     use rig::message::AssistantContent;
@@ -660,6 +678,28 @@ mod tests {
             "msg_123"
         );
         assert!(matches!(&choices[1], RawStreamingChoice::Message(value) if value == "hello"));
+    }
+
+    #[test]
+    fn streams_id_only_reasoning_for_openai_replay() {
+        let choices = reasoning_stream_choices(
+            "",
+            None,
+            &Some(serde_json::json!({
+                "openai": {
+                    "itemId": "rs_123",
+                    "reasoningEncryptedContent": null
+                }
+            })),
+        );
+
+        assert!(matches!(
+            choices.as_slice(),
+            [RawStreamingChoice::Reasoning {
+                id: Some(id),
+                content: rig::message::ReasoningContent::Text { text, .. }
+            }] if id == "rs_123" && text.is_empty()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve OpenAI reasoning item references even when they contain no visible summary or encrypted payload.
- Carry ID-only reasoning through both live Rig tool turns and rebuilt Convex agent history.
- Add focused regressions for both replay paths.

## Root cause

OpenAI can return a stored reasoning item with only an rs_ item ID. Sprocket discarded these empty-looking items while retaining the following msg_ reference. On the next tool turn, OpenAI rejected that message because its required reasoning item was missing.

## Impact

Reasoning-model runs can continue reliably across tool calls and later thread turns without malformed Responses API history.

## Validation

- nix develop -c cargo test -p sprocket-convex-provider streams_id_only_reasoning_for_openai_replay
- nix develop -c bun test apps/web/src/convex/lib/agentHistory.test.ts
- nix develop -c bun convex dev --once (apps/web)
- nix develop -c prek run -a

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves OpenAI reasoning references when no visible or encrypted reasoning content is present. The main changes are:

- Retain ID-only reasoning in rebuilt Convex agent history.
- Emit an ID-only reasoning chunk during live Rig tool turns.
- Add focused tests for both replay paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Collected the complete command and Cargo output for the convex-id-only reasoning replay, extracted concise test source and results, and located the relevant test source at crates/sprocket-convex-provider/src/client.rs:684-703.
- Before: regression against HEAD^ failed because the reconstructed history omitted the ID-only reasoning item; After: the exact requested focused suite exited 0 with 8/8 tests passing.

<a href="https://app.greptile.com/trex/runs/14535300/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/agentHistory.ts | Keeps empty reasoning entries when OpenAI metadata contains an item ID. |
| crates/sprocket-convex-provider/src/client.rs | Emits an empty reasoning text choice for ID-only OpenAI references while preserving existing text and encrypted-content handling. |
| apps/web/src/convex/lib/agentHistory.test.ts | Tests that ID-only reasoning remains before its associated OpenAI message. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Preserve OpenAI reasoning re..."](https://github.com/spikonado/sprocket/commit/2de5b68f50486ac6963317d5e4507baf00b04d85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44444177)</sub>

<!-- /greptile_comment -->