### PR TITLE
refactor(agent): Simplify system prompt and remove workspace overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,15 +66,6 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
-
-[[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "archery"
@@ -262,12 +247,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -288,17 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,12 +277,6 @@ name = "bytemuck"
 version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -379,15 +341,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clru"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "cmake"
@@ -492,21 +445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,55 +455,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "defmt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
-dependencies = [
- "defmt-parser",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror",
-]
 
 [[package]]
 name = "deranged"
@@ -636,15 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,48 +556,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -873,772 +725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix"
-version = "0.85.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
-dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-date",
- "gix-diff",
- "gix-dir",
- "gix-discover",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-pathspec",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-status",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "gix-worktree-stream",
- "nonempty",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
-dependencies = [
- "bstr",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
- "memmap2",
- "nonempty",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
-dependencies = [
- "bitflags 2.13.0",
- "bstr",
- "gix-path",
- "libc",
- "thiserror",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
-dependencies = [
- "bstr",
- "gix-error",
- "itoa",
- "jiff",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-command",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-imara-diff",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "thiserror",
-]
-
-[[package]]
-name = "gix-dir"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f"
-dependencies = [
- "bstr",
- "gix-discover",
- "gix-fs",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-trace",
- "gix-utils",
- "gix-worktree",
- "thiserror",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
-dependencies = [
- "bytes",
- "crc32fast",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "once_cell",
- "prodash",
- "thiserror",
- "walkdir",
- "zlib-rs",
-]
-
-[[package]]
-name = "gix-filter"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "gix-utils",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
-dependencies = [
- "bitflags 2.13.0",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
-dependencies = [
- "gix-hash",
- "hashbrown 0.17.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-trace",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-imara-diff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
-dependencies = [
- "bstr",
- "hashbrown 0.17.1",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
-dependencies = [
- "bitflags 2.13.0",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate",
- "hashbrown 0.17.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-lock"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.82.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
-dependencies = [
- "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "memmap2",
- "parking_lot",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "memmap2",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
-dependencies = [
- "bitflags 2.13.0",
- "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
- "thiserror",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-ref",
- "gix-shallow",
- "gix-transport",
- "gix-utils",
- "maybe-async",
- "nonempty",
- "thiserror",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-utils",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.65.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
-dependencies = [
- "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "nonempty",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
-dependencies = [
- "bitflags 2.13.0",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-lock",
- "nonempty",
- "thiserror",
-]
-
-[[package]]
-name = "gix-status"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e"
-dependencies = [
- "bstr",
- "filetime",
- "gix-diff",
- "gix-dir",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-worktree",
- "portable-atomic",
- "thiserror",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
-dependencies = [
- "bstr",
- "gix-config",
- "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
- "thiserror",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "23.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
-dependencies = [
- "dashmap",
- "gix-fs",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
-
-[[package]]
-name = "gix-transport"
-version = "0.57.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "thiserror",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
-dependencies = [
- "bitflags 2.13.0",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
-dependencies = [
- "bstr",
- "gix-path",
- "percent-encoding",
- "thiserror",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
-dependencies = [
- "bstr",
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-validate",
-]
-
-[[package]]
-name = "gix-worktree-stream"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
-dependencies = [
- "gix-attributes",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-object",
- "gix-path",
- "gix-traverse",
- "parking_lot",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,41 +743,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "headers"
@@ -1715,16 +770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1962,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2003,48 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
-dependencies = [
- "defmt",
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-link",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,15 +1069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,12 +1079,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2129,30 +1117,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "mime"
@@ -2196,12 +1164,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nonempty"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2326,21 +1288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,15 +1318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prodash"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]
@@ -2447,7 +1385,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2578,19 +1516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,7 +1640,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2834,16 +1759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest",
- "sha1",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,12 +1766,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2968,7 +1877,6 @@ name = "sprocket-workspace"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "gix",
  "libc",
  "serde",
  "serde_json",
@@ -2983,12 +1891,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -3052,19 +1954,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3135,21 +2024,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3252,7 +2126,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3270,7 +2144,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3415,25 +2289,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3840,12 +2699,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -99,7 +99,6 @@ export function isRunFinalStatus(
 }
 
 export const vExecutorJobKind = v.union(
-	v.literal('get_workspace_overview'),
 	v.literal('get_workspace_instructions'),
 	v.literal('exec_command'),
 	v.literal('create_file'),

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -71,8 +71,6 @@
 				return 'Created Files';
 			case 'replace_in_file':
 				return 'Edited Files';
-			case 'get_workspace_overview':
-				return 'Checked Workspace';
 			case 'get_workspace_instructions':
 				return 'Read Instructions';
 			case 'check_docs':
@@ -113,8 +111,6 @@
 			case 'create_file':
 			case 'replace_in_file':
 				return typeof fields?.path === 'string' ? fields.path : 'File';
-			case 'get_workspace_overview':
-				return 'Workspace overview';
 			case 'get_workspace_instructions':
 				return 'Workspace instructions';
 			case 'check_docs':
@@ -354,7 +350,7 @@
 																				</span>
 																			</summary>
 																			<p
-																				class="mt-1.5 whitespace-pre-wrap break-words text-xs leading-5 {toolFailureKind ===
+																				class="mt-1.5 whitespace-pre-wrap wrap-break-word text-xs leading-5 {toolFailureKind ===
 																				'cancelled'
 																					? 'text-amber-200'
 																					: 'text-rose-200'}"

--- a/apps/web/src/lib/components/home/workspace-picker.svelte
+++ b/apps/web/src/lib/components/home/workspace-picker.svelte
@@ -27,7 +27,6 @@
 	export type WorkspaceSelection = {
 		workspacePath: string;
 		workspaceName: string;
-		createIfMissing: boolean;
 	};
 
 	let {
@@ -199,22 +198,24 @@
 		errorMessage = null;
 
 		try {
-			const workspaceName = workspacePath.split(/[/\\]/).filter(Boolean).at(-1);
-			if (!workspaceName) {
-				errorMessage = 'Enter a project directory path.';
-				return;
-			}
+			const resolution = await desktopApi.resolveWorkspacePath({
+				workspacePath,
+				createIfMissing: willCreateDirectory
+			});
 
 			if (
 				mode === 'reconnect' &&
 				expectedWorkspaceName &&
-				workspaceName !== expectedWorkspaceName
+				resolution.workspaceName !== expectedWorkspaceName
 			) {
 				errorMessage = `Selected project must be named "${expectedWorkspaceName}" to reconnect.`;
 				return;
 			}
 
-			await onSelect({ workspacePath, workspaceName, createIfMissing: willCreateDirectory });
+			await onSelect({
+				workspacePath: resolution.workspacePath,
+				workspaceName: resolution.workspaceName
+			});
 			onClose();
 		} catch (error) {
 			errorMessage =

--- a/apps/web/src/lib/components/home/workspace-picker.svelte
+++ b/apps/web/src/lib/components/home/workspace-picker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { CornerLeftUp, Folder, FolderPlus, LoaderCircle } from '@lucide/svelte';
-	import type { DesktopApi, FilesystemBrowseEntry, WorkspaceOverview } from '$lib/types/sprocket';
+	import type { DesktopApi, FilesystemBrowseEntry } from '$lib/types/sprocket';
 	import {
 		appendBrowsePathSegment,
 		getBrowseLeafPathSegment,
@@ -21,7 +21,13 @@
 		expectedWorkspaceName?: string;
 		recentWorkspaces?: RecentWorkspace[];
 		onClose: () => void;
-		onSelect: (overview: WorkspaceOverview) => void | Promise<void>;
+		onSelect: (selection: WorkspaceSelection) => void | Promise<void>;
+	};
+
+	export type WorkspaceSelection = {
+		workspacePath: string;
+		workspaceName: string;
+		createIfMissing: boolean;
 	};
 
 	let {
@@ -193,21 +199,22 @@
 		errorMessage = null;
 
 		try {
-			const overview = await desktopApi.workspaceOverviewForPath({
-				workspacePath,
-				createIfMissing: willCreateDirectory
-			});
+			const workspaceName = workspacePath.split(/[/\\]/).filter(Boolean).at(-1);
+			if (!workspaceName) {
+				errorMessage = 'Enter a project directory path.';
+				return;
+			}
 
 			if (
 				mode === 'reconnect' &&
 				expectedWorkspaceName &&
-				overview.name !== expectedWorkspaceName
+				workspaceName !== expectedWorkspaceName
 			) {
 				errorMessage = `Selected project must be named "${expectedWorkspaceName}" to reconnect.`;
 				return;
 			}
 
-			await onSelect(overview);
+			await onSelect({ workspacePath, workspaceName, createIfMissing: willCreateDirectory });
 			onClose();
 		} catch (error) {
 			errorMessage =
@@ -264,12 +271,12 @@
 					/>
 					{#if isLoadingBrowse}
 						<LoaderCircle
-							class="pointer-events-none absolute end-24 top-1/2 size-4 -translate-y-1/2 animate-spin text-slate-500"
+							class="pointer-events-none absolute inset-e-24 top-1/2 size-4 -translate-y-1/2 animate-spin text-slate-500"
 						/>
 					{/if}
 					<button
 						type="button"
-						class="absolute end-2 top-1/2 -translate-y-1/2 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[12px] text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+						class="absolute inset-e-2 top-1/2 -translate-y-1/2 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[12px] text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
 						disabled={!canSubmit || isSubmitting}
 						onclick={() => {
 							void confirmSelection();

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -24,10 +24,8 @@ const recoveredSubmission = {
 function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 	return {
 		browseFilesystem: vi.fn(),
-		workspaceOverviewForPath: vi.fn(),
 		listWorkspaceSessions: vi.fn(),
 		attachWorkspaceSession: vi.fn(),
-		getWorkspaceSessionOverview: vi.fn(),
 		runAgent,
 		waitForAgentAuthRefresh: vi.fn().mockResolvedValue('complete'),
 		refreshAgentAuth: vi.fn()

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -24,6 +24,7 @@ const recoveredSubmission = {
 function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 	return {
 		browseFilesystem: vi.fn(),
+		resolveWorkspacePath: vi.fn(),
 		listWorkspaceSessions: vi.fn(),
 		attachWorkspaceSession: vi.fn(),
 		runAgent,

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -224,12 +224,10 @@ export async function attachLocalWorkspaceSession(args: {
 	desktopApi: DesktopApi;
 	workspaceSessionId: Id<'workspaceSessions'>;
 	workspacePath: string;
-	createIfMissing?: boolean;
 }) {
 	return await args.desktopApi.attachWorkspaceSession({
 		workspaceSessionId: args.workspaceSessionId,
-		workspacePath: args.workspacePath,
-		...(args.createIfMissing ? { createIfMissing: true } : {})
+		workspacePath: args.workspacePath
 	} satisfies WorkspaceSessionAttachment);
 }
 

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -224,10 +224,12 @@ export async function attachLocalWorkspaceSession(args: {
 	desktopApi: DesktopApi;
 	workspaceSessionId: Id<'workspaceSessions'>;
 	workspacePath: string;
+	createIfMissing?: boolean;
 }) {
 	return await args.desktopApi.attachWorkspaceSession({
 		workspaceSessionId: args.workspaceSessionId,
-		workspacePath: args.workspacePath
+		workspacePath: args.workspacePath,
+		...(args.createIfMissing ? { createIfMissing: true } : {})
 	} satisfies WorkspaceSessionAttachment);
 }
 
@@ -327,7 +329,12 @@ export async function verifyWorkspaceSession(args: {
 	}
 
 	try {
-		await args.desktopApi.getWorkspaceSessionOverview(args.workspaceSessionId);
+		const session = (await args.desktopApi.listWorkspaceSessions()).find(
+			(session) => session.workspaceSessionId === args.workspaceSessionId
+		);
+		if (!session || session.availability !== 'available') {
+			throw new Error(session?.unavailableReason ?? 'Workspace path is unavailable.');
+		}
 		await args.refreshDesktopWorkspaceSessions();
 	} catch (error) {
 		await args.refreshDesktopWorkspaceSessions();

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -2,7 +2,8 @@ import type {
 	AgentAuthStatus,
 	AgentRunStart,
 	DesktopApi,
-	FilesystemBrowseResult
+	FilesystemBrowseResult,
+	WorkspacePathResolution
 } from '$lib/types/sprocket';
 
 export type LocalBootstrap = {
@@ -191,6 +192,14 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 				body: JSON.stringify({
 					partialPath: input.partialPath,
 					...(input.cwd ? { cwd: input.cwd } : {})
+				})
+			}),
+		resolveWorkspacePath: (input) =>
+			request<WorkspacePathResolution>('/api/workspace/resolve', {
+				method: 'POST',
+				body: JSON.stringify({
+					workspacePath: input.workspacePath,
+					...(input.createIfMissing ? { createIfMissing: true } : {})
 				})
 			}),
 		listWorkspaceSessions: () => request('/api/workspace/sessions'),

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -2,8 +2,7 @@ import type {
 	AgentAuthStatus,
 	AgentRunStart,
 	DesktopApi,
-	FilesystemBrowseResult,
-	WorkspaceOverview
+	FilesystemBrowseResult
 } from '$lib/types/sprocket';
 
 export type LocalBootstrap = {
@@ -194,22 +193,12 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 					...(input.cwd ? { cwd: input.cwd } : {})
 				})
 			}),
-		workspaceOverviewForPath: (input) =>
-			request<WorkspaceOverview>('/api/workspace/overview', {
-				method: 'POST',
-				body: JSON.stringify({
-					workspacePath: input.workspacePath,
-					...(input.createIfMissing ? { createIfMissing: true } : {})
-				})
-			}),
 		listWorkspaceSessions: () => request('/api/workspace/sessions'),
 		attachWorkspaceSession: (session) =>
 			request('/api/workspace/sessions', {
 				method: 'POST',
 				body: JSON.stringify(session)
 			}),
-		getWorkspaceSessionOverview: (workspaceSessionId) =>
-			request(`/api/workspace/sessions/${workspaceSessionId}`),
 		runAgent: (requestBody) =>
 			request<AgentRunStart>('/api/agent/run', {
 				method: 'POST',

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -14,23 +14,7 @@ import {
 	type WorkspaceInstruction
 } from '$convex/lib/validators';
 
-export type WorkspaceEntry = {
-	name: string;
-	kind: string;
-};
-
 export type LocalWorkspaceAvailability = 'available' | 'unavailable' | 'unlinked';
-
-export type WorkspaceOverview = {
-	rootPath: string;
-	name: string;
-	gitBranch: string | null;
-	gitDirty: boolean;
-	fileCount: number;
-	directoryCount: number;
-	topLevelEntries: WorkspaceEntry[];
-	recentFiles: string[];
-};
 
 export type { WorkspaceInstruction, ExecutorJobPayload, ExecutorJobResult };
 
@@ -163,17 +147,10 @@ export type DesktopApi = {
 		partialPath: string;
 		cwd?: string;
 	}) => Promise<FilesystemBrowseResult>;
-	workspaceOverviewForPath: (input: {
-		workspacePath: string;
-		createIfMissing?: boolean;
-	}) => Promise<WorkspaceOverview>;
 	listWorkspaceSessions: () => Promise<WorkspaceSessionLocation[]>;
 	attachWorkspaceSession: (
 		session: WorkspaceSessionAttachment
 	) => Promise<WorkspaceSessionLocation>;
-	getWorkspaceSessionOverview: (
-		workspaceSessionId: Id<'workspaceSessions'>
-	) => Promise<WorkspaceOverview>;
 	runAgent: (request: AgentRunRequest) => Promise<AgentRunStart>;
 	waitForAgentAuthRefresh: (authSessionId: string) => Promise<AgentAuthStatus>;
 	refreshAgentAuth: (authSessionId: string, authToken: string) => Promise<void>;
@@ -182,6 +159,7 @@ export type DesktopApi = {
 export type WorkspaceSessionAttachment = {
 	workspaceSessionId: Id<'workspaceSessions'>;
 	workspacePath: string;
+	createIfMissing?: boolean;
 };
 
 export type WorkspaceSessionLocation = {

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -147,6 +147,10 @@ export type DesktopApi = {
 		partialPath: string;
 		cwd?: string;
 	}) => Promise<FilesystemBrowseResult>;
+	resolveWorkspacePath: (input: {
+		workspacePath: string;
+		createIfMissing?: boolean;
+	}) => Promise<WorkspacePathResolution>;
 	listWorkspaceSessions: () => Promise<WorkspaceSessionLocation[]>;
 	attachWorkspaceSession: (
 		session: WorkspaceSessionAttachment
@@ -156,10 +160,14 @@ export type DesktopApi = {
 	refreshAgentAuth: (authSessionId: string, authToken: string) => Promise<void>;
 };
 
+export type WorkspacePathResolution = {
+	workspacePath: string;
+	workspaceName: string;
+};
+
 export type WorkspaceSessionAttachment = {
 	workspaceSessionId: Id<'workspaceSessions'>;
 	workspacePath: string;
-	createIfMissing?: boolean;
 };
 
 export type WorkspaceSessionLocation = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -422,8 +422,7 @@
 
 	async function attachLocalWorkspaceSession(
 		workspaceSessionId: Id<'workspaceSessions'>,
-		workspacePath: string,
-		createIfMissing = false
+		workspacePath: string
 	) {
 		if (!desktopApi) {
 			throw new Error(localServerRequiredMessage);
@@ -432,8 +431,7 @@
 		const session = await attachLocalWorkspaceSessionForPath({
 			desktopApi,
 			workspaceSessionId,
-			workspacePath,
-			createIfMissing
+			workspacePath
 		});
 		desktopWorkspaceSessionsGeneration += 1;
 		desktopWorkspaceSessionsById = {
@@ -505,8 +503,7 @@
 
 				await attachLocalWorkspaceSession(
 					workspacePickerReconnectSessionId,
-					selection.workspacePath,
-					selection.createIfMissing
+					selection.workspacePath
 				);
 				if (getCurrentUserId() !== pickerUserId) {
 					return;
@@ -527,11 +524,7 @@
 				return;
 			}
 
-			await attachLocalWorkspaceSession(
-				session._id,
-				selection.workspacePath,
-				selection.createIfMissing
-			);
+			await attachLocalWorkspaceSession(session._id, selection.workspacePath);
 			if (getCurrentUserId() !== pickerUserId) {
 				return;
 			}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -25,7 +25,9 @@
 	import SettingsArchived from '$lib/components/home/settings-archived.svelte';
 	import SettingsSidebar, { type SettingsPage } from '$lib/components/home/settings-sidebar.svelte';
 	import ThreadTranscript from '$lib/components/home/thread-transcript.svelte';
-	import WorkspacePicker from '$lib/components/home/workspace-picker.svelte';
+	import WorkspacePicker, {
+		type WorkspaceSelection
+	} from '$lib/components/home/workspace-picker.svelte';
 	import WorkspaceSidebar from '$lib/components/home/workspace-sidebar.svelte';
 	import {
 		attachLocalWorkspaceSession as attachLocalWorkspaceSessionForPath,
@@ -70,7 +72,6 @@
 		DesktopApi,
 		ThreadMessage,
 		ThreadSummary,
-		WorkspaceOverview,
 		WorkspaceSession,
 		WorkspaceSessionLocation,
 		WorkspaceThreadGroup
@@ -421,7 +422,8 @@
 
 	async function attachLocalWorkspaceSession(
 		workspaceSessionId: Id<'workspaceSessions'>,
-		workspacePath: string
+		workspacePath: string,
+		createIfMissing = false
 	) {
 		if (!desktopApi) {
 			throw new Error(localServerRequiredMessage);
@@ -430,7 +432,8 @@
 		const session = await attachLocalWorkspaceSessionForPath({
 			desktopApi,
 			workspaceSessionId,
-			workspacePath
+			workspacePath,
+			createIfMissing
 		});
 		desktopWorkspaceSessionsGeneration += 1;
 		desktopWorkspaceSessionsById = {
@@ -479,7 +482,7 @@
 		currentError = null;
 	}
 
-	async function handleWorkspaceSelected(overview: WorkspaceOverview) {
+	async function handleWorkspaceSelected(selection: WorkspaceSelection) {
 		if (!desktopApi || !executorClientId) {
 			currentError = localServerRequiredMessage;
 			return;
@@ -500,7 +503,11 @@
 					return;
 				}
 
-				await attachLocalWorkspaceSession(workspacePickerReconnectSessionId, overview.rootPath);
+				await attachLocalWorkspaceSession(
+					workspacePickerReconnectSessionId,
+					selection.workspacePath,
+					selection.createIfMissing
+				);
 				if (getCurrentUserId() !== pickerUserId) {
 					return;
 				}
@@ -510,7 +517,7 @@
 			}
 
 			const session = await upsertWorkspaceSession({
-				workspaceName: overview.name,
+				workspaceName: selection.workspaceName,
 				connectedClientId: executorClientId
 			});
 			if (!session) {
@@ -520,11 +527,15 @@
 				return;
 			}
 
-			await attachLocalWorkspaceSession(session._id, overview.rootPath);
+			await attachLocalWorkspaceSession(
+				session._id,
+				selection.workspacePath,
+				selection.createIfMissing
+			);
 			if (getCurrentUserId() !== pickerUserId) {
 				return;
 			}
-			setWorkspaceSelection(overview.name, null, true);
+			setWorkspaceSelection(selection.workspaceName, null, true);
 			currentError = null;
 		} catch (error) {
 			if (getCurrentUserId() !== pickerUserId) {
@@ -1459,9 +1470,9 @@
 					workspacePickerReconnectSessionId = null;
 					workspacePickerExpectedName = undefined;
 				}}
-				onSelect={async (overview) => {
+				onSelect={async (selection) => {
 					try {
-						await handleWorkspaceSelected(overview);
+						await handleWorkspaceSelected(selection);
 					} catch {
 						await refreshDesktopWorkspaceSessions();
 					}

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use sprocket_workspace::{
-    WorkspaceInstruction, WorkspaceOverview, build_workspace_overview, load_workspace_instructions,
-    resolve_workspace_root,
+    WorkspaceInstruction, load_workspace_instructions, resolve_workspace_root,
 };
 use std::future::Future;
 use std::time::Duration;
@@ -62,7 +61,6 @@ impl RunFinalStatus {
 
 fn build_workspace_preamble(
     workspace_path: &str,
-    workspace_overview: &WorkspaceOverview,
     workspace_instructions: &[WorkspaceInstruction],
 ) -> String {
     let instruction_block = if workspace_instructions.is_empty() {
@@ -86,8 +84,7 @@ fn build_workspace_preamble(
         "Do not guess about repo state or file contents. Always inspect before editing.",
         "Fix the root-cause of problems.",
         "Keep changes minimal, consistent with the existing codebase, and completely focused on the requested task.",
-        "If the workspace is already dirty, protect user changes and work around them rather than reverting them.",
-        "Use commands for inspection, builds, tests, and formatting, but do not mutate files through shell redirection or destructive git commands.",
+        "If the workspace is already dirty, do not revert the changes. Try and work around them. If they conflict with the changes you need to make, ask the user what to do with them.",
         "Validate your work when the repo has relevant tests or build checks. Start with the most targeted checks for the code you changed.",
         "When you finish, respond with a concise summary of what changed and which checks you ran.",
         "AGENTS.md spec:",
@@ -97,16 +94,6 @@ fn build_workspace_preamble(
         "- System and user instructions override AGENTS.md instructions.",
         "- The AGENTS.md instructions for the current workspace path are already included below and do not need to be re-read.",
         "- If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
-        "",
-        "Workspace root:",
-        workspace_path,
-        "Workspace summary:",
-        &format!("- Name: {}", workspace_overview.name),
-        &format!(
-            "- Git branch: {}",
-            workspace_overview.git_branch.as_deref().unwrap_or("unknown")
-        ),
-        &format!("- Git dirty: {}", workspace_overview.git_dirty),
         "",
         &instruction_block,
     ]
@@ -490,7 +477,6 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
     eprintln!("sprocket-agent: loaded run context {}", run_id);
 
     let prepared = (|| {
-        let workspace_overview = build_workspace_overview(&workspace_root)?;
         let workspace_instructions = load_workspace_instructions(&workspace_root)?;
         let prompt = context.prompt.trim().to_string();
         if prompt.is_empty() {
@@ -498,13 +484,8 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         }
         let provider = AgentProvider::default_for_run(&runtime, &context, &run_id);
         let prior_history = deserialize_agent_history(context.agent_history)?;
-        let preamble = build_workspace_preamble(
-            &request.workspace_path,
-            &workspace_overview,
-            &workspace_instructions,
-        );
+        let preamble = build_workspace_preamble(&request.workspace_path, &workspace_instructions);
         Ok((
-            workspace_overview,
             workspace_instructions,
             prompt,
             provider,
@@ -513,7 +494,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         ))
     })();
 
-    let (_, _, prompt, provider, prior_history, preamble) = match prepared {
+    let (_, prompt, provider, prior_history, preamble) = match prepared {
         Ok(values) => values,
         Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };

--- a/crates/sprocket-server/src/routes/workspace.rs
+++ b/crates/sprocket-server/src/routes/workspace.rs
@@ -1,5 +1,5 @@
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -8,18 +8,8 @@ use serde::Deserialize;
 
 use crate::AppState;
 use crate::auth::require_session;
-use crate::workspace_sessions::{
-    AttachWorkspaceSessionRequest, WorkspaceSessionRecord, workspace_overview_for_path,
-};
+use crate::workspace_sessions::{AttachWorkspaceSessionRequest, WorkspaceSessionRecord};
 use sprocket_workspace::{FilesystemBrowseResult, browse_filesystem};
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct WorkspaceOverviewRequest {
-    workspace_path: String,
-    #[serde(default)]
-    create_if_missing: bool,
-}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -34,11 +24,6 @@ pub fn routes() -> axum::Router<AppState> {
             "/workspace/sessions",
             get(list_sessions).post(attach_session),
         )
-        .route(
-            "/workspace/sessions/{workspace_session_id}",
-            get(session_overview),
-        )
-        .route("/workspace/overview", post(overview_for_path))
         .route("/workspace/browse", post(browse_path))
 }
 
@@ -73,37 +58,6 @@ async fn attach_session(
         .await
         .map_err(ApiError::bad_request)?;
     Ok(Json(session))
-}
-
-async fn session_overview(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    Path(workspace_session_id): Path<String>,
-) -> Result<Json<sprocket_workspace::WorkspaceOverview>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    let overview = state
-        .workspace_sessions
-        .overview(&workspace_session_id)
-        .await
-        .map_err(ApiError::bad_request)?;
-    Ok(Json(overview))
-}
-
-async fn overview_for_path(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    Json(payload): Json<WorkspaceOverviewRequest>,
-) -> Result<Json<sprocket_workspace::WorkspaceOverview>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    let overview = workspace_overview_for_path(&payload.workspace_path, payload.create_if_missing)
-        .map_err(ApiError::bad_request)?;
-    Ok(Json(overview))
 }
 
 async fn browse_path(

--- a/crates/sprocket-server/src/routes/workspace.rs
+++ b/crates/sprocket-server/src/routes/workspace.rs
@@ -8,8 +8,19 @@ use serde::Deserialize;
 
 use crate::AppState;
 use crate::auth::require_session;
-use crate::workspace_sessions::{AttachWorkspaceSessionRequest, WorkspaceSessionRecord};
+use crate::workspace_sessions::{
+    AttachWorkspaceSessionRequest, WorkspacePathResolution, WorkspaceSessionRecord,
+    resolve_workspace_path,
+};
 use sprocket_workspace::{FilesystemBrowseResult, browse_filesystem};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspacePathResolutionRequest {
+    workspace_path: String,
+    #[serde(default)]
+    create_if_missing: bool,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,6 +35,7 @@ pub fn routes() -> axum::Router<AppState> {
             "/workspace/sessions",
             get(list_sessions).post(attach_session),
         )
+        .route("/workspace/resolve", post(resolve_path))
         .route("/workspace/browse", post(browse_path))
 }
 
@@ -58,6 +70,20 @@ async fn attach_session(
         .await
         .map_err(ApiError::bad_request)?;
     Ok(Json(session))
+}
+
+async fn resolve_path(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<WorkspacePathResolutionRequest>,
+) -> Result<Json<WorkspacePathResolution>, ApiError> {
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    let resolution = resolve_workspace_path(&payload.workspace_path, payload.create_if_missing)
+        .map_err(ApiError::bad_request)?;
+    Ok(Json(resolution))
 }
 
 async fn browse_path(

--- a/crates/sprocket-server/src/workspace_sessions.rs
+++ b/crates/sprocket-server/src/workspace_sessions.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -36,8 +37,13 @@ pub enum WorkspaceAvailability {
 pub struct AttachWorkspaceSessionRequest {
     pub workspace_session_id: String,
     pub workspace_path: String,
-    #[serde(default)]
-    pub create_if_missing: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacePathResolution {
+    pub workspace_path: String,
+    pub workspace_name: String,
 }
 
 pub struct WorkspaceSessionStore {
@@ -68,8 +74,7 @@ impl WorkspaceSessionStore {
     ) -> Result<WorkspaceSessionRecord> {
         self.ensure_loaded().await?;
         let now = now_ms();
-        let workspace_path =
-            resolve_workspace_path(&request.workspace_path, request.create_if_missing)?;
+        let workspace_path = resolve_workspace_path(&request.workspace_path, false)?.workspace_path;
         let validated = validate_session(WorkspaceSessionRecord {
             workspace_session_id: request.workspace_session_id,
             workspace_path,
@@ -212,9 +217,9 @@ struct ValidatedWorkspaceSession {
 
 fn validate_session(session: WorkspaceSessionRecord) -> Result<ValidatedWorkspaceSession> {
     match resolve_workspace_path(&session.workspace_path, false) {
-        Ok(workspace_path) => Ok(ValidatedWorkspaceSession {
+        Ok(resolution) => Ok(ValidatedWorkspaceSession {
             session: WorkspaceSessionRecord {
-                workspace_path,
+                workspace_path: resolution.workspace_path,
                 availability: WorkspaceAvailability::Available,
                 last_validated_at: now_ms(),
                 unavailable_reason: None,
@@ -232,7 +237,10 @@ fn validate_session(session: WorkspaceSessionRecord) -> Result<ValidatedWorkspac
     }
 }
 
-fn resolve_workspace_path(workspace_path: &str, create_if_missing: bool) -> Result<String> {
+pub fn resolve_workspace_path(
+    workspace_path: &str,
+    create_if_missing: bool,
+) -> Result<WorkspacePathResolution> {
     let root = if create_if_missing {
         resolve_or_create_workspace_root(workspace_path)?
     } else {
@@ -242,7 +250,16 @@ fn resolve_workspace_path(workspace_path: &str, create_if_missing: bool) -> Resu
     if workspace_path.is_empty() {
         anyhow::bail!("failed to resolve workspace path");
     }
-    Ok(workspace_path)
+    let workspace_name = root
+        .file_name()
+        .unwrap_or_else(|| OsStr::new("workspace"))
+        .to_string_lossy()
+        .to_string();
+
+    Ok(WorkspacePathResolution {
+        workspace_path,
+        workspace_name,
+    })
 }
 
 fn now_ms() -> u64 {
@@ -267,7 +284,6 @@ mod tests {
             .attach(AttachWorkspaceSessionRequest {
                 workspace_session_id: "session-1".to_string(),
                 workspace_path: env!("CARGO_MANIFEST_DIR").to_string(),
-                create_if_missing: false,
             })
             .await
             .expect("attach");
@@ -275,6 +291,27 @@ mod tests {
         assert_eq!(session.availability, WorkspaceAvailability::Available);
         let listed = store.list().await.expect("list");
         assert_eq!(listed.len(), 1);
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workspace_path_resolution_uses_canonical_name_and_root_fallback() {
+        use std::os::unix::fs::symlink;
+
+        let temp_root = std::env::temp_dir().join(format!("sprocket-workspace-path-{}", now_ms()));
+        let target = temp_root.join("real-project");
+        let link = temp_root.join("project-link");
+        fs::create_dir_all(&target).expect("target dir");
+        symlink(&target, &link).expect("symlink");
+
+        let linked = resolve_workspace_path(&link.to_string_lossy(), false).expect("linked path");
+        assert_eq!(linked.workspace_path, target.to_string_lossy());
+        assert_eq!(linked.workspace_name, "real-project");
+
+        let root = resolve_workspace_path("/", false).expect("filesystem root");
+        assert_eq!(root.workspace_name, "workspace");
 
         let _ = fs::remove_dir_all(temp_root);
     }

--- a/crates/sprocket-server/src/workspace_sessions.rs
+++ b/crates/sprocket-server/src/workspace_sessions.rs
@@ -5,10 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sprocket_workspace::{
-    WorkspaceOverview, build_workspace_overview, resolve_or_create_workspace_root,
-    resolve_workspace_root,
-};
+use sprocket_workspace::{resolve_or_create_workspace_root, resolve_workspace_root};
 use tokio::sync::RwLock;
 
 const WORKSPACE_SESSIONS_FILE: &str = "workspace-sessions.json";
@@ -39,6 +36,8 @@ pub enum WorkspaceAvailability {
 pub struct AttachWorkspaceSessionRequest {
     pub workspace_session_id: String,
     pub workspace_path: String,
+    #[serde(default)]
+    pub create_if_missing: bool,
 }
 
 pub struct WorkspaceSessionStore {
@@ -69,9 +68,11 @@ impl WorkspaceSessionStore {
     ) -> Result<WorkspaceSessionRecord> {
         self.ensure_loaded().await?;
         let now = now_ms();
+        let workspace_path =
+            resolve_workspace_path(&request.workspace_path, request.create_if_missing)?;
         let validated = validate_session(WorkspaceSessionRecord {
             workspace_session_id: request.workspace_session_id,
-            workspace_path: request.workspace_path,
+            workspace_path,
             availability: WorkspaceAvailability::Available,
             last_validated_at: now,
             last_used_at: now,
@@ -91,28 +92,6 @@ impl WorkspaceSessionStore {
         );
         self.save_to_disk().await?;
         Ok(validated.session)
-    }
-
-    pub async fn overview(&self, workspace_session_id: &str) -> Result<WorkspaceOverview> {
-        self.ensure_loaded().await?;
-        let session = self.get_or_error(workspace_session_id).await?;
-        let validated = validate_session(session)?;
-        self.sessions.write().await.insert(
-            workspace_session_id.to_string(),
-            WorkspaceSessionRecord {
-                last_used_at: now_ms(),
-                ..validated.session.clone()
-            },
-        );
-        self.save_to_disk().await?;
-        validated.overview.ok_or_else(|| {
-            anyhow::anyhow!(
-                validated
-                    .session
-                    .unavailable_reason
-                    .unwrap_or_else(|| "workspace path is unavailable".to_string())
-            )
-        })
     }
 
     pub async fn workspace_path(&self, workspace_session_id: &str) -> Result<String> {
@@ -229,20 +208,18 @@ impl WorkspaceSessionStore {
 
 struct ValidatedWorkspaceSession {
     session: WorkspaceSessionRecord,
-    overview: Option<WorkspaceOverview>,
 }
 
 fn validate_session(session: WorkspaceSessionRecord) -> Result<ValidatedWorkspaceSession> {
-    match workspace_overview_for_path(&session.workspace_path, false) {
-        Ok(overview) => Ok(ValidatedWorkspaceSession {
+    match resolve_workspace_path(&session.workspace_path, false) {
+        Ok(workspace_path) => Ok(ValidatedWorkspaceSession {
             session: WorkspaceSessionRecord {
-                workspace_path: overview.root_path.clone(),
+                workspace_path,
                 availability: WorkspaceAvailability::Available,
                 last_validated_at: now_ms(),
                 unavailable_reason: None,
                 ..session
             },
-            overview: Some(overview),
         }),
         Err(error) => Ok(ValidatedWorkspaceSession {
             session: WorkspaceSessionRecord {
@@ -251,25 +228,21 @@ fn validate_session(session: WorkspaceSessionRecord) -> Result<ValidatedWorkspac
                 unavailable_reason: Some(error.to_string()),
                 ..session
             },
-            overview: None,
         }),
     }
 }
 
-pub fn workspace_overview_for_path(
-    workspace_path: &str,
-    create_if_missing: bool,
-) -> Result<WorkspaceOverview> {
+fn resolve_workspace_path(workspace_path: &str, create_if_missing: bool) -> Result<String> {
     let root = if create_if_missing {
         resolve_or_create_workspace_root(workspace_path)?
     } else {
         resolve_workspace_root(workspace_path)?
     };
-    let overview = build_workspace_overview(&root)?;
-    if overview.root_path.is_empty() {
+    let workspace_path = root.to_string_lossy().to_string();
+    if workspace_path.is_empty() {
         anyhow::bail!("failed to resolve workspace path");
     }
-    Ok(overview)
+    Ok(workspace_path)
 }
 
 fn now_ms() -> u64 {
@@ -290,12 +263,11 @@ mod tests {
         fs::create_dir_all(&temp_root).expect("temp dir");
         let store = WorkspaceSessionStore::new(temp_root.clone());
 
-        let overview =
-            workspace_overview_for_path(env!("CARGO_MANIFEST_DIR"), false).expect("overview");
         let session = store
             .attach(AttachWorkspaceSessionRequest {
                 workspace_session_id: "session-1".to_string(),
-                workspace_path: overview.root_path,
+                workspace_path: env!("CARGO_MANIFEST_DIR").to_string(),
+                create_if_missing: false,
             })
             .await
             .expect("attach");

--- a/crates/sprocket-workspace/Cargo.toml
+++ b/crates/sprocket-workspace/Cargo.toml
@@ -6,7 +6,6 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.102"
-gix = { version = "0.85.0", default-features = false, features = ["sha1", "status"] }
 libc = "0.2.186"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -15,5 +15,4 @@ pub use tools::{
     WorkspaceOperationCancelled, create_workspace_file, exec_workspace_command,
     replace_workspace_file,
 };
-pub use workspace::{WorkspaceEntry, WorkspaceOverview};
-pub use workspace::{build_workspace_overview, resolve_workspace_root};
+pub use workspace::resolve_workspace_root;

--- a/crates/sprocket-workspace/src/workspace.rs
+++ b/crates/sprocket-workspace/src/workspace.rs
@@ -1,45 +1,6 @@
-use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
-use serde::Serialize;
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkspaceOverview {
-    pub root_path: String,
-    pub name: String,
-    pub git_branch: Option<String>,
-    pub git_dirty: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorkspaceEntry {
-    pub name: String,
-    pub kind: String,
-}
-
-pub fn build_workspace_overview(root: &Path) -> Result<WorkspaceOverview> {
-    let canonical_root: PathBuf = root
-        .canonicalize()
-        .with_context(|| format!("failed to resolve {}", root.display()))?;
-    let root_name: String = canonical_root
-        .file_name()
-        .unwrap_or_else(|| OsStr::new("workspace"))
-        .to_string_lossy()
-        .to_string();
-
-    let (git_branch, git_dirty): (Option<String>, bool) =
-        git_state(&canonical_root).unwrap_or((None, false));
-
-    Ok(WorkspaceOverview {
-        root_path: canonical_root.to_string_lossy().to_string(),
-        name: root_name,
-        git_branch,
-        git_dirty,
-    })
-}
-
 pub fn resolve_workspace_root(path: &str) -> Result<PathBuf> {
     let expanded = crate::paths::expand_home(path.trim());
     let root: PathBuf = PathBuf::from(&expanded);
@@ -155,30 +116,6 @@ pub fn relative_to_root(root: &Path, path: &Path) -> String {
     } else {
         relative
     }
-}
-
-fn git_state(root: &Path) -> Result<(Option<String>, bool)> {
-    let Ok(repo) = gix::discover(root) else {
-        return Ok((None, false));
-    };
-
-    let branch: Option<String> = repo
-        .head_name()
-        .context("failed to read git head")?
-        .map(|name| name.shorten().to_string())
-        .or_else(|| Some("HEAD".to_string()));
-    let dirty: bool = repo
-        .status(gix::progress::Discard)
-        .context("failed to build git status")?
-        .untracked_files(gix::status::UntrackedFiles::Collapsed)
-        .into_iter(std::iter::empty())
-        .context("failed to iterate git status")?
-        .next()
-        .transpose()
-        .context("failed to read git status item")?
-        .is_some();
-
-    Ok((branch, dirty))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies workspace setup and removes workspace-overview generation. The main changes are:

- Replaces workspace overviews with canonical path and name resolution.
- Uses resolved workspace identity for selection, reconnection, and attachment.
- Removes workspace-overview data, routes, tools, and dependencies.
- Simplifies the agent system prompt while retaining workspace instructions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after resolving the existing stored-job compatibility concern.

Canonical workspace names now handle symlinks consistently, and filesystem roots use the expected fallback name.

No distinct blocking issue was found in the updated fix paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general contract proof that the canonical resolution path occurs after successful local pairing and the account-authentication gate.
- Compared the before and after recordings to confirm the closest reachable real surface remains the same.
- Reviewed browser logs to confirm the blocker is rendered and that the 401 for desktop-bootstrap occurs after pairing but does not block the authenticated local resolve request.
- Verified the contract proof shows canonical resolution without requesting workspace-overview data.
- Mapped the available video, image, and log artifacts to the findings to aid review.

<a href="https://app.greptile.com/trex/runs/14666814/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/validators.ts | Removes the legacy workspace-overview executor job kind. |
| apps/web/src/lib/components/home/workspace-picker.svelte | Uses the server-resolved canonical path and name for workspace selection. |
| apps/web/src/routes/+page.svelte | Passes resolved workspace identity through session creation and attachment. |
| crates/sprocket-server/src/workspace_sessions.rs | Adds canonical workspace path and name resolution with root fallback. |
| crates/sprocket-agent/src/run.rs | Removes workspace-overview generation and simplifies the agent preamble. |

</details>

<sub>Reviews (2): Last reviewed commit: ["updates"](https://github.com/spikonado/sprocket/commit/4f3b97c4580f00ac21f8c12cb3c277eaec33aad9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697455)</sub>

<!-- /greptile_comment -->