### PR TITLE
fix(models): Configure prompt caching across providers

### DIFF
--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -424,6 +424,7 @@ export const completionActor = query({
 		args
 	): Promise<{
 		userId: string;
+		threadId: Id<'threadRecords'>;
 		status: Infer<typeof vRunStatus>;
 		claimId?: string;
 		completionAttemptSeq: number;
@@ -437,6 +438,7 @@ export const completionActor = query({
 			: null;
 		return {
 			userId,
+			threadId: run.threadId,
 			status: run.status,
 			...(run.claimId ? { claimId: run.claimId } : {}),
 			completionAttemptSeq: run.completionAttemptSeq ?? 0,

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -116,7 +116,16 @@ export const complete = action({
 		const toolChoice: ToolChoice | undefined = args.toolChoiceJson
 			? parseJson<ToolChoice>(args.toolChoiceJson, 'toolChoiceJson')
 			: undefined;
-		const sharedArgs = buildSharedCompletionRequest({ ...args, modelId }, tools, toolChoice);
+		if (args.prompt === undefined && messages === undefined) {
+			throw new Error('Either prompt or messagesJson is required.');
+		}
+		const completionContext = await prepareCompletionContext(ctx, args.streamRunId);
+		const sharedArgs = buildSharedCompletionRequest(
+			{ ...args, modelId },
+			tools,
+			toolChoice,
+			completionContext.promptCacheKey
+		);
 		let request: CompletionRequest;
 		if (args.prompt !== undefined) {
 			request = buildCompletionRequest(sharedArgs, args.prompt, undefined);
@@ -126,7 +135,6 @@ export const complete = action({
 			throw new Error('Either prompt or messagesJson is required.');
 		}
 
-		const streamSequence = await enforceCompletionLimit(ctx, args.streamRunId);
 		const abortController = new AbortController();
 		let result: CompletionActionResult;
 		try {
@@ -138,7 +146,7 @@ export const complete = action({
 					claimId: args.claimId,
 					attemptSeq: args.attemptSeq,
 					streamId: args.streamId,
-					initialSequence: streamSequence
+					initialSequence: completionContext.streamSequence
 				},
 				abortController
 			);
@@ -510,13 +518,19 @@ function delay(milliseconds: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function enforceCompletionLimit(ctx: ActionCtx, runId: Id<'runs'>): Promise<number> {
+async function prepareCompletionContext(
+	ctx: ActionCtx,
+	runId: Id<'runs'>
+): Promise<{ promptCacheKey: string; streamSequence: number }> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
 		runId
 	});
 	assertRunAcceptsModelCompletion(actor.status);
 	await enforceModelCompletionLimit(ctx, actor.userId);
-	return actor.streamSequence;
+	return {
+		promptCacheKey: `thread:${actor.threadId}`,
+		streamSequence: actor.streamSequence
+	};
 }
 
 function buildSharedCompletionRequest(
@@ -528,19 +542,21 @@ function buildSharedCompletionRequest(
 		tools?: Array<{ name: string }>;
 	},
 	tools: Record<string, ReturnType<typeof tool>>,
-	toolChoice: ToolChoice | undefined
+	toolChoice: ToolChoice | undefined,
+	promptCacheKey: string
 ): SharedCompletionRequest {
 	const serviceTier = args.serviceTier ?? defaultServiceTier;
 	return {
-		model: resolveLanguageModel(args.modelId, serviceTier),
+		model: resolveLanguageModel(args.modelId, serviceTier, promptCacheKey),
 		...(args.instructions !== undefined ? { instructions: args.instructions } : {}),
 		...(args.tools?.length ? { tools } : {}),
 		...(toolChoice !== undefined ? { toolChoice } : {}),
-		...(args.reasoningEffort !== undefined || args.serviceTier !== undefined
-			? {
-					providerOptions: resolveProviderOptions(args.modelId, args.reasoningEffort, serviceTier)
-				}
-			: {})
+		providerOptions: resolveProviderOptions(
+			args.modelId,
+			args.reasoningEffort,
+			serviceTier,
+			promptCacheKey
+		)
 	};
 }
 

--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createProviderFetch, resolveProviderOptions } from '@convex/lib/modelRegistry';
+
+describe('model provider request configuration', () => {
+	it('enables provider-native prompt caching controls', () => {
+		expect(resolveProviderOptions('claude-fable-5', undefined, 'standard', 'thread:abc')).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral' } }
+		});
+		expect(resolveProviderOptions('gpt-5.6-sol', 'high', 'fast', 'thread:abc')).toEqual({
+			openai: {
+				reasoningEffort: 'high',
+				serviceTier: 'priority',
+				promptCacheKey: 'thread:abc',
+				promptCacheOptions: { mode: 'implicit', ttl: '30m' }
+			}
+		});
+	});
+
+	it('adds xAI prompt cache routing only to Responses API requests', async () => {
+		const bodies: unknown[] = [];
+		const fetch = createProviderFetch({ promptCacheKey: 'thread:abc' }, async (_input, init) => {
+			bodies.push(JSON.parse(String(init?.body)));
+			return new Response('{}');
+		});
+
+		await fetch('https://api.x.ai/v1/responses', {
+			method: 'POST',
+			body: JSON.stringify({ model: 'grok-4.5' })
+		});
+		await fetch('https://api.anthropic.com/v1/messages', {
+			method: 'POST',
+			body: JSON.stringify({ model: 'claude-fable-5' })
+		});
+
+		expect(bodies).toEqual([
+			{
+				model: 'grok-4.5',
+				prompt_cache_key: 'thread:abc'
+			},
+			{ model: 'claude-fable-5' }
+		]);
+	});
+});

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -9,13 +9,20 @@ import {
 	type SupportedReasoningEffort,
 	type SupportedServiceTier
 } from '@convex/lib/models';
-import type { LanguageModel } from 'ai';
+import type { JSONValue, LanguageModel } from 'ai';
 
 type ProviderFetch = NonNullable<NonNullable<Parameters<typeof createAnthropic>[0]>['fetch']>;
+type ProviderFetchInput = Parameters<ProviderFetch>[0];
+type ProviderRequestOptions = {
+	serviceTier?: 'auto' | 'priority' | 'standard_only';
+	promptCacheKey?: string;
+};
 
-function supportsServiceTier(input: Parameters<ProviderFetch>[0]): boolean {
-	const url = input instanceof Request ? input.url : input.toString();
-	const pathname = new URL(url).pathname;
+function providerPathname(input: ProviderFetchInput): string {
+	return new URL(input instanceof Request ? input.url : input.toString()).pathname;
+}
+
+function supportsProviderRequestOptions(pathname: string): boolean {
 	return (
 		pathname.endsWith('/messages') ||
 		pathname.endsWith('/responses') ||
@@ -24,24 +31,31 @@ function supportsServiceTier(input: Parameters<ProviderFetch>[0]): boolean {
 }
 
 // The pinned Anthropic and xAI adapters do not expose their service-tier fields yet.
-export function createServiceTierFetch(
-	serviceTier: 'auto' | 'priority' | 'standard_only',
+// The xAI adapter also does not expose the Responses API prompt_cache_key field.
+export function createProviderFetch(
+	options: ProviderRequestOptions,
 	baseFetch: ProviderFetch = globalThis.fetch
 ): ProviderFetch {
 	return (input, init) => {
-		if (!supportsServiceTier(input)) return baseFetch(input, init);
+		const pathname = providerPathname(input);
+		if (!supportsProviderRequestOptions(pathname)) return baseFetch(input, init);
 		if (typeof init?.body !== 'string') {
-			throw new Error('Cannot apply a provider service tier to a request without a JSON body.');
+			throw new Error('Cannot apply provider request options without a JSON body.');
 		}
 
 		const body: unknown = JSON.parse(init.body);
 		if (body === null || typeof body !== 'object' || Array.isArray(body)) {
-			throw new Error('Cannot apply a provider service tier to a non-object JSON body.');
+			throw new Error('Cannot apply provider request options to a non-object JSON body.');
 		}
-
 		return baseFetch(input, {
 			...init,
-			body: JSON.stringify({ ...body, service_tier: serviceTier })
+			body: JSON.stringify({
+				...body,
+				...(options.serviceTier !== undefined ? { service_tier: options.serviceTier } : {}),
+				...(options.promptCacheKey !== undefined && pathname.endsWith('/responses')
+					? { prompt_cache_key: options.promptCacheKey }
+					: {})
+			})
 		});
 	};
 }
@@ -51,40 +65,49 @@ const openai: OpenAIProvider = createOpenAI({
 });
 const anthropic: AnthropicProvider = createAnthropic({
 	apiKey: process.env.ANTHROPIC_API_KEY,
-	fetch: createServiceTierFetch('standard_only')
+	fetch: createProviderFetch({ serviceTier: 'standard_only' })
 });
 const anthropicFast: AnthropicProvider = createAnthropic({
 	apiKey: process.env.ANTHROPIC_API_KEY,
-	fetch: createServiceTierFetch('auto')
-});
-const xai: XaiProvider = createXai({
-	apiKey: process.env.XAI_API_KEY
-});
-const xaiPriority: XaiProvider = createXai({
-	apiKey: process.env.XAI_API_KEY,
-	fetch: createServiceTierFetch('priority')
+	fetch: createProviderFetch({ serviceTier: 'auto' })
 });
 
 export function resolveLanguageModel(
 	modelId: SupportedModelId,
-	serviceTier: SupportedServiceTier
+	serviceTier: SupportedServiceTier,
+	promptCacheKey: string
 ): LanguageModel {
 	const provider = getModelDefinition(modelId).provider;
 	if (provider === 'anthropic') {
 		return serviceTier === 'fast' ? anthropicFast(modelId) : anthropic(modelId);
 	}
-	if (provider === 'xai') return serviceTier === 'fast' ? xaiPriority(modelId) : xai(modelId);
+	if (provider === 'xai') {
+		const xai: XaiProvider = createXai({
+			apiKey: process.env.XAI_API_KEY,
+			fetch: createProviderFetch({
+				...(serviceTier === 'fast' ? { serviceTier: 'priority' } : {}),
+				promptCacheKey
+			})
+		});
+		return xai(modelId);
+	}
 	return openai(modelId);
 }
 
 export function resolveProviderOptions(
 	modelId: SupportedModelId,
 	reasoningEffort: SupportedReasoningEffort | undefined,
-	serviceTier: SupportedServiceTier
-): Record<string, Record<string, string>> {
+	serviceTier: SupportedServiceTier,
+	promptCacheKey: string
+): Record<string, Record<string, JSONValue>> {
 	const provider = getModelDefinition(modelId).provider;
 	if (provider === 'anthropic') {
-		return { anthropic: { ...(reasoningEffort !== undefined ? { effort: reasoningEffort } : {}) } };
+		return {
+			anthropic: {
+				...(reasoningEffort !== undefined ? { effort: reasoningEffort } : {}),
+				cacheControl: { type: 'ephemeral' }
+			}
+		};
 	}
 	if (provider === 'xai') {
 		return { xai: { ...(reasoningEffort !== undefined ? { reasoningEffort } : {}) } };
@@ -92,7 +115,9 @@ export function resolveProviderOptions(
 	return {
 		openai: {
 			...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
-			serviceTier: serviceTier === 'fast' ? 'priority' : 'default'
+			serviceTier: serviceTier === 'fast' ? 'priority' : 'default',
+			promptCacheKey,
+			promptCacheOptions: { mode: 'implicit', ttl: '30m' }
 		}
 	};
 }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -236,6 +236,8 @@ pub struct Usage {
 pub struct InputTokenDetails {
     #[serde(default, deserialize_with = "deserialize_convex_u64")]
     pub cache_read_tokens: u64,
+    #[serde(default, deserialize_with = "deserialize_convex_u64")]
+    pub cache_write_tokens: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -252,7 +254,7 @@ impl GetTokenUsage for CompletionOutput {
             output_tokens: self.usage.output_tokens,
             total_tokens: self.usage.total_tokens,
             cached_input_tokens: self.usage.input_token_details.cache_read_tokens,
-            cache_creation_input_tokens: 0,
+            cache_creation_input_tokens: self.usage.input_token_details.cache_write_tokens,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: self.usage.output_token_details.reasoning_tokens,
         }
@@ -728,11 +730,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        COMPLETION_STREAM_SUPERSEDED, CompletionOutput, CompletionStreamEvent, ToolCall, Usage,
-        clone_locked, completion_choice, is_completion_stream_superseded, reasoning_stream_choices,
-        text_stream_choices,
+        COMPLETION_STREAM_SUPERSEDED, CompletionOutput, CompletionStreamEvent, InputTokenDetails,
+        ToolCall, Usage, clone_locked, completion_choice, is_completion_stream_superseded,
+        reasoning_stream_choices, text_stream_choices,
     };
-    use rig::completion::CompletionError;
+    use rig::completion::{CompletionError, GetTokenUsage};
     use rig::message::AssistantContent;
     use rig::streaming::RawStreamingChoice;
     use std::sync::Arc;
@@ -873,6 +875,27 @@ mod tests {
         };
         assert_eq!(tool_call.id, "call_123");
         assert_eq!(tool_call.call_id.as_deref(), Some("call_123"));
+    }
+
+    #[test]
+    fn preserves_provider_cache_usage() {
+        let output = CompletionOutput {
+            text: String::new(),
+            usage: Usage {
+                input_token_details: InputTokenDetails {
+                    cache_read_tokens: 120,
+                    cache_write_tokens: 80,
+                },
+                ..Usage::default()
+            },
+            message_id: None,
+            tool_calls: Vec::new(),
+            stream_events: Vec::new(),
+        };
+
+        let usage = output.token_usage();
+        assert_eq!(usage.cached_input_tokens, 120);
+        assert_eq!(usage.cache_creation_input_tokens, 80);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- enable Anthropic automatic prompt caching on every completion
- use a stable, server-derived thread cache key for OpenAI and xAI requests
- preserve provider cache-write usage when translating AI SDK usage into Rig usage
- add focused coverage for provider cache request shaping and usage accounting

## Why

The completion path only forwarded reasoning and service-tier options. Anthropic caching was therefore disabled, while OpenAI and xAI relied on best-effort automatic routing without a stable conversation key. Cache-write tokens were also dropped at the TypeScript-to-Rust boundary, preventing accurate cache usage reporting.

Using the owned thread ID keeps retries and subsequent turns on the same cache identity without accepting a caller-controlled key. This reduces repeated prompt processing while preserving cache misses as a safe fallback.

## Validation

- `cargo test -p sprocket-convex-provider`
- `bun run test` in `apps/web` — 131 tests
- `bun convex dev --once` in `apps/web`
- `bun run build`
- `prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds provider-specific prompt caching and preserves cache-write usage. The main changes are:

- Derive a stable cache key from the owned thread ID.
- Configure caching for Anthropic, OpenAI, and xAI requests.
- Forward cache-write token counts into Rig usage.
- Add focused request-shaping and accounting tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks mergeable with a small xAI routing limitation.

Anthropic and OpenAI cache settings follow the intended provider-specific paths. Thread-derived keys remain scoped to the owned conversation.

xAI chat-completion requests do not receive the new cache key.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general-contract-validation-proof using the full suite log to validate contract behavior.
- Executed a focused before/after proof with the focused-before and focused-after logs to pinpoint changes in convex cache usage.
- Documented the intentional exclusion of the known xAI chat-completions cache-key issue from this proof set.

<a href="https://app.greptile.com/trex/runs/14943993/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Returns the run's thread ID so completion requests can use a server-derived cache identity. |
| apps/web/src/convex/completion.ts | Builds completion context with the thread cache key and forwards it into model and provider configuration. |
| apps/web/src/convex/lib/modelRegistry.ts | Adds provider cache controls, but xAI cache-key injection is limited to Responses API paths. |
| apps/web/src/convex/lib/modelRegistry.test.ts | Covers provider option shapes and endpoint-specific xAI request rewriting. |
| crates/sprocket-convex-provider/src/client.rs | Deserializes cache-write tokens and maps them into Rig's cache-creation usage field. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[Completion action] --> B[Load thread ID]
B --> C[Build stable cache key]
C --> D{Provider}
D -->|Anthropic| E[Ephemeral cache control]
D -->|OpenAI| F[Provider cache options]
D -->|xAI Responses API| G[Inject prompt_cache_key]
E --> H[Completion response]
F --> H
G --> H
H --> I[Map cache read and write usage into Rig]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
A[Completion action] --> B[Load thread ID]
B --> C[Build stable cache key]
C --> D{Provider}
D -->|Anthropic| E[Ephemeral cache control]
D -->|OpenAI| F[Provider cache options]
D -->|xAI Responses API| G[Inject prompt_cache_key]
E --> H[Completion response]
F --> H
G --> H
H --> I[Map cache read and write usage into Rig]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A54-56%0A**Cache%20Key%20Skips%20Chat%20Completions**%0A%0AWhen%20%60xai%28modelId%29%60%20sends%20a%20request%20through%20%60%2Fchat%2Fcompletions%60%2C%20this%20condition%20omits%20%60prompt_cache_key%60%3B%20only%20%60%2Fresponses%60%20receives%20it.%20Those%20xAI%20completions%20therefore%20continue%20without%20the%20stable%20thread%20cache%20identity%20this%20change%20is%20intended%20to%20provide.%0A%0A&pr=69&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A54-56%0A**Cache%20Key%20Skips%20Chat%20Completions**%0A%0AWhen%20%60xai%28modelId%29%60%20sends%20a%20request%20through%20%60%2Fchat%2Fcompletions%60%2C%20this%20condition%20omits%20%60prompt_cache_key%60%3B%20only%20%60%2Fresponses%60%20receives%20it.%20Those%20xAI%20completions%20therefore%20continue%20without%20the%20stable%20thread%20cache%20identity%20this%20change%20is%20intended%20to%20provide.%0A%0A&repo=spikonado%2Fsprocket&pr=69&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fmodel-token-caching%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmodel-token-caching%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A54-56%0A**Cache%20Key%20Skips%20Chat%20Completions**%0A%0AWhen%20%60xai%28modelId%29%60%20sends%20a%20request%20through%20%60%2Fchat%2Fcompletions%60%2C%20this%20condition%20omits%20%60prompt_cache_key%60%3B%20only%20%60%2Fresponses%60%20receives%20it.%20Those%20xAI%20completions%20therefore%20continue%20without%20the%20stable%20thread%20cache%20identity%20this%20change%20is%20intended%20to%20provide.%0A%0A&repo=spikonado%2Fsprocket&pr=69&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fmodel-token-caching%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmodel-token-caching%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fconvex%2Flib%2FmodelRegistry.ts%3A54-56%0A**Cache%20Key%20Skips%20Chat%20Completions**%0A%0AWhen%20%60xai%28modelId%29%60%20sends%20a%20request%20through%20%60%2Fchat%2Fcompletions%60%2C%20this%20condition%20omits%20%60prompt_cache_key%60%3B%20only%20%60%2Fresponses%60%20receives%20it.%20Those%20xAI%20completions%20therefore%20continue%20without%20the%20stable%20thread%20cache%20identity%20this%20change%20is%20intended%20to%20provide.%0A%0A&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/convex/lib/modelRegistry.ts:54-56
**Cache Key Skips Chat Completions**

When `xai(modelId)` sends a request through `/chat/completions`, this condition omits `prompt_cache_key`; only `/responses` receives it. Those xAI completions therefore continue without the stable thread cache identity this change is intended to provide.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): configure prompt caching ac..."](https://github.com/spikonado/sprocket/commit/625030df5545843792471898548f48a39b018086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45306119)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->