### PR TITLE
feat(models): Update supported model catalog

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,9 @@
 		"lint": "eslint . && convex typecheck"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^4.0.15",
 		"@ai-sdk/openai": "^4.0.11",
+		"@ai-sdk/xai": "^4.0.14",
 		"@convex-dev/rate-limiter": "^0.3.2",
 		"@fontsource-variable/ibm-plex-sans": "^5.2.8",
 		"@fontsource/dm-sans": "^5.2.8",

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -30,6 +30,7 @@ import type * as lib_threadTranscript from "../lib/threadTranscript.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as lib_workspaceConnection from "../lib/workspaceConnection.js";
 import type * as messages from "../messages.js";
+import type * as migrations from "../migrations.js";
 import type * as threads from "../threads.js";
 import type * as uiPreferences from "../uiPreferences.js";
 import type * as workspaceSessions from "../workspaceSessions.js";
@@ -63,6 +64,7 @@ declare const fullApi: ApiFromModules<{
   "lib/validators": typeof lib_validators;
   "lib/workspaceConnection": typeof lib_workspaceConnection;
   messages: typeof messages;
+  migrations: typeof migrations;
   threads: typeof threads;
   uiPreferences: typeof uiPreferences;
   workspaceSessions: typeof workspaceSessions;

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -3,6 +3,13 @@ import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
 import { getOwnedRun, getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
+import {
+	assertSupportedModelConfiguration,
+	normalizeModelId,
+	normalizeServiceTier,
+	type SupportedModelId,
+	type SupportedServiceTier
+} from '@convex/lib/models';
 import { buildCanonicalAgentHistory, findLatestPrompt } from '@convex/lib/agentHistory';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import { buildThreadTranscript, type ThreadTranscriptMessage } from '@convex/lib/threadTranscript';
@@ -32,6 +39,7 @@ import {
 	vExecutorJobPayload,
 	vModelId,
 	vReasoningEffort,
+	vServiceTier,
 	vRunFinalStatus,
 	vRunStatus
 } from '@convex/lib/validators';
@@ -133,7 +141,8 @@ export const createRun = mutation({
 		threadId: v.id('threadRecords'),
 		prompt: v.string(),
 		selectedModel: vModelId,
-		reasoningEffort: vReasoningEffort
+		reasoningEffort: vReasoningEffort,
+		serviceTier: vServiceTier
 	},
 	handler: async (
 		ctx,
@@ -144,6 +153,11 @@ export const createRun = mutation({
 		promptMessageId: Id<'threadMessages'>;
 		userId: string;
 	}> => {
+		assertSupportedModelConfiguration({
+			modelId: args.selectedModel,
+			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier
+		});
 		const userId: string = await getUserId(ctx);
 		const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecord(
 			ctx.db,
@@ -164,8 +178,9 @@ export const createRun = mutation({
 		if (existingRun) {
 			if (
 				existingRun.threadId !== args.threadId ||
-				existingRun.selectedModel !== args.selectedModel ||
+				normalizeModelId(existingRun.selectedModel) !== args.selectedModel ||
 				existingRun.reasoningEffort !== args.reasoningEffort ||
+				normalizeServiceTier(existingRun.serviceTier) !== args.serviceTier ||
 				!existingRun.promptMessageId
 			) {
 				throw new Error('Submission belongs to a different or incomplete run.');
@@ -197,6 +212,7 @@ export const createRun = mutation({
 			status: 'queued',
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier,
 			startedAt: Date.now()
 		});
 		const promptMessageId: Id<'threadMessages'> = await appendThreadMessage(ctx, {
@@ -212,7 +228,8 @@ export const createRun = mutation({
 		await ctx.db.patch(threadRecord._id, {
 			title: threadRecord.title ?? prompt.slice(0, 72),
 			selectedModel: args.selectedModel,
-			reasoningEffort: args.reasoningEffort
+			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier
 		});
 
 		return {
@@ -290,7 +307,10 @@ export const getContext = query({
 		ctx,
 		args
 	): Promise<{
-		run: Doc<'runs'>;
+		run: Omit<Doc<'runs'>, 'selectedModel' | 'serviceTier'> & {
+			selectedModel: SupportedModelId;
+			serviceTier: SupportedServiceTier;
+		};
 		threadRecord: Doc<'threadRecords'>;
 		workspaceSession: Doc<'workspaceSessions'>;
 		prompt: string;
@@ -320,7 +340,11 @@ export const getContext = query({
 		const prompt: string = findLatestPrompt(messages);
 
 		return {
-			run,
+			run: {
+				...run,
+				selectedModel: normalizeModelId(run.selectedModel),
+				serviceTier: normalizeServiceTier(run.serviceTier)
+			},
 			threadRecord,
 			prompt,
 			agentHistory,
@@ -537,6 +561,7 @@ export const finalizeFailedStart = mutation({
 		prompt: v.string(),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
+		serviceTier: vServiceTier,
 		text: v.string(),
 		lastError: v.string()
 	},
@@ -552,8 +577,9 @@ export const finalizeFailedStart = mutation({
 			!run ||
 			run.status !== 'queued' ||
 			run.threadId !== args.threadId ||
-			run.selectedModel !== args.selectedModel ||
+			normalizeModelId(run.selectedModel) !== args.selectedModel ||
 			run.reasoningEffort !== args.reasoningEffort ||
+			normalizeServiceTier(run.serviceTier) !== args.serviceTier ||
 			!run.promptMessageId
 		) {
 			return false;

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -3,6 +3,17 @@ import { query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
+import {
+	normalizeModelId,
+	normalizeServiceTier,
+	type SupportedModelId,
+	type SupportedServiceTier
+} from '@convex/lib/models';
+
+type NormalizedRun = Omit<Doc<'runs'>, 'selectedModel' | 'serviceTier'> & {
+	selectedModel: SupportedModelId;
+	serviceTier: SupportedServiceTier;
+};
 
 export const latestRunForThread = query({
 	args: {
@@ -13,7 +24,7 @@ export const latestRunForThread = query({
 		args
 	): Promise<{
 		threadId: typeof args.threadId;
-		run: Doc<'runs'> | null;
+		run: NormalizedRun | null;
 		jobs: Doc<'executorJobs'>[];
 		prompt?: string;
 		serverNow: number;
@@ -45,7 +56,11 @@ export const latestRunForThread = query({
 
 		return {
 			threadId: args.threadId,
-			run: latestRun,
+			run: {
+				...latestRun,
+				selectedModel: normalizeModelId(latestRun.selectedModel),
+				serviceTier: normalizeServiceTier(latestRun.serviceTier)
+			},
 			jobs: jobs.filter((job) => !job.hidden).sort((left, right) => left.sequence - right.sequence),
 			...(promptMessage?.type === 'prompt' ? { prompt: promptMessage.text } : {}),
 			serverNow: Date.now()

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -6,12 +6,19 @@ import { action, type ActionCtx } from '@convex/_generated/server';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
-import { resolveLanguageModel } from '@convex/lib/modelRegistry';
+import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { enforceModelCompletionLimit } from '@convex/lib/rateLimits';
 import { getUserId } from '@convex/lib/auth';
-import { vModelId, vReasoningEffort } from '@convex/lib/validators';
-import { type SupportedModelId, type SupportedReasoningEffort } from '@convex/lib/models';
+import { vPersistedModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
+import {
+	assertSupportedModelConfiguration,
+	defaultServiceTier,
+	normalizeModelId,
+	type SupportedModelId,
+	type SupportedReasoningEffort,
+	type SupportedServiceTier
+} from '@convex/lib/models';
 import {
 	appendCompletionStreamEvent,
 	COMPLETION_STREAM_SUPERSEDED,
@@ -36,8 +43,9 @@ const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 1_000;
 
 export const complete = action({
 	args: {
-		modelId: vModelId,
+		modelId: vPersistedModelId,
 		reasoningEffort: v.optional(vReasoningEffort),
+		serviceTier: v.optional(vServiceTier),
 		instructions: v.optional(v.string()),
 		prompt: v.optional(v.string()),
 		messagesJson: v.optional(v.string()),
@@ -69,6 +77,14 @@ export const complete = action({
 		stream_events: CompletionStreamEvent[];
 	}> => {
 		await getUserId(ctx);
+		const modelId = normalizeModelId(args.modelId);
+		if (args.reasoningEffort !== undefined || args.serviceTier !== undefined) {
+			assertSupportedModelConfiguration({
+				modelId,
+				reasoningEffort: args.reasoningEffort,
+				serviceTier: args.serviceTier ?? defaultServiceTier
+			});
+		}
 		const tools: Record<string, ReturnType<typeof tool>> = Object.fromEntries(
 			(args.tools ?? []).map((toolDefinition) => [
 				toolDefinition.name,
@@ -86,7 +102,7 @@ export const complete = action({
 		const toolChoice: ToolChoice | undefined = args.toolChoiceJson
 			? parseJson<ToolChoice>(args.toolChoiceJson, 'toolChoiceJson')
 			: undefined;
-		const sharedArgs = buildSharedCompletionRequest(args, tools, toolChoice);
+		const sharedArgs = buildSharedCompletionRequest({ ...args, modelId }, tools, toolChoice);
 		let request: CompletionRequest;
 		if (args.prompt !== undefined) {
 			request = buildCompletionRequest(sharedArgs, args.prompt, undefined);
@@ -486,6 +502,7 @@ function buildSharedCompletionRequest(
 	args: {
 		modelId: SupportedModelId;
 		reasoningEffort?: SupportedReasoningEffort;
+		serviceTier?: SupportedServiceTier;
 		instructions?: string;
 		tools?: Array<{ name: string }>;
 	},
@@ -497,7 +514,15 @@ function buildSharedCompletionRequest(
 		...(args.instructions !== undefined ? { instructions: args.instructions } : {}),
 		...(args.tools?.length ? { tools } : {}),
 		...(toolChoice !== undefined ? { toolChoice } : {}),
-		...(args.reasoningEffort !== undefined ? { reasoning: args.reasoningEffort } : {})
+		...(args.reasoningEffort !== undefined || args.serviceTier !== undefined
+			? {
+					providerOptions: resolveProviderOptions(
+						args.modelId,
+						args.reasoningEffort,
+						args.serviceTier ?? defaultServiceTier
+					)
+				}
+			: {})
 	};
 }
 

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -1,13 +1,49 @@
 'use node';
 
+import { createAnthropic, type AnthropicProvider } from '@ai-sdk/anthropic';
 import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
-import { type SupportedModelId } from '@convex/lib/models';
+import { createXai, type XaiProvider } from '@ai-sdk/xai';
+import {
+	getModelDefinition,
+	type SupportedModelId,
+	type SupportedReasoningEffort,
+	type SupportedServiceTier
+} from '@convex/lib/models';
 import type { LanguageModel } from 'ai';
 
 const openai: OpenAIProvider = createOpenAI({
 	apiKey: process.env.OPENAI_API_KEY
 });
+const anthropic: AnthropicProvider = createAnthropic({
+	apiKey: process.env.ANTHROPIC_API_KEY
+});
+const xai: XaiProvider = createXai({
+	apiKey: process.env.XAI_API_KEY
+});
 
 export function resolveLanguageModel(modelId: SupportedModelId): LanguageModel {
+	const provider = getModelDefinition(modelId).provider;
+	if (provider === 'anthropic') return anthropic(modelId);
+	if (provider === 'xai') return xai(modelId);
 	return openai(modelId);
+}
+
+export function resolveProviderOptions(
+	modelId: SupportedModelId,
+	reasoningEffort: SupportedReasoningEffort | undefined,
+	serviceTier: SupportedServiceTier
+): Record<string, Record<string, string>> {
+	const provider = getModelDefinition(modelId).provider;
+	if (provider === 'anthropic') {
+		return { anthropic: { ...(reasoningEffort !== undefined ? { effort: reasoningEffort } : {}) } };
+	}
+	if (provider === 'xai') {
+		return { xai: { ...(reasoningEffort !== undefined ? { reasoningEffort } : {}) } };
+	}
+	return {
+		openai: {
+			...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+			serviceTier: serviceTier === 'fast' ? 'priority' : 'default'
+		}
+	};
 }

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { assertSupportedModelConfiguration, modelIds } from '@convex/lib/models';
+
+describe('model configuration', () => {
+	it('exposes only the configured GPT-5.6, Fable, and Grok models', () => {
+		expect(modelIds).toEqual([
+			'gpt-5.6-sol',
+			'gpt-5.6-terra',
+			'gpt-5.6-luna',
+			'claude-fable-5',
+			'grok-4.5'
+		]);
+	});
+
+	it('rejects reasoning and service tiers that a model cannot serve', () => {
+		expect(() =>
+			assertSupportedModelConfiguration({
+				modelId: 'gpt-5.6-sol',
+				reasoningEffort: 'max',
+				serviceTier: 'fast'
+			})
+		).not.toThrow();
+		expect(() =>
+			assertSupportedModelConfiguration({
+				modelId: 'grok-4.5',
+				reasoningEffort: 'xhigh',
+				serviceTier: 'standard'
+			})
+		).toThrow('Grok 4.5 does not support xhigh reasoning.');
+		expect(() =>
+			assertSupportedModelConfiguration({
+				modelId: 'claude-fable-5',
+				reasoningEffort: 'high',
+				serviceTier: 'fast'
+			})
+		).toThrow('Fable-5 does not support the fast service tier.');
+	});
+});

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -1,7 +1,106 @@
-export const reasoningEffortIds = ['low', 'medium', 'high', 'xhigh'] as const;
-export const modelIds = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex'] as const;
-export const defaultModelId = 'gpt-5.4' as const;
-export const defaultReasoningEffort = 'medium' as const;
+export const reasoningEffortIds = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+export const serviceTierIds = ['standard', 'fast'] as const;
+export const modelIds = [
+	'gpt-5.6-sol',
+	'gpt-5.6-terra',
+	'gpt-5.6-luna',
+	'claude-fable-5',
+	'grok-4.5'
+] as const;
+export const legacyModelIds = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex'] as const;
+export const persistedModelIds = [...modelIds, ...legacyModelIds] as const;
 
 export type SupportedModelId = (typeof modelIds)[number];
+export type PersistedModelId = (typeof persistedModelIds)[number];
 export type SupportedReasoningEffort = (typeof reasoningEffortIds)[number];
+export type SupportedServiceTier = (typeof serviceTierIds)[number];
+export type ModelProvider = 'openai' | 'anthropic' | 'xai';
+
+type ModelDefinition = {
+	id: SupportedModelId;
+	label: string;
+	provider: ModelProvider;
+	reasoningEfforts: readonly SupportedReasoningEffort[];
+	serviceTiers: readonly SupportedServiceTier[];
+};
+
+const standardReasoning = ['low', 'medium', 'high', 'xhigh'] as const;
+const grokReasoning = ['low', 'medium', 'high'] as const;
+const standardServiceTier = ['standard'] as const;
+
+export const modelDefinitions = [
+	{
+		id: 'gpt-5.6-sol',
+		label: 'GPT-5.6-Sol',
+		provider: 'openai',
+		reasoningEfforts: reasoningEffortIds,
+		serviceTiers: serviceTierIds
+	},
+	{
+		id: 'gpt-5.6-terra',
+		label: 'GPT-5.6-Terra',
+		provider: 'openai',
+		reasoningEfforts: reasoningEffortIds,
+		serviceTiers: serviceTierIds
+	},
+	{
+		id: 'gpt-5.6-luna',
+		label: 'GPT-5.6-Luna',
+		provider: 'openai',
+		reasoningEfforts: reasoningEffortIds,
+		serviceTiers: serviceTierIds
+	},
+	{
+		id: 'claude-fable-5',
+		label: 'Fable-5',
+		provider: 'anthropic',
+		reasoningEfforts: standardReasoning,
+		serviceTiers: standardServiceTier
+	},
+	{
+		id: 'grok-4.5',
+		label: 'Grok 4.5',
+		provider: 'xai',
+		reasoningEfforts: grokReasoning,
+		serviceTiers: standardServiceTier
+	}
+] as const satisfies readonly ModelDefinition[];
+
+export const defaultModelId = 'gpt-5.6-sol' as const;
+export const defaultReasoningEffort = 'low' as const;
+export const defaultServiceTier = 'standard' as const;
+
+export function getModelDefinition(modelId: SupportedModelId): ModelDefinition {
+	const definition = modelDefinitions.find((model) => model.id === modelId);
+	if (!definition) throw new Error(`Unsupported model: ${modelId}`);
+	return definition;
+}
+
+export function normalizeModelId(modelId: PersistedModelId): SupportedModelId {
+	return (modelIds as readonly string[]).includes(modelId)
+		? (modelId as SupportedModelId)
+		: defaultModelId;
+}
+
+export function normalizeServiceTier(
+	serviceTier: SupportedServiceTier | undefined
+): SupportedServiceTier {
+	return serviceTier ?? defaultServiceTier;
+}
+
+export function assertSupportedModelConfiguration(args: {
+	modelId: SupportedModelId;
+	reasoningEffort?: SupportedReasoningEffort;
+	serviceTier: SupportedServiceTier;
+}) {
+	const model = getModelDefinition(args.modelId);
+	if (
+		args.reasoningEffort !== undefined &&
+		!(model.reasoningEfforts as readonly SupportedReasoningEffort[]).includes(args.reasoningEffort)
+	) {
+		throw new Error(`${model.label} does not support ${args.reasoningEffort} reasoning.`);
+	}
+	if (!(model.serviceTiers as readonly SupportedServiceTier[]).includes(args.serviceTier)) {
+		throw new Error(`${model.label} does not support the ${args.serviceTier} service tier.`);
+	}
+}

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -1,5 +1,10 @@
 import { v, type Infer } from 'convex/values';
-import { modelIds, reasoningEffortIds } from '@convex/lib/models';
+import {
+	modelIds,
+	persistedModelIds,
+	reasoningEffortIds,
+	serviceTierIds
+} from '@convex/lib/models';
 
 function literals<const TValues extends readonly string[]>(values: TValues) {
 	return values.map((value) => v.literal(value)) as {
@@ -9,7 +14,12 @@ function literals<const TValues extends readonly string[]>(values: TValues) {
 
 export const vReasoningEffort = v.union(...literals(reasoningEffortIds));
 
+export const vServiceTier = v.union(...literals(serviceTierIds));
+
 export const vModelId = v.union(...literals(modelIds));
+
+/** Temporary persisted-data validator; remove legacy IDs after the model migration runs. */
+export const vPersistedModelId = v.union(...literals(persistedModelIds));
 
 export const vWorkspaceInstruction = v.object({
 	path: v.string(),

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -1,0 +1,38 @@
+import { paginationOptsValidator } from 'convex/server';
+import { v } from 'convex/values';
+import { internalMutation } from '@convex/_generated/server';
+import { defaultServiceTier, normalizeModelId } from '@convex/lib/models';
+
+/**
+ * Temporary migration for the GPT-5.6 model rollout. Invoke once per table,
+ * following each returned cursor until `isDone`, then remove the legacy model
+ * validator and make `serviceTier` required in the schema.
+ */
+export const backfillModelConfigurations = internalMutation({
+	args: {
+		table: v.union(v.literal('threadRecords'), v.literal('runs')),
+		paginationOpts: paginationOptsValidator
+	},
+	handler: async (ctx, args) => {
+		const page =
+			args.table === 'threadRecords'
+				? await ctx.db.query('threadRecords').paginate(args.paginationOpts)
+				: await ctx.db.query('runs').paginate(args.paginationOpts);
+		let migrated = 0;
+		for (const document of page.page) {
+			const selectedModel = normalizeModelId(document.selectedModel);
+			if (document.selectedModel === selectedModel && document.serviceTier !== undefined) continue;
+			await ctx.db.patch(document._id, {
+				selectedModel,
+				serviceTier: document.serviceTier ?? defaultServiceTier
+			});
+			migrated += 1;
+		}
+
+		return {
+			continueCursor: page.continueCursor,
+			isDone: page.isDone,
+			migrated
+		};
+	}
+});

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -5,8 +5,9 @@ import {
 	vExecutorJobPayload,
 	vExecutorJobResult,
 	vExecutorJobStatus,
-	vModelId,
+	vPersistedModelId,
 	vReasoningEffort,
+	vServiceTier,
 	vRunStatus,
 	vAssistantMessagePart,
 	vThreadMessageType
@@ -33,8 +34,9 @@ export default defineSchema({
 		submissionId: v.string(),
 		workspaceSessionId: v.id('workspaceSessions'),
 		title: v.optional(v.string()),
-		selectedModel: vModelId,
+		selectedModel: vPersistedModelId,
 		reasoningEffort: vReasoningEffort,
+		serviceTier: v.optional(vServiceTier),
 		lastMessageAt: v.number(),
 		archivedAt: v.optional(v.number())
 	})
@@ -49,8 +51,9 @@ export default defineSchema({
 		status: vRunStatus,
 		claimId: v.optional(v.string()),
 		claimExpiresAt: v.optional(v.number()),
-		selectedModel: vModelId,
+		selectedModel: vPersistedModelId,
 		reasoningEffort: vReasoningEffort,
+		serviceTier: v.optional(vServiceTier),
 		startedAt: v.number(),
 		completedAt: v.optional(v.number()),
 		lastError: v.optional(v.string()),

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -3,7 +3,12 @@ import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
-import { isRunFinalStatus, vModelId, vReasoningEffort } from '@convex/lib/validators';
+import {
+	assertSupportedModelConfiguration,
+	normalizeModelId,
+	normalizeServiceTier
+} from '@convex/lib/models';
+import { isRunFinalStatus, vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
 
 async function patchOwnedThread(
 	ctx: MutationCtx,
@@ -20,7 +25,8 @@ export const create = mutation({
 		submissionId: v.string(),
 		workspaceSessionId: v.id('workspaceSessions'),
 		selectedModel: vModelId,
-		reasoningEffort: vReasoningEffort
+		reasoningEffort: vReasoningEffort,
+		serviceTier: vServiceTier
 	},
 	handler: async (
 		ctx,
@@ -29,6 +35,11 @@ export const create = mutation({
 		threadId: Id<'threadRecords'>;
 		submissionRunStatus: Doc<'runs'>['status'] | null;
 	}> => {
+		assertSupportedModelConfiguration({
+			modelId: args.selectedModel,
+			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier
+		});
 		const userId: string = await getUserId(ctx);
 		await getOwnedWorkspaceSession(ctx.db, userId, args.workspaceSessionId);
 		const existingRecord = await ctx.db
@@ -40,8 +51,9 @@ export const create = mutation({
 		if (existingRecord) {
 			if (
 				existingRecord.workspaceSessionId !== args.workspaceSessionId ||
-				existingRecord.selectedModel !== args.selectedModel ||
-				existingRecord.reasoningEffort !== args.reasoningEffort
+				normalizeModelId(existingRecord.selectedModel) !== args.selectedModel ||
+				existingRecord.reasoningEffort !== args.reasoningEffort ||
+				normalizeServiceTier(existingRecord.serviceTier) !== args.serviceTier
 			) {
 				throw new Error('Submission settings do not match the existing thread.');
 			}
@@ -70,6 +82,7 @@ export const create = mutation({
 			workspaceSessionId: args.workspaceSessionId,
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier,
 			lastMessageAt: now
 		});
 
@@ -108,6 +121,8 @@ export const listMine = query({
 					.first();
 				return {
 					...record,
+					selectedModel: normalizeModelId(record.selectedModel),
+					serviceTier: normalizeServiceTier(record.serviceTier),
 					threadId: record._id,
 					title: record.title?.trim() || 'New thread',
 					threadStatus:
@@ -130,7 +145,12 @@ export const getByThreadId = query({
 	},
 	handler: async (ctx, args) => {
 		const userId: string = await getUserId(ctx);
-		return await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const record = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		return {
+			...record,
+			selectedModel: normalizeModelId(record.selectedModel),
+			serviceTier: normalizeServiceTier(record.serviceTier)
+		};
 	}
 });
 

--- a/apps/web/src/lib/chat/model-options.ts
+++ b/apps/web/src/lib/chat/model-options.ts
@@ -1,21 +1,30 @@
-import type { SupportedModelId, SupportedReasoningEffort } from '$convex/lib/models';
+import {
+	modelDefinitions,
+	type ModelProvider,
+	type SupportedModelId,
+	type SupportedReasoningEffort,
+	type SupportedServiceTier
+} from '$convex/lib/models';
 
-type SelectorOption<T extends string> = {
-	id: T;
+export type ModelSelectorOption = {
+	id: SupportedModelId;
 	label: string;
-	triggerLabel?: string;
+	provider: ModelProvider;
 };
 
-export const modelOptions: SelectorOption<SupportedModelId>[] = [
-	{ id: 'gpt-5.5', label: 'GPT-5.5' },
-	{ id: 'gpt-5.4', label: 'GPT-5.4 (default)', triggerLabel: 'GPT-5.4' },
-	{ id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-	{ id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' }
-];
+export const modelOptions: ModelSelectorOption[] = modelDefinitions.map(
+	({ id, label, provider }) => ({ id, label, provider })
+);
 
-export const reasoningEffortOptions: SelectorOption<SupportedReasoningEffort>[] = [
-	{ id: 'low', label: 'Low' },
-	{ id: 'medium', label: 'Medium (default)', triggerLabel: 'Medium' },
-	{ id: 'high', label: 'High' },
-	{ id: 'xhigh', label: 'Extra High' }
-];
+export const reasoningEffortLabels: Record<SupportedReasoningEffort, string> = {
+	low: 'Low',
+	medium: 'Medium',
+	high: 'High',
+	xhigh: 'Extra High',
+	max: 'Max'
+};
+
+export const serviceTierLabels: Record<SupportedServiceTier, string> = {
+	standard: 'Standard',
+	fast: 'Fast'
+};

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
 	import { ArrowUp, ChevronDown, Cpu, LockOpen, Square } from '@lucide/svelte';
-	import OpenAiBlossom from '$lib/components/openai-blossom.svelte';
 	import OptionSelector from '$lib/components/option-selector.svelte';
+	import ProviderLogo from '$lib/components/provider-logo.svelte';
+	import ReasoningServiceSelector from '$lib/components/reasoning-service-selector.svelte';
 	import { shouldSubmitComposerFromKeydown } from '$lib/chat/composer';
-	import { defaultModelId, defaultReasoningEffort } from '$convex/lib/models';
-	import type { SupportedModelId, SupportedReasoningEffort } from '$convex/lib/models';
-	import { modelOptions, reasoningEffortOptions } from '$lib/chat/model-options';
+	import { defaultModelId, defaultReasoningEffort, defaultServiceTier } from '$convex/lib/models';
+	import type {
+		SupportedModelId,
+		SupportedReasoningEffort,
+		SupportedServiceTier
+	} from '$convex/lib/models';
+	import { modelOptions } from '$lib/chat/model-options';
 
 	type Props = {
 		prompt?: string;
 		selectedModel?: SupportedModelId;
 		selectedReasoningEffort?: SupportedReasoningEffort;
+		selectedServiceTier?: SupportedServiceTier;
 		canSend: boolean;
 		isSubmitting: boolean;
 		isStarting: boolean;
@@ -24,6 +30,7 @@
 		prompt = $bindable(''),
 		selectedModel = $bindable(defaultModelId),
 		selectedReasoningEffort = $bindable(defaultReasoningEffort),
+		selectedServiceTier = $bindable(defaultServiceTier),
 		canSend,
 		isSubmitting,
 		isStarting,
@@ -131,24 +138,23 @@
 								ariaLabel="Select model"
 								menuTitle="Model"
 								disabled={isRunning}
+								searchable
 								className="z-20 shrink-0"
 								triggerClassName="h-9 border-0 bg-transparent px-2 text-[15px] text-slate-200 shadow-none hover:bg-transparent focus-visible:ring-0"
 							>
-								{#snippet icon()}
-									<OpenAiBlossom className="size-4 shrink-0 text-slate-400" />
+								{#snippet optionIcon(option)}
+									<ProviderLogo provider={option.provider} className="size-4 shrink-0" />
 								{/snippet}
 							</OptionSelector>
 
 							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>
 
-							<OptionSelector
-								bind:value={selectedReasoningEffort}
-								options={reasoningEffortOptions}
-								ariaLabel="Select reasoning effort"
-								menuTitle="Reasoning"
+							<ReasoningServiceSelector
+								modelId={selectedModel}
+								bind:reasoningEffort={selectedReasoningEffort}
+								bind:serviceTier={selectedServiceTier}
 								disabled={isRunning}
 								className="z-20 shrink-0"
-								triggerClassName="h-9 border-0 bg-transparent px-2 text-[15px] text-slate-300 shadow-none hover:bg-transparent focus-visible:ring-0"
 							/>
 
 							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>

--- a/apps/web/src/lib/components/option-selector.svelte
+++ b/apps/web/src/lib/components/option-selector.svelte
@@ -1,22 +1,17 @@
-<script lang="ts">
-	import { Check, ChevronDown } from '@lucide/svelte';
+<script lang="ts" generics="TOption extends { id: string; label: string; triggerLabel?: string }">
+	import { Check, ChevronDown, Search } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
-
-	type SelectorOption = {
-		id: string;
-		label: string;
-		triggerLabel?: string;
-	};
 
 	type Props = {
 		value?: string;
-		options: SelectorOption[];
+		options: TOption[];
 		ariaLabel: string;
 		menuTitle: string;
 		disabled?: boolean;
 		className?: string;
 		triggerClassName?: string;
-		icon?: import('svelte').Snippet;
+		searchable?: boolean;
+		optionIcon?: import('svelte').Snippet<[TOption]>;
 	};
 
 	let {
@@ -27,14 +22,24 @@
 		disabled = false,
 		className = '',
 		triggerClassName = '',
-		icon
+		searchable = false,
+		optionIcon
 	}: Props = $props();
 
 	let isOpen = $state(false);
+	let searchQuery = $state('');
 	let rootElement = $state<HTMLDivElement | null>(null);
 	let triggerElement = $state<HTMLButtonElement | null>(null);
+	let searchElement = $state<HTMLInputElement | null>(null);
 	let selectedOption = $derived(
 		options.find((option) => option.id === value) ?? options[0] ?? null
+	);
+	let filteredOptions = $derived(
+		searchable && searchQuery.trim()
+			? options.filter((option) =>
+					option.label.toLocaleLowerCase().includes(searchQuery.trim().toLocaleLowerCase())
+				)
+			: options
 	);
 
 	function toggleMenu() {
@@ -43,16 +48,26 @@
 		}
 
 		isOpen = !isOpen;
+		if (isOpen && searchable) queueMicrotask(() => searchElement?.focus());
+		else searchQuery = '';
 	}
 
 	function selectOption(optionId: string) {
 		value = optionId;
 		isOpen = false;
+		searchQuery = '';
 		triggerElement?.focus();
+	}
+
+	function handleSearchKeydown(event: KeyboardEvent) {
+		if (event.key !== 'Enter' || filteredOptions.length === 0) return;
+		event.preventDefault();
+		selectOption(filteredOptions[0].id);
 	}
 
 	$effect(() => {
 		if (!isOpen) {
+			searchQuery = '';
 			return;
 		}
 
@@ -98,17 +113,17 @@
 		type="button"
 		class={cn(
 			'focus-visible:ring-ring/60 inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-transparent bg-transparent px-2 text-sm font-medium text-slate-300 transition outline-none hover:bg-white/[0.03] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
-			!icon && 'gap-1',
+			!optionIcon && 'gap-1',
 			triggerClassName
 		)}
-		aria-haspopup="menu"
+		aria-haspopup="dialog"
 		aria-expanded={isOpen}
 		aria-label={ariaLabel}
 		{disabled}
 		onclick={toggleMenu}
 	>
-		{#if icon}
-			{@render icon()}
+		{#if optionIcon && selectedOption}
+			{@render optionIcon(selectedOption)}
 		{/if}
 		<span class="truncate">{selectedOption?.triggerLabel ?? selectedOption?.label ?? value}</span>
 		<ChevronDown
@@ -118,31 +133,58 @@
 
 	{#if isOpen}
 		<div
-			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[15rem] rounded-[22px] border border-white/8 p-2 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[19rem] rounded-[18px] border border-white/8 p-2 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+			role="dialog"
+			aria-label={menuTitle}
 		>
-			<p class="text-muted-foreground px-3 pt-1 pb-2 text-[11px] tracking-[0.22em] uppercase">
-				{menuTitle}
-			</p>
+			{#if searchable}
+				<label class="flex h-10 items-center gap-2 border-b border-white/6 px-2 text-slate-400">
+					<Search class="size-4 shrink-0" />
+					<span class="sr-only">Search {menuTitle.toLocaleLowerCase()}</span>
+					<input
+						bind:this={searchElement}
+						bind:value={searchQuery}
+						class="min-w-0 flex-1 bg-transparent text-sm text-slate-100 outline-none placeholder:text-slate-500"
+						placeholder={`Search ${menuTitle.toLocaleLowerCase()}…`}
+						onkeydown={handleSearchKeydown}
+					/>
+				</label>
+			{:else}
+				<p class="text-muted-foreground px-3 pt-1 pb-2 text-[11px] font-medium">{menuTitle}</p>
+			{/if}
 
-			<div class="space-y-1">
-				{#each options as option (option.id)}
+			<div class={cn('space-y-0.5', searchable && 'pt-1.5')}>
+				{#each filteredOptions as option (option.id)}
 					<button
 						type="button"
-						class="focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-2xl px-3 py-2.5 text-left outline-none hover:bg-white/4 focus-visible:ring-2"
+						class={cn(
+							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left outline-none hover:bg-white/4 focus-visible:ring-2',
+							option.id === value && 'bg-white/[0.035]'
+						)}
 						aria-pressed={option.id === value}
 						onclick={() => {
 							selectOption(option.id);
 						}}
 					>
+						{#if optionIcon}
+							<span class="flex size-7 shrink-0 items-center justify-center text-slate-300">
+								{@render optionIcon(option)}
+							</span>
+						{/if}
+						<span class="min-w-0 flex-1 truncate text-sm font-medium text-slate-100"
+							>{option.label}</span
+						>
 						<Check
 							class={cn(
-								'size-4 shrink-0 text-slate-100 transition-opacity',
+								'size-4 shrink-0 text-blue-400 transition-opacity',
 								option.id === value ? 'opacity-100' : 'opacity-0'
 							)}
 						/>
-						<span class="truncate text-sm text-slate-100">{option.label}</span>
 					</button>
 				{/each}
+				{#if filteredOptions.length === 0}
+					<p class="px-3 py-5 text-center text-sm text-slate-500">No matches found</p>
+				{/if}
 			</div>
 		</div>
 	{/if}

--- a/apps/web/src/lib/components/provider-logo.svelte
+++ b/apps/web/src/lib/components/provider-logo.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import OpenAiBlossom from '$lib/components/openai-blossom.svelte';
+	import type { ModelProvider } from '$convex/lib/models';
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		provider: ModelProvider;
+		className?: string;
+	};
+
+	let { provider, className = '' }: Props = $props();
+</script>
+
+{#if provider === 'openai'}
+	<OpenAiBlossom className={cn('size-4 text-white', className)} />
+{:else if provider === 'anthropic'}
+	<svg
+		viewBox="0 0 24 24"
+		class={cn('size-4 text-[#D97757]', className)}
+		role="img"
+		aria-label="Anthropic"
+		fill="currentColor"
+	>
+		<path
+			d="M17.304 3.541h-3.672l6.696 16.918H24Zm-10.608 0L0 20.459h3.744l1.37-3.553h7.005l1.369 3.553h3.744L10.536 3.541Zm-.371 10.223 2.291-5.945 2.292 5.945Z"
+		/>
+	</svg>
+{:else}
+	<svg
+		viewBox="0 0 24 24"
+		class={cn('size-4 text-white', className)}
+		role="img"
+		aria-label="xAI"
+		fill="currentColor"
+	>
+		<path
+			d="M6.469 8.776 16.512 23h-4.464L2.005 8.776H6.47Zm-.004 7.9 2.233 3.164L6.467 23H2l4.465-6.324ZM22 2.582V23h-3.659V7.764L22 2.582ZM22 1l-9.952 14.095-2.233-3.163L17.533 1H22Z"
+		/>
+	</svg>
+{/if}

--- a/apps/web/src/lib/components/reasoning-service-selector.svelte
+++ b/apps/web/src/lib/components/reasoning-service-selector.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import { Check, ChevronDown, Zap } from '@lucide/svelte';
+	import {
+		defaultReasoningEffort,
+		defaultServiceTier,
+		getModelDefinition,
+		serviceTierIds,
+		type SupportedModelId,
+		type SupportedReasoningEffort,
+		type SupportedServiceTier
+	} from '$convex/lib/models';
+	import { reasoningEffortLabels, serviceTierLabels } from '$lib/chat/model-options';
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		modelId: SupportedModelId;
+		reasoningEffort?: SupportedReasoningEffort;
+		serviceTier?: SupportedServiceTier;
+		disabled?: boolean;
+		className?: string;
+	};
+
+	let {
+		modelId,
+		reasoningEffort = $bindable(defaultReasoningEffort),
+		serviceTier = $bindable(defaultServiceTier),
+		disabled = false,
+		className = ''
+	}: Props = $props();
+
+	let isOpen = $state(false);
+	let rootElement = $state<HTMLDivElement | null>(null);
+	let triggerElement = $state<HTMLButtonElement | null>(null);
+	let model = $derived(getModelDefinition(modelId));
+	let supportsFast = $derived(model.serviceTiers.includes('fast'));
+
+	function selectReasoning(next: SupportedReasoningEffort) {
+		reasoningEffort = next;
+	}
+
+	function selectServiceTier(next: SupportedServiceTier) {
+		if (next === 'fast' && !supportsFast) return;
+		serviceTier = next;
+	}
+
+	$effect(() => {
+		const supportedReasoning = model.reasoningEfforts as readonly SupportedReasoningEffort[];
+		if (!supportedReasoning.includes(reasoningEffort)) {
+			reasoningEffort = supportedReasoning.includes(defaultReasoningEffort)
+				? defaultReasoningEffort
+				: supportedReasoning[0];
+		}
+		if (!model.serviceTiers.includes(serviceTier)) serviceTier = defaultServiceTier;
+	});
+
+	$effect(() => {
+		if (!isOpen) return;
+
+		function handlePointerDown(event: PointerEvent) {
+			if (event.target instanceof Node && !rootElement?.contains(event.target)) isOpen = false;
+		}
+
+		function handleKeyDown(event: KeyboardEvent) {
+			if (event.key !== 'Escape') return;
+			isOpen = false;
+			triggerElement?.focus();
+		}
+
+		document.addEventListener('pointerdown', handlePointerDown);
+		document.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.removeEventListener('pointerdown', handlePointerDown);
+			document.removeEventListener('keydown', handleKeyDown);
+		};
+	});
+
+	$effect(() => {
+		if (disabled) isOpen = false;
+	});
+</script>
+
+<div bind:this={rootElement} class={cn('relative', className)}>
+	<button
+		bind:this={triggerElement}
+		type="button"
+		class="focus-visible:ring-ring/60 inline-flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-[15px] text-slate-300 outline-none transition hover:bg-white/[0.03] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
+		aria-haspopup="dialog"
+		aria-expanded={isOpen}
+		aria-label="Select reasoning effort and service tier"
+		{disabled}
+		onclick={() => {
+			isOpen = !isOpen;
+		}}
+	>
+		<span>{reasoningEffortLabels[reasoningEffort]} · {serviceTierLabels[serviceTier]}</span>
+		<ChevronDown
+			class={cn('size-3 shrink-0 text-slate-500 transition-transform', isOpen && 'rotate-180')}
+		/>
+	</button>
+
+	{#if isOpen}
+		<div
+			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[15rem] rounded-[18px] border border-white/8 p-2 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+			role="dialog"
+			aria-label="Reasoning and service tier"
+		>
+			<p class="px-3 pt-1 pb-1.5 text-[11px] font-medium text-slate-500">Reasoning</p>
+			<div class="space-y-0.5">
+				{#each model.reasoningEfforts as effort (effort)}
+					<button
+						type="button"
+						class="focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-slate-100 outline-none hover:bg-white/4 focus-visible:ring-2"
+						aria-pressed={effort === reasoningEffort}
+						onclick={() => selectReasoning(effort)}
+					>
+						<Check
+							class={cn(
+								'size-4 shrink-0 transition-opacity',
+								effort === reasoningEffort ? 'opacity-100' : 'opacity-0'
+							)}
+						/>
+						<span>{reasoningEffortLabels[effort]}</span>
+						{#if effort === defaultReasoningEffort}
+							<span class="ml-auto text-xs text-slate-500">Default</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+
+			<div class="mx-2 my-2 h-px bg-white/6"></div>
+			<p class="px-3 pb-1.5 text-[11px] font-medium text-slate-500">Service tier</p>
+			<div class="space-y-0.5">
+				{#each serviceTierIds as tier (tier)}
+					{@const unavailable = tier === 'fast' && !supportsFast}
+					<button
+						type="button"
+						class={cn(
+							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-slate-100 outline-none focus-visible:ring-2',
+							unavailable ? 'cursor-not-allowed opacity-40' : 'hover:bg-white/4'
+						)}
+						aria-pressed={tier === serviceTier}
+						aria-disabled={unavailable}
+						onclick={() => selectServiceTier(tier)}
+					>
+						<Check
+							class={cn(
+								'size-4 shrink-0 transition-opacity',
+								tier === serviceTier ? 'opacity-100' : 'opacity-0'
+							)}
+						/>
+						{#if tier === 'fast'}<Zap class="size-3.5 text-amber-400" />{/if}
+						<span>{serviceTierLabels[tier]}</span>
+						{#if unavailable}
+							<span class="ml-auto text-xs text-slate-500">Unavailable</span>
+						{:else if tier === defaultServiceTier}
+							<span class="ml-auto text-xs text-slate-500">Default</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -17,7 +17,8 @@ import type {
 const recoveredSubmission = {
 	prompt: 'Inspect the robot',
 	reasoningEffort: 'medium' as const,
-	selectedModel: 'gpt-5.4' as const,
+	serviceTier: 'standard' as const,
+	selectedModel: 'gpt-5.6-sol' as const,
 	submissionId: 'recovered-id'
 };
 
@@ -47,8 +48,9 @@ function launchArgs(
 		onStarted: vi.fn(),
 		threadId: 'thread-1' as never,
 		prompt: 'Inspect src/lib.rs',
-		selectedModel: 'gpt-5.4',
+		selectedModel: 'gpt-5.6-sol',
 		reasoningEffort: 'medium',
+		serviceTier: 'standard',
 		submissionId: 'submission-1',
 		workspaceSessionId: 'workspace-1' as never,
 		...overrides
@@ -63,6 +65,7 @@ function resolveRecoveredSubmission(
 		newSubmissionId: 'new-id',
 		prompt: recoveredSubmission.prompt,
 		reasoningEffort: recoveredSubmission.reasoningEffort,
+		serviceTier: recoveredSubmission.serviceTier,
 		recoveredSubmission,
 		selectedModel: recoveredSubmission.selectedModel,
 		...overrides
@@ -92,9 +95,10 @@ describe('launchAgentRun', () => {
 			authToken: 'token-1',
 			threadId: 'thread-1',
 			prompt: 'Inspect src/lib.rs',
-			selectedModel: 'gpt-5.4',
+			selectedModel: 'gpt-5.6-sol',
 			submissionId: 'submission-1',
 			reasoningEffort: 'medium',
+			serviceTier: 'standard',
 			workspaceSessionId: 'workspace-1'
 		});
 		await vi.waitFor(() => {
@@ -195,6 +199,7 @@ describe('resolveSubmissionId', () => {
 		expect(resolveRecoveredSubmission()).toBe('recovered-id');
 		expect(resolveRecoveredSubmission({ prompt: 'Inspect and fix the robot' })).toBe('new-id');
 		expect(resolveRecoveredSubmission({ reasoningEffort: 'high' })).toBe('new-id');
+		expect(resolveRecoveredSubmission({ serviceTier: 'fast' })).toBe('new-id');
 	});
 
 	it('uses a fresh id when the visible latest submission has finished or supersedes recovery', () => {

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -23,9 +23,11 @@ export function resolveSubmissionId(args: {
 	newSubmissionId: string;
 	prompt: string;
 	reasoningEffort: AgentRunRequest['reasoningEffort'];
+	serviceTier: AgentRunRequest['serviceTier'];
 	recoveredSubmission?: {
 		prompt: string;
 		reasoningEffort: AgentRunRequest['reasoningEffort'];
+		serviceTier: AgentRunRequest['serviceTier'];
 		selectedModel: AgentRunRequest['selectedModel'];
 		submissionId: string;
 	};
@@ -44,7 +46,8 @@ export function resolveSubmissionId(args: {
 	return canReuseRecoveredSubmission &&
 		recoveredSubmission?.prompt === args.prompt &&
 		recoveredSubmission.selectedModel === args.selectedModel &&
-		recoveredSubmission.reasoningEffort === args.reasoningEffort
+		recoveredSubmission.reasoningEffort === args.reasoningEffort &&
+		recoveredSubmission.serviceTier === args.serviceTier
 		? recoveredSubmission.submissionId
 		: args.newSubmissionId;
 }
@@ -80,6 +83,7 @@ export function launchAgentRun(args: {
 	prompt: string;
 	selectedModel: AgentRunRequest['selectedModel'];
 	reasoningEffort: AgentRunRequest['reasoningEffort'];
+	serviceTier: AgentRunRequest['serviceTier'];
 	submissionId: string;
 	workspaceSessionId: Id<'workspaceSessions'>;
 }) {
@@ -120,6 +124,7 @@ export function launchAgentRun(args: {
 			prompt: args.prompt,
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
+			serviceTier: args.serviceTier,
 			submissionId: args.submissionId,
 			workspaceSessionId: args.workspaceSessionId
 		})

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -7,6 +7,7 @@ import {
 	vExecutorStatus,
 	vModelId,
 	vReasoningEffort,
+	vServiceTier,
 	vRunStatus,
 	vThreadMessageType,
 	type ExecutorJobPayload,
@@ -58,6 +59,7 @@ export type ThreadSummary = {
 	title: string;
 	selectedModel: Infer<typeof vModelId>;
 	reasoningEffort: Infer<typeof vReasoningEffort>;
+	serviceTier: Infer<typeof vServiceTier>;
 	lastMessageAt: number;
 	threadStatus: 'active' | 'archived';
 	latestRunStatus: RunState['status'] | null;
@@ -109,6 +111,7 @@ export type RunState = {
 	claimExpiresAt?: number;
 	selectedModel: Infer<typeof vModelId>;
 	reasoningEffort: Infer<typeof vReasoningEffort>;
+	serviceTier: Infer<typeof vServiceTier>;
 	startedAt: number;
 	completedAt?: number;
 	lastError?: string;
@@ -139,6 +142,7 @@ export type AgentRunRequest = {
 	prompt: string;
 	selectedModel: Infer<typeof vModelId>;
 	reasoningEffort: Infer<typeof vReasoningEffort>;
+	serviceTier: Infer<typeof vServiceTier>;
 	workspaceSessionId: Id<'workspaceSessions'>;
 };
 

--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -16,7 +16,7 @@ import {
 	type PendingAgentLaunch,
 	type PendingAgentLaunches
 } from '$lib/workspace/threads';
-import { defaultModelId, defaultReasoningEffort } from '$convex/lib/models';
+import { defaultModelId, defaultReasoningEffort, defaultServiceTier } from '$convex/lib/models';
 import type { ThreadSummary, WorkspaceSession } from '$lib/types/sprocket';
 
 type RunId = NonNullable<ThreadSummary['latestRunId']>;
@@ -53,6 +53,7 @@ function makeThreadSummary(overrides: Partial<ThreadSummary> = {}): ThreadSummar
 		title: 'Thread',
 		selectedModel: overrides.selectedModel ?? defaultModelId,
 		reasoningEffort: overrides.reasoningEffort ?? defaultReasoningEffort,
+		serviceTier: overrides.serviceTier ?? defaultServiceTier,
 		lastMessageAt: 0,
 		threadStatus: 'active',
 		latestRunStatus: null,

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -43,8 +43,10 @@
 	import {
 		defaultModelId,
 		defaultReasoningEffort,
+		defaultServiceTier,
 		type SupportedModelId,
-		type SupportedReasoningEffort
+		type SupportedReasoningEffort,
+		type SupportedServiceTier
 	} from '$convex/lib/models';
 	import { isClaimedRunStatus } from '$convex/lib/runLease';
 	import {
@@ -124,6 +126,7 @@
 		message: string;
 		prompt: string;
 		reasoningEffort?: SupportedReasoningEffort;
+		serviceTier?: SupportedServiceTier;
 		selectedModel?: SupportedModelId;
 		submissionId?: string;
 	};
@@ -143,6 +146,7 @@
 	let draftWorkspaceName = $state<string | null>(null);
 	let selectedModel = $state<SupportedModelId>(defaultModelId);
 	let selectedReasoningEffort = $state<SupportedReasoningEffort>(defaultReasoningEffort);
+	let selectedServiceTier = $state<SupportedServiceTier>(defaultServiceTier);
 	let prompt = $state('');
 	let currentError = $state<string | null>(null);
 	let executorClientId = $state<string | null>(null);
@@ -155,6 +159,7 @@
 		{
 			prompt: string;
 			reasoningEffort: SupportedReasoningEffort;
+			serviceTier: SupportedServiceTier;
 			selectedModel: SupportedModelId;
 			submissionId: string;
 		}
@@ -173,6 +178,7 @@
 	let hasResolvedInitialSelection = $state(false);
 	let restoredWorkspaceSessionIdToAttach = $state<Id<'workspaceSessions'> | null>(null);
 	let lastSavedThreadId = $state<Id<'threadRecords'> | null>(null);
+	let lastSyncedComposerThreadId: Id<'threadRecords'> | null = null;
 	let workspaceSelectionGeneration = $state(0);
 	let pendingCreatedThreadId = $state<Id<'threadRecords'> | null>(null);
 	let desktopWorkspaceSessionsById = $state<Record<string, WorkspaceSessionLocation>>({});
@@ -550,6 +556,7 @@
 	function schedulePendingCreatedThreadExpiration(args: {
 		prompt: string;
 		reasoningEffort: SupportedReasoningEffort;
+		serviceTier: SupportedServiceTier;
 		selectedModel: SupportedModelId;
 		submissionId: string;
 		threadId: Id<'threadRecords'>;
@@ -576,6 +583,7 @@
 					message: 'The new thread did not appear. Review your prompt and try sending it again.',
 					prompt: args.prompt,
 					reasoningEffort: args.reasoningEffort,
+					serviceTier: args.serviceTier,
 					selectedModel: args.selectedModel,
 					submissionId: args.submissionId
 				});
@@ -589,6 +597,7 @@
 		selectionGeneration: number;
 		selectedModel: SupportedModelId;
 		selectedReasoningEffort: SupportedReasoningEffort;
+		selectedServiceTier: SupportedServiceTier;
 		submissionId: string;
 		userId: string;
 		workspaceName: string;
@@ -598,7 +607,8 @@
 			submissionId: args.submissionId,
 			workspaceSessionId: args.workspaceSessionId,
 			selectedModel: args.selectedModel,
-			reasoningEffort: args.selectedReasoningEffort
+			reasoningEffort: args.selectedReasoningEffort,
+			serviceTier: args.selectedServiceTier
 		});
 		if (!args.isSubmissionCurrent()) {
 			return null;
@@ -615,6 +625,7 @@
 			schedulePendingCreatedThreadExpiration({
 				prompt: args.prompt,
 				reasoningEffort: args.selectedReasoningEffort,
+				serviceTier: args.selectedServiceTier,
 				selectedModel: args.selectedModel,
 				submissionId: args.submissionId,
 				threadId: result.threadId,
@@ -730,6 +741,7 @@
 		const submittedPrompt = prompt.trim();
 		const submittedModel = selectedModel;
 		const submittedReasoningEffort = selectedReasoningEffort;
+		const submittedServiceTier = selectedServiceTier;
 		const previousRunId = selectedThreadId ? (runState?._id ?? null) : null;
 		let submissionScope = selectedThreadId
 			? `thread:${selectedThreadId}`
@@ -747,6 +759,7 @@
 			newSubmissionId: freshSubmissionId,
 			prompt: submittedPrompt,
 			reasoningEffort: submittedReasoningEffort,
+			serviceTier: submittedServiceTier,
 			recoveredSubmission,
 			selectedModel: submittedModel
 		});
@@ -768,6 +781,7 @@
 				message,
 				prompt: submittedPrompt,
 				reasoningEffort: submittedReasoningEffort,
+				serviceTier: submittedServiceTier,
 				selectedModel: submittedModel,
 				submissionId:
 					!selectedThreadId && recoveryScope === originatingRecoveryScope
@@ -806,6 +820,7 @@
 						selectionGeneration,
 						selectedModel: submittedModel,
 						selectedReasoningEffort: submittedReasoningEffort,
+						selectedServiceTier: submittedServiceTier,
 						submissionId: threadSubmissionId,
 						userId: submittedUserId,
 						workspaceName: submittedWorkspaceName,
@@ -922,6 +937,7 @@
 				selectedModel: submittedModel,
 				submissionId: runSubmissionId,
 				reasoningEffort: submittedReasoningEffort,
+				serviceTier: submittedServiceTier,
 				workspaceSessionId
 			});
 		} catch (error) {
@@ -1027,6 +1043,7 @@
 			message: 'The previous agent stopped responding. Retry to continue this submission.',
 			prompt: currentLatestRunData.prompt,
 			reasoningEffort: staleRun.reasoningEffort,
+			serviceTier: staleRun.serviceTier,
 			selectedModel: staleRun.selectedModel,
 			submissionId: staleRun.submissionId
 		});
@@ -1047,6 +1064,7 @@
 		pendingAgentLaunches = {};
 		restoredWorkspaceSessionIdToAttach = null;
 		lastSavedThreadId = null;
+		lastSyncedComposerThreadId = null;
 		workspaceSelectionGeneration += 1;
 		prompt = '';
 		currentError = null;
@@ -1054,9 +1072,21 @@
 		elapsedSeconds = 0;
 		selectedModel = defaultModelId;
 		selectedReasoningEffort = defaultReasoningEffort;
+		selectedServiceTier = defaultServiceTier;
 		workspacePickerOpen = false;
 		workspacePickerReconnectSessionId = null;
 		workspacePickerExpectedName = undefined;
+	});
+
+	$effect(() => {
+		const thread = currentActiveThread;
+		const threadId = thread?._id ?? null;
+		if (threadId === lastSyncedComposerThreadId) return;
+		lastSyncedComposerThreadId = threadId;
+		if (!thread) return;
+		selectedModel = thread.selectedModel;
+		selectedReasoningEffort = thread.reasoningEffort;
+		selectedServiceTier = thread.serviceTier;
 	});
 
 	$effect(() => {
@@ -1094,6 +1124,7 @@
 				recoveredSubmissionIds.set(recoveryKey, {
 					prompt: recovery.prompt,
 					reasoningEffort: recovery.reasoningEffort,
+					serviceTier: recovery.serviceTier ?? defaultServiceTier,
 					selectedModel: recovery.selectedModel,
 					submissionId: recovery.submissionId
 				});
@@ -1431,6 +1462,7 @@
 						bind:prompt
 						bind:selectedModel
 						bind:selectedReasoningEffort
+						bind:selectedServiceTier
 						{canSend}
 						isSubmitting={isSubmittingPrompt || hasPendingAgentLaunch}
 						isStarting={hasPendingAgentLaunch}

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,9 @@
       "name": "@sprocket/web",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^4.0.15",
         "@ai-sdk/openai": "^4.0.11",
+        "@ai-sdk/xai": "^4.0.14",
         "@convex-dev/rate-limiter": "^0.3.2",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/dm-sans": "^5.2.8",
@@ -81,13 +83,19 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6iVlzqZjqqoHTmgO1WU9id/33pYykIRasWJFAMf1+d+nhju6d7566VRFsOGZ2W2GzgNtzKs8DGsYN7X5/wOGuw=="],
+
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww=="],
 
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@3.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PKLyt5PfjV2maWJPZpm3W29vCc+BbyqSPAcghXhl+iIxzFNjpGPa6UD/8J0b9l7w/lJCZKuhcef9q+Gp5WqUvw=="],
+
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
+
+    "@ai-sdk/xai": ["@ai-sdk/xai@4.0.14", "", { "dependencies": { "@ai-sdk/openai-compatible": "3.0.11", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BRalRQZPS0LSvH0ICZPGPivTi05YK4CvuVEAVeyUwg9FvfdrpENkd+Sv+gz5U1h99KvLJWa/3HB5DyHtqU71cw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
@@ -1363,6 +1371,10 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
+
     "@electron/fuses/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
@@ -1412,6 +1424,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
 
     "app-builder-lib/@electron/get": ["@electron/get@3.1.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ=="],
 

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -113,6 +113,10 @@ impl RuntimeClient {
             "reasoningEffort".to_string(),
             request.reasoning_effort.clone().into(),
         );
+        args.insert(
+            "serviceTier".to_string(),
+            request.service_tier.clone().into(),
+        );
 
         let mut retry_delay = CREATE_RUN_INITIAL_RETRY_DELAY;
         let mut last_error = None;
@@ -172,6 +176,10 @@ impl RuntimeClient {
         args.insert(
             "reasoningEffort".to_string(),
             request.reasoning_effort.clone().into(),
+        );
+        args.insert(
+            "serviceTier".to_string(),
+            request.service_tier.clone().into(),
         );
         args.insert("text".to_string(), text.to_string().into());
         args.insert("lastError".to_string(), last_error.to_string().into());

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -85,6 +85,7 @@ impl AgentProvider {
                 .completion_client()
                 .clone()
                 .with_reasoning_effort(context.run.reasoning_effort.clone())
+                .with_service_tier(context.run.service_tier.clone())
                 .with_stream_target(run_id.to_string()),
             model: context.run.selected_model.clone(),
         }

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -17,6 +17,7 @@ pub struct RunAgentRequest {
     pub prompt: String,
     pub selected_model: String,
     pub reasoning_effort: String,
+    pub service_tier: String,
     pub workspace_path: String,
 }
 
@@ -136,6 +137,7 @@ pub struct RunSnapshot {
     pub workspace_session_id: String,
     pub selected_model: String,
     pub reasoning_effort: String,
+    pub service_tier: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -38,6 +38,7 @@ pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
     completion_action: Arc<str>,
     default_reasoning_effort: Option<Arc<str>>,
+    default_service_tier: Option<Arc<str>>,
     stream_run_id: Option<Arc<str>>,
 }
 
@@ -54,6 +55,7 @@ impl Client {
             inner: Arc::new(Mutex::new(client)),
             completion_action: completion_action.into().into(),
             default_reasoning_effort: None,
+            default_service_tier: None,
             stream_run_id: None,
         })
     }
@@ -108,6 +110,11 @@ impl Client {
 
     pub fn with_reasoning_effort(mut self, reasoning_effort: impl Into<String>) -> Self {
         self.default_reasoning_effort = Some(reasoning_effort.into().into());
+        self
+    }
+
+    pub fn with_service_tier(mut self, service_tier: impl Into<String>) -> Self {
+        self.default_service_tier = Some(service_tier.into().into());
         self
     }
 
@@ -235,6 +242,7 @@ impl GetTokenUsage for CompletionOutput {
 struct ConvexActionArgs {
     model_id: String,
     reasoning_effort: Option<String>,
+    service_tier: Option<String>,
     instructions: Option<String>,
     prompt: Option<String>,
     messages_json: String,
@@ -284,6 +292,11 @@ impl RigCompletionModel for CompletionModel {
             reasoning_effort: self
                 .client
                 .default_reasoning_effort
+                .as_deref()
+                .map(str::to_owned),
+            service_tier: self
+                .client
+                .default_service_tier
                 .as_deref()
                 .map(str::to_owned),
             instructions,
@@ -490,6 +503,9 @@ fn action_args(args: &ConvexActionArgs, stream_run_id: &str) -> BTreeMap<String,
             "reasoningEffort".to_string(),
             reasoning_effort.clone().into(),
         );
+    }
+    if let Some(service_tier) = &args.service_tier {
+        payload.insert("serviceTier".to_string(), service_tier.clone().into());
     }
     if !args.tools.is_empty() {
         payload.insert(

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -37,6 +37,7 @@ struct RunAgentApiRequest {
     prompt: String,
     selected_model: String,
     reasoning_effort: String,
+    service_tier: String,
     workspace_session_id: String,
 }
 
@@ -284,6 +285,7 @@ async fn run_agent_handler(
         prompt: payload.prompt,
         selected_model: payload.selected_model,
         reasoning_effort: payload.reasoning_effort,
+        service_tier: payload.service_tier,
         workspace_path,
     };
 


### PR DESCRIPTION
## Summary

- restrict the model catalog to GPT-5.6 Sol/Terra/Luna, Anthropic Fable 5, and xAI Grok 4.5
- add provider-aware model selection, branded logos, reasoning controls, and supported Fast service-tier selection
- route each model through its provider and persist model, reasoning, and service-tier settings across the web, Convex, server, and agent layers
- normalize legacy persisted model settings and provide a paginated migration

## Why

Sprocket should expose only the supported model lineup and make each model's available reasoning and service-tier capabilities clear at selection time.

## Impact

Users get a searchable model picker with recognizable provider branding and capability-aware reasoning and Fast-mode controls. Existing threads with legacy model settings continue safely through normalization and migration.

## Validation

- `bun run --cwd apps/web test`
- `cargo test -p sprocket-convex-provider -p sprocket-agent -p sprocket-server`
- `bun convex dev --once` in `apps/web`
- `bun run --cwd apps/web check`
- `bun run build`
- repository pre-commit hooks: Cargo formatting/checks, ESLint, Svelte checks, Prettier, and repository hygiene checks

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the supported model catalog and carries model capabilities across the application. The main changes are:

- Adds GPT-5.6, Fable 5, and Grok 4.5 model definitions.
- Adds provider-specific routing and completion options.
- Persists reasoning and service-tier settings across web, Convex, server, and agent layers.
- Normalizes and migrates legacy model settings.
- Adds searchable provider-aware model controls.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Fable reasoning contract needs a fix before merging; deployments must also account for unavailable provider credentials.

Fable accepts `xhigh` but forwards it to an API that expects `max`. Newly visible Anthropic and xAI models fail at runtime when their provider credentials are absent.

apps/web/src/convex/lib/models.ts and apps/web/src/convex/lib/modelRegistry.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Bun harness to exercise the repository's model validation and provider-option resolution, reproducing that claude-fable-5 accepts an xhigh reasoning effort and forwards anthropic.effort=xhigh.
- Reviewed the before/after videos, screenshots, and browser and validation logs that show the authentication blocker persists at the same browser scope, with the sign-in page rendered and the composer absent, alongside runtime evidence without exposing credentials.

<a href="https://app.greptile.com/trex/runs/14649573/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/models.ts | Defines the new catalog, defaults, normalization, and capability validation; Fable currently inherits an incompatible effort value. |
| apps/web/src/convex/lib/modelRegistry.ts | Adds provider routing and provider-specific options, with runtime credential dependencies for the newly exposed providers. |
| apps/web/src/convex/agentRuntime.ts | Validates and persists service tiers while normalizing legacy values at run boundaries. |
| apps/web/src/convex/migrations.ts | Adds paginated normalization of legacy model IDs and missing service tiers. |
| apps/web/src/routes/+page.svelte | Carries model, reasoning, and service-tier state through restoration and submission. |
| crates/sprocket-convex-provider/src/client.rs | Forwards reasoning and service-tier values to the Convex completion action. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Model and capability picker] --> State[Thread and recovery state]
  State --> Run[Convex run creation]
  Run --> Agent[Rust agent]
  Agent --> Completion[Convex completion action]
  Completion --> Registry{Provider routing}
  Registry --> OpenAI[OpenAI]
  Registry --> Anthropic[Anthropic]
  Registry --> XAI[xAI]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
  UI[Model and capability picker] --> State[Thread and recovery state]
  State --> Run[Convex run creation]
  Run --> Agent[Rust agent]
  Agent --> Completion[Convex completion action]
  Completion --> Registry{Provider routing}
  Registry --> OpenAI[OpenAI]
  Registry --> Anthropic[Anthropic]
  Registry --> XAI[xAI]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2Fmodels.ts%3A27%0A**Anthropic%20Effort%20Uses%20Invalid%20Value**%0A%0A%60claude-fable-5%60%20inherits%20%60xhigh%60%20from%20this%20list%2C%20so%20validation%20accepts%20that%20selection%20and%20the%20completion%20path%20sends%20%60anthropic.effort%20%3D%20%22xhigh%22%60.%20The%20Anthropic%20effort%20contract%20uses%20%60max%60%20rather%20than%20%60xhigh%60%2C%20so%20Fable%20requests%20at%20Extra%20High%20can%20be%20rejected%20or%20run%20without%20the%20requested%20effort.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A17-22%0A**Optional%20Providers%20Require%20Global%20Credentials**%0A%0AThe%20catalog%20always%20exposes%20Anthropic%20and%20xAI%20models%2C%20but%20these%20clients%20are%20created%20from%20optional%20deployment%20variables%20without%20any%20availability%20gate.%20In%20a%20deployment%20that%20only%20has%20the%20previously%20required%20OpenAI%20key%2C%20selecting%20Fable%20or%20Grok%20reaches%20the%20completion%20action%20and%20fails%20authentication%20instead%20of%20hiding%20or%20rejecting%20the%20unavailable%20model%20before%20a%20run%20starts.%0A%0A&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2Fmodels.ts%3A27%0A**Anthropic%20Effort%20Uses%20Invalid%20Value**%0A%0A%60claude-fable-5%60%20inherits%20%60xhigh%60%20from%20this%20list%2C%20so%20validation%20accepts%20that%20selection%20and%20the%20completion%20path%20sends%20%60anthropic.effort%20%3D%20%22xhigh%22%60.%20The%20Anthropic%20effort%20contract%20uses%20%60max%60%20rather%20than%20%60xhigh%60%2C%20so%20Fable%20requests%20at%20Extra%20High%20can%20be%20rejected%20or%20run%20without%20the%20requested%20effort.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A17-22%0A**Optional%20Providers%20Require%20Global%20Credentials**%0A%0AThe%20catalog%20always%20exposes%20Anthropic%20and%20xAI%20models%2C%20but%20these%20clients%20are%20created%20from%20optional%20deployment%20variables%20without%20any%20availability%20gate.%20In%20a%20deployment%20that%20only%20has%20the%20previously%20required%20OpenAI%20key%2C%20selecting%20Fable%20or%20Grok%20reaches%20the%20completion%20action%20and%20fails%20authentication%20instead%20of%20hiding%20or%20rejecting%20the%20unavailable%20model%20before%20a%20run%20starts.%0A%0A&repo=spikonado%2Fsprocket&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22feat%2Fupdate-models%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fupdate-models%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2Fmodels.ts%3A27%0A**Anthropic%20Effort%20Uses%20Invalid%20Value**%0A%0A%60claude-fable-5%60%20inherits%20%60xhigh%60%20from%20this%20list%2C%20so%20validation%20accepts%20that%20selection%20and%20the%20completion%20path%20sends%20%60anthropic.effort%20%3D%20%22xhigh%22%60.%20The%20Anthropic%20effort%20contract%20uses%20%60max%60%20rather%20than%20%60xhigh%60%2C%20so%20Fable%20requests%20at%20Extra%20High%20can%20be%20rejected%20or%20run%20without%20the%20requested%20effort.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A17-22%0A**Optional%20Providers%20Require%20Global%20Credentials**%0A%0AThe%20catalog%20always%20exposes%20Anthropic%20and%20xAI%20models%2C%20but%20these%20clients%20are%20created%20from%20optional%20deployment%20variables%20without%20any%20availability%20gate.%20In%20a%20deployment%20that%20only%20has%20the%20previously%20required%20OpenAI%20key%2C%20selecting%20Fable%20or%20Grok%20reaches%20the%20completion%20action%20and%20fails%20authentication%20instead%20of%20hiding%20or%20rejecting%20the%20unavailable%20model%20before%20a%20run%20starts.%0A%0A&repo=spikonado%2Fsprocket&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22feat%2Fupdate-models%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fupdate-models%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2Fmodels.ts%3A27%0A**Anthropic%20Effort%20Uses%20Invalid%20Value**%0A%0A%60claude-fable-5%60%20inherits%20%60xhigh%60%20from%20this%20list%2C%20so%20validation%20accepts%20that%20selection%20and%20the%20completion%20path%20sends%20%60anthropic.effort%20%3D%20%22xhigh%22%60.%20The%20Anthropic%20effort%20contract%20uses%20%60max%60%20rather%20than%20%60xhigh%60%2C%20so%20Fable%20requests%20at%20Extra%20High%20can%20be%20rejected%20or%20run%20without%20the%20requested%20effort.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A17-22%0A**Optional%20Providers%20Require%20Global%20Credentials**%0A%0AThe%20catalog%20always%20exposes%20Anthropic%20and%20xAI%20models%2C%20but%20these%20clients%20are%20created%20from%20optional%20deployment%20variables%20without%20any%20availability%20gate.%20In%20a%20deployment%20that%20only%20has%20the%20previously%20required%20OpenAI%20key%2C%20selecting%20Fable%20or%20Grok%20reaches%20the%20completion%20action%20and%20fails%20authentication%20instead%20of%20hiding%20or%20rejecting%20the%20unavailable%20model%20before%20a%20run%20starts.%0A%0A&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/convex/lib/models.ts:27
**Anthropic Effort Uses Invalid Value**

`claude-fable-5` inherits `xhigh` from this list, so validation accepts that selection and the completion path sends `anthropic.effort = "xhigh"`. The Anthropic effort contract uses `max` rather than `xhigh`, so Fable requests at Extra High can be rejected or run without the requested effort.

### Issue 2 of 2
apps/web/src/convex/lib/modelRegistry.ts:17-22
**Optional Providers Require Global Credentials**

The catalog always exposes Anthropic and xAI models, but these clients are created from optional deployment variables without any availability gate. In a deployment that only has the previously required OpenAI key, selecting Fable or Grok reaches the completion action and fails authentication instead of hiding or rejecting the unavailable model before a run starts.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(models): update supported model cat..."](https://github.com/spikonado/sprocket/commit/20556ce10b2ef7ed475e23b62c1d8b553910dc76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44698381)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->