### PR TITLE
feat(web): Add subscription tiers with proportional usage limits

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
 		"@ai-sdk/xai": "^4.0.14",
 		"@context-dot-dev/convex": "^1.0.1",
 		"@convex-dev/rate-limiter": "^0.3.2",
+		"@dodopayments/convex": "^0.2.12",
 		"@exalabs/convex-exa": "^0.1.0",
 		"@fontsource-variable/ibm-plex-sans": "^5.2.8",
 		"@fontsource/dm-sans": "^5.2.8",

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -10,10 +10,12 @@
 
 import type * as agentRuntime from "../agentRuntime.js";
 import type * as authBootstrap from "../authBootstrap.js";
+import type * as billing from "../billing.js";
 import type * as chat from "../chat.js";
 import type * as completion from "../completion.js";
 import type * as crons from "../crons.js";
 import type * as executor from "../executor.js";
+import type * as http from "../http.js";
 import type * as imageUploads from "../imageUploads.js";
 import type * as lib_access from "../lib/access.js";
 import type * as lib_agentErrors from "../lib/agentErrors.js";
@@ -30,11 +32,13 @@ import type * as lib_runLease from "../lib/runLease.js";
 import type * as lib_runs from "../lib/runs.js";
 import type * as lib_threadMessages from "../lib/threadMessages.js";
 import type * as lib_threadTranscript from "../lib/threadTranscript.js";
+import type * as lib_tiers from "../lib/tiers.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as lib_workspaceConnection from "../lib/workspaceConnection.js";
 import type * as messages from "../messages.js";
 import type * as threads from "../threads.js";
 import type * as uiPreferences from "../uiPreferences.js";
+import type * as usage from "../usage.js";
 import type * as webTools from "../webTools.js";
 import type * as workspaceSessions from "../workspaceSessions.js";
 
