### PR TITLE
feat(agent): Change how rate limits for web tools work

### DIFF
--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -1,14 +1,25 @@
 import {
+	DAY,
 	HOUR,
+	MINUTE,
 	RateLimiter,
+	SECOND,
+	WEEK,
 	isRateLimitError,
-	type RateLimitConfig
+	type RateLimitConfig,
+	type RunMutationCtx
 } from '@convex-dev/rate-limiter';
-import { components } from '@convex/_generated/api';
-import type { ActionCtx } from '@convex/_generated/server';
+import { components, internal } from '@convex/_generated/api';
+import { internalMutation, type ActionCtx } from '@convex/_generated/server';
+import { v } from 'convex/values';
+
+const MONTH = 30 * DAY;
 
 const hourlyModelCompletionLimit = 300;
-const hourlyWebToolLimit = 600;
+const weeklyUrlScrapeLimit = 100;
+const monthlyUrlScrapeLimit = 280;
+const weeklyWebSearchLimit = 25;
+const monthlyWebSearchLimit = 60;
 
 const rateLimitConfigs = {
 	modelCompletion: {
@@ -16,22 +27,57 @@ const rateLimitConfigs = {
 		period: HOUR,
 		rate: hourlyModelCompletionLimit
 	},
-	webTool: {
+	urlScrapeWeekly: {
 		kind: 'fixed window',
-		period: HOUR,
-		rate: hourlyWebToolLimit
+		period: WEEK,
+		rate: weeklyUrlScrapeLimit
+	},
+	urlScrapeMonthly: {
+		kind: 'fixed window',
+		period: MONTH,
+		rate: monthlyUrlScrapeLimit
+	},
+	webSearchWeekly: {
+		kind: 'fixed window',
+		period: WEEK,
+		rate: weeklyWebSearchLimit
+	},
+	webSearchMonthly: {
+		kind: 'fixed window',
+		period: MONTH,
+		rate: monthlyWebSearchLimit
 	}
 } satisfies Record<string, RateLimitConfig>;
 
 export const rateLimiter = new RateLimiter(components.rateLimiter, rateLimitConfigs);
 
+type RateLimitName = keyof typeof rateLimitConfigs;
+type PairedLimit = { name: RateLimitName; label: string };
+
+const urlScrapeLimits: ReadonlyArray<PairedLimit> = [
+	{ name: 'urlScrapeMonthly', label: 'URL scrape monthly limit' },
+	{ name: 'urlScrapeWeekly', label: 'URL scrape weekly limit' }
+];
+
+const webSearchLimits: ReadonlyArray<PairedLimit> = [
+	{ name: 'webSearchMonthly', label: 'Web search monthly limit' },
+	{ name: 'webSearchWeekly', label: 'Web search weekly limit' }
+];
+
 function formatRetryAfter(milliseconds: number): string {
-	const totalSeconds = Math.max(1, Math.ceil(milliseconds / 1000));
-	const hours = Math.floor(totalSeconds / 3600);
-	const minutes = Math.floor((totalSeconds % 3600) / 60);
-	const seconds = totalSeconds % 60;
+	let remaining = Math.max(SECOND, Math.ceil(milliseconds / SECOND) * SECOND);
+	const days = Math.floor(remaining / DAY);
+	remaining %= DAY;
+	const hours = Math.floor(remaining / HOUR);
+	remaining %= HOUR;
+	const minutes = Math.floor(remaining / MINUTE);
+	remaining %= MINUTE;
+	const seconds = remaining / SECOND;
 	const parts: string[] = [];
 
+	if (days > 0) {
+		parts.push(`${days}d`);
+	}
 	if (hours > 0) {
 		parts.push(`${hours}h`);
 	}
@@ -45,9 +91,15 @@ function formatRetryAfter(milliseconds: number): string {
 	return parts.join(' ');
 }
 
+function rateLimitError(label: string, retryAfter: number, cause?: unknown): Error {
+	return new Error(`${label} reached. Try again in ${formatRetryAfter(retryAfter)}.`, {
+		cause
+	});
+}
+
 async function enforceLimit(
-	ctx: ActionCtx,
-	name: keyof typeof rateLimitConfigs,
+	ctx: RunMutationCtx,
+	name: RateLimitName,
 	key: string,
 	label: string
 ): Promise<void> {
@@ -61,16 +113,66 @@ async function enforceLimit(
 			throw error;
 		}
 
-		throw new Error(`${label} reached. Try again in ${formatRetryAfter(error.data.retryAfter)}.`, {
-			cause: error
-		});
+		throw rateLimitError(label, error.data.retryAfter, error);
 	}
 }
+
+/**
+ * Check and consume both windows in one mutation so a denial on either rolls
+ * back the other consume.
+ */
+async function enforcePairedLimits(
+	ctx: RunMutationCtx,
+	limits: ReadonlyArray<PairedLimit>,
+	key: string
+): Promise<void> {
+	const statuses = await Promise.all(
+		limits.map(async ({ name, label }) => {
+			const status = await rateLimiter.check(ctx, name, { key });
+			return { label, status };
+		})
+	);
+
+	let blocked: { label: string; retryAfter: number } | undefined;
+	for (const { label, status } of statuses) {
+		if (!status.ok) {
+			if (blocked === undefined || status.retryAfter > blocked.retryAfter) {
+				blocked = { label, retryAfter: status.retryAfter };
+			}
+		}
+	}
+
+	if (blocked !== undefined) {
+		throw rateLimitError(blocked.label, blocked.retryAfter);
+	}
+
+	for (const { name, label } of limits) {
+		await enforceLimit(ctx, name, key, label);
+	}
+}
+
+export const consumeUrlScrapeLimits = internalMutation({
+	args: { userId: v.string() },
+	handler: async (ctx, args) => {
+		await enforcePairedLimits(ctx, urlScrapeLimits, args.userId);
+	}
+});
+
+export const consumeWebSearchLimits = internalMutation({
+	args: { userId: v.string() },
+	handler: async (ctx, args) => {
+		await enforcePairedLimits(ctx, webSearchLimits, args.userId);
+	}
+});
 
 export async function enforceModelCompletionLimit(ctx: ActionCtx, userId: string): Promise<void> {
 	await enforceLimit(ctx, 'modelCompletion', userId, 'Model completion limit');
 }
 
-export async function enforceWebToolLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await enforceLimit(ctx, 'webTool', userId, 'Web tool limit');
+export async function enforceUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.consumeUrlScrapeLimits, { userId });
+}
+
+export async function enforceWebSearchLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.consumeWebSearchLimits, { userId });
 }

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -6,7 +6,7 @@ import { ExaClient } from '@exalabs/convex-exa';
 import { action } from '@convex/_generated/server';
 import { components } from '@convex/_generated/api';
 import { getUserId } from '@convex/lib/auth';
