### PR TITLE
fix(agent): Recover threads after cancelled runs

### DIFF
--- a/apps/web/src/convex/lib/agentHistory.test.ts
+++ b/apps/web/src/convex/lib/agentHistory.test.ts
@@ -247,7 +247,7 @@ describe('canonical agent history', () => {
 	});
 
 	it.each(['failed', 'cancelled'] as const)(
-		'reconciles persisted tool parts for a %s run without losing metadata or order',
+		'reconciles a %s run without replaying untrusted provider item references',
 		(runStatus) => {
 			const runId = `${runStatus}-run`;
 			const callId = `${runStatus}-call`;
@@ -260,19 +260,36 @@ describe('canonical agent history', () => {
 						text: '',
 						parts: [
 							{
+								type: 'reasoning',
+								id: `${runStatus}-reasoning`,
+								text: '',
+								turnId: `${runStatus}-turn`,
+								providerMetadata: {
+									openai: {
+										itemId: `${runStatus}-reasoning-item`,
+										reasoningEncryptedContent: null
+									}
+								}
+							},
+							{
 								type: 'tool-call',
 								callId,
 								name: 'exec_command',
 								input: { cmd: runStatus },
 								turnId: `${runStatus}-turn`,
-								providerMetadata: { openai: { itemId: `${runStatus}-item` } }
+								providerMetadata: {
+									openai: { itemId: `${runStatus}-item`, namespace: 'sprocket' }
+								}
 							},
 							{ type: 'tool-result', callId, output: { persisted: runStatus } },
 							{
 								type: 'text',
 								id: `${runStatus}-text`,
 								text: 'after result',
-								turnId: `${runStatus}-next-turn`
+								turnId: `${runStatus}-next-turn`,
+								providerMetadata: {
+									openai: { itemId: `${runStatus}-text-item`, phase: 'commentary' }
+								}
 							}
 						]
 					}
@@ -299,12 +316,18 @@ describe('canonical agent history', () => {
 					name: 'exec_command',
 					argumentsJson: JSON.stringify({ cmd: runStatus }),
 					additionalParamsJson: JSON.stringify({
-						openai: { itemId: `${runStatus}-item` }
+						openai: { namespace: 'sprocket' }
 					})
 				}
 			]);
 			expect(history[1]?.contents).toMatchObject([{ type: 'toolResult', callId }]);
-			expect(history[2]?.contents).toEqual([{ type: 'text', text: 'after result' }]);
+			expect(history[2]?.contents).toEqual([
+				{
+					type: 'text',
+					text: 'after result',
+					additionalParamsJson: JSON.stringify({ openai: { phase: 'commentary' } })
+				}
+			]);
 		}
 	);
 

--- a/apps/web/src/convex/lib/agentHistory.ts
+++ b/apps/web/src/convex/lib/agentHistory.ts
@@ -12,6 +12,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 	parts: AssistantPart[];
 	jobs: PersistableExecutorToolJob[];
 	fallbackText: string;