@@ -47,10 +51,12 @@ import type {
 declare const fullApi: ApiFromModules<{
   agentRuntime: typeof agentRuntime;
   authBootstrap: typeof authBootstrap;
+  billing: typeof billing;
   chat: typeof chat;
   completion: typeof completion;
   crons: typeof crons;
   executor: typeof executor;
+  http: typeof http;
   imageUploads: typeof imageUploads;
   "lib/access": typeof lib_access;
   "lib/agentErrors": typeof lib_agentErrors;
@@ -67,11 +73,13 @@ declare const fullApi: ApiFromModules<{
   "lib/runs": typeof lib_runs;
   "lib/threadMessages": typeof lib_threadMessages;
   "lib/threadTranscript": typeof lib_threadTranscript;
+  "lib/tiers": typeof lib_tiers;
   "lib/validators": typeof lib_validators;
   "lib/workspaceConnection": typeof lib_workspaceConnection;
   messages: typeof messages;
   threads: typeof threads;
   uiPreferences: typeof uiPreferences;
+  usage: typeof usage;
   webTools: typeof webTools;
   workspaceSessions: typeof workspaceSessions;
 }>;
@@ -106,4 +114,5 @@ export declare const components: {
   contextDev: import("@context-dot-dev/convex/_generated/component.js").ComponentApi<"contextDev">;
   exa: import("@exalabs/convex-exa/_generated/component.js").ComponentApi<"exa">;
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
+  dodopayments: import("@dodopayments/convex/_generated/component.js").ComponentApi<"dodopayments">;
 };

--- a/apps/web/src/convex/billing.ts
+++ b/apps/web/src/convex/billing.ts
@@ -5,10 +5,10 @@ import {
 } from '@dodopayments/convex';
 import type { ComponentApi } from '@dodopayments/convex/_generated/component';
 import { v } from 'convex/values';
-import { action, internalMutation, internalQuery } from '@convex/_generated/server';
+import { action, internalMutation, internalQuery, query } from '@convex/_generated/server';
 import { components, internal } from '@convex/_generated/api';
 import { getUserId } from '@convex/lib/auth';
-import { tierProductIds } from '@convex/lib/tiers';
+import { getSubscriptionTier, tierProductIds } from '@convex/lib/tiers';
 import { vSubscriptionStatus, vSubscriptionTier } from '@convex/lib/validators';
 
 export const getBillingCustomer = internalQuery({
@@ -34,6 +34,14 @@ const payments: ReturnType<DodoPayments['api']> = dodo.api();
 function assertPaymentsConfigured(): void {
 	if (!process.env.DODO_PAYMENTS_API_KEY) throw new Error('Payments are not configured.');
 }
+
+export const getMySubscription = query({
+	args: {},
+	handler: async (ctx) => {
+		const userId = await getUserId(ctx);
+		return { tier: await getSubscriptionTier(ctx, userId) };
+	}
+});
 
 export const checkout = action({
 	args: { tier: vSubscriptionTier },

--- a/apps/web/src/convex/billing.ts
+++ b/apps/web/src/convex/billing.ts
@@ -1,0 +1,112 @@
+import {
+	DodoPayments,
+	type CheckoutResponse,
+	type CustomerPortalResponse
+} from '@dodopayments/convex';
+import type { ComponentApi } from '@dodopayments/convex/_generated/component';
+import { v } from 'convex/values';
+import { action, internalMutation, internalQuery } from '@convex/_generated/server';
+import { components, internal } from '@convex/_generated/api';
+import { getUserId } from '@convex/lib/auth';
+import { tierProductIds } from '@convex/lib/tiers';
+import { vSubscriptionStatus, vSubscriptionTier } from '@convex/lib/validators';
+
+export const getBillingCustomer = internalQuery({
+	args: { userId: v.string() },
+	handler: async (ctx, { userId }) =>
+		ctx.db
+			.query('billingCustomers')
+			.withIndex('by_userId', (q) => q.eq('userId', userId))
+			.unique()
+});
+
+const dodo: DodoPayments = new DodoPayments(components.dodopayments as ComponentApi, {
+	identify: async (ctx): Promise<{ dodoCustomerId: string } | null> => {
+		const userId = await getUserId(ctx);
+		const customer = await ctx.runQuery(internal.billing.getBillingCustomer, { userId });
+		return customer ? { dodoCustomerId: customer.dodoCustomerId } : null;
+	},
+	apiKey: process.env.DODO_PAYMENTS_API_KEY!,
+	environment: (process.env.DODO_PAYMENTS_ENVIRONMENT as 'test_mode' | 'live_mode') ?? 'test_mode'
+});
+const payments: ReturnType<DodoPayments['api']> = dodo.api();
+
+function assertPaymentsConfigured(): void {
+	if (!process.env.DODO_PAYMENTS_API_KEY) throw new Error('Payments are not configured.');
+}
+
+export const checkout = action({
+	args: { tier: vSubscriptionTier },
+	handler: async (ctx, { tier }): Promise<CheckoutResponse> => {
+		assertPaymentsConfigured();
+		const productId = tierProductIds[tier];
+		if (!productId) throw new Error(`No checkout product is configured for the ${tier} tier.`);
+		const userId = await getUserId(ctx);
+		return payments.checkout(ctx, {
+			payload: {
+				product_cart: [{ product_id: productId, quantity: 1 }],
+				metadata: { userId }
+			}
+		});
+	}
+});
+
+export const customerPortal = action({
+	args: {},
+	handler: async (ctx): Promise<CustomerPortalResponse> => {
+		assertPaymentsConfigured();
+		await getUserId(ctx);
+		return payments.customerPortal(ctx);
+	}
+});
+
+export const upsertSubscription = internalMutation({
+	args: {
+		userId: v.string(),
+		tier: vSubscriptionTier,
+		dodoSubscriptionId: v.string(),
+		dodoProductId: v.string(),
+		dodoCustomerId: v.string(),
+		status: vSubscriptionStatus,
+		eventAt: v.number()
+	},
+	handler: async (ctx, args) => {
+		const existing = await ctx.db
+			.query('subscriptions')
+			.withIndex('by_userId', (q) => q.eq('userId', args.userId))
+			.unique();
+		// Ignore out-of-order webhook events; retries (equal eventAt) still apply.
+		if (existing && args.eventAt < existing.eventAt) return;
+		// A non-active event for a different subscription than the stored one is
+		// about a defunct subscription (e.g. a cancellation racing its
+		// replacement) and must not downgrade the current one.
+		if (
+			existing &&
+			args.status !== 'active' &&
+			existing.dodoSubscriptionId !== args.dodoSubscriptionId
+		) {
+			return;
+		}
+		const subscription = {
+			userId: args.userId,
+			tier: args.tier,
+			dodoSubscriptionId: args.dodoSubscriptionId,
+			dodoProductId: args.dodoProductId,
+			status: args.status,
+			eventAt: args.eventAt
+		};
+		if (existing) await ctx.db.replace(existing._id, subscription);
+		else await ctx.db.insert('subscriptions', subscription);
+
+		const customer = await ctx.db
+			.query('billingCustomers')
+			.withIndex('by_userId', (q) => q.eq('userId', args.userId))
+			.unique();
+		if (customer) await ctx.db.patch(customer._id, { dodoCustomerId: args.dodoCustomerId });
+		else
+			await ctx.db.insert('billingCustomers', {
+				userId: args.userId,
+				dodoCustomerId: args.dodoCustomerId
+			});
+	}
+});

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -3,7 +3,7 @@
 import { generateText, jsonSchema, streamText, tool, type ModelMessage } from 'ai';
 import { v } from 'convex/values';
 import { action, type ActionCtx } from '@convex/_generated/server';
-import { api, internal } from '@convex/_generated/api';
+import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
@@ -156,23 +156,12 @@ export const complete = action({
 			abortController.abort(error);
 			throw error;
 		}
-		// Accounting must not fail the completion: fall back to a durable
-		// scheduled charge, and as a last resort log and continue.
-		const chargeArgs = {
+		await chargeModelUsage(ctx, {
 			userId: completionContext.userId,
 			modelId,
 			serviceTier,
 			tokens: normalizeCompletionUsage(result.usage)
-		};
-		try {
-			await chargeModelUsage(ctx, chargeArgs);
-		} catch (chargeError) {
-			try {
-				await ctx.scheduler.runAfter(0, internal.lib.rateLimits.chargeModelUsageLimits, chargeArgs);
-			} catch (scheduleError) {
-				console.error('Failed to charge model usage.', chargeError, scheduleError);
-			}
-		}
+		});
 
 		return {
 			text: result.text,

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -3,18 +3,19 @@
 import { generateText, jsonSchema, streamText, tool, type ModelMessage } from 'ai';
 import { v } from 'convex/values';
 import { action, type ActionCtx } from '@convex/_generated/server';
-import { api } from '@convex/_generated/api';
+import { api, internal } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
 import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { isCurrentCompletionAttempt } from '@convex/lib/runLease';
-import { enforceModelCompletionLimit } from '@convex/lib/rateLimits';
+import { chargeModelUsage, checkModelUsageLimit } from '@convex/lib/rateLimits';
 import { getUserId } from '@convex/lib/auth';
 import { vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
 import {
 	assertSupportedModelConfiguration,
 	defaultServiceTier,
+	normalizeCompletionUsage,
 	type SupportedModelId,
 	type SupportedReasoningEffort,
 	type SupportedServiceTier
@@ -153,6 +154,22 @@ export const complete = action({
 		} catch (error) {
 			abortController.abort(error);
 			throw error;
+		}
+		// Accounting must not fail the completion: fall back to a durable
+		// scheduled charge, and as a last resort log and continue.
+		const chargeArgs = {
+			userId: completionContext.userId,
+			modelId,
+			tokens: normalizeCompletionUsage(result.usage)
+		};
+		try {
+			await chargeModelUsage(ctx, chargeArgs);
+		} catch (chargeError) {
+			try {
+				await ctx.scheduler.runAfter(0, internal.lib.rateLimits.chargeModelUsageLimits, chargeArgs);
+			} catch (scheduleError) {
+				console.error('Failed to charge model usage.', chargeError, scheduleError);
+			}
 		}
 
 		return {
@@ -521,15 +538,16 @@ function delay(milliseconds: number): Promise<void> {
 async function prepareCompletionContext(
 	ctx: ActionCtx,
 	runId: Id<'runs'>
-): Promise<{ promptCacheKey: string; streamSequence: number }> {
+): Promise<{ promptCacheKey: string; streamSequence: number; userId: string }> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
 		runId
 	});
 	assertRunAcceptsModelCompletion(actor.status);
-	await enforceModelCompletionLimit(ctx, actor.userId);
+	await checkModelUsageLimit(ctx, actor.userId);
 	return {
 		promptCacheKey: `thread:${actor.threadId}`,
-		streamSequence: actor.streamSequence
+		streamSequence: actor.streamSequence,
+		userId: actor.userId
 	};
 }
 

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -93,11 +93,12 @@ export const complete = action({
 				: {})
 		});
 		const modelId = args.modelId;
+		const serviceTier = args.serviceTier ?? defaultServiceTier;
 		if (args.reasoningEffort !== undefined || args.serviceTier !== undefined) {
 			assertSupportedModelConfiguration({
 				modelId,
 				reasoningEffort: args.reasoningEffort,
-				serviceTier: args.serviceTier ?? defaultServiceTier
+				serviceTier
 			});
 		}
 		const tools: Record<string, ReturnType<typeof tool>> = Object.fromEntries(
@@ -122,7 +123,7 @@ export const complete = action({
 		}
 		const completionContext = await prepareCompletionContext(ctx, args.streamRunId);
 		const sharedArgs = buildSharedCompletionRequest(
-			{ ...args, modelId },
+			{ ...args, modelId, serviceTier },
 			tools,
 			toolChoice,
 			completionContext.promptCacheKey
@@ -160,6 +161,7 @@ export const complete = action({
 		const chargeArgs = {
 			userId: completionContext.userId,
 			modelId,
+			serviceTier,
 			tokens: normalizeCompletionUsage(result.usage)
 		};
 		try {

--- a/apps/web/src/convex/convex.config.ts
+++ b/apps/web/src/convex/convex.config.ts
@@ -2,6 +2,7 @@ import { defineApp } from 'convex/server';
 import { v } from 'convex/values';
 import contextDev from '@context-dot-dev/convex/convex.config';
 import rateLimiter from '@convex-dev/rate-limiter/convex.config';
+import dodopayments from '@dodopayments/convex/convex.config';
 import exa from '@exalabs/convex-exa/convex.config';
 
 const app = defineApp({
@@ -14,5 +15,6 @@ const app = defineApp({
 app.use(contextDev, { env: { CONTEXT_DEV_API_KEY: app.env.CONTEXT_DEV_API_KEY } });
 app.use(exa, { env: { EXA_API_KEY: app.env.EXA_API_KEY } });
 app.use(rateLimiter);
+app.use(dodopayments);
 
 export default app;

--- a/apps/web/src/convex/http.ts
+++ b/apps/web/src/convex/http.ts
@@ -1,0 +1,71 @@
+import { createDodoWebhookHandler, type Subscription } from '@dodopayments/convex';
+import { httpRouter, type GenericActionCtx, type GenericDataModel } from 'convex/server';
+import type { Infer } from 'convex/values';
+import { internal } from '@convex/_generated/api';
+import { tierForProductId } from '@convex/lib/tiers';
+import { vSubscriptionStatus } from '@convex/lib/validators';
+
+const http = httpRouter();
+
+function eventTimestampMs(timestamp: Date | string | undefined): number {
+	const ms =
+		timestamp instanceof Date
+			? timestamp.getTime()
+			: timestamp
+				? Date.parse(timestamp)
+				: Number.NaN;
+	// An unknown provider time must never win ordering over a known one.
+	return Number.isFinite(ms) ? ms : 0;
+}
+
+async function persistSubscription(
+	ctx: GenericActionCtx<GenericDataModel>,
+	data: Subscription,
+	status: Infer<typeof vSubscriptionStatus>,
+	timestamp: Date | string | undefined
+): Promise<void> {
+	const userId = typeof data.metadata?.userId === 'string' ? data.metadata.userId : undefined;
+	if (!userId) {
+		console.error(
+			'Skipping Dodo subscription webhook without Sprocket userId.',
+			data.subscription_id
+		);
+		return;
+	}
+	const tier = tierForProductId(data.product_id);
+	if (tier === undefined) {
+		console.warn('Unknown Dodo product; keeping user on free tier.', data.product_id);
+	}
+	await ctx.runMutation(internal.billing.upsertSubscription, {
+		userId,
+		tier: tier ?? 'free',
+		dodoSubscriptionId: data.subscription_id,
+		dodoProductId: data.product_id,
+		dodoCustomerId: data.customer.customer_id,
+		status,
+		eventAt: eventTimestampMs(timestamp)
+	});
+}
+
+http.route({
+	path: '/dodopayments-webhook',
+	method: 'POST',
+	handler: createDodoWebhookHandler({
+		onSubscriptionActive: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'active', payload.timestamp),
+		onSubscriptionRenewed: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'active', payload.timestamp),
+		onSubscriptionPlanChanged: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'active', payload.timestamp),
+		onSubscriptionOnHold: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'on_hold', payload.timestamp),
+		onSubscriptionCancelled: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'cancelled', payload.timestamp),
+		onSubscriptionExpired: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'expired', payload.timestamp),
+		onSubscriptionFailed: (ctx, payload) =>
+			persistSubscription(ctx, payload.data, 'failed', payload.timestamp)
+	})
+});
+
+export default http;

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { assertSupportedModelConfiguration, modelIds } from '@convex/lib/models';
+import {
+	assertSupportedModelConfiguration,
+	completionUsageUnits,
+	modelIds
+} from '@convex/lib/models';
 
 describe('model configuration', () => {
 	it('exposes only the configured GPT-5.6, Fable, and Grok models', () => {
@@ -27,5 +31,23 @@ describe('model configuration', () => {
 				serviceTier: 'standard'
 			})
 		).toThrow('Claude Fable 5 does not support none reasoning.');
+	});
+
+	it('prices service tiers and long contexts', () => {
+		const shortUsage = { input: 100_000, cacheRead: 0, cacheWrite: 0, output: 100_000 };
+		expect(completionUsageUnits('gpt-5.6-sol', 'standard', shortUsage)).toBe(3_500);
+		expect(completionUsageUnits('gpt-5.6-sol', 'fast', shortUsage)).toBe(7_000);
+		expect(
+			completionUsageUnits('gpt-5.6-sol', 'standard', {
+				input: 300_000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				output: 100_000
+			})
+		).toBe(7_500);
+
+		const grokLongUsage = { input: 200_000, cacheRead: 0, cacheWrite: 0, output: 100_000 };
+		expect(completionUsageUnits('grok-4.5', 'standard', grokLongUsage)).toBe(2_000);
+		expect(completionUsageUnits('grok-4.5', 'fast', grokLongUsage)).toBe(4_000);
 	});
 });

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -33,21 +33,22 @@ describe('model configuration', () => {
 		).toThrow('Claude Fable 5 does not support none reasoning.');
 	});
 
-	it('prices service tiers and long contexts', () => {
+	it('weights usage by service tier and context length', () => {
 		const shortUsage = { input: 100_000, cacheRead: 0, cacheWrite: 0, output: 100_000 };
-		expect(completionUsageUnits('gpt-5.6-sol', 'standard', shortUsage)).toBe(3_500);
-		expect(completionUsageUnits('gpt-5.6-sol', 'fast', shortUsage)).toBe(7_000);
-		expect(
-			completionUsageUnits('gpt-5.6-sol', 'standard', {
-				input: 300_000,
-				cacheRead: 0,
-				cacheWrite: 0,
-				output: 100_000
-			})
-		).toBe(7_500);
+		expect(completionUsageUnits('gpt-5.6-sol', 'fast', shortUsage)).toBeGreaterThan(
+			completionUsageUnits('gpt-5.6-sol', 'standard', shortUsage)
+		);
+
+		// Long-context requests are billed at higher per-token rates, so doubling
+		// the input across the threshold more than doubles the charged units.
+		const inputOnly = (input: number) => ({ input, cacheRead: 0, cacheWrite: 0, output: 0 });
+		expect(completionUsageUnits('gpt-5.6-sol', 'standard', inputOnly(400_000))).toBeGreaterThan(
+			2 * completionUsageUnits('gpt-5.6-sol', 'standard', inputOnly(200_000))
+		);
 
 		const grokLongUsage = { input: 200_000, cacheRead: 0, cacheWrite: 0, output: 100_000 };
-		expect(completionUsageUnits('grok-4.5', 'standard', grokLongUsage)).toBe(2_000);
-		expect(completionUsageUnits('grok-4.5', 'fast', grokLongUsage)).toBe(4_000);
+		expect(completionUsageUnits('grok-4.5', 'fast', grokLongUsage)).toBeGreaterThan(
+			completionUsageUnits('grok-4.5', 'standard', grokLongUsage)
+		);
 	});
 });

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -1,3 +1,5 @@
+import type { LanguageModelUsage } from 'ai';
+
 export const reasoningEffortIds = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 export const serviceTierIds = ['standard', 'fast'] as const;
 export const modelIds = [
@@ -20,6 +22,7 @@ type ModelDefinition = {
 	reasoningEfforts: readonly SupportedReasoningEffort[];
 	defaultReasoningEffort: SupportedReasoningEffort;
 	serviceTiers: readonly SupportedServiceTier[];
+	usageWeights: { input: number; cacheRead: number; cacheWrite: number; output: number };
 };
 
 export const modelDefinitions = [
@@ -29,7 +32,8 @@ export const modelDefinitions = [
 		provider: 'openai',
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
-		serviceTiers: serviceTierIds
+		serviceTiers: serviceTierIds,
+		usageWeights: { input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 20 }
 	},
 	{
 		id: 'gpt-5.6-terra',
@@ -37,7 +41,8 @@ export const modelDefinitions = [
 		provider: 'openai',
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
-		serviceTiers: serviceTierIds
+		serviceTiers: serviceTierIds,
+		usageWeights: { input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 4 }
 	},
 	{
 		id: 'gpt-5.6-luna',
@@ -45,7 +50,8 @@ export const modelDefinitions = [
 		provider: 'openai',
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
-		serviceTiers: serviceTierIds
+		serviceTiers: serviceTierIds,
+		usageWeights: { input: 2, cacheRead: 0.2, cacheWrite: 2.5, output: 8 }
 	},
 	{
 		id: 'claude-fable-5',
@@ -53,7 +59,8 @@ export const modelDefinitions = [
 		provider: 'anthropic',
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
-		serviceTiers: serviceTierIds
+		serviceTiers: serviceTierIds,
+		usageWeights: { input: 6, cacheRead: 0.6, cacheWrite: 7.5, output: 24 }
 	},
 	{
 		id: 'grok-4.5',
@@ -61,7 +68,8 @@ export const modelDefinitions = [
 		provider: 'xai',
 		reasoningEfforts: ['low', 'medium', 'high'],
 		defaultReasoningEffort: 'high',
-		serviceTiers: serviceTierIds
+		serviceTiers: serviceTierIds,
+		usageWeights: { input: 1.5, cacheRead: 0.15, cacheWrite: 2, output: 6 }
 	}
 ] as const satisfies readonly ModelDefinition[];
 
@@ -74,6 +82,36 @@ export function getModelDefinition(modelId: SupportedModelId): ModelDefinition {
 	const definition = modelDefinitions.find((model) => model.id === modelId);
 	if (!definition) throw new Error(`Unsupported model: ${modelId}`);
 	return definition;
+}
+
+export function normalizeCompletionUsage(usage: LanguageModelUsage): {
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	output: number;
+} {
+	const details = usage.inputTokenDetails;
+	const cacheRead = details.cacheReadTokens ?? 0;
+	const cacheWrite = details.cacheWriteTokens ?? 0;
+	return {
+		input: details.noCacheTokens ?? Math.max(0, (usage.inputTokens ?? 0) - cacheRead - cacheWrite),
+		cacheRead,
+		cacheWrite,
+		output: usage.outputTokens ?? 0
+	};
+}
+
+export function completionUsageUnits(
+	modelId: SupportedModelId,
+	tokens: { input: number; cacheRead: number; cacheWrite: number; output: number }
+): number {
+	const weights = getModelDefinition(modelId).usageWeights;
+	return Math.ceil(
+		tokens.input * weights.input +
+			tokens.cacheRead * weights.cacheRead +
+			tokens.cacheWrite * weights.cacheWrite +
+			tokens.output * weights.output
+	);
 }
 
 export function assertSupportedModelConfiguration(args: {

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -22,8 +22,14 @@ type ModelDefinition = {
 	reasoningEfforts: readonly SupportedReasoningEffort[];
 	defaultReasoningEffort: SupportedReasoningEffort;
 	serviceTiers: readonly SupportedServiceTier[];
-	usageWeights: { input: number; cacheRead: number; cacheWrite: number; output: number };
+	usageWeights: {
+		short: TokenUsageWeights;
+		long?: { minimumInputTokens: number; weights: TokenUsageWeights; fastMultiplier: number };
+		fastMultiplier: number;
+	};
 };
+
+type TokenUsageWeights = { input: number; cacheRead: number; cacheWrite: number; output: number };
 
 export const modelDefinitions = [
 	{
@@ -33,7 +39,15 @@ export const modelDefinitions = [
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
-		usageWeights: { input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 20 }
+		usageWeights: {
+			short: { input: 0.005, cacheRead: 0.0005, cacheWrite: 0.00625, output: 0.03 },
+			long: {
+				minimumInputTokens: 272_001,
+				weights: { input: 0.01, cacheRead: 0.001, cacheWrite: 0.0125, output: 0.045 },
+				fastMultiplier: 1
+			},
+			fastMultiplier: 2
+		}
 	},
 	{
 		id: 'gpt-5.6-terra',
@@ -42,7 +56,20 @@ export const modelDefinitions = [
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
-		usageWeights: { input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 4 }
+		usageWeights: {
+			short: { input: 0.0025, cacheRead: 0.00025, cacheWrite: 0.003125, output: 0.015 },
+			long: {
+				minimumInputTokens: 272_001,
+				weights: {
+					input: 0.005,
+					cacheRead: 0.0005,
+					cacheWrite: 0.00625,
+					output: 0.0225
+				},
+				fastMultiplier: 1
+			},
+			fastMultiplier: 2
+		}
 	},
 	{
 		id: 'gpt-5.6-luna',
@@ -51,7 +78,15 @@ export const modelDefinitions = [
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
-		usageWeights: { input: 2, cacheRead: 0.2, cacheWrite: 2.5, output: 8 }
+		usageWeights: {
+			short: { input: 0.001, cacheRead: 0.0001, cacheWrite: 0.00125, output: 0.006 },
+			long: {
+				minimumInputTokens: 272_001,
+				weights: { input: 0.002, cacheRead: 0.0002, cacheWrite: 0.0025, output: 0.009 },
+				fastMultiplier: 1
+			},
+			fastMultiplier: 2
+		}
 	},
 	{
 		id: 'claude-fable-5',
@@ -60,7 +95,10 @@ export const modelDefinitions = [
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,
-		usageWeights: { input: 6, cacheRead: 0.6, cacheWrite: 7.5, output: 24 }
+		usageWeights: {
+			short: { input: 0.01, cacheRead: 0.001, cacheWrite: 0.0125, output: 0.05 },
+			fastMultiplier: 1
+		}
 	},
 	{
 		id: 'grok-4.5',
@@ -69,7 +107,15 @@ export const modelDefinitions = [
 		reasoningEfforts: ['low', 'medium', 'high'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,
-		usageWeights: { input: 1.5, cacheRead: 0.15, cacheWrite: 2, output: 6 }
+		usageWeights: {
+			short: { input: 0.002, cacheRead: 0.0005, cacheWrite: 0.002, output: 0.006 },
+			long: {
+				minimumInputTokens: 200_000,
+				weights: { input: 0.004, cacheRead: 0.001, cacheWrite: 0.004, output: 0.012 },
+				fastMultiplier: 2
+			},
+			fastMultiplier: 2
+		}
 	}
 ] as const satisfies readonly ModelDefinition[];
 
@@ -103,14 +149,22 @@ export function normalizeCompletionUsage(usage: LanguageModelUsage): {
 
 export function completionUsageUnits(
 	modelId: SupportedModelId,
+	serviceTier: SupportedServiceTier,
 	tokens: { input: number; cacheRead: number; cacheWrite: number; output: number }
 ): number {
-	const weights = getModelDefinition(modelId).usageWeights;
+	const pricing = getModelDefinition(modelId).usageWeights;
+	const totalInput = tokens.input + tokens.cacheRead + tokens.cacheWrite;
+	const longPricing =
+		pricing.long && totalInput >= pricing.long.minimumInputTokens ? pricing.long : undefined;
+	const weights = longPricing?.weights ?? pricing.short;
+	const multiplier =
+		serviceTier === 'fast' ? (longPricing?.fastMultiplier ?? pricing.fastMultiplier) : 1;
 	return Math.ceil(
-		tokens.input * weights.input +
-			tokens.cacheRead * weights.cacheRead +
-			tokens.cacheWrite * weights.cacheWrite +
-			tokens.output * weights.output
+		multiplier *
+			(tokens.input * weights.input +
+				tokens.cacheRead * weights.cacheRead +
+				tokens.cacheWrite * weights.cacheWrite +
+				tokens.output * weights.output)
 	);
 }
 

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -5,168 +5,203 @@ import {
 	RateLimiter,
 	SECOND,
 	WEEK,
+	calculateRateLimit,
 	isRateLimitError,
 	type RateLimitConfig,
-	type RunMutationCtx
+	type RunMutationCtx,
+	type RunQueryCtx
 } from '@convex-dev/rate-limiter';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation, type ActionCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
+import { completionUsageUnits, type SupportedModelId } from '@convex/lib/models';
+import { getSubscriptionTier, tierLimits, type TierLimits } from '@convex/lib/tiers';
+import { vModelId } from '@convex/lib/validators';
 
 const MONTH = 30 * DAY;
+export const rateLimiter = new RateLimiter(components.rateLimiter, {});
 
-const hourlyModelCompletionLimit = 300;
-const weeklyUrlScrapeLimit = 100;
-const monthlyUrlScrapeLimit = 280;
-const weeklyWebSearchLimit = 25;
-const monthlyWebSearchLimit = 60;
+export const usageMeters = [
+	{ id: 'modelUsage', label: 'Model usage', noun: 'model usage' },
+	{ id: 'webSearch', label: 'Web searches', noun: 'web search' },
+	{ id: 'urlScrape', label: 'URL scrapes', noun: 'URL scrape' }
+] as const;
 
-const rateLimitConfigs = {
-	modelCompletion: {
-		kind: 'fixed window',
-		period: HOUR,
-		rate: hourlyModelCompletionLimit
-	},
-	urlScrapeWeekly: {
-		kind: 'fixed window',
-		period: WEEK,
-		rate: weeklyUrlScrapeLimit
-	},
-	urlScrapeMonthly: {
-		kind: 'fixed window',
-		period: MONTH,
-		rate: monthlyUrlScrapeLimit
-	},
-	webSearchWeekly: {
-		kind: 'fixed window',
-		period: WEEK,
-		rate: weeklyWebSearchLimit
-	},
-	webSearchMonthly: {
-		kind: 'fixed window',
-		period: MONTH,
-		rate: monthlyWebSearchLimit
-	}
-} satisfies Record<string, RateLimitConfig>;
+export type UsageMeterId = (typeof usageMeters)[number]['id'];
 
-export const rateLimiter = new RateLimiter(components.rateLimiter, rateLimitConfigs);
+export const usagePeriods = ['weekly', 'monthly'] as const;
+export type UsagePeriod = (typeof usagePeriods)[number];
 
-type RateLimitName = keyof typeof rateLimitConfigs;
-type PairedLimit = { name: RateLimitName; label: string };
+const periodDurations: Record<UsagePeriod, number> = { weekly: WEEK, monthly: MONTH };
 
-const urlScrapeLimits: ReadonlyArray<PairedLimit> = [
-	{ name: 'urlScrapeMonthly', label: 'URL scrape monthly limit' },
-	{ name: 'urlScrapeWeekly', label: 'URL scrape weekly limit' }
-];
+function meterLimitName(meterId: UsageMeterId, period: UsagePeriod): string {
+	return `${meterId}${period === 'weekly' ? 'Weekly' : 'Monthly'}`;
+}
 
-const webSearchLimits: ReadonlyArray<PairedLimit> = [
-	{ name: 'webSearchMonthly', label: 'Web search monthly limit' },
-	{ name: 'webSearchWeekly', label: 'Web search weekly limit' }
-];
+function meterLimitConfig(
+	meterId: UsageMeterId,
+	period: UsagePeriod,
+	limits: TierLimits
+): RateLimitConfig {
+	return { kind: 'fixed window', period: periodDurations[period], rate: limits[meterId][period] };
+}
+
+function meterLimitLabel(meterId: UsageMeterId, period: UsagePeriod): string {
+	const meter = usageMeters.find(({ id }) => id === meterId);
+	if (!meter) throw new Error(`Unknown usage meter: ${meterId}`);
+	return `${period === 'weekly' ? 'Weekly' : 'Monthly'} ${meter.noun} limit`;
+}
 
 function formatRetryAfter(milliseconds: number): string {
 	let remaining = Math.max(SECOND, Math.ceil(milliseconds / SECOND) * SECOND);
-	const days = Math.floor(remaining / DAY);
-	remaining %= DAY;
-	const hours = Math.floor(remaining / HOUR);
-	remaining %= HOUR;
-	const minutes = Math.floor(remaining / MINUTE);
-	remaining %= MINUTE;
-	const seconds = remaining / SECOND;
 	const parts: string[] = [];
-
-	if (days > 0) {
-		parts.push(`${days}d`);
+	for (const [suffix, size] of [
+		['d', DAY],
+		['h', HOUR],
+		['m', MINUTE]
+	] as const) {
+		const value = Math.floor(remaining / size);
+		remaining %= size;
+		if (value > 0) parts.push(`${value}${suffix}`);
 	}
-	if (hours > 0) {
-		parts.push(`${hours}h`);
-	}
-	if (minutes > 0) {
-		parts.push(`${minutes}m`);
-	}
-	if (seconds > 0 || parts.length === 0) {
-		parts.push(`${seconds}s`);
-	}
-
+	const seconds = remaining / SECOND;
+	if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
 	return parts.join(' ');
 }
 
 function rateLimitError(label: string, retryAfter: number, cause?: unknown): Error {
-	return new Error(`${label} reached. Try again in ${formatRetryAfter(retryAfter)}.`, {
-		cause
-	});
+	return new Error(`${label} reached. Try again in ${formatRetryAfter(retryAfter)}.`, { cause });
 }
 
-async function enforceLimit(
+async function checkMeterLimits(
 	ctx: RunMutationCtx,
-	name: RateLimitName,
+	meterId: UsageMeterId,
 	key: string,
-	label: string
-): Promise<void> {
-	try {
-		await rateLimiter.limit(ctx, name, {
-			key,
-			throws: true
-		});
-	} catch (error) {
-		if (!isRateLimitError(error)) {
-			throw error;
-		}
-
-		throw rateLimitError(label, error.data.retryAfter, error);
-	}
-}
-
-/**
- * Check and consume both windows in one mutation so a denial on either rolls
- * back the other consume.
- */
-async function enforcePairedLimits(
-	ctx: RunMutationCtx,
-	limits: ReadonlyArray<PairedLimit>,
-	key: string
+	limits: TierLimits
 ): Promise<void> {
 	const statuses = await Promise.all(
-		limits.map(async ({ name, label }) => {
-			const status = await rateLimiter.check(ctx, name, { key });
-			return { label, status };
-		})
+		usagePeriods.map(async (period) => ({
+			period,
+			status: await rateLimiter.check(ctx, meterLimitName(meterId, period), {
+				key,
+				config: meterLimitConfig(meterId, period, limits)
+			})
+		}))
 	);
+	const blocked = statuses
+		.filter(({ status }) => !status.ok)
+		.sort((a, b) => (b.status.retryAfter ?? 0) - (a.status.retryAfter ?? 0))[0];
+	if (blocked && !blocked.status.ok) {
+		throw rateLimitError(meterLimitLabel(meterId, blocked.period), blocked.status.retryAfter);
+	}
+}
 
-	let blocked: { label: string; retryAfter: number } | undefined;
-	for (const { label, status } of statuses) {
-		if (!status.ok) {
-			if (blocked === undefined || status.retryAfter > blocked.retryAfter) {
-				blocked = { label, retryAfter: status.retryAfter };
-			}
+async function consumeMeterLimits(
+	ctx: RunMutationCtx,
+	meterId: UsageMeterId,
+	key: string,
+	limits: TierLimits
+): Promise<void> {
+	await checkMeterLimits(ctx, meterId, key, limits);
+	for (const period of usagePeriods) {
+		try {
+			await rateLimiter.limit(ctx, meterLimitName(meterId, period), {
+				key,
+				config: meterLimitConfig(meterId, period, limits),
+				throws: true
+			});
+		} catch (error) {
+			if (!isRateLimitError(error)) throw error;
+			throw rateLimitError(meterLimitLabel(meterId, period), error.data.retryAfter, error);
 		}
 	}
+}
 
-	if (blocked !== undefined) {
-		throw rateLimitError(blocked.label, blocked.retryAfter);
-	}
-
-	for (const { name, label } of limits) {
-		await enforceLimit(ctx, name, key, label);
-	}
+export async function getMeterWindow(
+	ctx: RunQueryCtx,
+	meterId: UsageMeterId,
+	period: UsagePeriod,
+	userId: string,
+	limits: TierLimits
+): Promise<{ used: number; limit: number; resetsAt: number | null }> {
+	const config = meterLimitConfig(meterId, period, limits);
+	const stored = await rateLimiter.getValue(ctx, meterLimitName(meterId, period), {
+		key: userId,
+		config
+	});
+	// A fixed window starts on first use; ts === 0 means it never has.
+	if (stored.ts === 0) return { used: 0, limit: config.rate, resetsAt: null };
+	const current = calculateRateLimit({ value: stored.value, ts: stored.ts }, config, Date.now());
+	return {
+		used: Math.max(0, config.rate - current.value),
+		limit: config.rate,
+		resetsAt: current.ts + config.period
+	};
 }
 
 export const consumeUrlScrapeLimits = internalMutation({
 	args: { userId: v.string() },
-	handler: async (ctx, args) => {
-		await enforcePairedLimits(ctx, urlScrapeLimits, args.userId);
+	handler: async (ctx, { userId }) => {
+		const tier = await getSubscriptionTier(ctx, userId);
+		await consumeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier]);
 	}
 });
 
 export const consumeWebSearchLimits = internalMutation({
 	args: { userId: v.string() },
-	handler: async (ctx, args) => {
-		await enforcePairedLimits(ctx, webSearchLimits, args.userId);
+	handler: async (ctx, { userId }) => {
+		const tier = await getSubscriptionTier(ctx, userId);
+		await consumeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier]);
 	}
 });
 
-export async function enforceModelCompletionLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await enforceLimit(ctx, 'modelCompletion', userId, 'Model completion limit');
+export const checkModelUsageLimits = internalMutation({
+	args: { userId: v.string() },
+	handler: async (ctx, { userId }) => {
+		const tier = await getSubscriptionTier(ctx, userId);
+		await checkMeterLimits(ctx, 'modelUsage', userId, tierLimits[tier]);
+	}
+});
+
+export const chargeModelUsageLimits = internalMutation({
+	args: {
+		userId: v.string(),
+		modelId: vModelId,
+		tokens: v.object({
+			input: v.number(),
+			cacheRead: v.number(),
+			cacheWrite: v.number(),
+			output: v.number()
+		})
+	},
+	handler: async (ctx, args) => {
+		const tier = await getSubscriptionTier(ctx, args.userId);
+		const limits = tierLimits[tier];
+		const count = completionUsageUnits(args.modelId, args.tokens);
+		for (const period of usagePeriods) {
+			await rateLimiter.limit(ctx, meterLimitName('modelUsage', period), {
+				key: args.userId,
+				config: meterLimitConfig('modelUsage', period, limits),
+				count,
+				reserve: true
+			});
+		}
+	}
+});
+
+export async function checkModelUsageLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.checkModelUsageLimits, { userId });
+}
+
+export async function chargeModelUsage(
+	ctx: ActionCtx,
+	args: {
+		userId: string;
+		modelId: SupportedModelId;
+		tokens: { input: number; cacheRead: number; cacheWrite: number; output: number };
+	}
+): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.chargeModelUsageLimits, args);
 }
 
 export async function enforceUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -6,7 +6,6 @@ import {
 	SECOND,
 	WEEK,
 	calculateRateLimit,
-	isRateLimitError,
 	type RateLimitConfig,
 	type RunMutationCtx,
 	type RunQueryCtx
@@ -103,7 +102,7 @@ async function checkMeterLimits(
 	}
 }
 
-async function consumeMeterLimits(
+async function chargeMeterLimits(
 	ctx: RunMutationCtx,
 	meterId: UsageMeterId,
 	key: string,
@@ -111,17 +110,12 @@ async function consumeMeterLimits(
 	count: number
 ): Promise<void> {
 	for (const period of usagePeriods) {
-		try {
-			await rateLimiter.limit(ctx, meterLimitName(meterId, period), {
-				key,
-				config: meterLimitConfig(meterId, period, limits),
-				count,
-				throws: true
-			});
-		} catch (error) {
-			if (!isRateLimitError(error)) throw error;
-			throw rateLimitError(meterLimitLabel(meterId, period), error.data.retryAfter, error);
-		}
+		await rateLimiter.limit(ctx, meterLimitName(meterId, period), {
+			key,
+			config: meterLimitConfig(meterId, period, limits),
+			count,
+			reserve: true
+		});
 	}
 }
 
@@ -147,20 +141,36 @@ export async function getMeterWindow(
 	};
 }
 
-export const consumeUrlScrapeLimits = internalMutation({
+export const checkUrlScrapeLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await consumeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier], URL_SCRAPE_USAGE_UNITS);
+		await checkMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier]);
 	}
 });
 
-export const consumeWebSearchLimits = internalMutation({
+export const chargeUrlScrapeLimits = internalMutation({
+	args: { userId: v.string() },
+	handler: async (ctx, { userId }) => {
+		const tier = await getSubscriptionTier(ctx, userId);
+		await chargeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier], URL_SCRAPE_USAGE_UNITS);
+	}
+});
+
+export const checkWebSearchLimits = internalMutation({
+	args: { userId: v.string() },
+	handler: async (ctx, { userId }) => {
+		const tier = await getSubscriptionTier(ctx, userId);
+		await checkMeterLimits(ctx, 'webSearch', userId, tierLimits[tier]);
+	}
+});
+
+export const chargeWebSearchLimits = internalMutation({
 	args: { userId: v.string(), numResults: v.number() },
 	handler: async (ctx, { userId, numResults }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
 		const count = EXA_SEARCH_USAGE_UNITS + numResults * EXA_CONTENT_USAGE_UNITS;
-		await consumeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier], count);
+		await chargeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier], count);
 	}
 });
 
@@ -186,16 +196,8 @@ export const chargeModelUsageLimits = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const tier = await getSubscriptionTier(ctx, args.userId);
-		const limits = tierLimits[tier];
 		const count = completionUsageUnits(args.modelId, args.serviceTier, args.tokens);
-		for (const period of usagePeriods) {
-			await rateLimiter.limit(ctx, meterLimitName('modelUsage', period), {
-				key: args.userId,
-				config: meterLimitConfig('modelUsage', period, limits),
-				count,
-				reserve: true
-			});
-		}
+		await chargeMeterLimits(ctx, 'modelUsage', args.userId, tierLimits[tier], count);
 	}
 });
 
@@ -215,14 +217,22 @@ export async function chargeModelUsage(
 	await ctx.runMutation(internal.lib.rateLimits.chargeModelUsageLimits, args);
 }
 
-export async function enforceUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.consumeUrlScrapeLimits, { userId });
+export async function checkUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.checkUrlScrapeLimits, { userId });
 }
 
-export async function enforceWebSearchLimit(
+export async function chargeUrlScrapeUsage(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
+}
+
+export async function checkWebSearchLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.checkWebSearchLimits, { userId });
+}
+
+export async function chargeWebSearchUsage(
 	ctx: ActionCtx,
 	userId: string,
 	numResults: number
 ): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.consumeWebSearchLimits, { userId, numResults });
+	await ctx.runMutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults });
 }

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -12,6 +12,7 @@ import {
 } from '@convex-dev/rate-limiter';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation, type ActionCtx } from '@convex/_generated/server';
+import { getFunctionName, type FunctionArgs, type FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
 import {
 	completionUsageUnits,
@@ -201,6 +202,29 @@ export const chargeModelUsageLimits = internalMutation({
 	}
 });
 
+// Usage was already provided when these run, so accounting must not fail the
+// caller: fall back to a durable scheduled charge, and as a last resort log.
+async function chargeUsageDurably<Mutation extends FunctionReference<'mutation', 'internal'>>(
+	ctx: ActionCtx,
+	mutation: Mutation,
+	args: FunctionArgs<Mutation>
+): Promise<void> {
+	try {
+		await ctx.runMutation(mutation, args);
+	} catch (chargeError) {
+		try {
+			await ctx.scheduler.runAfter(0, mutation, args);
+		} catch (scheduleError) {
+			console.error(
+				`Failed to charge usage (${getFunctionName(mutation)}).`,
+				args,
+				chargeError,
+				scheduleError
+			);
+		}
+	}
+}
+
 export async function checkModelUsageLimit(ctx: ActionCtx, userId: string): Promise<void> {
 	await ctx.runMutation(internal.lib.rateLimits.checkModelUsageLimits, { userId });
 }
@@ -214,7 +238,7 @@ export async function chargeModelUsage(
 		tokens: { input: number; cacheRead: number; cacheWrite: number; output: number };
 	}
 ): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.chargeModelUsageLimits, args);
+	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeModelUsageLimits, args);
 }
 
 export async function checkUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {
@@ -222,7 +246,7 @@ export async function checkUrlScrapeLimit(ctx: ActionCtx, userId: string): Promi
 }
 
 export async function chargeUrlScrapeUsage(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
+	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
 }
 
 export async function checkWebSearchLimit(ctx: ActionCtx, userId: string): Promise<void> {
@@ -234,5 +258,8 @@ export async function chargeWebSearchUsage(
 	userId: string,
 	numResults: number
 ): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults });
