### PR TITLE
fix(chat): Improve composer and tool call transcript UI

### DIFF
--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -4,10 +4,12 @@ import {
 	assistantTimelineToolFailureKind,
 	assistantTimelineToolKey,
 	buildAssistantTimeline,
+	buildCommandSessionCommandMap,
 	groupAssistantTimeline,
 	groupAssistantTimelineSections,
 	isAssistantTimelineToolRunning,
 	partitionWorkSectionTools,
+	resolveCommandSessionLabel,
 	workSectionTimingAnchor,
 	workSectionTimingIndexes,
 	type AssistantTimelineTool,
@@ -394,6 +396,104 @@ describe('partitionWorkSectionTools', () => {
 			})
 		]);
 		expect(isAssistantTimelineToolRunning(runningTools[0], true)).toBe(true);
+	});
+
+	it('keeps yielded command sessions in Running across write_stdin monitor polls', () => {
+		const blocks: AssistantTimelineWorkBlock[] = [
+			{
+				type: 'tool-group',
+				toolKey: 'exec_command',
+				tools: [
+					tool('exec-1', 'exec_command', {
+						input: { cmd: 'npm run dev' },
+						output: { sessionId: '7', running: true },
+						job: executorJob('job-exec', 1, { status: 'completed', kind: 'exec_command' })
+					})
+				]
+			},
+			{
+				type: 'tool-group',
+				toolKey: 'write_stdin',
+				tools: [
+					tool('monitor-1', 'write_stdin', {
+						input: { sessionId: '7' },
+						job: executorJob('job-monitor', 2, {
+							status: 'claimed',
+							kind: 'write_stdin',
+							payload: { sessionId: '7' }
+						})
+					})
+				]
+			}
+		];
+
+		const { settledBlocks, runningTools } = partitionWorkSectionTools(blocks, true);
+
+		expect(runningTools.map((item) => item.callId)).toEqual(['exec-1']);
+		expect(settledBlocks).toEqual([]);
+	});
+
+	it('moves finished command sessions out of Running after the final monitor', () => {
+		const blocks: AssistantTimelineWorkBlock[] = [
+			{
+				type: 'tool-group',
+				toolKey: 'exec_command',
+				tools: [
+					tool('exec-1', 'exec_command', {
+						input: { cmd: 'sleep 1' },
+						output: { sessionId: '3', running: true },
+						job: executorJob('job-exec', 1, { status: 'completed', kind: 'exec_command' })
+					})
+				]
+			},
+			{
+				type: 'tool-group',
+				toolKey: 'write_stdin',
+				tools: [
+					tool('monitor-1', 'write_stdin', {
+						input: { sessionId: '3' },
+						output: { running: false },
+						job: executorJob('job-monitor', 2, {
+							status: 'completed',
+							kind: 'write_stdin',
+							payload: { sessionId: '3' }
+						})
+					})
+				]
+			}
+		];
+
+		const { settledBlocks, runningTools } = partitionWorkSectionTools(blocks, true);
+
+		expect(runningTools).toEqual([]);
+		expect(settledBlocks).toEqual([
+			expect.objectContaining({
+				type: 'tool-group',
+				toolKey: 'exec_command',
+				tools: [expect.objectContaining({ callId: 'exec-1' })]
+			}),
+			expect.objectContaining({
+				type: 'tool-group',
+				toolKey: 'write_stdin',
+				tools: [expect.objectContaining({ callId: 'monitor-1' })]
+			})
+		]);
+	});
+});
+
+describe('command session labels', () => {
+	it('resolves write_stdin labels from the originating exec_command', () => {
+		const tools = [
+			tool('exec-1', 'exec_command', {
+				input: { cmd: 'cargo test' },
+				output: { command: 'cargo test', sessionId: '9' }
+			}),
+			tool('monitor-1', 'write_stdin', { input: { sessionId: '9' } })
+		];
+
+		expect(resolveCommandSessionLabel(tools[1], buildCommandSessionCommandMap(tools))).toBe(
+			'cargo test'
+		);
 	});
 });
 

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -5,6 +5,7 @@ import {
 	assistantTimelineToolKey,
 	buildAssistantTimeline,
 	buildCommandSessionCommandMap,
+	buildOpenExecCommandSessions,
 	groupAssistantTimeline,
 	groupAssistantTimelineSections,
 	isAssistantTimelineToolRunning,
@@ -476,6 +477,42 @@ describe('partitionWorkSectionTools', () => {
 				type: 'tool-group',
 				toolKey: 'write_stdin',
 				tools: [expect.objectContaining({ callId: 'monitor-1' })]
+			})
+		]);
+	});
+
+	it('closes sessions using message-wide open state across text section breaks', () => {
+		const exec = tool('exec-1', 'exec_command', {
+			input: { cmd: 'npm run dev' },
+			output: { sessionId: '7', running: true },
+			job: executorJob('job-exec', 1, { status: 'completed', kind: 'exec_command' })
+		});
+		const monitor = tool('monitor-1', 'write_stdin', {
+			input: { sessionId: '7' },
+			output: { running: false },
+			job: executorJob('job-monitor', 2, {
+				status: 'completed',
+				kind: 'write_stdin',
+				payload: { sessionId: '7' }
+			})
+		});
+		const openSessions = buildOpenExecCommandSessions([exec, monitor]);
+		const earlierSection: AssistantTimelineWorkBlock[] = [
+			{ type: 'tool-group', toolKey: 'exec_command', tools: [exec] }
+		];
+
+		const { settledBlocks, runningTools } = partitionWorkSectionTools(
+			earlierSection,
+			true,
+			openSessions
+		);
+
+		expect(openSessions.size).toBe(0);
+		expect(runningTools).toEqual([]);
+		expect(settledBlocks).toEqual([
+			expect.objectContaining({
+				type: 'tool-group',
+				tools: [expect.objectContaining({ callId: 'exec-1' })]
 			})
 		]);
 	});

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -4,7 +4,7 @@ import {
 	type AssistantPart,
 	type AssistantToolCallPart
 } from '$convex/lib/assistantParts';
