### PR TITLE
docs: Add architecture and crate documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,224 @@
+# Sprocket Architecture
+
+Sprocket is a local-first agentic development environment for robotics. Its web
+interface and durable conversation state are cloud-connected, while filesystem
+access and command execution stay on the user's machine.
+
+This document describes the stable system boundaries and data flows. User setup
+belongs in [README.md](README.md); crate-specific implementation notes live in
+the READMEs under [`crates/`](crates/).
+
+## Design principles
+
+- **Local execution:** source files, patches, and shell processes are handled by
+  a local Rust process, not by the cloud backend.
+- **Durable coordination:** conversations and agent-run state survive browser,
+  process, and network interruptions.
+- **Explicit ownership:** authenticated cloud records belong to a user, and
+  active agent work belongs to a renewable run claim.
+- **Portable clients:** the same web application runs in a browser, during Vite
+  development, and inside Electron.
+- **Layered implementation:** workspace primitives do not depend on HTTP,
+  Convex, or model providers.
+
+## System overview
+
+```mermaid
+flowchart LR
+    User[User] --> Web[Svelte web app]
+    CLI[Sprocket CLI] --> Desktop[Electron shell]
+    Desktop --> Web
+    CLI --> Local[Local Rust server]
+    Desktop --> Local
+    Web <--> Local
+    Web <--> Convex[Convex backend]
+    Local <--> Convex
+    Convex <--> Models[Model providers]
+    Web <--> Auth[WorkOS]
+    Local --> Workspace[Local workspace and processes]
+```
+
+The system has three main planes:
+
+1. **Client plane:** Svelte provides the UI; Electron supplies a desktop shell;
+   the CLI launches clients and the local server.
+2. **Local execution plane:** the Rust server authenticates local requests,
+   resolves workspace attachments, starts agent runs, and executes tools.
+3. **Cloud coordination plane:** Convex stores durable application state,
+   coordinates run ownership, streams responses, and calls model providers.
+
+WorkOS establishes cloud user identity. A separate local pairing mechanism
+authorizes the browser or Electron renderer to access the machine-facing API.
+
+## Component boundaries
+
+| Component               | Owns                                                             | Does not own                          |
+| ----------------------- | ---------------------------------------------------------------- | ------------------------------------- |
+| Svelte app              | User interaction, reactive views, submission recovery            | Filesystem access or provider secrets |
+| Electron shell          | Desktop lifecycle, trusted renderer bridge, local server process | Conversation or agent state           |
+| CLI                     | Process launch and server-mode selection                         | Agent implementation                  |
+| Local server            | Local authorization, workspace attachment, agent task lifetime   | Durable conversation state            |
+| Agent runtime           | Run claim, model/tool loop, cancellation, finalization           | HTTP presentation or cloud schema     |
+| Workspace crate         | Paths, commands, patches, workspace instructions                 | Authentication or networking          |
+| Convex provider adapter | Rig-to-Convex completion translation                             | Model selection policy                |
+| Convex backend          | User data, run coordination, transcript, model access            | Local paths and process execution     |
+
+The Rust dependency direction follows these boundaries:
+
+```text
+sprocket-cli -> sprocket-server -> sprocket-agent -> sprocket-convex-provider
+       |              |                |
+       +--------------+----------------+-> sprocket-workspace
+```
+
+Lower layers remain usable without importing higher-level concerns.
+
+## Runtime modes
+
+### Desktop
+
+The CLI launches Electron. Electron attaches to a compatible local server or
+starts the packaged Rust executable, then loads the same web build used by the
+browser mode. A narrow preload bridge exposes desktop-only actions to the
+renderer.
+
+### Browser
+
+The CLI starts or reuses a local server and opens the locally served web app.
+The server hosts both the static application and its machine-facing API.
+
+### Development
+
+Vite serves the web app while the Rust process serves only the local API.
+Requests to the API are proxied during development so the application code uses
+the same paths in every runtime mode.
+
+## State ownership
+
+Sprocket deliberately separates cloud and machine-local state.
+
+| State                                                                      | Owner                |
+| -------------------------------------------------------------------------- | -------------------- |
+| Users, workspace identities, threads, messages, runs, and tool-job records | Convex               |
+| Workspace identity to local path mapping                                   | Local server         |
+| Pairing credential and local browser sessions                              | Local server         |
+| Active commands, cancellation tokens, and access-token refresh sessions    | Local process memory |
+| Source files and build artifacts                                           | User workspace       |
+| Model and authentication provider secrets                                  | Cloud deployment     |
+
+A cloud workspace identity never needs to expose its machine path. The web app
+joins cloud workspace metadata with the local server's attachment state.
+
+## Agent run flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Web app
+    participant C as Convex
+    participant S as Local server
+    participant A as Rust agent
+    participant M as Model provider
+    participant W as Workspace
+
+    UI->>C: Create or recover thread
+    UI->>S: Start run with user token and workspace identity
+    S->>A: Prepare local run
+    A->>C: Create or recover durable run
+    A->>C: Claim run and load context
+    loop Model and tool turns
+        A->>C: Request completion
+        C->>M: Call selected model
+        M-->>C: Stream response
+        C-->>UI: Publish durable transcript updates
+        opt Model requests a tool
+            A->>C: Record tool job
+            A->>W: Execute locally
+            A->>C: Record result
+        end
+    end
+    A->>C: Finalize run
+```
+
+The submission identifier makes thread and run creation safe to retry after an
+ambiguous network failure. Once started, a worker must hold a renewable claim;
+stale workers cannot continue tool execution or overwrite a newer result.
+
+Tool operations are recorded before and after local execution. This gives the
+UI a durable audit trail and lets terminal run state cancel work still running
+on the machine.
+
+Model output is persisted incrementally by Convex. Stream attempt and ordering
+metadata prevent a delayed completion attempt from replacing a newer one.
+
+## Authentication and trust boundaries
+
+Cloud and local authorization solve different problems:
+
+- **Cloud identity:** WorkOS tokens authenticate the user to Convex. Convex
+  checks ownership before reading or changing user records.
+- **Local authorization:** a machine-local pairing credential bootstraps a
+  local session used for filesystem and agent endpoints.
+- **Agent delegation:** the browser provides a short-lived user token to the
+  local server for a run. Refreshes must remain bound to the same cloud user.
+- **Desktop trust:** Electron isolates the renderer, validates its origin, and
+  exposes only a constrained IPC surface.
+
+The local server binds to loopback by default. Exposing it on another interface
+changes the trust model and should be treated as a security-sensitive
+deployment choice.
+
+Workspace patches are confined to the attached workspace. Shell commands are
+not sandboxed: they run with the permissions of the local Sprocket process.
+
+## Reliability model
+
+The distributed run protocol assumes that requests can time out after either
+succeeding or failing. Its main safeguards are:
+
+- idempotent creation keyed by a client submission identifier;
+- renewable claims that reject stale workers;
+- durable transcript and tool-job updates;
+- explicit terminal states and failure reconciliation;
+- cancellation propagated from durable state to local operations;
+- bounded command output and process-tree termination; and
+- transactional workspace patches with rollback.
+
+These behaviors are cross-layer contracts. Changes to run ownership,
+cancellation, tool payloads, history representation, or streaming must be made
+in the Rust agent and Convex backend together.
+
+## Repository layout
+
+| Path                               | Responsibility                        |
+| ---------------------------------- | ------------------------------------- |
+| `apps/web/`                        | Svelte application and Convex backend |
+| `apps/desktop/`                    | Electron shell and packaging          |
+| `crates/sprocket-cli/`             | User-facing launcher                  |
+| `crates/sprocket-server/`          | Local HTTP and process boundary       |
+| `crates/sprocket-agent/`           | Agent run lifecycle and tools         |
+| `crates/sprocket-convex-provider/` | Rig completion adapter                |
+| `crates/sprocket-workspace/`       | Local workspace primitives            |
+| `packages/`                        | Shared JavaScript configuration       |
+
+## Build and deployment
+
+The web app is built as static assets. Installed desktop packages combine those
+assets with Electron and the native Sprocket executable. A standalone CLI
+bundle includes the native executable and the assets needed for browser mode.
+
+The local executable receives only public runtime configuration. WorkOS and
+model-provider secrets remain in the Convex deployment.
+
+## Validation
+
+Run checks relevant to a change from the repository root:
+
+```sh
+cargo test
+bun run test
+bun run build
+prek run -a
+```
+
+After changing Convex code, validate the deployment functions from `apps/web/`
+as described in [AGENTS.md](AGENTS.md).

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -1,0 +1,55 @@
+# sprocket-agent
+
+`sprocket-agent` owns the local lifecycle of an agent run. It coordinates
+durable run state in Convex, drives Rig, and exposes local workspace tools.
+
+It is used by `sprocket-server` and depends on
+[`sprocket-convex-provider`](../sprocket-convex-provider/README.md) and
+[`sprocket-workspace`](../sprocket-workspace/README.md).
+
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the distributed run protocol.
+
+## Run lifecycle
+
+An agent run:
+
+1. creates or recovers durable run state;
+2. resolves the workspace and loads applicable instructions;
+3. reconstructs prior model history;
+4. acquires and renews ownership of the run;
+5. alternates between model completions and local tools; and
+6. records a terminal result.
+
+Creation is retryable through the submission identifier. The run claim prevents
+an old worker from executing tools or finalizing after ownership has moved.
+Failure paths attempt to reconcile partially created or claimed runs so durable
+state does not remain indefinitely active.
+
+## Tools
+
+The agent currently offers command execution, command-session input, and
+workspace patching. Every tool call is wrapped in a durable executor-job record
+and observes run cancellation while local work is active.
+
+Command execution has full local process permissions. Patch operations are
+confined to the workspace by `sprocket-workspace`.
+
+## Main areas
+
+- `run.rs`: ownership, preparation, and finalization.
+- `provider.rs`: Rig agent loop and provider outcomes.
+- `tools.rs`: model tools and durable job coordination.
+- `convex.rs`: run-control communication.
+- `types.rs`: history and context wire types.
+- `hooks.rs`: tool-call correlation and invalid-call handling.
+
+Changes to run state, history, cancellation, or tool shapes usually require a
+matching Convex change.
+
+## Validation
+
+```sh
+cargo test -p sprocket-agent
+bun run test
+prek run -a
+```

--- a/crates/sprocket-cli/README.md
+++ b/crates/sprocket-cli/README.md
@@ -1,0 +1,33 @@
+# sprocket-cli
+
+`sprocket-cli` builds the user-facing `sprocket` executable. It selects a
+runtime mode, resolves an optional workspace, launches the desktop application,
+or runs the local server for browser and development use.
+
+The crate is binary-only. Reusable server behavior belongs in
+[`sprocket-server`](../sprocket-server/README.md), and path behavior belongs in
+[`sprocket-workspace`](../sprocket-workspace/README.md).
+
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) for runtime topology and packaging.
+
+## Responsibilities
+
+- Parse the desktop, browser, and server launch modes.
+- Canonicalize a workspace before forwarding it to another process.
+- Locate and launch the installed desktop application.
+- Start or safely reuse a compatible local server in browser mode.
+- Provide the server entry point used by Electron and development scripts.
+
+Server reuse is verified against local pairing state so a process on the
+expected port is not trusted merely because it responds like Sprocket.
+
+All implementation currently lives in `src/main.rs`. Keep authentication,
+workspace execution, and agent behavior in their library crates rather than
+duplicating them here.
+
+## Validation
+
+```sh
+cargo test -p sprocket-cli
+prek run -a
+```

--- a/crates/sprocket-convex-provider/README.md
+++ b/crates/sprocket-convex-provider/README.md
@@ -1,0 +1,41 @@
+# sprocket-convex-provider
+
+`sprocket-convex-provider` adapts Convex-backed model completion to Rig's
+completion traits. It lets the Rust agent use Rig's normal multi-turn loop while
+provider credentials, model selection, rate limiting, and response persistence
+remain in the cloud backend.
+
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the end-to-end run flow.
+
+## Role in the system
+
+The adapter translates Rig history, tool schemas, provider options, and usage
+into a Convex action request. It translates the result back into Rig assistant
+content and streaming events.
+
+The Convex action persists live output for the web UI. The Rust side receives
+the completed event sequence so Rig can continue its local tool loop without
+becoming the source of truth for the transcript.
+
+## Design constraints
+
+- Authentication is supplied by the local server through an asynchronous token
+  callback.
+- Provider-specific reasoning and tool metadata must survive history replay.
+- Concurrent Convex operations must not be serialized behind a long model call.
+- A superseded stream is treated as stale ownership rather than a model
+  failure.
+- Wire-format changes must be coordinated with the Convex completion action.
+
+The supported crate interface is re-exported from `src/lib.rs`. Transport and
+Rig integration live in `client.rs`; history conversion lives in `messages.rs`.
+
+## Validation
+
+```sh
+cargo test -p sprocket-convex-provider
+bun run test
+prek run -a
+```
+
+Validate Convex functions as well when the wire contract changes.

--- a/crates/sprocket-server/README.md
+++ b/crates/sprocket-server/README.md
@@ -1,0 +1,53 @@
+# sprocket-server
+
+`sprocket-server` is the boundary between browser-controlled requests and the
+user's machine. It provides the local API, serves the web application when
+needed, maps cloud workspace identities to local paths, and owns local agent
+tasks.
+
+The crate is a library used by `sprocket-cli` and also provides a small
+standalone server binary. See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the
+full process topology.
+
+## Responsibilities
+
+- Establish local browser or desktop authorization.
+- Resolve, attach, and revalidate local workspaces.
+- Start agent runs with the authenticated cloud user token.
+- Coordinate token refresh while a run is active.
+- Serve the local API and optional static web build.
+- Persist only machine-local state.
+
+## Boundaries
+
+The server does not store conversations or model credentials. Durable user,
+thread, run, and transcript state belongs to Convex. The server keeps local
+pairing/session data and the mapping from a cloud workspace identity to a local
+path.
+
+Local authorization and cloud authentication are separate. A local session
+permits access to machine-facing operations; a WorkOS token identifies the user
+to Convex. Refreshed run tokens are checked against the user that started the
+run.
+
+The server binds locally by default. Static serving and API-only operation are
+two configurations of the same router rather than separate applications.
+
+## Main areas
+
+- `auth.rs`: local sessions, pairing, and desktop browser sign-in.
+- `workspace_sessions.rs`: local workspace attachment state.
+- `routes/`: HTTP boundaries for configuration, workspaces, auth, and agents.
+- `static_dir.rs` and `static_files.rs`: web-build discovery and serving.
+- `config.rs`: process configuration.
+- `lib.rs`: shared state, router construction, and server lifecycle.
+
+Reusable filesystem behavior belongs in `sprocket-workspace`; run behavior
+belongs in `sprocket-agent`.
+
+## Validation
+
+```sh
+cargo test -p sprocket-server
+prek run -a
+```

--- a/crates/sprocket-workspace/README.md
+++ b/crates/sprocket-workspace/README.md
@@ -1,0 +1,46 @@
+# sprocket-workspace
+
+`sprocket-workspace` contains the local workspace primitives shared by the CLI,
+server, and agent runtime. It is deliberately independent of HTTP, Convex, and
+model providers.
+
+See [ARCHITECTURE.md](../../ARCHITECTURE.md) for its role in the complete system.
+
+## Responsibilities
+
+- Resolve and browse workspace paths.
+- Load scoped workspace instructions.
+- Run cancellable shell commands and manage long-running sessions.
+- Apply multi-file patches inside a workspace.
+
+## Design
+
+Path and patch operations canonicalize their inputs and prevent patch paths
+from escaping the workspace, including through symlinks. Patches are prepared
+before mutation, serialized per workspace, and rolled back when application
+fails.
+
+Command execution has a different trust boundary. Commands start in the
+workspace by default, but they are not sandboxed and may access the wider
+machine with the permissions of the Sprocket process. Output is bounded, and
+cancellation or timeout stops the process tree.
+
+Workspace instruction loading follows the project hierarchy so deeper
+instructions can refine root-level guidance without coupling that behavior to
+the agent implementation.
+
+## Main areas
+
+- `workspace.rs`, `paths.rs`, and `browse.rs`: path resolution and selection.
+- `agents.rs`: workspace instruction discovery.
+- `tools.rs`: command sessions and cancellation.
+- `patch.rs`: confined transactional patches.
+
+The crate exposes these capabilities through the re-exports in `src/lib.rs`.
+
+## Validation
+
+```sh
+cargo test -p sprocket-workspace
+prek run -a
+```


### PR DESCRIPTION
## Summary

- add a root architecture overview covering system boundaries, state ownership, runtime modes, trust boundaries, and the agent run flow
- add a concise README for every Rust crate describing its role, dependency boundary, main implementation areas, and validation commands
- document stable design constraints without duplicating volatile API inventories or implementation constants

## Why

The repository did not have a single architectural overview or crate-level entry points for contributors. These documents make cross-layer ownership and dependency direction discoverable while keeping details close to the code that owns them.

## Impact

Documentation only. Runtime behavior and public APIs are unchanged.

## Validation

- `prek run -a`
- verified all five Cargo packages have a crate README
- verified relative Markdown links

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds contributor-facing architecture and crate documentation. The main changes are:

- A root overview of system boundaries, runtime modes, state ownership, security, and agent runs.
- A README for each Rust crate describing its role and dependency boundary.
- Crate-specific implementation pointers and validation commands.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed documentation. The documented links, source areas, dependency boundaries, and safety claims match the implementation.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the baseline and post-change integrity by examining docs-integrity-01-before.log and docs-integrity-02-after.log.
- Confirmed that the head revision passes all five README checks and relative-links verifications as recorded by the after-log.
- Validated the additional contract checks, including that Prettier passed and diff whitespace integrity passed.
- Observed that the prek executable was unavailable and captured with exit code 127.
- Curated and referenced the seven proof artifacts to support the validation review.

<a href="https://app.greptile.com/trex/runs/14783031/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ARCHITECTURE.md | Adds the system architecture, runtime topology, state ownership, trust boundaries, reliability model, and repository layout. |
| crates/sprocket-agent/README.md | Documents agent lifecycle, durable run coordination, tools, dependencies, and implementation areas. |
| crates/sprocket-cli/README.md | Documents launcher modes, workspace handling, local server reuse, and crate boundaries. |
| crates/sprocket-convex-provider/README.md | Documents the Rig-to-Convex adapter, streaming behavior, history translation, and wire-contract constraints. |
| crates/sprocket-server/README.md | Documents the local API boundary, authorization model, workspace attachment state, and routing modes. |
| crates/sprocket-workspace/README.md | Documents workspace primitives, patch confinement and rollback, command execution, and dependency independence. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Add architecture and crate documen..."](https://github.com/spikonado/sprocket/commit/48f0680920b182e86f96146c728dad167bd8dad3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44967248)</sub>

<!-- /greptile_comment -->