+	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeWebSearchLimits, {
+		userId,
+		numResults
+	});
 }

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -14,11 +14,18 @@ import {
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation, type ActionCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
-import { completionUsageUnits, type SupportedModelId } from '@convex/lib/models';
+import {
+	completionUsageUnits,
+	type SupportedModelId,
+	type SupportedServiceTier
+} from '@convex/lib/models';
 import { getSubscriptionTier, tierLimits, type TierLimits } from '@convex/lib/tiers';
-import { vModelId } from '@convex/lib/validators';
+import { vModelId, vServiceTier } from '@convex/lib/validators';
 
 const MONTH = 30 * DAY;
+const URL_SCRAPE_USAGE_UNITS = 1.5;
+const EXA_SEARCH_USAGE_UNITS = 7;
+const EXA_CONTENT_USAGE_UNITS = 1;
 export const rateLimiter = new RateLimiter(components.rateLimiter, {});
 
 export const usageMeters = [
@@ -100,14 +107,15 @@ async function consumeMeterLimits(
 	ctx: RunMutationCtx,
 	meterId: UsageMeterId,
 	key: string,
-	limits: TierLimits
+	limits: TierLimits,
+	count: number
 ): Promise<void> {
-	await checkMeterLimits(ctx, meterId, key, limits);
 	for (const period of usagePeriods) {
 		try {
 			await rateLimiter.limit(ctx, meterLimitName(meterId, period), {
 				key,
 				config: meterLimitConfig(meterId, period, limits),
+				count,
 				throws: true
 			});
 		} catch (error) {
@@ -143,15 +151,16 @@ export const consumeUrlScrapeLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await consumeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier]);
+		await consumeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier], URL_SCRAPE_USAGE_UNITS);
 	}
 });
 
 export const consumeWebSearchLimits = internalMutation({
-	args: { userId: v.string() },
-	handler: async (ctx, { userId }) => {
+	args: { userId: v.string(), numResults: v.number() },
+	handler: async (ctx, { userId, numResults }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await consumeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier]);
+		const count = EXA_SEARCH_USAGE_UNITS + numResults * EXA_CONTENT_USAGE_UNITS;
+		await consumeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier], count);
 	}
 });
 
