### PR TITLE
test(web): Add convex-test for agent runtime and executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,8 @@
 
 1. `cargo test`
 2. `bun run test`
-3. `bun convex dev --once in ./apps/web/` -> After every convex-related change
-4. `bun run build`
-5. `prek run -a` -> Always run this for ALL formatting and linting
+3. `bun run build`
+4. `prek run -a` -> Always run this for ALL formatting and linting
 
 Run only the tests relevant to your changes unless instructed otherwise.
 If you are a subagent, don't run any of the above.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
 		"zod": "^3.25.76"
 	},
 	"devDependencies": {
+		"@edge-runtime/vm": "^5.0.0",
 		"@sprocket/eslint-config": "workspace:*",
 		"@sprocket/typescript-config": "workspace:*",
 		"@sveltejs/adapter-static": "^3.0.10",
@@ -40,6 +41,7 @@
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.4",
 		"@types/node": "^26.0.0",
+		"convex-test": "^0.0.54",
 		"eslint": "^10.0.0",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.7",

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('agentRuntime.createRun', () => {
+	it('rejects an empty prompt with no images', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				submissionId: 'sub-empty',
+				threadId,
+				prompt: '   ',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard'
+			})
+		).rejects.toThrow('Message cannot be empty.');
+	});
+
+	it('creates a queued run and is idempotent for the same submission', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, subject } = await seedOwnedThread(t);
+		const args = {
+			submissionId: 'sub-1',
+			threadId,
+			prompt: 'Hello',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+
+		const created = await asUser.mutation(api.agentRuntime.createRun, args);
+		expect(created).toMatchObject({
+			created: true,
+			userId: subject
+		});
+
+		const again = await asUser.mutation(api.agentRuntime.createRun, args);
+		expect(again).toEqual({
+			created: false,
+			runId: created.runId,
+			promptMessageId: created.promptMessageId,
+			userId: subject
+		});
+
+		const run = await t.run(async (ctx) => ctx.db.get(created.runId));
+		expect(run).toMatchObject({
+			status: 'queued',
+			submissionId: 'sub-1',
+			promptMessageId: created.promptMessageId
+		});
+	});
+
+	it('rejects a second run while the thread has an active run', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-active',
+			threadId,
+			prompt: 'First',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				submissionId: 'sub-next',
+				threadId,
+				prompt: 'Second',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard'
+			})
+		).rejects.toThrow('Finish or cancel the active run before sending another message.');
+	});
+
+	it('allows a new run after the previous run reaches a final status', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		const first = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-done',
+			threadId,
+			prompt: 'First',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(first.runId, { status: 'completed', completedAt: Date.now() });
+		});
+
+		const second = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-after',
+			threadId,
+			prompt: 'Second',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		expect(second.created).toBe(true);
+		expect(second.runId).not.toBe(first.runId);
+	});
+});

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { RUN_CLAIM_LEASE_DURATION_MS } from '@convex/lib/runLease';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+async function createQueuedRun(
+	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
+	threadId: Id<'threadRecords'>,
+	submissionId: string
+) {
+	return await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId,
+		threadId,
+		prompt: 'Do the thing',
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard'
+	});
+}
+
+describe('agentRuntime.start', () => {
+	it('claims a queued run and renews the same claim', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-claim');
+
+		const claimed = await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-a',
+			runId
+		});
+		expect(claimed.claimed).toBe(true);
+		expect(claimed.claimExpiresAt).toBeTypeOf('number');
+
+		const run = await t.run(async (ctx) => ctx.db.get(runId));
+		expect(run).toMatchObject({
+			status: 'running',
+			claimId: 'claim-a',
+			claimExpiresAt: claimed.claimExpiresAt
+		});
+
+		const renewed = await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-a',
+			runId
+		});
+		expect(renewed.claimed).toBe(true);
+		expect(renewed.claimExpiresAt).toBeGreaterThanOrEqual(claimed.claimExpiresAt ?? 0);
+		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.completionAttemptSeq)).toBe(0);
+	});
+
+	it('refuses a different claim while the lease is active', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-busy');
+
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId });
+		await expect(
+			asUser.mutation(api.agentRuntime.start, { claimId: 'claim-b', runId })
+		).resolves.toEqual({ claimed: false });
+	});
+
+	it('takes over an expired claim, hides in-flight jobs, and clears partial response', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, workspaceSessionId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-takeover');
+
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId });
+
+		const { responseMessageId, pendingJobId, completedJobId } = await t.run(async (ctx) => {
+			const responseMessageId = await ctx.db.insert('threadMessages', {
+				threadId,
+				runId,
+				userId: 'user_alice',
+				type: 'response',
+				text: 'partial',
+				parts: [{ type: 'text', id: 'text-1', text: 'partial', turnId: 'turn-1' }],
+				streamSequence: 3,
+				streamAttemptId: 'attempt-a'
+			});
+			const pendingJobId = await ctx.db.insert('executorJobs', {
+				workspaceSessionId,
+				threadId,
+				runId,
+				kind: 'exec_command',
+				payload: { cmd: 'sleep 1' },
+				hidden: false,
+				status: 'pending',
+				enqueuedAt: Date.now(),
+				sequence: 0
+			});
+			const completedJobId = await ctx.db.insert('executorJobs', {
+				workspaceSessionId,
+				threadId,
+				runId,
+				kind: 'exec_command',
+				payload: { cmd: 'echo ok' },
+				hidden: false,
+				status: 'completed',
+				enqueuedAt: Date.now(),
+				completedAt: Date.now(),
+				result: {
+					command: 'echo ok',
+					cwd: '/',
+					exitCode: 0,
+					success: true,
+					running: false,
+					timedOut: false,
+					stdout: 'ok',
+					stderr: '',
+					output: 'ok',
+					truncated: false
+				},
+				sequence: 1
+			});
+			await ctx.db.patch(runId, {
+				responseMessageId,
+				activeJobId: pendingJobId,
+				completionAttemptSeq: 4,
+				claimExpiresAt: Date.now() - 1
+			});
+			return { responseMessageId, pendingJobId, completedJobId };
+		});
+
+		const takeover = await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-b',
+			runId
+		});
+		expect(takeover.claimed).toBe(true);
+		expect(takeover.claimExpiresAt).toBeGreaterThan(Date.now());
+
+		const state = await t.run(async (ctx) => {
+			const run = await ctx.db.get(runId);
+			const response = await ctx.db.get(responseMessageId);
+			const pending = await ctx.db.get(pendingJobId);
+			const completed = await ctx.db.get(completedJobId);
+			return { run, response, pending, completed };
+		});
+
+		expect(state.run).toMatchObject({
+			claimId: 'claim-b',
+			status: 'running',
+			completionAttemptSeq: 0
+		});
+		expect(state.run?.activeJobId ?? undefined).toBeUndefined();
+		expect(state.run?.claimExpiresAt).toBe(takeover.claimExpiresAt);
+		expect(state.response).toMatchObject({
+			text: '',
+			parts: [],
+			streamSequence: 0
+		});
+		expect(state.response?.streamAttemptId ?? undefined).toBeUndefined();
+		expect(state.pending).toMatchObject({
+			hidden: true,
+			status: 'cancelled',
+			error: 'The agent worker claim expired.'
+		});
+		expect(state.completed).toMatchObject({
+			hidden: false,
+			status: 'completed'
+		});
+		expect(takeover.claimExpiresAt).toBeLessThanOrEqual(
+			Date.now() + RUN_CLAIM_LEASE_DURATION_MS + 1_000
+		);
+	});
+});

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { initConvexTest, seedOwnedThread, type ConvexTestInstance } from './test.setup';
+
+async function seedRunWithJob(
+	t: ConvexTestInstance,
+	options: {
+		runStatus?: 'queued' | 'running' | 'awaiting_executor' | 'failed' | 'completed';
+		jobStatus?: 'pending' | 'claimed' | 'completed' | 'failed' | 'cancelled';
+		activeJobMatches?: boolean;
+	} = {}
+) {
+	const { asUser, threadId, workspaceSessionId, subject } = await seedOwnedThread(t);
+	const created = await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId: `sub-job-${Math.random()}`,
+		threadId,
+		prompt: 'Use a tool',
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard'
+	});
+
+	const jobId = await t.run(async (ctx) => {
+		const jobId = await ctx.db.insert('executorJobs', {
+			workspaceSessionId,
+			threadId,
+			runId: created.runId,
+			kind: 'exec_command',
+			payload: { cmd: 'echo hi' },
+			hidden: false,
+			status: options.jobStatus ?? 'claimed',
+			enqueuedAt: Date.now(),
+			claimedAt: Date.now(),
+			sequence: 0
+		});
+		const otherJobId = await ctx.db.insert('executorJobs', {
+			workspaceSessionId,
+			threadId,
+			runId: created.runId,
+			kind: 'exec_command',
+			payload: { cmd: 'echo other' },
+			hidden: false,
+			status: 'pending',
+			enqueuedAt: Date.now(),
+			sequence: 1
+		});
+		await ctx.db.patch(created.runId, {
+			status: options.runStatus ?? 'awaiting_executor',
+			activeJobId: options.activeJobMatches === false ? otherJobId : (jobId as Id<'executorJobs'>)
+		});
+		return jobId;
+	});
+
+	return { asUser, subject, runId: created.runId, jobId };
+}
+
+const commandResult = {
+	command: 'echo hi',
+	cwd: '/',
+	exitCode: 0,
+	success: true,
+	running: false,
+	timedOut: false,
+	stdout: 'hi',
+	stderr: '',
+	output: 'hi',
+	truncated: false
+};
+
+describe('executor', () => {
+	it('completes the active job and releases the run back to running', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, jobId } = await seedRunWithJob(t);
+
+		await expect(
+			asUser.mutation(api.executor.complete, { jobId, result: commandResult })
+		).resolves.toBe(true);
+
+		const state = await t.run(async (ctx) => ({
+			job: await ctx.db.get(jobId),
+			run: await ctx.db.get(runId)
+		}));
+		expect(state.job).toMatchObject({
+			status: 'completed',
+			result: commandResult
+		});
+		expect(state.job?.completedAt).toBeTypeOf('number');
+		expect(state.run?.status).toBe('running');
+		expect(state.run?.activeJobId ?? undefined).toBeUndefined();
+	});
+
+	it('is idempotent for an already completed job and ignores terminal runs', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, jobId } = await seedRunWithJob(t, {
+			jobStatus: 'completed',
+			runStatus: 'running'
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(jobId, { result: commandResult, completedAt: 1 });
+		});
+
+		await expect(
+			asUser.mutation(api.executor.complete, { jobId, result: commandResult })
+		).resolves.toBe(true);
+
+		const {
+			asUser: asUser2,
+			runId: terminalRunId,
+			jobId: terminalJobId
+		} = await seedRunWithJob(t, { runStatus: 'completed' });
+		await expect(
+			asUser2.mutation(api.executor.complete, {
+				jobId: terminalJobId,
+				result: commandResult
+			})
+		).resolves.toBe(false);
+		expect(await t.run(async (ctx) => (await ctx.db.get(terminalRunId))?.status)).toBe('completed');
+		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('running');
+	});
+
+	it('fails a job and clears activeJobId only when it matches', async () => {
+		const t = initConvexTest();
+		const matching = await seedRunWithJob(t, { activeJobMatches: true });
+		await expect(
+			matching.asUser.mutation(api.executor.fail, {
+				jobId: matching.jobId,
+				error: 'boom'
+			})
+		).resolves.toBe(true);
+		expect(
+			await t.run(async (ctx) => ({
+				job: await ctx.db.get(matching.jobId),
+				run: await ctx.db.get(matching.runId)
+			}))
+		).toMatchObject({
+			job: { status: 'failed', error: 'boom' },
+			run: { status: 'running' }
+		});
+		expect(
+			(await t.run(async (ctx) => (await ctx.db.get(matching.runId))?.activeJobId)) ?? undefined
+		).toBeUndefined();
+
+		const mismatched = await seedRunWithJob(t, { activeJobMatches: false });
+		const before = await t.run(async (ctx) => ctx.db.get(mismatched.runId));
+		await expect(
+			mismatched.asUser.mutation(api.executor.fail, {
+				jobId: mismatched.jobId,
+				error: 'boom'
+			})
+		).resolves.toBe(true);
+		const after = await t.run(async (ctx) => ctx.db.get(mismatched.runId));
+		expect(after?.status).toBe(before?.status);
+		expect(after?.activeJobId).toBe(before?.activeJobId);
+		expect(await t.run(async (ctx) => (await ctx.db.get(mismatched.jobId))?.status)).toBe('failed');
+	});
+
+	it('does not revive a run that is already final', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, jobId } = await seedRunWithJob(t, { runStatus: 'failed' });
+
+		await expect(
+			asUser.mutation(api.executor.fail, { jobId, error: 'late failure' })
+		).resolves.toBe(true);
+		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('failed');
+		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.activeJobId)).toBeTruthy();
+	});
+});

