### PR TITLE
fix(web): Exclude tests from Convex typecheck

### DIFF
--- a/apps/web/src/convex/tsconfig.json
+++ b/apps/web/src/convex/tsconfig.json
@@ -19,5 +19,5 @@
 		"noEmit": true
 	},
 	"include": ["./**/*"],
-	"exclude": ["./_generated"]
+	"exclude": ["./_generated", "./**/*.test.ts", "./**/test.setup.ts"]
 }


### PR DESCRIPTION
## Summary

- exclude Vitest files and test setup helpers from the Convex deployment TypeScript project
- keep the existing `convex-test` suite under the web TypeScript and Vitest projects

## Root cause

The convex-test commit placed test-only modules under `src/convex`, while the Convex-specific `tsconfig.json` included every file in that tree. As a result, `convex dev` typechecked Vitest-only imports as deployment code and failed when `convex-test` was not present in the active install.

## Validation

- `bun convex dev --once` with the `convex-test` package link temporarily hidden
- `bun run --filter @sprocket/web test` (131 tests)
- `bun run --filter @sprocket/web build`
- `prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates Convex deployment typechecking from its Vitest-only files. The main changes are:

- Exclude `*.test.ts` files from the Convex TypeScript project.
- Exclude the Convex test setup helper.
- Keep tests covered by the separate web and Vitest projects.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification as part of the general contract validation.
- T-Rex did not upload local artifact references for the verification.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/tsconfig.json | Adds precise exclusions for the existing Convex test files and setup helper without changing their Vitest coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Exclude tests from Convex type..."](https://github.com/spikonado/sprocket/commit/389f84f31dc127a9d6caee5d94619125d9e5e16d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45310482)</sub>

<!-- /greptile_comment -->