### PR TITLE
feat(agent): Accept apply_patch envelopes for workspace edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ coverage
 .turbo
 turbo-cache-key.json
 
+.claude
 .codex
 dist
 ref-repos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,9 @@ All of these are core priorities; try your best to achieve all of them without h
 
 ## Maintaining Code
 
-- Don't be afraid to change existing code in order to improve on any of the priorities.
+- Don't be afraid to completely refactor existing code in order to improve on any of the priorities.
 - Make sure that changes are made in all the layers of the app when needed.
 - Deleting code, often fixes more problems than writing code does. Sometimes writing too much code introduces problems.
-- Don't maintain backwards compatibility in any of the code unless explicitly asked. It's recommended to add temporary migration functions for the backend data instead.
 
 ## Writing Code
 
@@ -53,12 +52,12 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 - Do the deep dives and figure out what needs to be done and delegate the rest accordingly and as needed to subagents.
 - Use subagents for LARGE tasks that will benefit from your context being less polluted and multiple subagents working in parallel.
 - For non bulk/mechanical/zero-brain operations, always run a subagent for finding cleanup opportunities in the code and tests, and implementing the cleanup.
-- For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents must have >=8 intelligence and review the code overall, the other must have >=7 taste and review the UI/UX, API design, and code quality parts.
+- For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents should review the code overall, the other should review the UI/UX, API design, and code quality parts.
 - When getting code reviewed by subagents in a loop, use gpt-5.6-sol as the review subagent for a max of 3 reviews. After this, rely on some other model for the review subagent.
 
 #### PR Workflow
 
-- Unless very specifically requested, PRs should be made only against the default branch and should not be a draft.
+- Unless requested, PRs should be made only against the default branch and should not be a draft.
 - After a PR is made, don't perform any code review using subagents, let Greptile review the code.
 
 1. When requested, push code and make a PR. The PR title should have the same format as past PR titles. Ensure that your branch is updated with the latest main.
@@ -101,7 +100,6 @@ How to apply:
 - Only use the models listed above.
 - If you have a tool available for spawning subagents, never use that. Instead use the CLI of a specific coding agent harness directly.
 - If a cheaper model's output doesn't meet the bar, rerun/redo the work with a better model without asking.
-- Intelligence > taste > cost for actual work.
-- Prefer models with the highest intelligence for really hard long-running tasks.
+- The produced code meeting the priorities in "Priorities in Order" is much more important than what it costed.
 - For bulk/mechanical/zero-brain operations, always use the cheapest model first and only switch to a better model if the output doesn't meet the bar.
 - For user-facing UI/UX and APIs, use a model with good taste (>=7). If making those UIs/APIs is highly complicated, get a model with higher intelligence to complete the work after the core UI/API has been decided by the model with good taste.

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -85,6 +85,7 @@ fn build_workspace_preamble(
         "A response without a tool call ends the run. Before sending one, reread the user request and continue with the next tool call if any work remains, including work requested after an explanation or update.",
         "Behave like a careful senior software engineer.",
         "Do not guess about repo state or file contents. Always inspect before editing.",
+        "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations.",
         "Fix the root-cause of problems.",
         "It is highly recommended that you check the latest documentation on the frameworks, libraries, and tools you are using as your training data is outdated and wrong for many of them.",
         "If the workspace is already dirty, do not revert the changes. Try and work around them. If they conflict with the changes you need to make, ask the user what to do with them.",

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -254,7 +254,7 @@ pub(crate) struct WriteStdinArgs {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct ApplyPatchArgs {
-    /// Git-style unified diff to apply inside the workspace.
+    /// `*** Begin Patch` / `*** End Patch` envelope (Add/Update/Delete; Move under Update) or a unified/`diff --git` patch.
     patch: String,
 }
 
@@ -373,7 +373,7 @@ impl rig::tool::Tool for ApplyPatchTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Apply a git-style unified diff to files in the workspace. Supports creating, updating, deleting, renaming, and copying text files in one call. Every path must remain inside the workspace."
+        "Apply a *** Begin Patch envelope (Add File / Update File with optional Move to / Delete File) or a unified/`diff --git` patch inside the workspace. Prefer Begin Patch for add/update/delete/rename; use diff --git when you need copy. Every path must remain inside the workspace."
             .to_string()
     }
 

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -254,7 +254,7 @@ pub(crate) struct WriteStdinArgs {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct ApplyPatchArgs {
-    /// `*** Begin Patch` / `*** End Patch` envelope (Add/Update/Delete; Move under Update) or a unified/`diff --git` patch.
+    /// `*** Begin Patch` envelope (Add/Update/Delete/Copy/Move) or a unified/`diff --git` patch. Any supported format is fine.
     patch: String,
 }
 
@@ -373,7 +373,7 @@ impl rig::tool::Tool for ApplyPatchTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Apply a *** Begin Patch envelope (Add File / Update File with optional Move to / Delete File) or a unified/`diff --git` patch inside the workspace. Prefer Begin Patch for add/update/delete/rename; use diff --git when you need copy. Every path must remain inside the workspace."
+        "Apply file changes inside the workspace. Accepts a *** Begin Patch envelope (Add File, Update File with optional Move to, Copy File with Copy to, Delete File) or a unified/`diff --git` patch. Create, update, delete, rename, and copy are supported in both styles—use whichever format you prefer. Every path must remain inside the workspace."
             .to_string()
     }
 

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -254,7 +254,7 @@ pub(crate) struct WriteStdinArgs {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct ApplyPatchArgs {
-    /// `*** Begin Patch` envelope (Add/Update/Delete/Copy/Move) or a unified/`diff --git` patch. Any supported format is fine.
+    /// Begin Patch envelope or unified/`diff --git` patch.
     patch: String,
 }
 
@@ -373,7 +373,7 @@ impl rig::tool::Tool for ApplyPatchTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Apply file changes inside the workspace. Accepts a *** Begin Patch envelope (Add File, Update File with optional Move to, Copy File with Copy to, Delete File) or a unified/`diff --git` patch. Create, update, delete, rename, and copy are supported in both styles—use whichever format you prefer. Every path must remain inside the workspace."
+        "Create, update, delete, rename, or copy workspace files via a Begin Patch envelope or unified/`diff --git` patch."
             .to_string()
     }
 

--- a/crates/sprocket-workspace/src/apply_patch_format.rs
+++ b/crates/sprocket-workspace/src/apply_patch_format.rs
@@ -90,9 +90,6 @@ pub(crate) fn parse_apply_patch(patch: &str) -> Result<Vec<PatchHunk>> {
                 contents.push(b'\n');
                 index += 1;
             }
-            if contents.is_empty() {
-                bail!("add-file hunk for '{path}' has no content");
-            }
             hunks.push(PatchHunk::Add { path, contents });
             continue;
         }