-import type { JsonValue } from '$convex/lib/json';
+import { isJsonObject, type JsonValue } from '$convex/lib/json';
 import type { ExecutorJob } from '$lib/types/sprocket';
 
 export type AssistantTimelineTool = {
@@ -224,9 +224,90 @@ export function isAssistantTimelineToolRunning(
 	return isStreaming && tool.output === undefined;
 }
 
+function jsonStringProp(value: JsonValue | undefined, key: string): string | undefined {
+	return isJsonObject(value) && typeof value[key] === 'string' ? value[key] : undefined;
+}
+
+/** Session id from command tool output, else input/payload (write_stdin completion omits it). */
+function commandSessionIdFromTool(tool: AssistantTimelineTool): string | undefined {
+	return (
+		jsonStringProp(tool.output, 'sessionId') ??
+		jsonStringProp(tool.input, 'sessionId') ??
+		jsonStringProp(tool.job?.payload, 'sessionId')
+	);
+}
+
+/** Map session id → shell command from exec_command / write_stdin results. */
+export function buildCommandSessionCommandMap(
+	tools: readonly AssistantTimelineTool[]
+): Map<string, string> {
+	const sessionCommands = new Map<string, string>();
+
+	for (const tool of tools) {
+		const sessionId = commandSessionIdFromTool(tool);
+		if (!sessionId) {
+			continue;
+		}
+
+		const cmd =
+			jsonStringProp(tool.output, 'command') ??
+			(assistantTimelineToolKey(tool) === 'exec_command'
+				? (jsonStringProp(tool.input, 'cmd') ?? jsonStringProp(tool.job?.payload, 'cmd'))
+				: undefined);
+		if (cmd) {
+			sessionCommands.set(sessionId, cmd);
+		}
+	}
+
+	return sessionCommands;
+}
+
+/** User-facing command label for write_stdin / open sessions. */
+export function resolveCommandSessionLabel(
+	tool: AssistantTimelineTool,
+	sessionCommands: ReadonlyMap<string, string>
+): string | undefined {
+	const sessionId = commandSessionIdFromTool(tool);
+	return (
+		jsonStringProp(tool.output, 'command') ??
+		(sessionId ? sessionCommands.get(sessionId) : undefined)
+	);
+}
+
+/**
+ * Sessions still running that also have an exec_command row.
+ * Later tool outputs win on the running flag (write_stdin completion clears the session).
+ */
+function openExecCommandSessions(tools: readonly AssistantTimelineTool[]): Set<string> {
+	const sessionRunning = new Map<string, boolean>();
+	const execSessions = new Set<string>();
+
+	for (const tool of tools) {
+		const sessionId = commandSessionIdFromTool(tool);
+		if (!sessionId) {
+			continue;
+		}
+		if (assistantTimelineToolKey(tool) === 'exec_command') {
+			execSessions.add(sessionId);
+		}
+		if (isJsonObject(tool.output) && typeof tool.output.running === 'boolean') {
+			sessionRunning.set(sessionId, tool.output.running);
+		}
+	}
+
+	return new Set([...execSessions].filter((sessionId) => sessionRunning.get(sessionId) === true));
+}
+
+function collectWorkSectionTools(blocks: AssistantTimelineWorkBlock[]): AssistantTimelineTool[] {
+	return blocks.flatMap((block) => (block.type === 'tool-group' ? block.tools : []));
+}
+
 /**
  * Split a work section's blocks into settled content (reasoning + finished tools) and
  * currently running tools pulled out for a separate Running dropdown.
+ *
+ * Open command sessions stay in Running across write_stdin monitor polls until a later
+ * monitor reports running:false.
  */
 export function partitionWorkSectionTools(
 	blocks: AssistantTimelineWorkBlock[],
@@ -237,6 +318,7 @@ export function partitionWorkSectionTools(
 } {
 	const settledBlocks: AssistantTimelineWorkBlock[] = [];
 	const runningTools: AssistantTimelineTool[] = [];
+	const openSessions = openExecCommandSessions(collectWorkSectionTools(blocks));
 
 	for (const block of blocks) {
 		if (block.type === 'reasoning') {
@@ -246,7 +328,29 @@ export function partitionWorkSectionTools(
 
 		const settledTools: AssistantTimelineTool[] = [];
 		for (const tool of block.tools) {
-			if (isAssistantTimelineToolRunning(tool, isStreaming)) {
+			const kind = assistantTimelineToolKey(tool);
+			const sessionId = commandSessionIdFromTool(tool);
+			const sessionOpen = sessionId !== undefined && openSessions.has(sessionId);
+			const traditionallyRunning = isAssistantTimelineToolRunning(tool, isStreaming);
+
+			if (kind === 'exec_command' && sessionOpen) {
+				runningTools.push(tool);
+				continue;
+			}
+
+			if (kind === 'write_stdin') {
+				if (traditionallyRunning) {
+					// Prefer the open exec_command row over in-flight monitor polls.
+					if (!sessionOpen) {
+						runningTools.push(tool);
+					}
+					continue;
+				}
+				settledTools.push(tool);
+				continue;
+			}
+
+			if (traditionallyRunning) {
 				runningTools.push(tool);
 			} else {
 				settledTools.push(tool);

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -277,8 +277,9 @@ export function resolveCommandSessionLabel(
 /**
  * Sessions still running that also have an exec_command row.
  * Later tool outputs win on the running flag (write_stdin completion clears the session).
+ * Pass the full message tool list so monitors after text section breaks still close sessions.
  */
-function openExecCommandSessions(tools: readonly AssistantTimelineTool[]): Set<string> {
+export function buildOpenExecCommandSessions(tools: readonly AssistantTimelineTool[]): Set<string> {
 	const sessionRunning = new Map<string, boolean>();
 	const execSessions = new Set<string>();
 
@@ -307,18 +308,19 @@ function collectWorkSectionTools(blocks: AssistantTimelineWorkBlock[]): Assistan
  * currently running tools pulled out for a separate Running dropdown.
  *
  * Open command sessions stay in Running across write_stdin monitor polls until a later
- * monitor reports running:false.
+ * monitor reports running:false. Prefer message-wide `openSessions` so text-separated
+ * sections share the same session lifecycle.
  */
 export function partitionWorkSectionTools(
 	blocks: AssistantTimelineWorkBlock[],
-	isStreaming: boolean
+	isStreaming: boolean,
+	openSessions: ReadonlySet<string> = buildOpenExecCommandSessions(collectWorkSectionTools(blocks))
 ): {
 	settledBlocks: AssistantTimelineWorkBlock[];
 	runningTools: AssistantTimelineTool[];
 } {
 	const settledBlocks: AssistantTimelineWorkBlock[] = [];
 	const runningTools: AssistantTimelineTool[] = [];
-	const openSessions = openExecCommandSessions(collectWorkSectionTools(blocks));
 
 	for (const block of blocks) {
 		if (block.type === 'reasoning') {

--- a/apps/web/src/lib/chat/tool-icons.ts
+++ b/apps/web/src/lib/chat/tool-icons.ts
@@ -1,0 +1,31 @@
+import {
+	BookOpen,
+	FileDiff,
+	Globe,
+	ScrollText,
+	Search,
+	SquareTerminal,
+	Terminal,
+	Wrench,
+	type LucideIcon
+} from '@lucide/svelte';
+
+const TOOL_KIND_ICONS: Record<string, LucideIcon> = {
+	apply_patch: FileDiff,
+	check_docs: BookOpen,
+	exec_command: Terminal,
+	get_workspace_instructions: ScrollText,
+	scrape_url: Globe,
+	web_search: Search,
+	write_stdin: SquareTerminal
+};
+
+/** Small lucide icon for a tool kind / tool-group key. */
+export function toolKindIcon(kind: string): LucideIcon {
+	return TOOL_KIND_ICONS[kind] ?? Wrench;
+}
+
+/** Icon for a timeline tool row (prefers job kind when present). */
+export function toolLogIcon(tool: { name: string; job?: { kind: string } | null }): LucideIcon {
+	return toolKindIcon(tool.job?.kind ?? tool.name);
+}

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -56,8 +56,8 @@
 		onCancel
 	}: Props = $props();
 
-	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
 	let attachmentInput = $state<HTMLInputElement | null>(null);
+	let attachTooltip = $state<{ top: number; left: number } | null>(null);
 
 	const hasMessageContent = $derived(Boolean(prompt.trim()) || attachments.length > 0);
 	const attachmentsPending = $derived(
@@ -66,6 +66,7 @@
 	const canAttachMore = $derived(
 		attachments.length < MAX_IMAGE_ATTACHMENTS && !isRunning && !isSubmitting
 	);
+	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
 
 	function handleAttachmentInputChange(event: Event) {
 		const input = event.currentTarget as HTMLInputElement;
@@ -87,25 +88,22 @@
 		onAttachFiles(files);
 	}
 
-	const COMPOSER_MIN_HEIGHT_PX = 68;
-	const COMPOSER_MAX_HEIGHT_PX = 160;
-
-	function syncComposerHeight() {
-		if (!composerTextarea) {
+	function showAttachTooltip(event: MouseEvent | FocusEvent) {
+		const target = event.currentTarget;
+		if (!(target instanceof HTMLButtonElement) || target.disabled) {
 			return;
 		}
-
-		const el = composerTextarea;
-		// Use auto (not 0px) and apply the result in the same turn so the transcript
-		// flex pane does not visibly collapse/expand on each keystroke.
-		el.style.height = 'auto';
-		const nextHeight = Math.min(
-			Math.max(el.scrollHeight, COMPOSER_MIN_HEIGHT_PX),
-			COMPOSER_MAX_HEIGHT_PX
-		);
-		el.style.height = `${nextHeight}px`;
-		el.style.overflowY = el.scrollHeight > nextHeight ? 'auto' : 'hidden';
+		const rect = target.getBoundingClientRect();
+		attachTooltip = {
+			top: rect.top - 8,
+			left: rect.left + rect.width / 2
+		};
 	}
+
+	function hideAttachTooltip() {
+		attachTooltip = null;
+	}
+
 	function handleComposerKeydown(event: KeyboardEvent) {
 		if (!canSend || isSubmitting || isRunning || !hasMessageContent || attachmentsPending) {
 			return;
@@ -122,14 +120,6 @@
 	function handleModelChange(modelId: SupportedModelId) {
 		selectedReasoningEffort = getModelDefinition(modelId).defaultReasoningEffort;
 	}
-
-	$effect(() => {
-		void prompt;
-		if (!composerTextarea) {
-			return;
-		}
-		syncComposerHeight();
-	});
 
 	const composerShellClass =
 		'mx-auto w-full max-w-[48rem] rounded-[28px] bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] p-px transition-colors duration-200';
@@ -214,15 +204,13 @@
 					{/if}
 					<div class="min-h-0 flex-1">
 						<textarea
-							bind:this={composerTextarea}
 							bind:value={prompt}
 							rows="1"
-							class="min-h-0 w-full resize-none border-0 bg-transparent px-0 py-0 text-[14px] leading-6 text-slate-100 outline-none placeholder:text-slate-500"
+							class="field-sizing-content max-h-40 min-h-17 w-full resize-none overflow-y-auto border-0 bg-transparent px-0 py-0 text-[14px] leading-6 text-slate-100 outline-none placeholder:text-slate-500"
 							placeholder="Ask anything, @tag files/directories, or use / to show available commands"
 							disabled={isRunning || isSubmitting}
 							onkeydown={handleComposerKeydown}
-							onpaste={handleComposerPaste}
-							oninput={syncComposerHeight}></textarea>
+							onpaste={handleComposerPaste}></textarea>
 					</div>
 
 					<div
@@ -240,10 +228,16 @@
 							<button
 								type="button"
 								class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-slate-400 transition enabled:cursor-pointer enabled:hover:text-slate-200 disabled:opacity-40"
-								aria-label="Attach images"
-								title="Attach images (up to {MAX_IMAGE_ATTACHMENTS})"
+								aria-label={attachTooltipLabel}
 								disabled={!canAttachMore}
-								onclick={() => attachmentInput?.click()}
+								onmouseenter={showAttachTooltip}
+								onmouseleave={hideAttachTooltip}
+								onfocus={showAttachTooltip}
+								onblur={hideAttachTooltip}
+								onclick={() => {
+									hideAttachTooltip();
+									attachmentInput?.click();
+								}}
 							>
 								<ImagePlus class="size-4" aria-hidden="true" />
 							</button>
@@ -327,3 +321,13 @@
 		</div>
 	</div>
 </footer>
+
+{#if attachTooltip}
+	<div
+		class="pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md bg-[#1a1d27] px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap text-slate-100 shadow-lg ring-1 ring-white/10"
+		style={`top: ${attachTooltip.top}px; left: ${attachTooltip.left}px;`}
+		role="tooltip"
+	>
+		{attachTooltipLabel}
+	</div>
+{/if}

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -56,6 +56,7 @@
 		onCancel
 	}: Props = $props();
 
+	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
 	let attachmentInput = $state<HTMLInputElement | null>(null);
 	let attachTooltip = $state<{ top: number; left: number } | null>(null);
 
@@ -67,6 +68,10 @@
 		attachments.length < MAX_IMAGE_ATTACHMENTS && !isRunning && !isSubmitting
 	);
 	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
+	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
+
+	const COMPOSER_MIN_HEIGHT_PX = 68;
+	const COMPOSER_MAX_HEIGHT_PX = 160;
 
 	function handleAttachmentInputChange(event: Event) {
 		const input = event.currentTarget as HTMLInputElement;
@@ -104,6 +109,21 @@
 		attachTooltip = null;
 	}
 
+	/** Fallback only when field-sizing is unavailable; CSS handles modern browsers. */
+	function syncComposerHeight() {
+		if (!composerTextarea || supportsFieldSizing) {
+			return;
+		}
+		const el = composerTextarea;
+		el.style.height = `${COMPOSER_MIN_HEIGHT_PX}px`;
+		const nextHeight = Math.min(
+			Math.max(el.scrollHeight, COMPOSER_MIN_HEIGHT_PX),
+			COMPOSER_MAX_HEIGHT_PX
+		);
+		el.style.height = `${nextHeight}px`;
+		el.style.overflowY = el.scrollHeight > nextHeight ? 'auto' : 'hidden';
+	}
+
 	function handleComposerKeydown(event: KeyboardEvent) {
 		if (!canSend || isSubmitting || isRunning || !hasMessageContent || attachmentsPending) {
 			return;
@@ -120,6 +140,11 @@
 	function handleModelChange(modelId: SupportedModelId) {
 		selectedReasoningEffort = getModelDefinition(modelId).defaultReasoningEffort;
 	}
+
+	$effect(() => {
+		void prompt;
+		syncComposerHeight();
+	});
 
 	const composerShellClass =
 		'mx-auto w-full max-w-[48rem] rounded-[28px] bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] p-px transition-colors duration-200';
@@ -204,13 +229,15 @@
 					{/if}
 					<div class="min-h-0 flex-1">
 						<textarea
+							bind:this={composerTextarea}
 							bind:value={prompt}
 							rows="1"
 							class="field-sizing-content max-h-40 min-h-17 w-full resize-none overflow-y-auto border-0 bg-transparent px-0 py-0 text-[14px] leading-6 text-slate-100 outline-none placeholder:text-slate-500"
 							placeholder="Ask anything, @tag files/directories, or use / to show available commands"
 							disabled={isRunning || isSubmitting}
 							onkeydown={handleComposerKeydown}
-							onpaste={handleComposerPaste}></textarea>
+							onpaste={handleComposerPaste}
+							oninput={syncComposerHeight}></textarea>
 					</div>
 
 					<div

--- a/apps/web/src/lib/components/home/reasoning-disclosure.svelte
+++ b/apps/web/src/lib/components/home/reasoning-disclosure.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronRight } from '@lucide/svelte';
+	import { Brain, ChevronRight } from '@lucide/svelte';
 
 	type Props = {
 		text: string;
@@ -34,10 +34,11 @@
 <div class="text-sm text-slate-500">
 	<button
 		type="button"
-		class="inline-flex items-center gap-1 text-slate-500 transition hover:text-slate-300"
+		class="inline-flex items-center gap-1.5 text-slate-500 transition hover:text-slate-300"
 		onclick={toggle}
 		aria-expanded={expanded}
 	>
+		<Brain class="size-3.5 shrink-0" aria-hidden="true" />
 		<span>{label}</span>
 		<ChevronRight
 			class={`size-3.5 shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Check, Copy } from '@lucide/svelte';
+	import { Check, Copy, LoaderCircle } from '@lucide/svelte';
 	import { tick } from 'svelte';
 	import { isJsonObject, type JsonValue } from '$convex/lib/json';
 	import {
@@ -17,6 +17,7 @@
 		workSectionTimingIndexes,
 		type AssistantTimelineTool
 	} from '$lib/chat/assistant-timeline';
+	import { toolKindIcon, toolLogIcon } from '$lib/chat/tool-icons';
 	import ChatMarkdown from '$lib/components/chat-markdown.svelte';
 	import ImageViewer, { type ViewerImage } from '$lib/components/image-viewer.svelte';
 	import ReasoningDisclosure from '$lib/components/home/reasoning-disclosure.svelte';
@@ -462,6 +463,7 @@
 														{:else}
 															<ToolCallsDisclosure
 																label={toolGroupLabel(block.toolKey)}
+																icon={toolKindIcon(block.toolKey)}
 																tools={block.tools}
 															>
 																{#snippet toolRow(tool)}
@@ -510,16 +512,20 @@
 											{#if runningTools.length > 0}
 												<ToolCallsDisclosure
 													label="Running"
+													icon={LoaderCircle}
+													iconClass="animate-spin"
 													tools={runningTools}
 													defaultExpanded={true}
 												>
 													{#snippet toolRow(tool)}
+														{@const ToolIcon = toolLogIcon(tool)}
 														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
 														<p
-															class="min-w-0 truncate"
+															class="flex min-w-0 items-center gap-1.5"
 															title={fullToolSummary(tool, isStreaming, sessionCommands)}
 														>
-															{toolSummary}
+															<ToolIcon class="size-3 shrink-0 text-slate-500" aria-hidden="true" />
+															<span class="truncate">{toolSummary}</span>
 														</p>
 													{/snippet}
 												</ToolCallsDisclosure>

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -6,10 +6,12 @@
 		assistantTimelineToolError,
 		assistantTimelineToolFailureKind,
 		buildAssistantTimeline,
+		buildCommandSessionCommandMap,
 		groupAssistantTimeline,
 		groupAssistantTimelineSections,
 		isAssistantTimelineToolRunning,
 		partitionWorkSectionTools,
+		resolveCommandSessionLabel,
 		workSectionTimingAnchor,
 		workSectionTimingIndexes,
 		type AssistantTimelineTool
@@ -185,7 +187,17 @@
 		return '';
 	}
 
-	function toolItemSummary(toolLog: AssistantTimelineTool) {
+	function toolItemSummary(
+		toolLog: AssistantTimelineTool,
+		sessionCommands: ReadonlyMap<string, string>
+	) {
+		const kind = toolLog.job?.kind ?? toolLog.name;
+		if (kind === 'write_stdin') {
+			return (
+				resolveCommandSessionLabel(toolLog, sessionCommands) ??
+				summarizeTool('write_stdin', toolLog.job?.payload ?? toolLog.input)
+			);
+		}
 		if (toolLog.job) {
 			if (toolLog.job.kind === 'apply_patch') {
 				const patchSummary = summarizePatchResult(toolLog.job.result);
@@ -201,8 +213,12 @@
 		return summarizeTool(toolLog.name, toolLog.input);
 	}
 
-	function fullToolSummary(toolLog: AssistantTimelineTool, isStreaming: boolean) {
-		const summary = toolItemSummary(toolLog);
+	function fullToolSummary(
+		toolLog: AssistantTimelineTool,
+		isStreaming: boolean,
+		sessionCommands: ReadonlyMap<string, string>
+	) {
+		const summary = toolItemSummary(toolLog, sessionCommands);
 		if (isAssistantTimelineToolRunning(toolLog, isStreaming)) {
 			return `${summary} (running)`;
 		}
@@ -379,6 +395,9 @@
 						{:else}
 							{@const messageActions = actions.filter((job) => job.runId === message.runId)}
 							{@const timeline = buildAssistantTimeline(message.parts ?? [], messageActions)}
+							{@const sessionCommands = buildCommandSessionCommandMap(
+								timeline.filter((item): item is AssistantTimelineTool => item.type === 'tool')
+							)}
 							{@const blocks = groupAssistantTimeline(timeline)}
 							{@const sections = groupAssistantTimelineSections(blocks)}
 							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
@@ -444,12 +463,12 @@
 																{#snippet toolRow(tool)}
 																	{@const toolError = assistantTimelineToolError(tool)}
 																	{@const toolFailureKind = assistantTimelineToolFailureKind(tool)}
-																	{@const toolSummary = toolItemSummary(tool)}
+																	{@const toolSummary = toolItemSummary(tool, sessionCommands)}
 																	{#if toolError && toolFailureKind}
 																		<details class="min-w-0">
 																			<summary
 																				class="min-w-0 cursor-pointer text-left"
-																				title={fullToolSummary(tool, isStreaming)}
+																				title={fullToolSummary(tool, isStreaming, sessionCommands)}
 																			>
 																				<span class="truncate">{toolSummary}</span>
 																				<span
@@ -473,7 +492,7 @@
 																	{:else}
 																		<p
 																			class="min-w-0 truncate"
-																			title={fullToolSummary(tool, isStreaming)}
+																			title={fullToolSummary(tool, isStreaming, sessionCommands)}
 																		>
 																			{toolSummary}
 																		</p>
@@ -491,8 +510,11 @@
 													defaultExpanded={true}
 												>
 													{#snippet toolRow(tool)}
-														{@const toolSummary = toolItemSummary(tool)}
-														<p class="min-w-0 truncate" title={fullToolSummary(tool, isStreaming)}>
+														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
+														<p
+															class="min-w-0 truncate"
+															title={fullToolSummary(tool, isStreaming, sessionCommands)}
+														>
 															{toolSummary}
 														</p>
 													{/snippet}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -7,6 +7,7 @@
 		assistantTimelineToolFailureKind,
 		buildAssistantTimeline,
 		buildCommandSessionCommandMap,
+		buildOpenExecCommandSessions,
 		groupAssistantTimeline,
 		groupAssistantTimelineSections,
 		isAssistantTimelineToolRunning,
@@ -395,9 +396,11 @@
 						{:else}
 							{@const messageActions = actions.filter((job) => job.runId === message.runId)}
 							{@const timeline = buildAssistantTimeline(message.parts ?? [], messageActions)}
-							{@const sessionCommands = buildCommandSessionCommandMap(
-								timeline.filter((item): item is AssistantTimelineTool => item.type === 'tool')
+							{@const timelineTools = timeline.filter(
+								(item): item is AssistantTimelineTool => item.type === 'tool'
 							)}
+							{@const sessionCommands = buildCommandSessionCommandMap(timelineTools)}
+							{@const openSessions = buildOpenExecCommandSessions(timelineTools)}
 							{@const blocks = groupAssistantTimeline(timeline)}
 							{@const sections = groupAssistantTimelineSections(blocks)}
 							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
@@ -426,7 +429,8 @@
 										{:else}
 											{@const { settledBlocks, runningTools } = partitionWorkSectionTools(
 												section.blocks,
-												isStreaming
+												isStreaming,
+												openSessions
 											)}
 											{@const workInProgress =
 												isStreaming &&

--- a/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
+++ b/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
-	import { ChevronRight } from '@lucide/svelte';
+	import { ChevronRight, type LucideIcon } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import type { AssistantTimelineTool } from '$lib/chat/assistant-timeline';
 
 	type Props = {
 		label: string;
+		icon: LucideIcon;
+		/** Extra classes for the leading icon (e.g. animate-spin). */
+		iconClass?: string;
 		tools: AssistantTimelineTool[];
 		/** When set, overrides the default open-when-≤2 rule. */
 		defaultExpanded?: boolean;
 		toolRow: Snippet<[AssistantTimelineTool]>;
 	};
 
-	let { label, tools, defaultExpanded, toolRow }: Props = $props();
+	let { label, icon: Icon, iconClass, tools, defaultExpanded, toolRow }: Props = $props();
 
 	let manual = $state<boolean | null>(null);
 
@@ -25,10 +28,11 @@
 <div class="text-sm text-slate-500">
 	<button
 		type="button"
-		class="inline-flex items-center gap-1 text-slate-500 transition hover:text-slate-300"
+		class="inline-flex items-center gap-1.5 text-slate-500 transition hover:text-slate-300"
 		onclick={toggle}
 		aria-expanded={expanded}
 	>
+		<Icon class={`size-3.5 shrink-0 ${iconClass ?? ''}`} aria-hidden="true" />
 		<span>{label}</span>
 		<ChevronRight
 			class={`size-3.5 shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}


### PR DESCRIPTION
## Summary
- Replace the attach-images native tooltip with a floating tooltip styled like thread titles, and stop composer height JS thrash via `field-sizing-content`
- Keep yielded `exec_command` sessions in the Running dropdown across `write_stdin` monitor polls instead of flickering away
- Show the shell command name for monitored/running command rows instead of `Session x`

## Test plan
- [ ] Hover the attach-images button and confirm the custom tooltip matches thread tooltip styling
- [ ] Type multi-line text in the composer and confirm the transcript no longer bounces
- [ ] Run a long-lived command so the agent yields a session, then monitors with `write_stdin`; Running should stay visible with the command text
- [ ] Confirm finished monitors land under Monitored Commands with the command name, not `Session <id>`
- [ ] Confirm default cwd `.` is not shown on command rows

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the chat composer and command-session display. The main changes are:

- Adds a custom tooltip and responsive textarea sizing to the composer.
- Tracks running command sessions across text-separated timeline sections.
- Shows command names and icons in running and monitored tool rows.
- Adds tests for command-session state and labels.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The message-wide session state closes completed commands across section boundaries. The composer includes a fallback for browsers without native field sizing.

No blocking issues were found in the updated code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Two browser runs loaded the real application and completed local pairing before rendering the Sign in to continue prompt.
- The first validation command exited with code 1, explicitly asserting that the composer was not visible.
- The second validation command exited with code 1, reinforcing that the composer was not visible and that no mock page or fabricated agent session was used.

<a href="https://app.greptile.com/trex/runs/14887652/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/chat/assistant-timeline.ts | Tracks command sessions across the full assistant message and resolves command labels. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Uses message-wide session state and adds command labels and tool icons. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Adds a custom attachment tooltip and responsive composer sizing with a compatibility fallback. |
| apps/web/src/lib/chat/assistant-timeline.test.ts | Covers active monitors, completed sessions, section boundaries, and command labels. |

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(chat): Add icons to tool and reason..."](https://github.com/spikonado/sprocket/commit/bac435dd19b61866355dd7a37b04c6691d7d0076) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45062119)</sub>

<!-- /greptile_comment -->