--- a/apps/web/src/convex/lib/runs.test.ts
+++ b/apps/web/src/convex/lib/runs.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-	assertThreadCanStartRun,
-	cancelExecutorJobsForTerminalRun,
-	executorFailureRunPatch
-} from '@convex/lib/runs';
+import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 
 describe('assertThreadCanStartRun', () => {
 	it('allows a thread with no prior run', () => {
@@ -29,24 +25,7 @@ describe('assertThreadCanStartRun', () => {
 	});
 });
 
-describe('executor run state', () => {
-	it('releases the active run after a recoverable tool failure', () => {
-		expect(
-			executorFailureRunPatch({
-				runStatus: 'awaiting_executor',
-				activeJobId: 'job-1',
-				failedJobId: 'job-1'
-			})
-		).toEqual({ status: 'running', activeJobId: undefined });
-		expect(
-			executorFailureRunPatch({
-				runStatus: 'failed',
-				activeJobId: 'job-1',
-				failedJobId: 'job-1'
-			})
-		).toBeUndefined();
-	});
-
+describe('cancelExecutorJobsForTerminalRun', () => {
 	it('cancels every live sibling while preserving terminal jobs', () => {
 		const completedAt = 42;
 		const jobs = cancelExecutorJobsForTerminalRun({

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -1,0 +1,70 @@
+/// <reference types="vite/client" />
+
+import contextDevTest from '@context-dot-dev/convex/test';
+import rateLimiterTest from '@convex-dev/rate-limiter/test';
+import exaTest from '@exalabs/convex-exa/test';
+import { convexTest, type TestConvex } from 'convex-test';
+import type { GenericSchema, SchemaDefinition } from 'convex/server';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import schema from './schema';
+
+/**
+ * Convex function modules for `convex-test`.
+ * `_generated` must be included; tests/configs/declarations stay out.
+ */
+export const modules = import.meta.glob([
+	'./**/*.ts',
+	'./**/*.js',
+	'!./**/*.test.ts',
+	'!./**/*.config.ts',
+	'!./**/*.d.ts',
+	'!./**/test.setup.ts'
+]);
+
+export type ConvexTestInstance = TestConvex<SchemaDefinition<GenericSchema, boolean>>;
+
+type AuthenticatedTest = ReturnType<ConvexTestInstance['withIdentity']>;
+
+/** Fresh mock backend with our schema, functions, and registered components. */
+export function initConvexTest(): ConvexTestInstance {
+	const t = convexTest(schema, modules);
+	// Component `/test` helpers disagree on `registerComponent` parameter variance.
+	const backend = t as never;
+	rateLimiterTest.register(backend);
+	contextDevTest.register(backend);
+	exaTest.register(backend);
+	return t;
+}
+
+export async function seedOwnedThread(
+	t: ConvexTestInstance,
+	subject = 'user_alice'
+): Promise<{
+	asUser: AuthenticatedTest;
+	subject: string;
+	workspaceSessionId: Id<'workspaceSessions'>;
+	threadId: Id<'threadRecords'>;
+}> {
+	const asUser = t.withIdentity({ subject });
+	const workspaceSession = await asUser.mutation(api.workspaceSessions.upsertSelected, {
+		workspaceName: 'alpha',
+		connectedClientId: 'client-1'
+	});
+	if (!workspaceSession) {
+		throw new Error('Expected workspace session');
+	}
+	const created = await asUser.mutation(api.threads.create, {
+		submissionId: `thread-${subject}-${Date.now()}-${Math.random()}`,
+		workspaceSessionId: workspaceSession._id,
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard'
+	});
+	return {
+		asUser,
+		subject,
+		workspaceSessionId: workspaceSession._id,
+		threadId: created.threadId
+	};
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { DEV_API_URL, WEB_DEV_PORT } from '../desktop/local-config.mjs';
 
 export default defineConfig({
@@ -21,5 +21,32 @@ export default defineConfig({
 			}
 		}
 	},
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [tailwindcss(), sveltekit()],
+	test: {
+		// Component `/test` entrypoints use `import.meta.glob`; Vite must transform them.
+		server: {
+			deps: {
+				inline: ['@context-dot-dev/convex', '@convex-dev/rate-limiter', '@exalabs/convex-exa']
+			}
+		},
+		projects: [
+			{
+				extends: true,
+				test: {
+					name: 'convex',
+					include: ['src/convex/**/*.test.{ts,js}'],
+					environment: 'edge-runtime'
+				}
+			},
+			{
+				extends: true,
+				test: {
+					name: 'frontend',
+					include: ['src/**/*.test.{ts,js}'],
+					exclude: ['src/convex/**'],
+					environment: 'node'
+				}
+			}
+		]
+	}
 });

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "zod": "^3.25.76",
       },
       "devDependencies": {
+        "@edge-runtime/vm": "^5.0.0",
         "@sprocket/eslint-config": "workspace:*",
         "@sprocket/typescript-config": "workspace:*",
         "@sveltejs/adapter-static": "^3.0.10",
@@ -51,6 +52,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.2.4",
         "@types/node": "^26.0.0",
+        "convex-test": "^0.0.54",
         "eslint": "^10.0.0",
         "svelte": "^5.55.5",
         "svelte-check": "^4.4.7",
@@ -135,6 +137,10 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@edge-runtime/primitives": ["@edge-runtime/primitives@6.0.0", "", {}, "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA=="],
+
+    "@edge-runtime/vm": ["@edge-runtime/vm@5.0.0", "", { "dependencies": { "@edge-runtime/primitives": "6.0.0" } }, "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w=="],
 
     "@electron-internal/extract-zip": ["@electron-internal/extract-zip@1.0.4", "", {}, "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg=="],
 
@@ -661,6 +667,8 @@
     "convex": ["convex@1.42.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug=="],
 
     "convex-svelte": ["convex-svelte@0.14.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": "^1.30.0", "svelte": "^5.19.0" } }, "sha512-eCaId++XnczQvEGc0sQi30BHkSEQ5AZjdDWaAqSlva2h9zKezGz8enp6MdFN7MIIMIlYZF3dKdzQ/LQ0d59KhQ=="],
+
+    "convex-test": ["convex-test@0.0.54", "", { "peerDependencies": { "convex": "^1.32.0" } }, "sha512-C0v2SQcuxrELAJRNzE6fQ686XDPor7UFoC22jcoJXeCRqhLo8ZIMZ4jyUHoo1UdAL2enCb0AbiprCVpLDN8u9Q=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 


### PR DESCRIPTION
## Summary
- Wire `convex-test` + Vitest edge-runtime so Convex function tests run in CI without a live backend
- Add coverage for `agentRuntime.createRun`, `agentRuntime.start` (claim/takeover), and `executor.complete`/`fail`
- Drop redundant `executorFailureRunPatch` unit cases and remove the `bun convex dev --once` testing step from AGENTS.md

## Test plan
- [x] `bun run test` in `apps/web` (includes new convex-test suites)
- [x] `bun run lint` / `bun run check`
- [ ] CI Build and Test workflow passes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds isolated Convex function tests to the web app. The main changes are:

- Adds `convex-test` with Vitest's edge runtime.
- Covers run creation, claim takeover, and executor state transitions.
- Splits Convex and frontend tests into separate Vitest projects.
- Removes redundant helper tests and the live-backend test instruction.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code. The new tests use isolated backends and consistent authenticated ownership. The integration tests retain the meaningful executor state coverage removed from the helper tests.

No files require additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the web app tests with bun run test and Vitest exited with code 0.
- Reran the tests with bun run test -- --reporter=verbose to capture test-level evidence, and it exited 0 in 4.45 seconds.
- The test output identified the requested tests under the convex project.
- No bun convex dev backend was started or required during the runs.
- Only the anticipated non-fatal sourcemap warnings for @exalabs/convex-exa appeared.

<a href="https://app.greptile.com/trex/runs/14933052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/vite.config.ts | Adds separate edge-runtime and Node Vitest projects while retaining the existing Vite configuration. |
| apps/web/src/convex/test.setup.ts | Adds an isolated Convex test backend with component registration and authenticated fixture setup. |
| apps/web/src/convex/agentRuntime.createRun.test.ts | Tests validation, idempotency, active-run exclusion, and creation after a final run. |
| apps/web/src/convex/agentRuntime.start.test.ts | Tests run claims, renewal, active-lease rejection, and expired-claim cleanup. |
| apps/web/src/convex/executor.test.ts | Tests executor completion, failure, idempotency, and terminal-run preservation. |
| apps/web/src/convex/lib/runs.test.ts | Removes helper-level cases now covered through executor mutation tests. |
| apps/web/package.json | Adds compatible development dependencies for Convex testing in the edge runtime. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): Add convex-test for agent run..."](https://github.com/spikonado/sprocket/commit/d596a7ad2cd78e7887cc65dd5c59e62234e0edad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45280416)</sub>

<!-- /greptile_comment -->