-import { enforceWebToolLimit } from '@convex/lib/rateLimits';
+import { enforceUrlScrapeLimit, enforceWebSearchLimit } from '@convex/lib/rateLimits';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
 
 const contextDev = new ContextDev(components.contextDev);
@@ -69,7 +69,6 @@ export const scrapeUrl = action({
 	},
 	handler: async (ctx, args): Promise<ScrapeUrlResult> => {
 		const userId: string = await getUserId(ctx);
-		await enforceWebToolLimit(ctx, userId);
 		let url: URL;
 		try {
 			url = new URL(args.url.trim());
@@ -79,6 +78,7 @@ export const scrapeUrl = action({
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			throw new Error('Only http(s) URLs can be scraped.');
 		}
+		await enforceUrlScrapeLimit(ctx, userId);
 
 		const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
 			contextDev.scrapeMarkdown(ctx, {
@@ -108,7 +108,6 @@ export const webSearch = action({
 	},
 	handler: async (ctx, args): Promise<WebSearchResult> => {
 		const userId: string = await getUserId(ctx);
-		await enforceWebToolLimit(ctx, userId);
 		const query = args.query.trim();
 		if (!query) {
 			throw new Error('Search query cannot be empty.');
@@ -117,6 +116,7 @@ export const webSearch = action({
 			? Math.floor(args.numResults as number)
 			: DEFAULT_SEARCH_RESULTS;
 		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
+		await enforceWebSearchLimit(ctx, userId);
 
 		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
 			exa.search(ctx, {


### PR DESCRIPTION
## Summary
- Replace the shared hourly web-tool quota with separate per-user scrape and search limits
- URL scrape: 100/week and 280/month; web search: 25/week and 60/month (30-day monthly windows)
- Enforce each pair in one internal mutation so weekly/monthly consumes stay transactional

## Test plan
- [ ] Hit scrape and search tools and confirm they count against separate quotas
- [ ] Exhaust weekly scrape limit and confirm search still works (and vice versa)
- [ ] Exhaust monthly limit while weekly remains and confirm the monthly error/retry message
- [ ] Confirm invalid scrape URLs / empty search queries fail before consuming quota

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gives URL scraping and web search separate per-user quotas. The main changes are:

- Adds weekly and 30-day limits for each web tool.
- Checks and consumes paired limits in one internal mutation.
- Validates tool input before consuming quota.
- Adds day-aware retry messages.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The paired limits run in one mutation, preserving atomic rollback.
- Input validation occurs before quota consumption.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed a preflight check of the Convex quota workflow and observed the live invocation failed because No CONVEX\_DEPLOYMENT was not set.
- Ran the quota tests and observed the progression: after 100 successful scrapes, the 101st attempt was blocked by the weekly limit while valid inputs continued to be accepted and invalid inputs produced no mutations.
- Validated Convex TypeScript types and confirmed the typecheck passed.

<a href="https://app.greptile.com/trex/runs/14932671/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/rateLimits.ts | Adds separate paired quotas, transactional consumption, and retry formatting for longer windows. |
| apps/web/src/convex/webTools.ts | Applies the new tool-specific quotas after validating scrape URLs and search queries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Split web tool rate limits ..."](https://github.com/spikonado/sprocket/commit/40fd6f4783ba5614f65ff2f7eb19fffedb53070f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45279605)</sub>

<!-- /greptile_comment -->