+	stripProviderItemReferences?: boolean;
 }): AgentHistoryMessage[] {
 	const parts = ensureAssistantToolPartsFromJobs(args.parts, args.jobs);
 	const history: AgentHistoryMessage[] = [];
@@ -85,18 +86,26 @@ export function buildAgentHistoryFromAssistantParts(args: {
 				continue;
 			}
 			sawAssistantText = true;
+			const providerMetadata = providerMetadataForReplay(
+				part.providerMetadata,
+				args.stripProviderItemReferences
+			);
 			turn.assistant.push({
 				type: 'text',
 				text: part.text,
-				...(part.providerMetadata !== undefined
-					? { additionalParamsJson: JSON.stringify(part.providerMetadata) }
+				...(providerMetadata !== undefined
+					? { additionalParamsJson: JSON.stringify(providerMetadata) }
 					: {})
 			});
 			continue;
 		}
 
 		if (part.type === 'reasoning') {
-			const openai = openAiMetadata(part.providerMetadata);
+			const providerMetadata = providerMetadataForReplay(
+				part.providerMetadata,
+				args.stripProviderItemReferences
+			);
+			const openai = openAiMetadata(providerMetadata);
 			const itemId = typeof openai?.itemId === 'string' ? openai.itemId : undefined;
 			const blocks: unknown[] = [];
 			if (part.text.length > 0) {
@@ -116,14 +125,18 @@ export function buildAgentHistoryFromAssistantParts(args: {
 		}
 
 		if (part.type === 'tool-call') {
+			const providerMetadata = providerMetadataForReplay(
+				part.providerMetadata,
+				args.stripProviderItemReferences
+			);
 			turn.assistant.push({
 				type: 'toolCall',
 				id: part.callId,
 				callId: part.callId,
 				name: part.name,
 				argumentsJson: JSON.stringify(part.input),
-				...(part.providerMetadata !== undefined
-					? { additionalParamsJson: JSON.stringify(part.providerMetadata) }
+				...(providerMetadata !== undefined
+					? { additionalParamsJson: JSON.stringify(providerMetadata) }
 					: {})
 			});
 			continue;
@@ -173,8 +186,33 @@ function buildAgentHistoryFromAssistantMessage(args: {
 				result: job.result,
 				error: job.error
 			})),
-		fallbackText: args.message.text
+		fallbackText: args.message.text,
+		stripProviderItemReferences: args.message.runStatus !== 'completed'
 	});
+}
+
+function providerMetadataForReplay(
+	value: unknown,
+	stripProviderItemReferences: boolean | undefined
+): unknown | undefined {
+	if (!stripProviderItemReferences || !value || typeof value !== 'object') {
+		return value;
+	}
+	if (Array.isArray(value)) return value;
+
+	const metadata = value as Record<string, unknown>;
+	const openai = openAiMetadata(metadata);
+	if (!openai || !Object.hasOwn(openai, 'itemId')) return value;
+
+	const replayableOpenAi = { ...openai };
+	delete replayableOpenAi.itemId;
+	const replayableMetadata = { ...metadata };
+	if (Object.keys(replayableOpenAi).length > 0) {
+		replayableMetadata.openai = replayableOpenAi;
+	} else {
+		delete replayableMetadata.openai;
+	}
+	return Object.keys(replayableMetadata).length > 0 ? replayableMetadata : undefined;
 }
 
 function openAiMetadata(value: unknown): Record<string, unknown> | undefined {


### PR DESCRIPTION
## Summary

- remove OpenAI provider item references when rebuilding history from failed or cancelled runs
- preserve replayable text, tool calls, tool results, encrypted reasoning, and non-reference provider metadata
- cover both failed and cancelled history reconstruction with regression tests

## Root cause

Cancelled model streams could persist an OpenAI Responses `itemId` before the corresponding provider item became replayable. Canonical history reused that ID on every later prompt, so the provider rejected each request with `Item with id 'rs_...' not found` and the thread could not recover.

## Impact

Existing affected threads recover on their next prompt because history is sanitized while it is rebuilt; no data migration is required. Successfully completed turns continue to use their provider item references.

## Validation

- `nix develop -c bun run --cwd apps/web test src/convex/lib/agentHistory.test.ts`
- `nix develop -c bun run --cwd apps/web check`
- `nix develop -c prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lets threads recover after failed or cancelled model runs. The main changes are:

- Removes OpenAI `itemId` references from incomplete run history.
- Preserves replayable content and unrelated provider metadata.
- Adds tests for failed and cancelled history reconstruction.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code. Failed and cancelled runs remove stale provider references while preserving text, tool data, encrypted reasoning, and other metadata. Completed-run behavior remains unchanged.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The contract validation run completed with a head result exit 0 and all files and tests passed.
- Two passing cases were named: reconciles a failed run without replaying untrusted provider item references, and reconciles a cancelled run without replaying untrusted provider item references.
- Before comparison, the head result was exit 1, and those two cases failed because OpenAI itemId references and id-only reasoning remained in reconstructed histories.
- The overall validation documents both the finding proofs and the contract-validation context for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/14948060/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/agentHistory.ts | Sanitizes provider item references for failed and cancelled runs without mutating stored metadata or removing replayable content. |
| apps/web/src/convex/lib/agentHistory.test.ts | Covers reference removal and metadata preservation for both affected terminal states. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): recover threads after cancel..."](https://github.com/spikonado/sprocket/commit/c5e55d8ea829dc7e901f2090f98e8b2ff99aecfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45314280)</sub>

<!-- /greptile_comment -->