### PR TITLE
fix(chat): Show patched file paths and remove dead UI chrome

### DIFF
--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowUp, ChevronDown, Cpu, ImagePlus, LockOpen, Square, X } from '@lucide/svelte';
+	import { ArrowUp, ImagePlus, Square, X } from '@lucide/svelte';
 	import OptionSelector from '$lib/components/option-selector.svelte';
 	import ProviderLogo from '$lib/components/provider-logo.svelte';
 	import ReasoningServiceSelector from '$lib/components/reasoning-service-selector.svelte';
@@ -296,27 +296,6 @@
 								disabled={isRunning}
 								className="z-20 shrink-0"
 							/>
-
-							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>
-
-							<button
-								type="button"
-								class="flex h-9 shrink-0 items-center gap-1.5 px-2 text-[15px] whitespace-nowrap text-slate-300 transition hover:text-slate-200"
-							>
-								<Cpu class="size-4 text-slate-400" />
-								<span>Build</span>
-							</button>
-
-							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>
-
-							<button
-								type="button"
-								class="flex h-9 shrink-0 items-center gap-1.5 px-2 text-[15px] whitespace-nowrap text-slate-300 transition hover:text-slate-200"
-							>
-								<LockOpen class="size-4 text-slate-400" />
-								<span>Full access</span>
-								<ChevronDown class="size-3 text-slate-500" />
-							</button>
 						</div>
 
 						<div class="flex shrink-0 flex-nowrap items-center justify-end gap-2.5">

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -142,24 +142,52 @@
 		return paths.length === 1 ? paths[0] : `${paths[0]} +${paths.length - 1} more`;
 	}
 
+	const PATCH_ENVELOPE_FILE_HEADERS = [
+		'*** Add File: ',
+		'*** Copy File: ',
+		'*** Delete File: ',
+		'*** Update File: '
+	];
+	const PATCH_ENVELOPE_DESTINATION_HEADERS = ['*** Copy to: ', '*** Move to: '];
+
+	function gitDiffPath(line: string) {
+		const quotedMarker = ' "b/';
+		const marker = line.lastIndexOf(quotedMarker);
+		if (marker >= 0) {
+			return line.slice(marker + quotedMarker.length).replace(/"$/, '');
+		}
+		const plainMarker = ' b/';
+		const plainMarkerIndex = line.lastIndexOf(plainMarker);
+		return plainMarkerIndex >= 0 ? line.slice(plainMarkerIndex + plainMarker.length) : null;
+	}
+
 	function summarizePatchInput(input: JsonValue | undefined) {
 		if (!isJsonObject(input) || typeof input.patch !== 'string') {
 			return null;
 		}
 
-		const paths = input.patch.split('\n').flatMap((line) => {
-			if (!line.startsWith('diff --git ')) {
-				return [];
+		const paths: string[] = [];
+		for (const line of input.patch.split('\n')) {
+			if (line.startsWith('diff --git ')) {
+				const path = gitDiffPath(line);
+				if (path !== null) {
+					paths.push(path);
+				}
+				continue;
 			}
-			const quotedMarker = ' "b/';
-			const plainMarker = ' b/';
-			const marker = line.lastIndexOf(quotedMarker);
-			if (marker >= 0) {
-				return [line.slice(marker + quotedMarker.length).replace(/"$/, '')];
+			const fileHeader = PATCH_ENVELOPE_FILE_HEADERS.find((header) => line.startsWith(header));
+			if (fileHeader) {
+				paths.push(line.slice(fileHeader.length).trim());
+				continue;
 			}
-			const plainMarkerIndex = line.lastIndexOf(plainMarker);
-			return plainMarkerIndex >= 0 ? [line.slice(plainMarkerIndex + plainMarker.length)] : [];
-		});
+			const destinationHeader = PATCH_ENVELOPE_DESTINATION_HEADERS.find((header) =>
+				line.startsWith(header)
+			);
+			if (destinationHeader && paths.length > 0) {
+				// A rename or copy: report the destination, matching the applied-patch result.
+				paths[paths.length - 1] = line.slice(destinationHeader.length).trim();
+			}
+		}
 		const uniquePaths = [...new Set(paths)];
 		return uniquePaths.length > 0 ? summarizePaths(uniquePaths) : null;
 	}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1732,12 +1732,6 @@
 						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
 					{/if}
 				{:else}
-					<header class="flex h-12 items-center border-b border-white/6 px-5">
-						<h1 class="truncate text-[1rem] font-medium tracking-[-0.03em] text-white">
-							{currentActiveThread?.title ?? 'New thread'}
-						</h1>
-					</header>
-
 					<ThreadTranscript
 						currentError={currentError ?? $authState.error ?? queryError?.message ?? null}
 						runError={runState?.lastError ?? null}


### PR DESCRIPTION
## Summary

- The "Changed Files" tool dropdown showed the literal "Patch" for every edit because the summary parser only understood `diff --git` patches, while the agent now sends `apply_patch` envelope patches (#66). The parser now also extracts file paths from envelope headers (`*** Add/Copy/Delete/Update File:`, `*** Move to:` / `*** Copy to:`), reporting the destination path for renames and copies to match the applied-patch result.
- Removed the top header bar that showed the thread name.
- Removed the "Build" and "Full access" composer buttons, which had no click handlers, along with their dividers and now-unused icon imports.

## Testing

- `bun run check`, `bun run test` (129 passing), and `prek run -a` all pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves changed-file summaries and removes unused chat controls. The main changes are:

- Parse file paths from apply-patch envelope headers.
- Show destination paths for copy and move operations.
- Remove inert composer buttons and unused icon imports.
- Remove the active-thread header.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Two browser runs of the Sprocket app loaded the internal URL and displayed the Connect to Sprocket pairing UI.
- A 401 Unauthorized response was observed on GET /api/auth/desktop-bootstrap, blocking the bootstrap flow.
- There was no hand-authored markup, no page.setContent injections, and no transcript data or mocked pages used to render the UI.
- Browser and HTTP logs were captured to support the observation of the blocker and UI state.

<a href="https://app.greptile.com/trex/runs/14945092/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/thread-transcript.svelte | Adds apply-patch envelope parsing while preserving git-diff path summaries. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Removes inert composer controls, dividers, and their unused icon imports. |
| apps/web/src/routes/+page.svelte | Removes the fixed-height active-thread title header. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chat): Show patched file paths and r..."](https://github.com/spikonado/sprocket/commit/4760ca20a659e0f08805ce57db14937672b05b58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45308301)</sub>

<!-- /greptile_comment -->