@@ -232,6 +229,7 @@ pub(crate) fn apply_update(
 ) -> Result<Vec<u8>> {
     let contents = std::str::from_utf8(contents)
         .with_context(|| format!("patch target is not valid UTF-8: {}", path.display()))?;
+    let had_trailing_newline = contents.ends_with('\n');
     let line_ending = if uses_crlf(contents) { "\r\n" } else { "\n" };
     let normalized = if line_ending == "\r\n" {
         contents.replace("\r\n", "\n")
@@ -291,7 +289,9 @@ pub(crate) fn apply_update(
     }
 
     let mut output = lines.join(line_ending).into_bytes();
-    output.extend_from_slice(line_ending.as_bytes());
+    if had_trailing_newline {
+        output.extend_from_slice(line_ending.as_bytes());
+    }
     Ok(output)
 }
 
@@ -412,6 +412,37 @@ mod tests {
         .expect("apply");
 
         assert_eq!(updated, b"alpha\nbeta\ngamma\n");
+    }
+
+    #[test]
+    fn preserves_missing_trailing_newline() {
+        let updated = apply_update(
+            Path::new("file.txt"),
+            b"alpha\nbeta",
+            &[UpdateChunk {
+                context: None,
+                old_lines: vec!["alpha".to_owned()],
+                new_lines: vec!["ALPHA".to_owned()],
+                end_of_file: false,
+            }],
+        )
+        .expect("apply");
+
+        assert_eq!(updated, b"ALPHA\nbeta");
+    }
+
+    #[test]
+    fn parses_empty_add_file() {
+        let hunks = parse_apply_patch("*** Begin Patch\n*** Add File: empty.txt\n*** End Patch")
+            .expect("parse");
+
+        match &hunks[..] {
+            [PatchHunk::Add { path, contents }] => {
+                assert_eq!(path, "empty.txt");
+                assert!(contents.is_empty());
+            }
+            _ => panic!("expected empty add hunk"),
+        }
     }
 
     #[test]

--- a/crates/sprocket-workspace/src/apply_patch_format.rs
+++ b/crates/sprocket-workspace/src/apply_patch_format.rs
@@ -1,0 +1,458 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+const BEGIN_PATCH: &str = "*** Begin Patch";
+const END_PATCH: &str = "*** End Patch";
+const ADD_FILE: &str = "*** Add File: ";
+const DELETE_FILE: &str = "*** Delete File: ";
+const UPDATE_FILE: &str = "*** Update File: ";
+const MOVE_TO: &str = "*** Move to: ";
+const END_OF_FILE: &str = "*** End of File";
+const ENVIRONMENT_ID: &str = "*** Environment ID: ";
+
+pub(crate) enum PatchHunk {
+    Add {
+        path: String,
+        contents: Vec<u8>,
+    },
+    Delete {
+        path: String,
+    },
+    Update {
+        path: String,
+        move_to: Option<String>,
+        chunks: Vec<UpdateChunk>,
+    },
+}
+
+pub(crate) struct UpdateChunk {
+    context: Option<String>,
+    old_lines: Vec<String>,
+    new_lines: Vec<String>,
+    end_of_file: bool,
+}
+
+impl UpdateChunk {
+    fn new(context: Option<String>) -> Self {
+        Self {
+            context,
+            old_lines: Vec::new(),
+            new_lines: Vec::new(),
+            end_of_file: false,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.old_lines.is_empty() && self.new_lines.is_empty()
+    }
+}
+
+pub(crate) fn is_apply_patch_format(patch: &str) -> bool {
+    patch.trim_start().starts_with(BEGIN_PATCH)
+}
+
+pub(crate) fn parse_apply_patch(patch: &str) -> Result<Vec<PatchHunk>> {
+    let lines = patch
+        .trim()
+        .lines()
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect::<Vec<_>>();
+
+    if lines.first().map(|line| line.trim()) != Some(BEGIN_PATCH) {
+        bail!("apply_patch input must start with '{BEGIN_PATCH}'");
+    }
+    if lines.last().map(|line| line.trim()) != Some(END_PATCH) {
+        bail!("apply_patch input must end with '{END_PATCH}'");
+    }
+
+    let mut hunks = Vec::new();
+    let mut index = 1;
+    while index < lines.len() - 1 {
+        let header = lines[index].trim();
+        if header.is_empty() || header.starts_with(ENVIRONMENT_ID) {
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = header.strip_prefix(ADD_FILE) {
+            let path = parse_path(path, index)?;
+            index += 1;
+            let mut contents = Vec::new();
+            while index < lines.len() - 1 && !is_file_header(lines[index]) {
+                let line = lines[index].strip_prefix('+').ok_or_else(|| {
+                    anyhow!(
+                        "invalid add-file line {}: every content line must start with '+'",
+                        index + 1
+                    )
+                })?;
+                contents.extend_from_slice(line.as_bytes());
+                contents.push(b'\n');
+                index += 1;
+            }
+            if contents.is_empty() {
+                bail!("add-file hunk for '{path}' has no content");
+            }
+            hunks.push(PatchHunk::Add { path, contents });
+            continue;
+        }
+
+        if let Some(path) = header.strip_prefix(DELETE_FILE) {
+            hunks.push(PatchHunk::Delete {
+                path: parse_path(path, index)?,
+            });
+            index += 1;
+            continue;
+        }
+
+        if let Some(path) = header.strip_prefix(UPDATE_FILE) {
+            let path = parse_path(path, index)?;
+            index += 1;
+            let mut move_to = None;
+            let mut chunks: Vec<UpdateChunk> = Vec::new();
+
+            if index < lines.len() - 1 {
+                let line = lines[index].trim();
+                if let Some(destination) = line.strip_prefix(MOVE_TO) {
+                    move_to = Some(parse_path(destination, index)?);
+                    index += 1;
+                }
+            }
+
+            while index < lines.len() - 1 && !is_file_header(lines[index]) {
+                let line = lines[index];
+                let trimmed_end = line.trim_end();
+                let previous_ended = chunks.last().is_some_and(|chunk| chunk.end_of_file);
+
+                if previous_ended && line.is_empty() {
+                    index += 1;
+                    continue;
+                }
+
+                if trimmed_end == "@@" {
+                    ensure_previous_chunk_has_lines(&chunks, index)?;
+                    chunks.push(UpdateChunk::new(None));
+                } else if let Some(context) = trimmed_end.strip_prefix("@@ ") {
+                    ensure_previous_chunk_has_lines(&chunks, index)?;
+                    chunks.push(UpdateChunk::new(Some(context.to_owned())));
+                } else if trimmed_end == END_OF_FILE {
+                    match chunks.last_mut() {
+                        Some(chunk) if !chunk.is_empty() => chunk.end_of_file = true,
+                        _ => bail!(
+                            "invalid update line {}: '{END_OF_FILE}' must follow a change",
+                            index + 1
+                        ),
+                    }
+                } else if previous_ended {
+                    bail!(
+                        "invalid update line {}: expected '@@' after '{END_OF_FILE}'",
+                        index + 1
+                    );
+                } else {
+                    if chunks.is_empty() {
+                        chunks.push(UpdateChunk::new(None));
+                    }
+                    let chunk = chunks.last_mut().expect("chunk exists");
+                    if let Some(content) = line.strip_prefix(' ') {
+                        chunk.old_lines.push(content.to_owned());
+                        chunk.new_lines.push(content.to_owned());
+                    } else if let Some(content) = line.strip_prefix('+') {
+                        chunk.new_lines.push(content.to_owned());
+                    } else if let Some(content) = line.strip_prefix('-') {
+                        chunk.old_lines.push(content.to_owned());
+                    } else if line.is_empty() {
+                        chunk.old_lines.push(String::new());
+                        chunk.new_lines.push(String::new());
+                    } else {
+                        bail!(
+                            "invalid update line {}: lines must start with ' ', '+', or '-'",
+                            index + 1
+                        );
+                    }
+                }
+                index += 1;
+            }
+
+            ensure_previous_chunk_has_lines(&chunks, index)?;
+            if chunks.is_empty() {
+                bail!("update-file hunk for '{path}' has no changes");
+            }
+            hunks.push(PatchHunk::Update {
+                path,
+                move_to,
+                chunks,
+            });
+            continue;
+        }
+
+        bail!(
+            "invalid apply_patch hunk header at line {}: '{header}'",
+            index + 1
+        );
+    }
+
+    if hunks.is_empty() {
+        bail!("patch does not contain any file changes");
+    }
+    Ok(hunks)
+}
+
+fn parse_path(path: &str, index: usize) -> Result<String> {
+    let path = path.trim();
+    if path.is_empty() {
+        bail!("patch path at line {} cannot be empty", index + 1);
+    }
+    Ok(path.to_owned())
+}
+
+fn is_file_header(line: &str) -> bool {
+    // Do not trim leading whitespace: indented markers are valid context/content
+    // lines (e.g. documentation that quotes apply_patch examples).
+    let line = line.trim_end();
+    line == END_PATCH
+        || line.starts_with(ADD_FILE)
+        || line.starts_with(DELETE_FILE)
+        || line.starts_with(UPDATE_FILE)
+}
+
+fn ensure_previous_chunk_has_lines(chunks: &[UpdateChunk], index: usize) -> Result<()> {
+    if chunks.last().is_some_and(UpdateChunk::is_empty) {
+        bail!(
+            "invalid update hunk at line {}: change contains no lines",
+            index + 1
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_update(
+    path: &Path,
+    contents: &[u8],
+    chunks: &[UpdateChunk],
+) -> Result<Vec<u8>> {
+    let contents = std::str::from_utf8(contents)
+        .with_context(|| format!("patch target is not valid UTF-8: {}", path.display()))?;
+    let line_ending = if uses_crlf(contents) { "\r\n" } else { "\n" };
+    let normalized = if line_ending == "\r\n" {
+        contents.replace("\r\n", "\n")
+    } else {
+        contents.to_owned()
+    };
+    let mut lines = normalized
+        .split('\n')
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+
+    let mut replacements = Vec::new();
+    let mut cursor = 0;
+    for chunk in chunks {
+        let context_position = match &chunk.context {
+            Some(context) => Some(
+                find_sequence(&lines, std::slice::from_ref(context), cursor, false).ok_or_else(
+                    || anyhow!("failed to find context '{context}' in {}", path.display()),
+                )?,
+            ),
+            None => None,
+        };
+        if let Some(position) = context_position {
+            cursor = position + 1;
+        }
+
+        let (position, old_len, new_lines) = if chunk.old_lines.is_empty() {
+            let position = if chunk.end_of_file || context_position.is_none() {
+                lines.len()
+            } else {
+                cursor
+            };
+            (position, 0, chunk.new_lines.clone())
+        } else {
+            locate_chunk_lines(&lines, chunk, cursor).ok_or_else(|| {
+                anyhow!(
+                    "failed to find expected lines in {}:\n{}",
+                    path.display(),
+                    chunk.old_lines.join("\n")
+                )
+            })?
+        };
+
+        replacements.push((position, old_len, new_lines));
+        cursor = position + old_len;
+    }
+
+    for (position, old_len, new_lines) in replacements.into_iter().rev() {
+        lines.splice(position..position + old_len, new_lines);
+    }
+
+    if lines.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut output = lines.join(line_ending).into_bytes();
+    output.extend_from_slice(line_ending.as_bytes());
+    Ok(output)
+}
+
+fn locate_chunk_lines(
+    lines: &[String],
+    chunk: &UpdateChunk,
+    cursor: usize,
+) -> Option<(usize, usize, Vec<String>)> {
+    if let Some(position) = find_sequence(lines, &chunk.old_lines, cursor, chunk.end_of_file) {
+        return Some((position, chunk.old_lines.len(), chunk.new_lines.clone()));
+    }
+
+    // Trailing empty strings represent the file's final newline, which
+    // is stripped from `lines` above.
+    let old_lines = strip_trailing_empty(&chunk.old_lines)?;
+    let new_lines = strip_trailing_empty(&chunk.new_lines).unwrap_or(&chunk.new_lines);
+    let position = find_sequence(lines, old_lines, cursor, chunk.end_of_file)?;
+    Some((position, old_lines.len(), new_lines.to_vec()))
+}
+
+fn strip_trailing_empty(lines: &[String]) -> Option<&[String]> {
+    match lines.split_last() {
+        Some((last, rest)) if last.is_empty() => Some(rest),
+        _ => None,
+    }
+}
+
+fn uses_crlf(contents: &str) -> bool {
+    let bytes = contents.as_bytes();
+    let mut saw_newline = false;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte != b'\n' {
+            continue;
+        }
+        saw_newline = true;
+        if index == 0 || bytes[index - 1] != b'\r' {
+            return false;
+        }
+    }
+    saw_newline
+}
+
+fn find_sequence(
+    lines: &[String],
+    pattern: &[String],
+    start: usize,
+    end_of_file: bool,
+) -> Option<usize> {
+    if pattern.is_empty() {
+        return Some(start.min(lines.len()));
+    }
+    if pattern.len() > lines.len() || start > lines.len() - pattern.len() {
+        return None;
+    }
+
+    let last = lines.len() - pattern.len();
+    let range = if end_of_file {
+        last..=last
+    } else {
+        start..=last
+    };
+    // Try progressively fuzzier matches so exact context always wins.
+    let comparisons: [fn(&str, &str) -> bool; 3] = [
+        |line, expected| line == expected,
+        |line, expected| line.trim_end() == expected.trim_end(),
+        |line, expected| line.trim() == expected.trim(),
+    ];
+    comparisons.into_iter().find_map(|matches| {
+        range.clone().find(|position| {
+            lines[*position..*position + pattern.len()]
+                .iter()
+                .zip(pattern)
+                .all(|(line, expected)| matches(line, expected))
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_blank_lines_after_end_of_file() {
+        let hunks = parse_apply_patch(
+            "*** Begin Patch\n\
+             *** Update File: file.txt\n\
+             @@\n\
+             +quux\n\
+             *** End of File\n\
+             \n\
+             *** End Patch",
+        )
+        .expect("parse");
+
+        match &hunks[..] {
+            [PatchHunk::Update { chunks, .. }] => {
+                assert_eq!(chunks.len(), 1);
+                assert_eq!(chunks[0].old_lines, Vec::<String>::new());
+                assert_eq!(chunks[0].new_lines, vec!["quux".to_owned()]);
+                assert!(chunks[0].end_of_file);
+            }
+            _ => panic!("expected a single update hunk"),
+        }
+    }
+
+    #[test]
+    fn applies_update_with_trailing_newline_sentinel() {
+        let updated = apply_update(
+            Path::new("file.txt"),
+            b"alpha\nbeta\n",
+            &[UpdateChunk {
+                context: None,
+                old_lines: vec!["beta".to_owned(), String::new()],
+                new_lines: vec!["beta".to_owned(), "gamma".to_owned(), String::new()],
+                end_of_file: true,
+            }],
+        )
+        .expect("apply");
+
+        assert_eq!(updated, b"alpha\nbeta\ngamma\n");
+    }
+
+    #[test]
+    fn deleting_all_content_yields_empty_file() {
+        let updated = apply_update(
+            Path::new("file.txt"),
+            b"only\n",
+            &[UpdateChunk {
+                context: None,
+                old_lines: vec!["only".to_owned()],
+                new_lines: Vec::new(),
+                end_of_file: true,
+            }],
+        )
+        .expect("apply");
+
+        assert_eq!(updated, b"");
+    }
+
+    #[test]
+    fn indented_update_marker_is_not_a_file_header() {
+        // Keep the leading space on the context line; do not use `\` line
+        // continuations here because Rust would eat that indentation.
+        let hunks = parse_apply_patch(
+            "*** Begin Patch\n*** Update File: file.txt\n@@\n-old\n *** Update File: example\n+new\n*** End Patch",
+        )
+        .expect("parse");
+
+        match &hunks[..] {
+            [PatchHunk::Update { chunks, .. }] => {
+                assert_eq!(chunks.len(), 1);
+                assert_eq!(
+                    chunks[0].old_lines,
+                    vec!["old".to_owned(), "*** Update File: example".to_owned()]
+                );
+                assert_eq!(
+                    chunks[0].new_lines,
+                    vec!["*** Update File: example".to_owned(), "new".to_owned()]
+                );
+            }
+            _ => panic!("expected a single update hunk"),
+        }
+    }
+}

--- a/crates/sprocket-workspace/src/apply_patch_format.rs
+++ b/crates/sprocket-workspace/src/apply_patch_format.rs
@@ -7,7 +7,9 @@ const END_PATCH: &str = "*** End Patch";
 const ADD_FILE: &str = "*** Add File: ";
 const DELETE_FILE: &str = "*** Delete File: ";
 const UPDATE_FILE: &str = "*** Update File: ";
+const COPY_FILE: &str = "*** Copy File: ";
 const MOVE_TO: &str = "*** Move to: ";
+const COPY_TO: &str = "*** Copy to: ";
 const END_OF_FILE: &str = "*** End of File";
 const ENVIRONMENT_ID: &str = "*** Environment ID: ";
 
@@ -22,6 +24,11 @@ pub(crate) enum PatchHunk {
     Update {
         path: String,
         move_to: Option<String>,
+        chunks: Vec<UpdateChunk>,
+    },
+    Copy {
+        path: String,
+        copy_to: String,
         chunks: Vec<UpdateChunk>,
     },
 }
@@ -106,7 +113,6 @@ pub(crate) fn parse_apply_patch(patch: &str) -> Result<Vec<PatchHunk>> {
             let path = parse_path(path, index)?;
             index += 1;
             let mut move_to = None;
-            let mut chunks: Vec<UpdateChunk> = Vec::new();
 
             if index < lines.len() - 1 {
                 let line = lines[index].trim();
@@ -116,67 +122,40 @@ pub(crate) fn parse_apply_patch(patch: &str) -> Result<Vec<PatchHunk>> {
                 }
             }
 
-            while index < lines.len() - 1 && !is_file_header(lines[index]) {
-                let line = lines[index];
-                let trimmed_end = line.trim_end();
-                let previous_ended = chunks.last().is_some_and(|chunk| chunk.end_of_file);
-
-                if previous_ended && line.is_empty() {
-                    index += 1;
-                    continue;
-                }
-
-                if trimmed_end == "@@" {
-                    ensure_previous_chunk_has_lines(&chunks, index)?;
-                    chunks.push(UpdateChunk::new(None));
-                } else if let Some(context) = trimmed_end.strip_prefix("@@ ") {
-                    ensure_previous_chunk_has_lines(&chunks, index)?;
-                    chunks.push(UpdateChunk::new(Some(context.to_owned())));
-                } else if trimmed_end == END_OF_FILE {
-                    match chunks.last_mut() {
-                        Some(chunk) if !chunk.is_empty() => chunk.end_of_file = true,
-                        _ => bail!(
-                            "invalid update line {}: '{END_OF_FILE}' must follow a change",
-                            index + 1
-                        ),
-                    }
-                } else if previous_ended {
-                    bail!(
-                        "invalid update line {}: expected '@@' after '{END_OF_FILE}'",
-                        index + 1
-                    );
-                } else {
-                    if chunks.is_empty() {
-                        chunks.push(UpdateChunk::new(None));
-                    }
-                    let chunk = chunks.last_mut().expect("chunk exists");
-                    if let Some(content) = line.strip_prefix(' ') {
-                        chunk.old_lines.push(content.to_owned());
-                        chunk.new_lines.push(content.to_owned());
-                    } else if let Some(content) = line.strip_prefix('+') {
-                        chunk.new_lines.push(content.to_owned());
-                    } else if let Some(content) = line.strip_prefix('-') {
-                        chunk.old_lines.push(content.to_owned());
-                    } else if line.is_empty() {
-                        chunk.old_lines.push(String::new());
-                        chunk.new_lines.push(String::new());
-                    } else {
-                        bail!(
-                            "invalid update line {}: lines must start with ' ', '+', or '-'",
-                            index + 1
-                        );
-                    }
-                }
-                index += 1;
-            }
-
-            ensure_previous_chunk_has_lines(&chunks, index)?;
-            if chunks.is_empty() {
+            let (chunks, next_index) = parse_update_chunks(&lines, index)?;
+            index = next_index;
+            if chunks.is_empty() && move_to.is_none() {
                 bail!("update-file hunk for '{path}' has no changes");
             }
             hunks.push(PatchHunk::Update {
                 path,
                 move_to,
+                chunks,
+            });
+            continue;
+        }
+
+        if let Some(path) = header.strip_prefix(COPY_FILE) {
+            let path = parse_path(path, index)?;
+            index += 1;
+            let copy_to = if index < lines.len() - 1 {
+                let line = lines[index].trim();
+                line.strip_prefix(COPY_TO)
+                    .map(|destination| parse_path(destination, index))
+                    .transpose()?
+            } else {
+                None
+            }
+            .ok_or_else(|| {
+                anyhow!("copy-file hunk for '{path}' must be followed by '{COPY_TO}<destination>'")
+            })?;
+            index += 1;
+
+            let (chunks, next_index) = parse_update_chunks(&lines, index)?;
+            index = next_index;
+            hunks.push(PatchHunk::Copy {
+                path,
+                copy_to,
                 chunks,
             });
             continue;
@@ -210,6 +189,68 @@ fn is_file_header(line: &str) -> bool {
         || line.starts_with(ADD_FILE)
         || line.starts_with(DELETE_FILE)
         || line.starts_with(UPDATE_FILE)
+        || line.starts_with(COPY_FILE)
+}
+
+fn parse_update_chunks(lines: &[&str], mut index: usize) -> Result<(Vec<UpdateChunk>, usize)> {
+    let mut chunks: Vec<UpdateChunk> = Vec::new();
+
+    while index < lines.len() - 1 && !is_file_header(lines[index]) {
+        let line = lines[index];
+        let trimmed_end = line.trim_end();
+        let previous_ended = chunks.last().is_some_and(|chunk| chunk.end_of_file);
+
+        if previous_ended && line.is_empty() {
+            index += 1;
+            continue;
+        }
+
+        if trimmed_end == "@@" {
+            ensure_previous_chunk_has_lines(&chunks, index)?;
+            chunks.push(UpdateChunk::new(None));
+        } else if let Some(context) = trimmed_end.strip_prefix("@@ ") {
+            ensure_previous_chunk_has_lines(&chunks, index)?;
+            chunks.push(UpdateChunk::new(Some(context.to_owned())));
+        } else if trimmed_end == END_OF_FILE {
+            match chunks.last_mut() {
+                Some(chunk) if !chunk.is_empty() => chunk.end_of_file = true,
+                _ => bail!(
+                    "invalid update line {}: '{END_OF_FILE}' must follow a change",
+                    index + 1
+                ),
+            }
+        } else if previous_ended {
+            bail!(
+                "invalid update line {}: expected '@@' after '{END_OF_FILE}'",
+                index + 1
+            );
+        } else {
+            if chunks.is_empty() {
+                chunks.push(UpdateChunk::new(None));
+            }
+            let chunk = chunks.last_mut().expect("chunk exists");
+            if let Some(content) = line.strip_prefix(' ') {
+                chunk.old_lines.push(content.to_owned());
+                chunk.new_lines.push(content.to_owned());
+            } else if let Some(content) = line.strip_prefix('+') {
+                chunk.new_lines.push(content.to_owned());
+            } else if let Some(content) = line.strip_prefix('-') {
+                chunk.old_lines.push(content.to_owned());
+            } else if line.is_empty() {
+                chunk.old_lines.push(String::new());
+                chunk.new_lines.push(String::new());
+            } else {
+                bail!(
+                    "invalid update line {}: lines must start with ' ', '+', or '-'",
+                    index + 1
+                );
+            }
+        }
+        index += 1;
+    }
+
+    ensure_previous_chunk_has_lines(&chunks, index)?;
+    Ok((chunks, index))
 }
 
 fn ensure_previous_chunk_has_lines(chunks: &[UpdateChunk], index: usize) -> Result<()> {
@@ -460,6 +501,42 @@ mod tests {
         .expect("apply");
 
         assert_eq!(updated, b"");
+    }
+
+    #[test]
+    fn parses_copy_and_rename_only() {
+        let hunks = parse_apply_patch(
+            "*** Begin Patch\n\
+             *** Copy File: src.txt\n\
+             *** Copy to: dest.txt\n\
+             *** Update File: old.txt\n\
+             *** Move to: new.txt\n\
+             *** End Patch",
+        )
+        .expect("parse");
+
+        match &hunks[..] {
+            [
+                PatchHunk::Copy {
+                    path,
+                    copy_to,
+                    chunks,
+                },
+                PatchHunk::Update {
+                    path: update_path,
+                    move_to,
+                    chunks: update_chunks,
+                },
+            ] => {
+                assert_eq!(path, "src.txt");
+                assert_eq!(copy_to, "dest.txt");
+                assert!(chunks.is_empty());
+                assert_eq!(update_path, "old.txt");
+                assert_eq!(move_to.as_deref(), Some("new.txt"));
+                assert!(update_chunks.is_empty());
+            }
+            _ => panic!("expected copy and rename-only update"),
+        }
     }
 
     #[test]

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -1,4 +1,5 @@
 mod agents;
+mod apply_patch_format;
 mod browse;
 mod patch;
 mod paths;

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -256,7 +256,7 @@ async fn prepare_changes(
     let (options, default_strip) = if patch.trim_start().starts_with("diff --git ") {
         (ParseOptions::gitdiff(), 1)
     } else {
-        (ParseOptions::unidiff(), 0)
+        (ParseOptions::unidiff(), unidiff_path_strip(patch))
     };
 
     let mut changes = Vec::new();
@@ -419,6 +419,21 @@ async fn prepare_apply_patch_changes(
     }
 
     Ok(changes)
+}
+
+fn unidiff_path_strip(patch: &str) -> usize {
+    // Header-only unified diffs often still use git's a/ and b/ path prefixes.
+    let mut saw_a = false;
+    let mut saw_b = false;
+    for line in patch.lines() {
+        let line = line.trim_start();
+        if line.starts_with("--- a/") || line.starts_with("--- \"a/") {
+            saw_a = true;
+        } else if line.starts_with("+++ b/") || line.starts_with("+++ \"b/") {
+            saw_b = true;
+        }
+    }
+    usize::from(saw_a && saw_b)
 }
 
 fn apply_text_patch(path: &Path, base: &[u8], patch: &PatchKind<'_, str>) -> Result<Vec<u8>> {
@@ -807,6 +822,29 @@ mod tests {
             fs::read_to_string(root.join("file.txt")).unwrap(),
             "after\n"
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn strips_ab_prefixes_from_header_only_unified_diff() {
+        let root = temp_workspace();
+        fs::write(root.join("file.txt"), "before\n").unwrap();
+        let patch = "--- a/file.txt\n\
+            +++ b/file.txt\n\
+            @@ -1 +1 @@\n\
+            -before\n\
+            +after\n";
+
+        apply_workspace_patch(root.clone(), WorkspaceCancellation::new(), patch)
+            .await
+            .expect("a/b unified diff should apply");
+
+        assert_eq!(
+            fs::read_to_string(root.join("file.txt")).unwrap(),
+            "after\n"
+        );
+        assert!(!root.join("a").exists());
+        assert!(!root.join("b").exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -392,8 +392,12 @@ async fn prepare_apply_patch_changes(
             } => {
                 let source = resolve_existing_file(filesystem, root, &path).await?;
                 reserve_path(&mut touched_paths, &source)?;
-                let contents =
-                    apply_update(&source, &read_file(filesystem, &source).await?, &chunks)?;
+                let base = read_file(filesystem, &source).await?;
+                let contents = if chunks.is_empty() {
+                    base
+                } else {
+                    apply_update(&source, &base, &chunks)?
+                };
                 let permissions = file_permissions(filesystem, &source).await?;
 
                 if let Some(destination) = move_to {
@@ -414,6 +418,28 @@ async fn prepare_apply_patch_changes(
                         permissions,
                     });
                 }
+            }
+            PatchHunk::Copy {
+                path,
+                copy_to,
+                chunks,
+            } => {
+                let source = resolve_existing_file(filesystem, root, &path).await?;
+                let destination = resolve_workspace_path(root, &copy_to, true)?;
+                ensure_missing(filesystem, &destination).await?;
+                reserve_path(&mut touched_paths, &destination)?;
+                let base = read_file(filesystem, &source).await?;
+                let contents = if chunks.is_empty() {
+                    base
+                } else {
+                    apply_update(&source, &base, &chunks)?
+                };
+                let permissions = file_permissions(filesystem, &source).await?;
+                changes.push(PreparedChange::Copy {
+                    destination,
+                    contents,
+                    permissions,
+                });
             }
         }
     }
@@ -801,6 +827,42 @@ mod tests {
         );
         assert!(!root.join("source.txt").exists());
         assert!(!root.join("delete.txt").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn copies_and_renames_with_begin_patch() {
+        let root = temp_workspace();
+        fs::write(root.join("src.txt"), "shared\n").unwrap();
+        fs::write(root.join("old.txt"), "keep\n").unwrap();
+        let patch = "*** Begin Patch\n\
+            *** Copy File: src.txt\n\
+            *** Copy to: dest.txt\n\
+            @@\n\
+            -shared\n\
+            +copied\n\
+            *** Update File: old.txt\n\
+            *** Move to: renamed.txt\n\
+            *** End Patch";
+
+        let output = apply_workspace_patch(root.clone(), WorkspaceCancellation::new(), patch)
+            .await
+            .expect("copy/rename envelope should apply");
+
+        assert_eq!(output.changes.len(), 2);
+        assert_eq!(
+            fs::read_to_string(root.join("src.txt")).unwrap(),
+            "shared\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("dest.txt")).unwrap(),
+            "copied\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("renamed.txt")).unwrap(),
+            "keep\n"
+        );
+        assert!(!root.join("old.txt").exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -10,6 +10,9 @@ use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex as AsyncMutex;
 
+use crate::apply_patch_format::{
+    PatchHunk, apply_update, is_apply_patch_format, parse_apply_patch,
+};
 use crate::tools::WorkspaceCancellation;
 use crate::workspace::{relative_to_root, resolve_workspace_path};
 
@@ -246,15 +249,25 @@ async fn prepare_changes(
     root: &Path,
     patch: &str,
 ) -> Result<Vec<PreparedChange>> {
+    if is_apply_patch_format(patch) {
+        return prepare_apply_patch_changes(filesystem, root, patch).await;
+    }
+
+    let (options, default_strip) = if patch.trim_start().starts_with("diff --git ") {
+        (ParseOptions::gitdiff(), 1)
+    } else {
+        (ParseOptions::unidiff(), 0)
+    };
+
     let mut changes = Vec::new();
     let mut touched_paths = BTreeSet::new();
 
-    for parsed in PatchSet::parse(patch, ParseOptions::gitdiff()) {
-        let parsed = parsed.context("failed to parse git-style unified diff")?;
+    for parsed in PatchSet::parse(patch, options) {
+        let parsed = parsed.context("failed to parse unified diff")?;
         let operation = parsed.operation();
         let strip = match operation {
             FileOperation::Rename { .. } | FileOperation::Copy { .. } => 0,
-            _ => 1,
+            _ => default_strip,
         };
 
         match operation.strip_prefix(strip) {
@@ -343,6 +356,64 @@ async fn prepare_changes(
                     contents,
                     permissions,
                 });
+            }
+        }
+    }
+
+    Ok(changes)
+}
+
+async fn prepare_apply_patch_changes(
+    filesystem: &PatchFilesystem,
+    root: &Path,
+    patch: &str,
+) -> Result<Vec<PreparedChange>> {
+    let hunks = parse_apply_patch(patch).context("failed to parse apply_patch input")?;
+    let mut changes = Vec::with_capacity(hunks.len());
+    let mut touched_paths = BTreeSet::new();
+
+    for hunk in hunks {
+        match hunk {
+            PatchHunk::Add { path, contents } => {
+                let path = resolve_workspace_path(root, &path, true)?;
+                ensure_missing(filesystem, &path).await?;
+                reserve_path(&mut touched_paths, &path)?;
+                changes.push(PreparedChange::Create { path, contents });
+            }
+            PatchHunk::Delete { path } => {
+                let path = resolve_existing_file(filesystem, root, &path).await?;
+                reserve_path(&mut touched_paths, &path)?;
+                changes.push(PreparedChange::Delete { path });
+            }
+            PatchHunk::Update {
+                path,
+                move_to,
+                chunks,
+            } => {
+                let source = resolve_existing_file(filesystem, root, &path).await?;
+                reserve_path(&mut touched_paths, &source)?;
+                let contents =
+                    apply_update(&source, &read_file(filesystem, &source).await?, &chunks)?;
+                let permissions = file_permissions(filesystem, &source).await?;
+
+                if let Some(destination) = move_to {
+                    let destination = resolve_workspace_path(root, &destination, true)?;
+                    ensure_missing(filesystem, &destination).await?;
+                    reserve_path(&mut touched_paths, &destination)?;
+                    changes.push(PreparedChange::Rename {
+                        source,
+                        destination,
+                        contents,
+                        permissions,
+                    });
+                } else {
+                    changes.push(PreparedChange::Modify {
+                        destination: source.clone(),
+                        source,
+                        contents,
+                        permissions,
+                    });
+                }
             }
         }
     }
@@ -683,6 +754,61 @@ mod tests {
     use super::{PatchFilesystem, apply_workspace_patch, write_new_file};
     use crate::test_support::temp_workspace;
     use crate::tools::{WorkspaceCancellation, WorkspaceOperationCancelled};
+
+    #[tokio::test]
+    async fn applies_begin_patch_format() {
+        let root = temp_workspace();
+        fs::write(root.join("source.txt"), "before\n").unwrap();
+        fs::write(root.join("delete.txt"), "delete me\n").unwrap();
+        let patch = "*** Begin Patch\n\
+            *** Add File: created.txt\n\
+            +created\n\
+            *** Delete File: delete.txt\n\
+            *** Update File: source.txt\n\
+            *** Move to: moved.txt\n\
+            @@\n\
+            -before\n\
+            +after\n\
+            *** End Patch";
+
+        let output = apply_workspace_patch(root.clone(), WorkspaceCancellation::new(), patch)
+            .await
+            .expect("apply_patch format should apply");
+
+        assert_eq!(output.changes.len(), 3);
+        assert_eq!(
+            fs::read_to_string(root.join("created.txt")).unwrap(),
+            "created\n"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("moved.txt")).unwrap(),
+            "after\n"
+        );
+        assert!(!root.join("source.txt").exists());
+        assert!(!root.join("delete.txt").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn applies_unified_diff_without_git_header() {
+        let root = temp_workspace();
+        fs::write(root.join("file.txt"), "before\n").unwrap();
+        let patch = "--- file.txt\n\
+            +++ file.txt\n\
+            @@ -1 +1 @@\n\
+            -before\n\
+            +after\n";
+
+        apply_workspace_patch(root.clone(), WorkspaceCancellation::new(), patch)
+            .await
+            .expect("unified diff should apply");
+
+        assert_eq!(
+            fs::read_to_string(root.join("file.txt")).unwrap(),
+            "after\n"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
 
     #[tokio::test]
     async fn applies_multi_file_patch() {


### PR DESCRIPTION
## Summary
- Teach `apply_patch` to accept Codex-style `*** Begin Patch` envelopes (add/update/delete/move) in addition to unified and `diff --git` patches
- Keep the existing workspace path validation, snapshot, and rollback path for both formats
- Update the tool description so models know which operations belong to which format

## Test plan
- [x] `cargo test -p sprocket-workspace --lib apply_patch_format`
- [x] `cargo test -p sprocket-workspace --lib patch::`
- [ ] Agent applies a Begin Patch multi-file edit (add/update+move/delete) in a real workspace
- [ ] Agent still applies a plain unified diff and a `diff --git` patch successfully

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Codex-style patch envelopes to workspace edits. The main changes are:

- Parses add, update, delete, move, and copy envelope operations.
- Reuses workspace path validation, snapshots, and rollback handling.
- Preserves existing unified and Git-style patch support.
- Updates agent guidance and tool descriptions for the accepted formats.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The latest changes address newline preservation, empty-file creation, and header-only Git path stripping. No remaining issue met the scope for this follow-up review.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, T-Rex seeded source.txt and obsolete.txt and confirmed that the destinations were absent.
- After capture, T-Rex recorded the exact patch input, serialized workspace output, and filesystem state, noting that the created and moved files had the expected contents while the source and delete targets remained absent.
- Artifact verification confirmed that the preserved harness exactly matches the compiled and executed test source by SHA-256.

<a href="https://app.greptile.com/trex/runs/14896783/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-workspace/src/apply_patch_format.rs | Adds envelope parsing and text-update handling, including the latest newline and empty-file fixes. |
| crates/sprocket-workspace/src/patch.rs | Routes envelope operations through the existing validated and reversible workspace change flow. |
| crates/sprocket-agent/src/tools.rs | Documents the expanded set of accepted patch formats. |

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(agent): Shorten apply\_patch too..."](https://github.com/spikonado/sprocket/commit/e783ca5b5d46c8856771ef13e904e09326e29e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45200044)</sub>

<!-- /greptile_comment -->