### PR TITLE
fix(chat): List all changed files

### DIFF
--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -141,7 +141,7 @@
 	/** Patch summaries list one path per line; give them room to wrap instead of truncating. */
 	function toolSummaryClass(toolLog: AssistantTimelineTool) {
 		return (toolLog.job?.kind ?? toolLog.name) === 'apply_patch'
-			? 'whitespace-pre-wrap wrap-anywhere'
+			? 'whitespace-pre-wrap [overflow-wrap:anywhere]'
 			: 'truncate';
 	}
 

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -138,8 +138,11 @@
 		}
 	}
 
-	function summarizePaths(paths: string[]) {
-		return paths.length === 1 ? paths[0] : `${paths[0]} +${paths.length - 1} more`;
+	/** Patch summaries list one path per line; give them room to wrap instead of truncating. */
+	function toolSummaryClass(toolLog: AssistantTimelineTool) {
+		return (toolLog.job?.kind ?? toolLog.name) === 'apply_patch'
+			? 'whitespace-pre-wrap wrap-anywhere'
+			: 'truncate';
 	}
 
 	const PATCH_ENVELOPE_FILE_HEADERS = [
@@ -189,7 +192,7 @@
 			}
 		}
 		const uniquePaths = [...new Set(paths)];
-		return uniquePaths.length > 0 ? summarizePaths(uniquePaths) : null;
+		return uniquePaths.length > 0 ? uniquePaths.join('\n') : null;
 	}
 
 	function summarizePatchResult(result: JsonValue | undefined) {
@@ -203,7 +206,18 @@
 		if (paths.length === 0) {
 			return null;
 		}
-		return summarizePaths(paths);
+		return [...new Set(paths)].join('\n');
+	}
+
+	function patchSummary(toolLog: AssistantTimelineTool) {
+		if (toolLog.job?.kind === 'apply_patch') {
+			return summarizePatchResult(toolLog.job.result) ?? summarizePatchInput(toolLog.job.payload);
+		}
+		return toolLog.name === 'apply_patch' ? summarizePatchInput(toolLog.input) : null;
+	}
+
+	function changedFileCount(tools: AssistantTimelineTool[]) {
+		return new Set(tools.flatMap((tool) => patchSummary(tool)?.split('\n') ?? [])).size;
 	}
 
 	function summarizeWebToolResult(kind: string, result: JsonValue | undefined) {
@@ -229,11 +243,9 @@
 			);
 		}
 		if (toolLog.job) {
-			if (toolLog.job.kind === 'apply_patch') {
-				const patchSummary = summarizePatchResult(toolLog.job.result);
-				if (patchSummary) {
-					return patchSummary;
-				}
+			const summary = patchSummary(toolLog);
+			if (summary) {
+				return summary;
 			}
 			return (
 				summarizeTool(toolLog.job.kind, toolLog.job.payload) +
@@ -493,6 +505,9 @@
 																label={toolGroupLabel(block.toolKey)}
 																icon={toolKindIcon(block.toolKey)}
 																tools={block.tools}
+																defaultExpanded={block.toolKey === 'apply_patch'
+																	? changedFileCount(block.tools) <= 2
+																	: undefined}
 															>
 																{#snippet toolRow(tool)}
 																	{@const toolError = assistantTimelineToolError(tool)}
@@ -504,7 +519,7 @@
 																				class="min-w-0 cursor-pointer text-left"
 																				title={fullToolSummary(tool, isStreaming, sessionCommands)}
 																			>
-																				<span class="truncate">{toolSummary}</span>
+																				<span class={toolSummaryClass(tool)}>{toolSummary}</span>
 																				<span
 																					class={toolFailureKind === 'cancelled'
 																						? 'text-amber-200'
@@ -525,7 +540,7 @@
 																		</details>
 																	{:else}
 																		<p
-																			class="min-w-0 truncate"
+																			class={`min-w-0 ${toolSummaryClass(tool)}`}
 																			title={fullToolSummary(tool, isStreaming, sessionCommands)}
 																		>
 																			{toolSummary}
@@ -549,11 +564,14 @@
 														{@const ToolIcon = toolLogIcon(tool)}
 														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
 														<p
-															class="flex min-w-0 items-center gap-1.5"
+															class="flex min-w-0 items-start gap-1.5"
 															title={fullToolSummary(tool, isStreaming, sessionCommands)}
 														>
-															<ToolIcon class="size-3 shrink-0 text-slate-500" aria-hidden="true" />
-															<span class="truncate">{toolSummary}</span>
+															<ToolIcon
+																class="mt-1.5 size-3 shrink-0 text-slate-500"
+																aria-hidden="true"
+															/>
+															<span class={toolSummaryClass(tool)}>{toolSummary}</span>
 														</p>
 													{/snippet}
 												</ToolCallsDisclosure>


### PR DESCRIPTION
## Summary
- list every changed file instead of collapsing paths into a `+ N more` summary
- wrap long changed-file paths while preserving truncation for other tool calls
- default the Changed Files disclosure open for up to two distinct files and closed above two
- deduplicate changed paths across patch results and grouped patch calls

## Validation
- `nix develop -c bun run --cwd apps/web test`
- `nix develop -c bun run --cwd apps/web check`
- `nix develop -c prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves how changed files appear in chat tool summaries. The main changes are:

- Lists every distinct changed file on its own line.
- Wraps long patch paths while keeping other tool summaries truncated.
- Expands patch disclosures by default for up to two changed files.
- Deduplicates paths across patch results and grouped calls.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The updated wrapping class handles long, unbroken patch paths. No blocking issues were found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change transcript behavior where both groups opened based on tool-call count and collapsed multiple paths into +N more summaries.
- Observed the post-change transcript behavior where the two-distinct-file group opened automatically and the four-distinct-file group remained closed until clicked.
- Observed that after expansion, all paths appeared on separate wrapped lines and a path repeated across calls remained visible in each corresponding call, while distinct-path counting controlled the disclosure state.
- Validated browser stability with no horizontal page overflow or runtime errors.

<a href="https://app.greptile.com/trex/runs/14950970/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/thread-transcript.svelte | Lists and deduplicates changed paths, wraps long patch summaries, and sets disclosure expansion from the distinct file count. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(chat): Ensure long paths wrap"](https://github.com/spikonado/sprocket/commit/99c8fd9709e254e2bf67dafde097206037be4539) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45318340)</sub>

<!-- /greptile_comment -->