@@ -167,6 +176,7 @@ export const chargeModelUsageLimits = internalMutation({
 	args: {
 		userId: v.string(),
 		modelId: vModelId,
+		serviceTier: vServiceTier,
 		tokens: v.object({
 			input: v.number(),
 			cacheRead: v.number(),
@@ -177,7 +187,7 @@ export const chargeModelUsageLimits = internalMutation({
 	handler: async (ctx, args) => {
 		const tier = await getSubscriptionTier(ctx, args.userId);
 		const limits = tierLimits[tier];
-		const count = completionUsageUnits(args.modelId, args.tokens);
+		const count = completionUsageUnits(args.modelId, args.serviceTier, args.tokens);
 		for (const period of usagePeriods) {
 			await rateLimiter.limit(ctx, meterLimitName('modelUsage', period), {
 				key: args.userId,
@@ -198,6 +208,7 @@ export async function chargeModelUsage(
 	args: {
 		userId: string;
 		modelId: SupportedModelId;
+		serviceTier: SupportedServiceTier;
 		tokens: { input: number; cacheRead: number; cacheWrite: number; output: number };
 	}
 ): Promise<void> {
@@ -208,6 +219,10 @@ export async function enforceUrlScrapeLimit(ctx: ActionCtx, userId: string): Pro
 	await ctx.runMutation(internal.lib.rateLimits.consumeUrlScrapeLimits, { userId });
 }
 
-export async function enforceWebSearchLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.consumeWebSearchLimits, { userId });
+export async function enforceWebSearchLimit(
+	ctx: ActionCtx,
+	userId: string,
+	numResults: number
+): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.consumeWebSearchLimits, { userId, numResults });
 }

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -1,0 +1,40 @@
+import type { GenericMutationCtx, GenericQueryCtx } from 'convex/server';
+import type { DataModel } from '@convex/_generated/dataModel';
+
+export const subscriptionTierIds = ['free', 'pro'] as const;
+export type SubscriptionTier = (typeof subscriptionTierIds)[number];
+
+export type TierLimits = {
+	modelUsage: { weekly: number; monthly: number };
+	urlScrape: { weekly: number; monthly: number };
+	webSearch: { weekly: number; monthly: number };
+};
+
+const sharedLimits: TierLimits = {
+	modelUsage: { weekly: 25_000_000, monthly: 60_000_000 },
+	urlScrape: { weekly: 100, monthly: 280 },
+	webSearch: { weekly: 25, monthly: 60 }
+};
+
+export const tierLimits: Record<SubscriptionTier, TierLimits> = {
+	free: sharedLimits,
+	pro: sharedLimits
+};
+
+/** Dodo product id per paid tier; 'free' never has one. */
+export const tierProductIds: Partial<Record<SubscriptionTier, string>> = {};
+
+export function tierForProductId(productId: string): SubscriptionTier | undefined {
+	return subscriptionTierIds.find((tier) => tierProductIds[tier] === productId);
+}
+
+export async function getSubscriptionTier(
+	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<SubscriptionTier> {
+	const subscription = await ctx.db
+		.query('subscriptions')
+		.withIndex('by_userId', (query) => query.eq('userId', userId))
+		.unique();
+	return subscription?.status === 'active' ? subscription.tier : 'free';
+}

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -13,9 +13,9 @@ export type TierLimits = {
 };
 
 const sharedLimits: TierLimits = {
-	modelUsage: { weekly: 25_000_000, monthly: 60_000_000 },
-	urlScrape: { weekly: 100, monthly: 280 },
-	webSearch: { weekly: 25, monthly: 60 }
+	modelUsage: { weekly: 2_500, monthly: 7_500 },
+	urlScrape: { weekly: 250, monthly: 750 },
+	webSearch: { weekly: 250, monthly: 750 }
 };
 
 export const tierLimits: Record<SubscriptionTier, TierLimits> = {

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -4,6 +4,8 @@ import type { DataModel } from '@convex/_generated/dataModel';
 export const subscriptionTierIds = ['free', 'pro'] as const;
 export type SubscriptionTier = (typeof subscriptionTierIds)[number];
 
+export const tierLabels: Record<SubscriptionTier, string> = { free: 'Free', pro: 'Pro' };
+
 export type TierLimits = {
 	modelUsage: { weekly: number; monthly: number };
 	urlScrape: { weekly: number; monthly: number };

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -1,5 +1,6 @@
 import { v, type Infer } from 'convex/values';
 import { modelIds, reasoningEffortIds, serviceTierIds } from '@convex/lib/models';
+import { subscriptionTierIds } from '@convex/lib/tiers';
 
 function literals<const TValues extends readonly string[]>(values: TValues) {
 	return values.map((value) => v.literal(value)) as {
@@ -12,6 +13,16 @@ export const vReasoningEffort = v.union(...literals(reasoningEffortIds));
 export const vServiceTier = v.union(...literals(serviceTierIds));
 
 export const vModelId = v.union(...literals(modelIds));
+
+export const vSubscriptionTier = v.union(...literals(subscriptionTierIds));
+
+export const vSubscriptionStatus = v.union(
+	v.literal('active'),
+	v.literal('on_hold'),
+	v.literal('cancelled'),
+	v.literal('expired'),
+	v.literal('failed')
+);
 
 export const vWorkspaceInstruction = v.object({
 	path: v.string(),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -10,10 +10,26 @@ import {
 	vServiceTier,
 	vRunStatus,
 	vAssistantMessagePart,
-	vThreadMessageType
+	vThreadMessageType,
+	vSubscriptionStatus,
+	vSubscriptionTier
 } from '@convex/lib/validators';
 
 export default defineSchema({
+	billingCustomers: defineTable({
+		userId: v.string(),
+		dodoCustomerId: v.string()
+	})
+		.index('by_userId', ['userId'])
+		.index('by_dodoCustomerId', ['dodoCustomerId']),
+	subscriptions: defineTable({
+		userId: v.string(),
+		tier: vSubscriptionTier,
+		dodoSubscriptionId: v.string(),
+		dodoProductId: v.string(),
+		status: vSubscriptionStatus,
+		eventAt: v.number()
+	}).index('by_userId', ['userId']),
 	uiPreferences: defineTable({
 		userId: v.string(),
 		lastThreadId: v.optional(v.id('threadRecords'))

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -10,15 +10,34 @@ describe('subscription and usage backend', () => {
 		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
 			userId,
 			modelId: 'gpt-5.6-sol',
+			serviceTier: 'standard',
 			tokens: { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 }
 		});
 
 		const usage = await asUser.query(api.usage.getMyUsage, {});
 		const model = usage.meters.find((meter) => meter.id === 'modelUsage');
-		expect(model?.windows.find((window) => window.period === 'weekly')?.used).toBe(45_000_000);
+		expect(model?.windows.find((window) => window.period === 'weekly')?.used).toBe(100_000);
 		await expect(
 			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
-		).rejects.toThrow('Weekly model usage limit reached');
+		).rejects.toThrow('Monthly model usage limit reached');
+	});
+
+	it('charges web tools in proportion to their API cost', async () => {
+		const t = initConvexTest();
+		const userId = 'user_web_tools';
+		const asUser = t.withIdentity({ subject: userId });
+
+		await t.mutation(internal.lib.rateLimits.consumeUrlScrapeLimits, { userId });
+		await t.mutation(internal.lib.rateLimits.consumeWebSearchLimits, {
+			userId,
+			numResults: 5
+		});
+
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		const scrape = usage.meters.find((meter) => meter.id === 'urlScrape');
+		const search = usage.meters.find((meter) => meter.id === 'webSearch');
+		expect(scrape?.windows.find((window) => window.period === 'monthly')?.used).toBe(1.5);
+		expect(search?.windows.find((window) => window.period === 'monthly')?.used).toBe(12);
 	});
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -22,13 +22,13 @@ describe('subscription and usage backend', () => {
 		).rejects.toThrow('Monthly model usage limit reached');
 	});
 
-	it('charges web tools in proportion to their API cost', async () => {
+	it('charges web tools in proportion to their request cost', async () => {
 		const t = initConvexTest();
 		const userId = 'user_web_tools';
 		const asUser = t.withIdentity({ subject: userId });
 
-		await t.mutation(internal.lib.rateLimits.consumeUrlScrapeLimits, { userId });
-		await t.mutation(internal.lib.rateLimits.consumeWebSearchLimits, {
+		await t.mutation(internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, {
 			userId,
 			numResults: 5
 		});

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { api, internal } from '@convex/_generated/api';
+import { initConvexTest } from './test.setup';
+
+describe('subscription and usage backend', () => {
+	it('reports weighted model usage and preserves overdraft', async () => {
+		const t = initConvexTest();
+		const userId = 'user_usage';
+		const asUser = t.withIdentity({ subject: userId });
+		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
+			userId,
+			modelId: 'gpt-5.6-sol',
+			tokens: { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 }
+		});
+
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		const model = usage.meters.find((meter) => meter.id === 'modelUsage');
+		expect(model?.windows.find((window) => window.period === 'weekly')?.used).toBe(45_000_000);
+		await expect(
+			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
+		).rejects.toThrow('Weekly model usage limit reached');
+	});
+
+	it('uses only active subscriptions and ignores stale webhook events', async () => {
+		const t = initConvexTest();
+		const userId = 'user_billing';
+		const asUser = t.withIdentity({ subject: userId });
+		const currentTier = async () => (await asUser.query(api.usage.getMyUsage, {})).tier;
+		const subscription = {
+			userId,
+			tier: 'pro',
+			dodoSubscriptionId: 'sub_1',
+			dodoProductId: 'prod_1',
+			dodoCustomerId: 'customer_1'
+		} as const;
+		expect(await currentTier()).toBe('free');
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			...subscription,
+			status: 'active',
+			eventAt: 1_000
+		});
+		expect(await currentTier()).toBe('pro');
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			...subscription,
+			status: 'cancelled',
+			eventAt: 2_000
+		});
+		expect(await currentTier()).toBe('free');
+
+		// A late-arriving older 'active' event must not resurrect the subscription.
+		await t.mutation(internal.billing.upsertSubscription, {
+			...subscription,
+			status: 'active',
+			eventAt: 1_500
+		});
+		expect(await currentTier()).toBe('free');
+	});
+});

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -16,28 +16,31 @@ describe('subscription and usage backend', () => {
 
 		const usage = await asUser.query(api.usage.getMyUsage, {});
 		const model = usage.meters.find((meter) => meter.id === 'modelUsage');
-		expect(model?.windows.find((window) => window.period === 'weekly')?.used).toBe(100_000);
+		const weekly = model?.windows.find((window) => window.period === 'weekly');
+		expect(weekly && weekly.used > weekly.limit).toBe(true);
 		await expect(
 			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
 		).rejects.toThrow('Monthly model usage limit reached');
 	});
 
-	it('charges web tools in proportion to their request cost', async () => {
+	it('weights web tool usage by request size', async () => {
 		const t = initConvexTest();
 		const userId = 'user_web_tools';
 		const asUser = t.withIdentity({ subject: userId });
+		const used = async (meterId: string) => {
+			const usage = await asUser.query(api.usage.getMyUsage, {});
+			const meter = usage.meters.find((meter) => meter.id === meterId);
+			return meter?.windows.find((window) => window.period === 'monthly')?.used ?? 0;
+		};
 
 		await t.mutation(internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
-		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, {
-			userId,
-			numResults: 5
-		});
+		expect(await used('urlScrape')).toBeGreaterThan(0);
 
-		const usage = await asUser.query(api.usage.getMyUsage, {});
-		const scrape = usage.meters.find((meter) => meter.id === 'urlScrape');
-		const search = usage.meters.find((meter) => meter.id === 'webSearch');
-		expect(scrape?.windows.find((window) => window.period === 'monthly')?.used).toBe(1.5);
-		expect(search?.windows.find((window) => window.period === 'monthly')?.used).toBe(12);
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults: 1 });
+		const smallSearch = await used('webSearch');
+		expect(smallSearch).toBeGreaterThan(0);
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults: 10 });
+		expect(await used('webSearch')).toBeGreaterThan(smallSearch * 2);
 	});
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {

--- a/apps/web/src/convex/usage.ts
+++ b/apps/web/src/convex/usage.ts
@@ -1,0 +1,28 @@
+import { query } from '@convex/_generated/server';
+import { getUserId } from '@convex/lib/auth';
+import { getMeterWindow, usageMeters, usagePeriods } from '@convex/lib/rateLimits';
+import { getSubscriptionTier, tierLimits } from '@convex/lib/tiers';
+
+export const getMyUsage = query({
+	args: {},
+	handler: async (ctx) => {
+		const userId = await getUserId(ctx);
+		const tier = await getSubscriptionTier(ctx, userId);
+		const limits = tierLimits[tier];
+		return {
+			tier,
+			meters: await Promise.all(
+				usageMeters.map(async (meter) => ({
+					id: meter.id,
+					label: meter.label,
+					windows: await Promise.all(
+						usagePeriods.map(async (period) => ({
+							period,
+							...(await getMeterWindow(ctx, meter.id, period, userId, limits))
+						}))
+					)
+				}))
+			)
+		};
+	}
+});

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -116,7 +116,7 @@ export const webSearch = action({
 			? Math.floor(args.numResults as number)
 			: DEFAULT_SEARCH_RESULTS;
 		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
-		await enforceWebSearchLimit(ctx, userId);
+		await enforceWebSearchLimit(ctx, userId, numResults);
 
 		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
 			exa.search(ctx, {

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -6,7 +6,12 @@ import { ExaClient } from '@exalabs/convex-exa';
 import { action } from '@convex/_generated/server';
 import { components } from '@convex/_generated/api';
 import { getUserId } from '@convex/lib/auth';
-import { enforceUrlScrapeLimit, enforceWebSearchLimit } from '@convex/lib/rateLimits';
+import {
+	chargeUrlScrapeUsage,
+	chargeWebSearchUsage,
+	checkUrlScrapeLimit,
+	checkWebSearchLimit
+} from '@convex/lib/rateLimits';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
 
 const contextDev = new ContextDev(components.contextDev);
@@ -78,7 +83,7 @@ export const scrapeUrl = action({
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			throw new Error('Only http(s) URLs can be scraped.');
 		}
-		await enforceUrlScrapeLimit(ctx, userId);
+		await checkUrlScrapeLimit(ctx, userId);
 
 		const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
 			contextDev.scrapeMarkdown(ctx, {
@@ -89,6 +94,7 @@ export const scrapeUrl = action({
 				}
 			})
 		);
+		await chargeUrlScrapeUsage(ctx, userId);
 
 		const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
 		return {
@@ -116,7 +122,7 @@ export const webSearch = action({
 			? Math.floor(args.numResults as number)
 			: DEFAULT_SEARCH_RESULTS;
 		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
-		await enforceWebSearchLimit(ctx, userId, numResults);
+		await checkWebSearchLimit(ctx, userId);
 
 		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
 			exa.search(ctx, {
@@ -126,6 +132,7 @@ export const webSearch = action({
 				contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
 			})
 		);
+		await chargeWebSearchUsage(ctx, userId, numResults);
 
 		return {
 			results: response.results.flatMap((result) => {

--- a/apps/web/src/lib/components/home/settings-account.svelte
+++ b/apps/web/src/lib/components/home/settings-account.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { LogOut } from '@lucide/svelte';
 	import type { User } from '@workos-inc/authkit-js';
+	import { useAuth, useQuery } from 'convex-svelte';
+	import { api } from '$convex/_generated/api';
+	import { tierLabels } from '$convex/lib/tiers';
 	import Button from '$lib/components/ui/button/button.svelte';
 
 	type Props = {
@@ -10,6 +13,11 @@
 
 	let { user, onSignOut }: Props = $props();
 	let emailRevealed = $state(false);
+
+	const convexAuth = useAuth();
+	const subscriptionQuery = useQuery(api.billing.getMySubscription, () =>
+		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
+	);
 
 	const displayName = $derived(
 		[user?.firstName, user?.lastName].filter(Boolean).join(' ').trim() || null
@@ -48,6 +56,19 @@
 					</div>
 				{:else}
 					<p class="mt-3 text-sm text-slate-400">You’re signed in to Sprocket.</p>
+				{/if}
+			</div>
+
+			<div>
+				<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">
+					Spikonado Subscription Tier
+				</p>
+				{#if subscriptionQuery.data}
+					<p class="mt-3 text-[15px] text-white">{tierLabels[subscriptionQuery.data.tier]}</p>
+				{:else if subscriptionQuery.error}
+					<p class="mt-3 text-sm text-slate-500">Couldn’t load your subscription right now.</p>
+				{:else}
+					<div class="mt-3.5 h-4 w-16 animate-pulse rounded bg-white/5" aria-hidden="true"></div>
 				{/if}
 			</div>
 

--- a/apps/web/src/lib/components/home/settings-sidebar.svelte
+++ b/apps/web/src/lib/components/home/settings-sidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Archive, ArrowLeft, UserRound } from '@lucide/svelte';
+	import { Archive, ArrowLeft, ChartNoAxesColumn, UserRound } from '@lucide/svelte';
 
-	export type SettingsPage = 'account' | 'archived';
+	export type SettingsPage = 'account' | 'usage' | 'archived';
 
 	type Props = {
 		activePage: SettingsPage;
@@ -10,6 +10,12 @@
 	};
 
 	let { activePage, onBack, onNavigate }: Props = $props();
+
+	const navItems: ReadonlyArray<{ id: SettingsPage; label: string; icon: typeof UserRound }> = [
+		{ id: 'account', label: 'Account', icon: UserRound },
+		{ id: 'usage', label: 'Usage', icon: ChartNoAxesColumn },
+		{ id: 'archived', label: 'Archived Threads', icon: Archive }
+	];
 
 	const navItemClass =
 		'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-[13px] transition';
@@ -34,28 +40,19 @@
 			class="hide-scrollbar min-h-0 flex-1 space-y-0.5 overflow-y-auto px-2.5 pb-4"
 			aria-label="Settings"
 		>
-			<button
-				type="button"
-				class={`${navItemClass} ${activePage === 'account' ? navItemActiveClass : navItemIdleClass}`}
-				aria-current={activePage === 'account' ? 'page' : undefined}
-				onclick={() => {
-					onNavigate('account');
-				}}
-			>
-				<UserRound class="size-4 shrink-0 text-slate-400" aria-hidden="true" />
-				<span class="truncate">Account</span>
-			</button>
-			<button
-				type="button"
-				class={`${navItemClass} ${activePage === 'archived' ? navItemActiveClass : navItemIdleClass}`}
-				aria-current={activePage === 'archived' ? 'page' : undefined}
-				onclick={() => {
-					onNavigate('archived');
-				}}
-			>
-				<Archive class="size-4 shrink-0 text-slate-400" aria-hidden="true" />
-				<span class="truncate">Archived Threads</span>
-			</button>
+			{#each navItems as item (item.id)}
+				<button
+					type="button"
+					class={`${navItemClass} ${activePage === item.id ? navItemActiveClass : navItemIdleClass}`}
+					aria-current={activePage === item.id ? 'page' : undefined}
+					onclick={() => {
+						onNavigate(item.id);
+					}}
+				>
+					<item.icon class="size-4 shrink-0 text-slate-400" aria-hidden="true" />
+					<span class="truncate">{item.label}</span>
+				</button>
+			{/each}
 		</nav>
 	</div>
 </aside>

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import { useAuth, useQuery } from 'convex-svelte';
+	import { api } from '$convex/_generated/api';
+	import type { SubscriptionTier } from '$convex/lib/tiers';
+
+	const convexAuth = useAuth();
+	const usageQuery = useQuery(api.usage.getMyUsage, () =>
+		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
+	);
+
+	let now = $state(Date.now());
+
+	$effect(() => {
+		const interval = setInterval(() => {
+			now = Date.now();
+		}, 60_000);
+		return () => {
+			clearInterval(interval);
+		};
+	});
+
+	const compactAmount = new Intl.NumberFormat('en-US', {
+		notation: 'compact',
+		maximumFractionDigits: 1
+	});
+
+	const periodLabels = { weekly: 'Weekly', monthly: 'Monthly' } as const;
+	const tierNames: Record<SubscriptionTier, string> = { free: 'Free', pro: 'Pro' };
+
+	function formatResetsIn(resetsAt: number) {
+		const remainingMs = Math.max(0, resetsAt - now);
+		const hours = Math.ceil(remainingMs / 3_600_000);
+		if (hours >= 24) {
+			const days = Math.floor(hours / 24);
+			const restHours = hours % 24;
+			return restHours > 0 ? `${days}d ${restHours}h` : `${days}d`;
+		}
+		if (remainingMs >= 3_600_000) {
+			return `${hours}h`;
+		}
+		return `${Math.max(1, Math.ceil(remainingMs / 60_000))}m`;
+	}
+
+	function fillClass(atLimit: boolean, nearLimit: boolean) {
+		if (atLimit) {
+			return 'bg-rose-400/90';
+		}
+		if (nearLimit) {
+			return 'bg-amber-400/90';
+		}
+		return 'bg-slate-200/90';
+	}
+</script>
+
+<section class="flex h-full min-h-0 flex-col overflow-hidden">
+	<header class="flex h-12 shrink-0 items-center px-6">
+		<h1 class="text-[1rem] font-medium tracking-[-0.03em] text-white">Usage</h1>
+	</header>
+
+	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
+		<div class="max-w-xl space-y-10">
+			{#if usageQuery.error}
+				<p class="text-sm leading-6 text-slate-500">
+					Couldn’t load your usage right now. Try again in a moment.
+				</p>
+			{:else if usageQuery.isLoading || usageQuery.data === undefined}
+				<div class="animate-pulse space-y-10" aria-hidden="true">
+					<div class="h-4 w-24 rounded bg-white/5"></div>
+					{#each ['modelUsage', 'webSearch', 'urlScrape'] as meterId (meterId)}
+						<div class="space-y-5">
+							<div class="h-3 w-28 rounded bg-white/5"></div>
+							{#each ['weekly', 'monthly'] as period (period)}
+								<div class="space-y-2">
+									<div class="h-3.5 w-full rounded bg-white/5"></div>
+									<div class="h-1.5 w-full rounded-full bg-white/5"></div>
+								</div>
+							{/each}
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<div>
+					<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Plan</p>
+					<p class="mt-3 text-[15px] text-white">
+						{tierNames[usageQuery.data.tier]} plan
+					</p>
+				</div>
+
+				{#each usageQuery.data.meters as meter (meter.id)}
+					<div>
+						<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">{meter.label}</p>
+						{#if meter.id === 'modelUsage'}
+							<p class="mt-1 text-[12px] text-slate-500">
+								Weighted by model and token type — pricier models and output tokens use more.
+							</p>
+						{/if}
+						<div class="mt-4 space-y-6">
+							{#each meter.windows as meterWindow (meterWindow.period)}
+								{@const hasLimit = meterWindow.limit > 0}
+								{@const percent = hasLimit
+									? Math.round((meterWindow.used / meterWindow.limit) * 100)
+									: 0}
+								{@const atLimit = hasLimit && meterWindow.used >= meterWindow.limit}
+								{@const nearLimit = hasLimit && meterWindow.used >= meterWindow.limit * 0.9}
+								<div>
+									<div class="flex items-baseline justify-between gap-3">
+										<p class="text-[13px] text-slate-300">{periodLabels[meterWindow.period]}</p>
+										{#if hasLimit}
+											<p
+												class={`text-[12px] ${atLimit ? 'text-rose-300' : nearLimit ? 'text-amber-300' : 'text-slate-500'}`}
+											>
+												{percent}% used
+											</p>
+										{/if}
+									</div>
+									<p class="mt-0.5 text-[12px] text-slate-500">
+										{compactAmount.format(hasLimit ? meterWindow.used : 0)} / {compactAmount.format(
+											hasLimit ? meterWindow.limit : 0
+										)}
+									</p>
+									<div
+										class="mt-2 h-1.5 overflow-hidden rounded-full bg-white/5"
+										role="progressbar"
+										aria-label={`${meter.label} — ${periodLabels[meterWindow.period]}`}
+										aria-valuemin={0}
+										aria-valuemax={hasLimit ? meterWindow.limit : 0}
+										aria-valuenow={hasLimit ? Math.min(meterWindow.used, meterWindow.limit) : 0}
+										aria-valuetext={hasLimit ? `${percent}% used` : '0 / 0'}
+									>
+										<div
+											class={`h-full rounded-full transition-[width] duration-300 ${fillClass(atLimit, nearLimit)}`}
+											style={`width: ${hasLimit ? Math.min(100, Math.max(0, percent)) : 0}%`}
+										></div>
+									</div>
+									{#if meterWindow.resetsAt !== null}
+										<p class="mt-1.5 text-[12px] text-slate-500">
+											Resets in {formatResetsIn(meterWindow.resetsAt)}
+										</p>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/each}
+			{/if}
+		</div>
+	</div>
+</section>

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { useAuth, useQuery } from 'convex-svelte';
 	import { api } from '$convex/_generated/api';
-	import type { SubscriptionTier } from '$convex/lib/tiers';
+	import { tierLabels } from '$convex/lib/tiers';
 
 	const convexAuth = useAuth();
 	const usageQuery = useQuery(api.usage.getMyUsage, () =>
@@ -25,7 +25,6 @@
 	});
 
 	const periodLabels = { weekly: 'Weekly', monthly: 'Monthly' } as const;
-	const tierNames: Record<SubscriptionTier, string> = { free: 'Free', pro: 'Pro' };
 
 	function formatResetsIn(resetsAt: number) {
 		const remainingMs = Math.max(0, resetsAt - now);
@@ -82,7 +81,7 @@
 				<div>
 					<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Plan</p>
 					<p class="mt-3 text-[15px] text-white">
-						{tierNames[usageQuery.data.tier]} plan
+						{tierLabels[usageQuery.data.tier]} plan
 					</p>
 				</div>
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -24,6 +24,7 @@
 	import SettingsAccount from '$lib/components/home/settings-account.svelte';
 	import SettingsArchived from '$lib/components/home/settings-archived.svelte';
 	import SettingsSidebar, { type SettingsPage } from '$lib/components/home/settings-sidebar.svelte';
+	import SettingsUsage from '$lib/components/home/settings-usage.svelte';
 	import ThreadTranscript from '$lib/components/home/thread-transcript.svelte';
 	import WorkspacePicker, {
 		type WorkspaceSelection
@@ -1728,6 +1729,8 @@
 								void restoreThread(threadId);
 							}}
 						/>
+					{:else if settingsPage === 'usage'}
+						<SettingsUsage />
 					{:else}
 						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
 					{/if}

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@ai-sdk/xai": "^4.0.14",
         "@context-dot-dev/convex": "^1.0.1",
         "@convex-dev/rate-limiter": "^0.3.2",
+        "@dodopayments/convex": "^0.2.12",
         "@exalabs/convex-exa": "^0.1.0",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/dm-sans": "^5.2.8",
@@ -137,6 +138,10 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@dodopayments/convex": ["@dodopayments/convex@0.2.12", "", { "dependencies": { "@dodopayments/core": "^0.3.10" }, "peerDependencies": { "convex": "^1.26.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-CiQ6tVfzbbY/QwUvDxfmBUI+XjCs9DXnR4/kh2x4cykItbtbc8HyBbav0PY3ZkIYk3M/AjrkrgO21zeLVRn6gg=="],
+
+    "@dodopayments/core": ["@dodopayments/core@0.3.12", "", { "dependencies": { "dodopayments": "^2.31.2", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-cahX0AmZI9QN6PhXDE24vUa/UBD4qU21iCgyJRC0L7jxX3dQNMwQSfP2ow9xovnrBQxrsebnwwlDoKi5wl20dA=="],
 
     "@edge-runtime/primitives": ["@edge-runtime/primitives@6.0.0", "", {}, "sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA=="],
 
@@ -409,6 +414,8 @@
     "@sprocket/typescript-config": ["@sprocket/typescript-config@workspace:packages/typescript-config"],
 
     "@sprocket/web": ["@sprocket/web@workspace:apps/web"],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -724,6 +731,8 @@
 
     "dmg-builder": ["dmg-builder@26.15.3", "", { "dependencies": { "app-builder-lib": "26.15.3", "builder-util": "26.15.3", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0" } }, "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ=="],
 
+    "dodopayments": ["dodopayments@2.42.2", "", { "dependencies": { "standardwebhooks": "^1.0.0" }, "bin": { "dodopayments": "bin/cli" } }, "sha512-XBF8zrnfkjAhX7OyrR3KauK6bH+oW3yZ+uqy6RBWI5XdZvrEtASabvvfHrBX3UGR3Bbxl3t1rkpcao+riKSOuw=="],
+
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
@@ -823,6 +832,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
@@ -1233,6 +1244,8 @@
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
 


### PR DESCRIPTION
Adds subscription tiers with usage limits across models and web tools.

## What's included

- **Subscription tiers**: `free` and `pro` tiers backed by Dodo subscriptions, with webhook handling that ignores stale events. A usage page in settings shows per-meter consumption, and the account page shows the current tier.
- **Proportional usage accounting**: rate-limit meters now charge model completions and web tools in proportion to their underlying request cost instead of counting requests.
- **Service-tier and long-context accounting**: model charges account for the `fast` service tier and long-context requests where providers price those differently.
- **Web tool accounting**: web searches scale with the number of requested results; scrapes have a fixed per-request weight.
- **Limits**: weekly and monthly caps per meter, currently identical for the free and pro tiers.

## Testing

- `bun run test` (all 135 tests pass)
- `prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds subscription tiers and proportional usage limits across the web app. The main changes are:

- Dodo checkout, customer portal, and subscription webhook handling.
- Weighted accounting for model completions, searches, and URL scrapes.
- Weekly and monthly usage meters for each subscription tier.
- Account and usage views in settings.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issue qualifies for this follow-up review.

The latest billing and accounting changes did not expose a separate blocking failure beyond the existing review findings. No qualifying security issue was found in the updated paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the full test suite on the parent revision d3d5faf05031ea7aab43196c0f0ac45a81558a07 and confirmed 135/135 tests passed in 4.96s.
- Checked out the updated revision and re-ran the full test suite, confirming 135/135 tests passed in 4.92s.
- Reviewed the proof logs to confirm they include the exact command, working directory, complete test output, and exit code for both runs.

<a href="https://app.greptile.com/trex/runs/14960003/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/billing.ts | Adds billing actions and persists subscription state from webhook events. |
| apps/web/src/convex/http.ts | Registers Dodo webhook handlers and maps provider events to subscription updates. |
| apps/web/src/convex/lib/tiers.ts | Defines subscription tiers, product mapping, and per-tier usage limits. |
| apps/web/src/convex/lib/rateLimits.ts | Adds weighted weekly and monthly usage checks, charges, and reporting. |
| apps/web/src/convex/completion.ts | Checks model usage before generation and records weighted usage afterward. |
| apps/web/src/convex/webTools.ts | Checks web-tool limits before provider calls and charges successful operations. |
| apps/web/src/lib/components/home/settings-usage.svelte | Adds a settings view for subscription usage and reset times. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(web): Preserve results when usage ch..."](https://github.com/spikonado/sprocket/commit/4560a7ac48ccc5ac63b08158f23bb2d538d2fac2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45318709)</sub>

<!-- /greptile_comment -->