### PR TITLE
fix(agent): Retry model completions across Convex reconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -276,8 +276,9 @@ export const start = mutation({
 
 		const isTakeover = isClaimedRunStatus(run.status) && run.claimId !== args.claimId;
 		const isSameClaimRenewal = isClaimedRunStatus(run.status) && run.claimId === args.claimId;
-		// Takeover restarts from the prompt; hide the previous claim's jobs and
-		// clear its partial response so neither resurfaces in the new stream.
+		// Takeover restarts from the prompt. Cancel/hide only in-flight jobs so
+		// completed side effects stay visible; clear the previous claim's
+		// partial response so it does not duplicate into the new stream.
 		if (isTakeover) {
 			const staleJobs = await ctx.db
 				.query('executorJobs')
@@ -286,15 +287,14 @@ export const start = mutation({
 			for (const job of staleJobs) {
 				const isFinal =
 					job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+				if (isFinal) {
+					continue;
+				}
 				await ctx.db.patch(job._id, {
 					hidden: true,
-					...(isFinal
-						? {}
-						: {
-								status: 'cancelled' as const,
-								error: 'The agent worker claim expired.',
-								completedAt: now
-							})
+					status: 'cancelled',
+					error: 'The agent worker claim expired.',
+					completedAt: now
 				});
 			}
 			if (run.responseMessageId) {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -275,13 +275,35 @@ export const start = mutation({
 
 		const isTakeover = isClaimedRunStatus(run.status) && run.claimId !== args.claimId;
 		const isSameClaimRenewal = isClaimedRunStatus(run.status) && run.claimId === args.claimId;
-		if (isTakeover && run.activeJobId) {
-			const activeJob = await ctx.db.get(run.activeJobId);
-			if (activeJob && (activeJob.status === 'pending' || activeJob.status === 'claimed')) {
-				await ctx.db.patch(activeJob._id, {
-					status: 'cancelled',
-					error: 'The agent worker claim expired.',
-					completedAt: now
+		// A takeover restarts the run from its prompt, so the previous claim's
+		// partial work must not resurface: cancel and hide its executor jobs
+		// (hidden jobs are excluded from finalization and agent history) and
+		// clear its partial response so the new stream does not duplicate it.
+		if (isTakeover) {
+			const staleJobs = await ctx.db
+				.query('executorJobs')
+				.withIndex('by_runId_sequence', (query) => query.eq('runId', args.runId))
+				.collect();
+			for (const job of staleJobs) {
+				const isFinal =
+					job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+				await ctx.db.patch(job._id, {
+					hidden: true,
+					...(isFinal
+						? {}
+						: {
+								status: 'cancelled' as const,
+								error: 'The agent worker claim expired.',
+								completedAt: now
+							})
+				});
+			}
+			if (run.responseMessageId) {
+				await ctx.db.patch(run.responseMessageId, {
+					text: '',
+					parts: [],
+					streamSequence: 0,
+					streamAttemptId: undefined
 				});
 			}
 		}

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -23,6 +23,7 @@ import {
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 import {
+	canClaimCompletionAttempt,
 	canFinalizeAfterClaimFailure,
 	canStartRunWithClaim,
 	claimExpiresAt,
@@ -35,6 +36,7 @@ import {
 	type AssistantPart
 } from '@convex/lib/assistantParts';
 import {
+	COMPLETION_STREAM_SUPERSEDED,
 	classifyCompletionStreamBatch,
 	type CompletionStreamBatchClassification,
 	vCompletionStreamEvent
@@ -291,6 +293,7 @@ export const start = mutation({
 			claimExpiresAt: nextClaimExpiresAt,
 			status: isSameClaimRenewal ? run.status : 'running',
 			lastError: undefined,
+			...(isSameClaimRenewal ? {} : { completionAttemptSeq: 0 }),
 			...(isTakeover ? { activeJobId: undefined } : {})
 		});
 
@@ -401,6 +404,8 @@ export const completionActor = query({
 	): Promise<{
 		userId: string;
 		status: Infer<typeof vRunStatus>;
+		claimId?: string;
+		completionAttemptSeq: number;
 		streamSequence: number;
 		streamAttemptId?: string;
 	}> => {
@@ -412,9 +417,28 @@ export const completionActor = query({
 		return {
 			userId,
 			status: run.status,
+			...(run.claimId ? { claimId: run.claimId } : {}),
+			completionAttemptSeq: run.completionAttemptSeq ?? 0,
 			streamSequence: message?.streamSequence ?? 0,
 			...(message?.streamAttemptId ? { streamAttemptId: message.streamAttemptId } : {})
 		};
+	}
+});
+
+export const claimCompletionAttempt = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		attemptSeq: v.number()
+	},
+	handler: async (ctx, args): Promise<void> => {
+		const userId: string = await getUserId(ctx);
+		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		assertRunAcceptsModelCompletion(run.status);
+		if (!canClaimCompletionAttempt(run, args.claimId, args.attemptSeq)) {
+			throw new Error(COMPLETION_STREAM_SUPERSEDED);
+		}
+		await ctx.db.patch(args.runId, { completionAttemptSeq: args.attemptSeq });
 	}
 });
 

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -23,11 +23,12 @@ import {
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 import {
-	canClaimCompletionAttempt,
+	canRegisterCompletionAttempt,
 	canFinalizeAfterClaimFailure,
 	canStartRunWithClaim,
 	claimExpiresAt,
 	isClaimedRunStatus,
+	isCurrentCompletionAttempt,
 	isRunClaimLeaseActive
 } from '@convex/lib/runLease';
 import {
@@ -275,10 +276,8 @@ export const start = mutation({
 
 		const isTakeover = isClaimedRunStatus(run.status) && run.claimId !== args.claimId;
 		const isSameClaimRenewal = isClaimedRunStatus(run.status) && run.claimId === args.claimId;
-		// A takeover restarts the run from its prompt, so the previous claim's
-		// partial work must not resurface: cancel and hide its executor jobs
-		// (hidden jobs are excluded from finalization and agent history) and
-		// clear its partial response so the new stream does not duplicate it.
+		// Takeover restarts from the prompt; hide the previous claim's jobs and
+		// clear its partial response so neither resurfaces in the new stream.
 		if (isTakeover) {
 			const staleJobs = await ctx.db
 				.query('executorJobs')
@@ -447,7 +446,7 @@ export const completionActor = query({
 	}
 });
 
-export const claimCompletionAttempt = mutation({
+export const registerCompletionAttempt = mutation({
 	args: {
 		runId: v.id('runs'),
 		claimId: v.string(),
@@ -458,17 +457,18 @@ export const claimCompletionAttempt = mutation({
 		const userId: string = await getUserId(ctx);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		assertRunAcceptsModelCompletion(run.status);
-		if (!canClaimCompletionAttempt(run, args.claimId, args.attemptSeq)) {
+		if (!canRegisterCompletionAttempt(run, args.claimId, args.attemptSeq)) {
 			throw new Error(COMPLETION_STREAM_SUPERSEDED);
 		}
 		await ctx.db.patch(args.runId, { completionAttemptSeq: args.attemptSeq });
-		// A retry redoes its whole turn, so drop whatever partial output the
-		// attempts it replaces already persisted.
-		const supersededStreamIds = new Set(args.supersededStreamIds ?? []);
-		if (supersededStreamIds.size > 0 && run.responseMessageId) {
+		// Completion turns stamp parts with turnId = streamId, so a retry can
+		// drop the partial parts its prior attempts persisted.
+		const supersededStreamIds = args.supersededStreamIds ?? [];
+		if (supersededStreamIds.length > 0 && run.responseMessageId) {
+			const superseded = new Set(supersededStreamIds);
 			const message = await getThreadMessage(ctx, run.responseMessageId);
 			const parts = ((message.parts ?? []) as AssistantPart[]).filter(
-				(part) => !('turnId' in part) || !part.turnId || !supersededStreamIds.has(part.turnId)
+				(part) => !('turnId' in part && part.turnId && superseded.has(part.turnId))
 			);
 			if (parts.length !== (message.parts?.length ?? 0)) {
 				await ctx.db.patch(run.responseMessageId, {
@@ -526,10 +526,9 @@ export const mergeAssistantStreamEvents = mutation({
 		const userId: string = await getUserId(ctx);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		assertRunAcceptsModelCompletion(run.status);
-		// Validate the attempt fence on every write: once a newer attempt has
-		// registered, a superseded attempt must not be able to append another
-		// batch (its periodic acceptance check alone leaves a window).
-		if (run.claimId !== args.claimId || (run.completionAttemptSeq ?? 0) !== args.attemptSeq) {
+		// Fence every write: periodic acceptance checks alone leave a window
+		// where a superseded attempt could still append after a newer one registers.
+		if (!isCurrentCompletionAttempt(run, args.claimId, args.attemptSeq)) {
 			return 'superseded';
 		}
 		if (!run.responseMessageId || args.events.length === 0) {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -429,7 +429,8 @@ export const claimCompletionAttempt = mutation({
 	args: {
 		runId: v.id('runs'),
 		claimId: v.string(),
-		attemptSeq: v.number()
+		attemptSeq: v.number(),
+		supersededStreamIds: v.optional(v.array(v.string()))
 	},
 	handler: async (ctx, args): Promise<void> => {
 		const userId: string = await getUserId(ctx);
@@ -439,6 +440,21 @@ export const claimCompletionAttempt = mutation({
 			throw new Error(COMPLETION_STREAM_SUPERSEDED);
 		}
 		await ctx.db.patch(args.runId, { completionAttemptSeq: args.attemptSeq });
+		// A retry redoes its whole turn, so drop whatever partial output the
+		// attempts it replaces already persisted.
+		const supersededStreamIds = new Set(args.supersededStreamIds ?? []);
+		if (supersededStreamIds.size > 0 && run.responseMessageId) {
+			const message = await getThreadMessage(ctx, run.responseMessageId);
+			const parts = ((message.parts ?? []) as AssistantPart[]).filter(
+				(part) => !('turnId' in part) || !part.turnId || !supersededStreamIds.has(part.turnId)
+			);
+			if (parts.length !== (message.parts?.length ?? 0)) {
+				await ctx.db.patch(run.responseMessageId, {
+					text: joinAssistantTextParts(parts),
+					parts
+				});
+			}
+		}
 	}
 });
 
@@ -475,6 +491,8 @@ export const beginAssistantMessage = mutation({
 export const mergeAssistantStreamEvents = mutation({
 	args: {
 		runId: v.id('runs'),
+		claimId: v.string(),
+		attemptSeq: v.number(),
 		streamId: v.string(),
 		sequence: v.number(),
 		events: v.array(vCompletionStreamEvent)
@@ -486,6 +504,12 @@ export const mergeAssistantStreamEvents = mutation({
 		const userId: string = await getUserId(ctx);
 		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
 		assertRunAcceptsModelCompletion(run.status);
+		// Validate the attempt fence on every write: once a newer attempt has
+		// registered, a superseded attempt must not be able to append another
+		// batch (its periodic acceptance check alone leaves a window).
+		if (run.claimId !== args.claimId || (run.completionAttemptSeq ?? 0) !== args.attemptSeq) {
+			return 'superseded';
+		}
 		if (!run.responseMessageId || args.events.length === 0) {
 			return 'merged';
 		}

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -8,6 +8,7 @@ import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { isCurrentCompletionAttempt } from '@convex/lib/runLease';
 import { enforceModelCompletionLimit } from '@convex/lib/rateLimits';
 import { getUserId } from '@convex/lib/auth';
 import { vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
@@ -80,12 +81,9 @@ export const complete = action({
 		stream_events: CompletionStreamEvent[];
 	}> => {
 		await getUserId(ctx);
-		// Register this attempt before doing anything else. A reconnecting
-		// Convex client can replay a completion action whose caller already
-		// gave up on it; registration is monotonic on (claimId, attemptSeq),
-		// so such an orphaned execution dies here instead of racing the live
-		// attempt for the run's model stream.
-		await ctx.runMutation(api.agentRuntime.claimCompletionAttempt, {
+		// Register before any model work so a reconnect-replayed orphan dies
+		// on the monotonic (claimId, attemptSeq) fence instead of racing the live attempt.
+		await ctx.runMutation(api.agentRuntime.registerCompletionAttempt, {
 			runId: args.streamRunId,
 			claimId: args.claimId,
 			attemptSeq: args.attemptSeq,
@@ -180,14 +178,14 @@ async function collectStreamingCompletion(
 	attempt: CompletionAttempt,
 	abortController: AbortController
 ): Promise<CompletionActionResult> {
-	const { runId, streamId } = attempt;
+	const { runId, claimId, attemptSeq, streamId, initialSequence } = attempt;
 	const streamEvents: CompletionStreamEvent[] = [];
 	const pendingEvents: CompletionStreamEvent[] = [];
 	const reasoning = new Map<
 		string,
 		{ partId: string; providerMetadata?: JsonValue; finalized: boolean }
 	>();
-	let nextBatchSequence = attempt.initialSequence + 1;
+	let nextBatchSequence = initialSequence + 1;
 
 	const flush = async (): Promise<void> => {
 		if (pendingEvents.length === 0) {
@@ -200,8 +198,8 @@ async function collectStreamingCompletion(
 			try {
 				const outcome = await ctx.runMutation(api.agentRuntime.mergeAssistantStreamEvents, {
 					runId,
-					claimId: attempt.claimId,
-					attemptSeq: attempt.attemptSeq,
+					claimId,
+					attemptSeq,
 					streamId,
 					sequence,
 					events
@@ -482,7 +480,7 @@ async function assertCompletionStillAccepted(
 		runId: attempt.runId
 	});
 	assertRunAcceptsModelCompletion(actor.status);
-	if (actor.claimId !== attempt.claimId || actor.completionAttemptSeq !== attempt.attemptSeq) {
+	if (!isCurrentCompletionAttempt(actor, attempt.claimId, attempt.attemptSeq)) {
 		throw new Error(COMPLETION_STREAM_SUPERSEDED);
 	}
 	if (

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -51,6 +51,8 @@ export const complete = action({
 		streamRunId: v.id('runs'),
 		claimId: v.string(),
 		attemptSeq: v.number(),
+		streamId: v.string(),
+		supersededStreamIds: v.optional(v.array(v.string())),
 		toolChoiceJson: v.optional(v.string()),
 		tools: v.optional(
 			v.array(
@@ -86,7 +88,10 @@ export const complete = action({
 		await ctx.runMutation(api.agentRuntime.claimCompletionAttempt, {
 			runId: args.streamRunId,
 			claimId: args.claimId,
-			attemptSeq: args.attemptSeq
+			attemptSeq: args.attemptSeq,
+			...(args.supersededStreamIds !== undefined
+				? { supersededStreamIds: args.supersededStreamIds }
+				: {})
 		});
 		const modelId = args.modelId;
 		if (args.reasoningEffort !== undefined || args.serviceTier !== undefined) {
@@ -124,7 +129,6 @@ export const complete = action({
 		}
 
 		const streamSequence = await enforceCompletionLimit(ctx, args.streamRunId);
-		const streamId = crypto.randomUUID();
 		const abortController = new AbortController();
 		let result: CompletionActionResult;
 		try {
@@ -135,7 +139,7 @@ export const complete = action({
 					runId: args.streamRunId,
 					claimId: args.claimId,
 					attemptSeq: args.attemptSeq,
-					streamId,
+					streamId: args.streamId,
 					initialSequence: streamSequence
 				},
 				abortController
@@ -192,10 +196,12 @@ async function collectStreamingCompletion(
 		const events = pendingEvents.slice();
 		const sequence = nextBatchSequence;
 		let lastError: unknown;
-		for (let attempt = 0; attempt < 2; attempt += 1) {
+		for (let flushAttempt = 0; flushAttempt < 2; flushAttempt += 1) {
 			try {
 				const outcome = await ctx.runMutation(api.agentRuntime.mergeAssistantStreamEvents, {
 					runId,
+					claimId: attempt.claimId,
+					attemptSeq: attempt.attemptSeq,
 					streamId,
 					sequence,
 					events
@@ -209,7 +215,7 @@ async function collectStreamingCompletion(
 			} catch (error) {
 				if (isCompletionStreamSuperseded(error)) throw error;
 				lastError = error;
-				if (attempt === 0) await delay(100);
+				if (flushAttempt === 0) await delay(100);
 			}
 		}
 		throw lastError;

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -49,6 +49,8 @@ export const complete = action({
 		prompt: v.optional(v.string()),
 		messagesJson: v.optional(v.string()),
 		streamRunId: v.id('runs'),
+		claimId: v.string(),
+		attemptSeq: v.number(),
 		toolChoiceJson: v.optional(v.string()),
 		tools: v.optional(
 			v.array(
@@ -76,6 +78,16 @@ export const complete = action({
 		stream_events: CompletionStreamEvent[];
 	}> => {
 		await getUserId(ctx);
+		// Register this attempt before doing anything else. A reconnecting
+		// Convex client can replay a completion action whose caller already
+		// gave up on it; registration is monotonic on (claimId, attemptSeq),
+		// so such an orphaned execution dies here instead of racing the live
+		// attempt for the run's model stream.
+		await ctx.runMutation(api.agentRuntime.claimCompletionAttempt, {
+			runId: args.streamRunId,
+			claimId: args.claimId,
+			attemptSeq: args.attemptSeq
+		});
 		const modelId = args.modelId;
 		if (args.reasoningEffort !== undefined || args.serviceTier !== undefined) {
 			assertSupportedModelConfiguration({
@@ -119,9 +131,13 @@ export const complete = action({
 			result = await collectStreamingCompletion(
 				ctx,
 				streamText({ ...request, abortSignal: abortController.signal }),
-				args.streamRunId,
-				streamId,
-				streamSequence,
+				{
+					runId: args.streamRunId,
+					claimId: args.claimId,
+					attemptSeq: args.attemptSeq,
+					streamId,
+					initialSequence: streamSequence
+				},
 				abortController
 			);
 		} catch (error) {
@@ -146,21 +162,28 @@ export const complete = action({
 	}
 });
 
+type CompletionAttempt = {
+	runId: Id<'runs'>;
+	claimId: string;
+	attemptSeq: number;
+	streamId: string;
+	initialSequence: number;
+};
+
 async function collectStreamingCompletion(
 	ctx: ActionCtx,
 	result: ReturnType<typeof streamText>,
-	runId: Id<'runs'>,
-	streamId: string,
-	streamSequence: number,
+	attempt: CompletionAttempt,
 	abortController: AbortController
 ): Promise<CompletionActionResult> {
+	const { runId, streamId } = attempt;
 	const streamEvents: CompletionStreamEvent[] = [];
 	const pendingEvents: CompletionStreamEvent[] = [];
 	const reasoning = new Map<
 		string,
 		{ partId: string; providerMetadata?: JsonValue; finalized: boolean }
 	>();
-	let nextBatchSequence = streamSequence + 1;
+	let nextBatchSequence = attempt.initialSequence + 1;
 
 	const flush = async (): Promise<void> => {
 		if (pendingEvents.length === 0) {
@@ -259,11 +282,7 @@ async function collectStreamingCompletion(
 				if (acceptanceTimer !== undefined) clearTimeout(acceptanceTimer);
 			}
 			if (next.type === 'acceptance-check') {
-				await assertCompletionStillAccepted(ctx, {
-					runId,
-					streamId,
-					initialSequence: streamSequence
-				});
+				await assertCompletionStillAccepted(ctx, attempt);
 				nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
 				continue;
 			}
@@ -451,22 +470,21 @@ async function collectStreamingCompletion(
 
 async function assertCompletionStillAccepted(
 	ctx: ActionCtx,
-	args: {
-		runId: Id<'runs'>;
-		streamId: string;
-		initialSequence: number;
-	}
+	attempt: CompletionAttempt
 ): Promise<void> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-		runId: args.runId
+		runId: attempt.runId
 	});
 	assertRunAcceptsModelCompletion(actor.status);
+	if (actor.claimId !== attempt.claimId || actor.completionAttemptSeq !== attempt.attemptSeq) {
+		throw new Error(COMPLETION_STREAM_SUPERSEDED);
+	}
 	if (
 		isCompletionStreamAttemptSuperseded({
-			initialSequence: args.initialSequence,
+			initialSequence: attempt.initialSequence,
 			observedSequence: actor.streamSequence,
 			observedStreamId: actor.streamAttemptId,
-			streamId: args.streamId
+			streamId: attempt.streamId
 		})
 	) {
 		throw new Error(COMPLETION_STREAM_SUPERSEDED);

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	RUN_CLAIM_LEASE_DURATION_MS,
+	canClaimCompletionAttempt,
 	canFinalizeAfterClaimFailure,
 	canStartRunWithClaim,
 	claimExpiresAt,
@@ -55,5 +56,13 @@ describe('run claim leases', () => {
 		expect(canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a')).toBe(
 			false
 		);
+	});
+
+	it('only lets strictly newer completion attempts of the current claim take the stream', () => {
+		const run = { claimId: 'claim-a', completionAttemptSeq: 2 };
+		expect(canClaimCompletionAttempt(run, 'claim-a', 3)).toBe(true);
+		expect(canClaimCompletionAttempt(run, 'claim-a', 2)).toBe(false);
+		expect(canClaimCompletionAttempt(run, 'claim-b', 3)).toBe(false);
+		expect(canClaimCompletionAttempt({ claimId: 'claim-a' }, 'claim-a', 1)).toBe(true);
 	});
 });

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
 	RUN_CLAIM_LEASE_DURATION_MS,
-	canClaimCompletionAttempt,
+	canRegisterCompletionAttempt,
 	canFinalizeAfterClaimFailure,
 	canStartRunWithClaim,
 	claimExpiresAt,
+	isCurrentCompletionAttempt,
 	isRunClaimLeaseActive
 } from '@convex/lib/runLease';
 
@@ -60,9 +61,12 @@ describe('run claim leases', () => {
 
 	it('only lets strictly newer completion attempts of the current claim take the stream', () => {
 		const run = { claimId: 'claim-a', completionAttemptSeq: 2 };
-		expect(canClaimCompletionAttempt(run, 'claim-a', 3)).toBe(true);
-		expect(canClaimCompletionAttempt(run, 'claim-a', 2)).toBe(false);
-		expect(canClaimCompletionAttempt(run, 'claim-b', 3)).toBe(false);
-		expect(canClaimCompletionAttempt({ claimId: 'claim-a' }, 'claim-a', 1)).toBe(true);
+		expect(canRegisterCompletionAttempt(run, 'claim-a', 3)).toBe(true);
+		expect(canRegisterCompletionAttempt(run, 'claim-a', 2)).toBe(false);
+		expect(canRegisterCompletionAttempt(run, 'claim-b', 3)).toBe(false);
+		expect(canRegisterCompletionAttempt({ claimId: 'claim-a' }, 'claim-a', 1)).toBe(true);
+		expect(isCurrentCompletionAttempt(run, 'claim-a', 2)).toBe(true);
+		expect(isCurrentCompletionAttempt(run, 'claim-a', 3)).toBe(false);
+		expect(isCurrentCompletionAttempt(run, 'claim-b', 2)).toBe(false);
 	});
 });

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -35,17 +35,20 @@ export function claimExpiresAt(now: number): number {
 	return now + RUN_CLAIM_LEASE_DURATION_MS;
 }
 
-/**
- * A completion attempt may only take over the run's model stream when it is
- * newer than every attempt seen so far under the current claim. Attempt
- * sequences are keyed on the action's immutable arguments, so a stale
- * execution replayed by a reconnecting client can never win this check,
- * regardless of arrival order.
- */
-export function canClaimCompletionAttempt(
+// Registering a completion attempt requires a strictly newer sequence than the
+// current one; ownership checks afterwards require exactly the current one.
+export function canRegisterCompletionAttempt(
 	run: CompletionAttemptRun,
 	claimId: string,
 	attemptSeq: number
 ): boolean {
 	return run.claimId === claimId && attemptSeq > (run.completionAttemptSeq ?? 0);
+}
+
+export function isCurrentCompletionAttempt(
+	run: CompletionAttemptRun,
+	claimId: string,
+	attemptSeq: number
+): boolean {
+	return run.claimId === claimId && (run.completionAttemptSeq ?? 0) === attemptSeq;
 }

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -6,6 +6,11 @@ type ClaimableRun = {
 	claimExpiresAt?: number;
 };
 
+type CompletionAttemptRun = {
+	claimId?: string;
+	completionAttemptSeq?: number;
+};
+
 export function isClaimedRunStatus(status: string): boolean {
 	return status === 'running' || status === 'awaiting_executor';
 }
@@ -28,4 +33,19 @@ export function canFinalizeAfterClaimFailure(run: ClaimableRun, claimId: string)
 
 export function claimExpiresAt(now: number): number {
 	return now + RUN_CLAIM_LEASE_DURATION_MS;
+}
+
+/**
+ * A completion attempt may only take over the run's model stream when it is
+ * newer than every attempt seen so far under the current claim. Attempt
+ * sequences are keyed on the action's immutable arguments, so a stale
+ * execution replayed by a reconnecting client can never win this check,
+ * regardless of arrival order.
+ */
+export function canClaimCompletionAttempt(
+	run: CompletionAttemptRun,
+	claimId: string,
+	attemptSeq: number
+): boolean {
+	return run.claimId === claimId && attemptSeq > (run.completionAttemptSeq ?? 0);
 }

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -51,6 +51,7 @@ export default defineSchema({
 		status: vRunStatus,
 		claimId: v.optional(v.string()),
 		claimExpiresAt: v.optional(v.number()),
+		completionAttemptSeq: v.optional(v.number()),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -87,7 +87,7 @@ impl AgentProvider {
                 .clone()
                 .with_reasoning_effort(context.run.reasoning_effort.clone())
                 .with_service_tier(context.run.service_tier.clone())
-                .with_stream_target(run_id.to_string(), claim_id.to_string()),
+                .with_completion_scope(run_id.to_string(), claim_id.to_string()),
             model: context.run.selected_model.clone(),
         }
     }

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -78,6 +78,7 @@ impl AgentProvider {
         runtime: &RuntimeClient,
         context: &RunContextResponse,
         run_id: &str,
+        claim_id: &str,
     ) -> Self {
         Self {
             kind: ProviderKind::DEFAULT,
@@ -86,7 +87,7 @@ impl AgentProvider {
                 .clone()
                 .with_reasoning_effort(context.run.reasoning_effort.clone())
                 .with_service_tier(context.run.service_tier.clone())
-                .with_stream_target(run_id.to_string()),
+                .with_stream_target(run_id.to_string(), claim_id.to_string()),
             model: context.run.selected_model.clone(),
         }
     }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -500,7 +500,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
             content: OneOrMany::many(prompt_contents)
                 .map_err(|_| anyhow!("run prompt content cannot be empty"))?,
         };
-        let provider = AgentProvider::default_for_run(&runtime, &context, &run_id);
+        let provider = AgentProvider::default_for_run(&runtime, &context, &run_id, &claim_id);
         let prior_history = deserialize_agent_history(context.agent_history)?;
         let preamble = build_workspace_preamble(&request.workspace_path, &workspace_instructions);
         Ok((

--- a/crates/sprocket-convex-provider/Cargo.toml
+++ b/crates/sprocket-convex-provider/Cargo.toml
@@ -13,3 +13,4 @@ rustls = { version = "0.23.40", features = ["ring"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.52.1", features = ["sync", "time"] }
+uuid = { version = "1.21.0", features = ["v4"] }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -18,11 +19,13 @@ use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompleti
 use rustls::crypto::ring::default_provider;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 use crate::messages::{build_model_messages, instructions_text, normalize_convex_json_numbers};
 
 const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const COMPLETION_TRANSPORT_ATTEMPTS: u32 = 3;
+const COMPLETION_TRANSPORT_RETRY_DELAY: Duration = Duration::from_millis(400);
 
 pub const COMPLETION_STREAM_SUPERSEDED: &str = "SPROCKET_COMPLETION_STREAM_SUPERSEDED";
 
@@ -40,6 +43,8 @@ pub struct Client {
     default_reasoning_effort: Option<Arc<str>>,
     default_service_tier: Option<Arc<str>>,
     stream_run_id: Option<Arc<str>>,
+    claim_id: Option<Arc<str>>,
+    attempt_counter: Arc<AtomicU32>,
 }
 
 impl Client {
@@ -57,6 +62,8 @@ impl Client {
             default_reasoning_effort: None,
             default_service_tier: None,
             stream_run_id: None,
+            claim_id: None,
+            attempt_counter: Arc::new(AtomicU32::new(0)),
         })
     }
 
@@ -130,8 +137,13 @@ impl Client {
         self
     }
 
-    pub fn with_stream_target(mut self, stream_run_id: String) -> Self {
+    /// Scope this client to a single run claim: stream events target
+    /// `stream_run_id`, and every completion attempt is fenced by `claim_id`
+    /// plus a per-scope monotonic attempt sequence.
+    pub fn with_stream_target(mut self, stream_run_id: String, claim_id: String) -> Self {
         self.stream_run_id = Some(stream_run_id.into());
+        self.claim_id = Some(claim_id.into());
+        self.attempt_counter = Arc::new(AtomicU32::new(0));
         self
     }
 }
@@ -259,6 +271,7 @@ struct ConvexActionArgs {
     prompt: Option<String>,
     messages_json: String,
     stream_run_id: Option<String>,
+    claim_id: Option<String>,
     tools: Vec<ToolDefinition>,
     tool_choice: Option<ConvexToolChoice>,
 }
@@ -315,6 +328,7 @@ impl RigCompletionModel for CompletionModel {
             prompt: None,
             messages_json: messages.to_string(),
             stream_run_id: self.client.stream_run_id.as_deref().map(str::to_owned),
+            claim_id: self.client.claim_id.as_deref().map(str::to_owned),
             tools: request.tools.clone(),
             tool_choice: request.tool_choice.as_ref().map(convert_tool_choice),
         };
@@ -464,41 +478,83 @@ async fn call_completion_action(
     client: &Client,
     args: &ConvexActionArgs,
 ) -> Result<Value, CompletionError> {
-    let mut convex = clone_locked(&client.inner).await;
-    eprintln!(
-        "sprocket-convex-provider: action start {}",
-        client.completion_action
-    );
     let stream_run_id = args.stream_run_id.as_ref().ok_or_else(|| {
         CompletionError::ProviderError(
             "streamRunId is required for completion:complete".to_string(),
         )
     })?;
-    let result = convex.action(&client.completion_action, action_args(args, stream_run_id));
-    let result = timeout(CONVEX_RPC_TIMEOUT, result)
+    let claim_id = args.claim_id.as_ref().ok_or_else(|| {
+        CompletionError::ProviderError("claimId is required for completion:complete".to_string())
+    })?;
+
+    let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
+    for attempt in 1..=COMPLETION_TRANSPORT_ATTEMPTS {
+        // Each try registers a fresh attempt sequence server-side, which
+        // fences out any orphaned execution of a previous try that the
+        // Convex client replays after a reconnect.
+        let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let mut convex = clone_locked(&client.inner).await;
+        eprintln!(
+            "sprocket-convex-provider: action start {} attempt {attempt_seq}",
+            client.completion_action
+        );
+        let result = timeout(
+            CONVEX_RPC_TIMEOUT,
+            convex.action(
+                &client.completion_action,
+                action_args(args, stream_run_id, claim_id, attempt_seq),
+            ),
+        )
         .await
         .map_err(|error| {
             CompletionError::ProviderError(format!(
                 "timed out calling {}: {error}",
                 client.completion_action
             ))
-        })?
-        .map_err(to_completion_error)?;
-    eprintln!(
-        "sprocket-convex-provider: action done {}",
-        client.completion_action
-    );
+        })?;
 
-    match result {
-        FunctionResult::Value(value) => Ok(value),
-        FunctionResult::ErrorMessage(message) => Err(CompletionError::ProviderError(message)),
-        FunctionResult::ConvexError(error) => Err(CompletionError::ProviderError(error.message)),
+        let transport_error = match result {
+            Ok(FunctionResult::Value(value)) => {
+                eprintln!(
+                    "sprocket-convex-provider: action done {}",
+                    client.completion_action
+                );
+                return Ok(value);
+            }
+            Ok(FunctionResult::ErrorMessage(message)) => {
+                return Err(CompletionError::ProviderError(message));
+            }
+            Ok(FunctionResult::ConvexError(error)) => {
+                return Err(CompletionError::ProviderError(error.message));
+            }
+            Err(error) => error,
+        };
+        if attempt == COMPLETION_TRANSPORT_ATTEMPTS {
+            return Err(to_completion_error(transport_error));
+        }
+        eprintln!(
+            "sprocket-convex-provider: transport failure calling {}; retrying: {transport_error:#}",
+            client.completion_action
+        );
+        sleep(retry_delay).await;
+        retry_delay = retry_delay.saturating_mul(2);
     }
+    unreachable!("completion retry loop returns from its final attempt")
 }
 
-fn action_args(args: &ConvexActionArgs, stream_run_id: &str) -> BTreeMap<String, Value> {
+fn action_args(
+    args: &ConvexActionArgs,
+    stream_run_id: &str,
+    claim_id: &str,
+    attempt_seq: u32,
+) -> BTreeMap<String, Value> {
     let mut payload = BTreeMap::new();
     payload.insert("modelId".to_string(), args.model_id.clone().into());
+    payload.insert("claimId".to_string(), claim_id.to_string().into());
+    payload.insert(
+        "attemptSeq".to_string(),
+        Value::Float64(f64::from(attempt_seq)),
+    );
     if let Some(prompt) = &args.prompt {
         payload.insert("prompt".to_string(), prompt.clone().into());
     }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -137,10 +137,7 @@ impl Client {
         self
     }
 
-    /// Scope this client to a single run claim: stream events target
-    /// `stream_run_id`, and every completion attempt is fenced by `claim_id`
-    /// plus a per-scope monotonic attempt sequence.
-    pub fn with_stream_target(mut self, stream_run_id: String, claim_id: String) -> Self {
+    pub fn with_completion_scope(mut self, stream_run_id: String, claim_id: String) -> Self {
         self.stream_run_id = Some(stream_run_id.into());
         self.claim_id = Some(claim_id.into());
         self.attempt_counter = Arc::new(AtomicU32::new(0));
@@ -489,11 +486,11 @@ async fn call_completion_action(
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
     let mut superseded_stream_ids: Vec<String> = Vec::new();
-    for attempt in 1..=COMPLETION_TRANSPORT_ATTEMPTS {
-        // Each try registers a fresh attempt sequence server-side, which
-        // fences out any orphaned execution of a previous try that the
-        // Convex client replays after a reconnect. Naming the prior tries'
-        // streams lets the backend drop their partial output.
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        // Fresh attempt_seq fences orphaned reconnect replays; prior stream
+        // ids let the backend drop their partial output on the next try.
         let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let stream_id = uuid::Uuid::new_v4().to_string();
         let mut convex = clone_locked(&client.inner).await;
@@ -523,7 +520,7 @@ async fn call_completion_action(
             ))
         })?;
 
-        let transport_error = match result {
+        match result {
             Ok(FunctionResult::Value(value)) => {
                 eprintln!(
                     "sprocket-convex-provider: action done {}",
@@ -537,20 +534,20 @@ async fn call_completion_action(
             Ok(FunctionResult::ConvexError(error)) => {
                 return Err(CompletionError::ProviderError(error.message));
             }
-            Err(error) => error,
-        };
-        if attempt == COMPLETION_TRANSPORT_ATTEMPTS {
-            return Err(to_completion_error(transport_error));
+            Err(error) => {
+                if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
+                    return Err(to_completion_error(error));
+                }
+                eprintln!(
+                    "sprocket-convex-provider: transport failure calling {}; retrying: {error:#}",
+                    client.completion_action
+                );
+                superseded_stream_ids.push(stream_id);
+                sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2);
+            }
         }
-        eprintln!(
-            "sprocket-convex-provider: transport failure calling {}; retrying: {transport_error:#}",
-            client.completion_action
-        );
-        superseded_stream_ids.push(stream_id);
-        sleep(retry_delay).await;
-        retry_delay = retry_delay.saturating_mul(2);
     }
-    unreachable!("completion retry loop returns from its final attempt")
 }
 
 fn action_args(

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -488,11 +488,14 @@ async fn call_completion_action(
     })?;
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
+    let mut superseded_stream_ids: Vec<String> = Vec::new();
     for attempt in 1..=COMPLETION_TRANSPORT_ATTEMPTS {
         // Each try registers a fresh attempt sequence server-side, which
         // fences out any orphaned execution of a previous try that the
-        // Convex client replays after a reconnect.
+        // Convex client replays after a reconnect. Naming the prior tries'
+        // streams lets the backend drop their partial output.
         let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let stream_id = uuid::Uuid::new_v4().to_string();
         let mut convex = clone_locked(&client.inner).await;
         eprintln!(
             "sprocket-convex-provider: action start {} attempt {attempt_seq}",
@@ -502,7 +505,14 @@ async fn call_completion_action(
             CONVEX_RPC_TIMEOUT,
             convex.action(
                 &client.completion_action,
-                action_args(args, stream_run_id, claim_id, attempt_seq),
+                action_args(
+                    args,
+                    stream_run_id,
+                    claim_id,
+                    attempt_seq,
+                    &stream_id,
+                    &superseded_stream_ids,
+                ),
             ),
         )
         .await
@@ -536,6 +546,7 @@ async fn call_completion_action(
             "sprocket-convex-provider: transport failure calling {}; retrying: {transport_error:#}",
             client.completion_action
         );
+        superseded_stream_ids.push(stream_id);
         sleep(retry_delay).await;
         retry_delay = retry_delay.saturating_mul(2);
     }
@@ -547,6 +558,8 @@ fn action_args(
     stream_run_id: &str,
     claim_id: &str,
     attempt_seq: u32,
+    stream_id: &str,
+    superseded_stream_ids: &[String],
 ) -> BTreeMap<String, Value> {
     let mut payload = BTreeMap::new();
     payload.insert("modelId".to_string(), args.model_id.clone().into());
@@ -555,6 +568,19 @@ fn action_args(
         "attemptSeq".to_string(),
         Value::Float64(f64::from(attempt_seq)),
     );
+    payload.insert("streamId".to_string(), stream_id.to_string().into());
+    if !superseded_stream_ids.is_empty() {
+        payload.insert(
+            "supersededStreamIds".to_string(),
+            Value::Array(
+                superseded_stream_ids
+                    .iter()
+                    .cloned()
+                    .map(Value::from)
+                    .collect(),
+            ),
+        );
+    }
     if let Some(prompt) = &args.prompt {
         payload.insert("prompt".to_string(), prompt.clone().into());
     }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -498,7 +498,7 @@ async fn call_completion_action(
             "sprocket-convex-provider: action start {} attempt {attempt_seq}",
             client.completion_action
         );
-        let result = timeout(
+        let result = match timeout(
             CONVEX_RPC_TIMEOUT,
             convex.action(
                 &client.completion_action,
@@ -513,12 +513,27 @@ async fn call_completion_action(
             ),
         )
         .await
-        .map_err(|error| {
-            CompletionError::ProviderError(format!(
-                "timed out calling {}: {error}",
-                client.completion_action
-            ))
-        })?;
+        {
+            Ok(result) => result,
+            Err(error) => {
+                // Timeouts are retryable: a reconnect can stall the action
+                // future until the RPC deadline instead of returning Err.
+                if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
+                    return Err(CompletionError::ProviderError(format!(
+                        "timed out calling {}: {error}",
+                        client.completion_action
+                    )));
+                }
+                eprintln!(
+                    "sprocket-convex-provider: timed out calling {}; retrying: {error}",
+                    client.completion_action
+                );
+                superseded_stream_ids.push(stream_id);
+                sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2);
+                continue;
+            }
+        };
 
         match result {
             Ok(FunctionResult::Value(value)) => {


### PR DESCRIPTION
## Summary
- Retry model completion actions when a Convex websocket reconnect (e.g. expired auth) drops the in-flight response channel as `ProviderError: channel closed`
- Fence each completion attempt with `(claimId, attemptSeq)` so orphaned or superseded executions cannot take over the run's model stream or append after a retry
- On takeover or retry, reset/purge prior attempt output so partial streamed responses do not duplicate into the new claim's stream

## Test plan
- [ ] Trigger a Convex auth/websocket reconnect while a completion is in flight and confirm the run retries instead of failing with `channel closed`
- [ ] Confirm a superseded attempt cannot append stream events after a newer `(claimId, attemptSeq)` is registered
- [ ] Confirm a takeover clears the previous claim's partial response message before the new claim streams
- [ ] `bun convex dev --once` in `apps/web/`
- [ ] Relevant Rust/Convex tests pass for the provider client and run lease fencing

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR retries model completions across Convex reconnects and fences concurrent attempts. The main changes are:

- Retries completion actions after transport failures and timeouts.
- Fences stream writes with claim and attempt identifiers.
- Removes partial output from superseded completion attempts.
- Preserves completed tool jobs during claim takeover.
- Adds lease helpers, schema fields, dependencies, and tests for attempt ownership.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issue qualifies for this follow-up review.

The timeout now remains inside the retry loop. Completion registration and stream writes use the same claim-and-attempt fence.

No distinct unresolved failure was identified beyond the issues already reported.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex documented the pre-change behavior, where retry payloads had strictly increasing attemptSeq values but no stream identity or purge list.
- T-Rex documented the post-change behavior, where the first attempt used stream-1 and the second attempt occurred after a simulated channel closure with stream-2 and supersededStreamIds: \[stream-1\].
- T-Rex ran fencing tests and confirmed that only strictly newer attempts are accepted under the current claim register and that superseded stream batches do not append.
- T-Rex reviewed the test run details showing that all captured commands include a working directory and an exit code.

<a href="https://app.greptile.com/trex/runs/14892089/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Adds takeover cleanup, completion-attempt registration, and per-write stream fencing. |
| apps/web/src/convex/completion.ts | Registers completion attempts before model work and checks ownership throughout streaming. |
| apps/web/src/convex/lib/runLease.ts | Adds monotonic attempt registration and exact ownership checks. |
| crates/sprocket-convex-provider/src/client.rs | Retries timed-out and failed completion actions with unique stream and attempt identifiers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent): Retry completion timeouts an..."](https://github.com/spikonado/sprocket/commit/7a47945015873c3d96e9b162edfca91785316f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45185866)</sub>

<!-- /greptile_comment -->