### PR TITLE
fix(agent): Recover runs after superseded completions

### DIFF
--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -69,7 +69,7 @@ pub(crate) struct AgentProviderRequest {
 pub(crate) enum AgentProviderResult {
     Completed { text: String },
     Cancelled { text: String },
-    Superseded,
+    Superseded { error: anyhow::Error },
     Failed { text: String, error: anyhow::Error },
 }
 
@@ -182,7 +182,9 @@ where
                         final_text
                     };
                     let result = match classify_provider_error(&error) {
-                        ProviderErrorDisposition::Superseded => AgentProviderResult::Superseded,
+                        ProviderErrorDisposition::Superseded => AgentProviderResult::Superseded {
+                            error: anyhow!(error),
+                        },
                         ProviderErrorDisposition::Cancelled => {
                             AgentProviderResult::Cancelled { text }
                         }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -172,13 +172,18 @@ async fn finalize_claim_failure(
     text: &str,
 ) -> anyhow::Result<()> {
     let last_error = error.to_string();
-    cleanup_twice(
+    let accepted = cleanup_twice(
         &format!("claim failure cleanup for run {run_id}"),
         FAILURE_CLEANUP_ATTEMPT_TIMEOUT,
         || runtime.finalize_claim_failure(run_id, claim_id, text, &last_error),
     )
-    .await
-    .map(|_| ())
+    .await?;
+    if !accepted {
+        eprintln!(
+            "sprocket-agent: claim failure cleanup skipped for run {run_id}; run no longer belongs to this active claim"
+        );
+    }
+    Ok(())
 }
 
 async fn abort_after_claim(
@@ -262,9 +267,18 @@ async fn finalize_provider_result(
             )
             .await
         }
-        AgentProviderResult::Superseded => {
-            eprintln!("sprocket-agent: provider attempt superseded {}", run_id);
-            Ok(())
+        AgentProviderResult::Superseded { error } => {
+            eprintln!(
+                "sprocket-agent: provider attempt superseded {}: {error}",
+                run_id
+            );
+            abort_after_claim(
+                runtime,
+                run_id,
+                claim_id,
+                anyhow!("the model connection could not be recovered"),
+            )
+            .await
         }
         AgentProviderResult::Failed { text, error } => {
             let error_text = error.to_string();

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -530,14 +530,13 @@ async fn call_completion_action(
                     "sprocket-convex-provider: timed out calling {}; retrying: {error}",
                     client.completion_action
                 );
-                superseded_stream_ids.push(stream_id);
-                sleep(retry_delay).await;
-                retry_delay = retry_delay.saturating_mul(2);
+                backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay)
+                    .await;
                 continue;
             }
         };
 
-        match result {
+        let provider_error = match result {
             Ok(FunctionResult::Value(value)) => {
                 eprintln!(
                     "sprocket-convex-provider: action done {}",
@@ -545,12 +544,8 @@ async fn call_completion_action(
                 );
                 return Ok(value);
             }
-            Ok(FunctionResult::ErrorMessage(message)) => {
-                return Err(CompletionError::ProviderError(message));
-            }
-            Ok(FunctionResult::ConvexError(error)) => {
-                return Err(CompletionError::ProviderError(error.message));
-            }
+            Ok(FunctionResult::ErrorMessage(message)) => message,
+            Ok(FunctionResult::ConvexError(error)) => error.message,
             Err(error) => {
                 if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
                     return Err(to_completion_error(error));
@@ -559,12 +554,37 @@ async fn call_completion_action(
                     "sprocket-convex-provider: transport failure calling {}; retrying: {error:#}",
                     client.completion_action
                 );
-                superseded_stream_ids.push(stream_id);
-                sleep(retry_delay).await;
-                retry_delay = retry_delay.saturating_mul(2);
+                backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay)
+                    .await;
+                continue;
             }
+        };
+        if should_retry_superseded_completion(&provider_error, attempt) {
+            // A takeover changes the claim id, so the backend rejects these retries
+            // before their attempt sequence can supersede the new owner.
+            eprintln!(
+                "sprocket-convex-provider: action {} transport attempt {attempt} was superseded; retrying with a fresh stream",
+                client.completion_action,
+            );
+            backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
+            continue;
         }
+        return Err(CompletionError::ProviderError(provider_error));
     }
+}
+
+fn should_retry_superseded_completion(message: &str, attempt: u32) -> bool {
+    attempt < COMPLETION_TRANSPORT_ATTEMPTS && is_completion_stream_superseded(message)
+}
+
+async fn backoff_completion_retry(
+    superseded_stream_ids: &mut Vec<String>,
+    stream_id: String,
+    retry_delay: &mut Duration,
+) {
+    superseded_stream_ids.push(stream_id);
+    sleep(*retry_delay).await;
+    *retry_delay = retry_delay.saturating_mul(2);
 }
 
 fn action_args(
@@ -730,9 +750,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        COMPLETION_STREAM_SUPERSEDED, CompletionOutput, CompletionStreamEvent, InputTokenDetails,
-        ToolCall, Usage, clone_locked, completion_choice, is_completion_stream_superseded,
-        reasoning_stream_choices, text_stream_choices,
+        COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
+        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, clone_locked, completion_choice,
+        is_completion_stream_superseded, reasoning_stream_choices,
+        should_retry_superseded_completion, text_stream_choices,
     };
     use rig::completion::{CompletionError, GetTokenUsage};
     use rig::message::AssistantContent;
@@ -905,5 +926,20 @@ mod tests {
         ));
 
         assert!(is_completion_stream_superseded(&error));
+    }
+
+    #[test]
+    fn retries_superseded_replays_until_the_transport_attempt_limit() {
+        let error = format!("completion:complete failed: {COMPLETION_STREAM_SUPERSEDED}");
+
+        assert!(should_retry_superseded_completion(
+            &error,
+            COMPLETION_TRANSPORT_ATTEMPTS - 1,
+        ));
+        assert!(!should_retry_superseded_completion(
+            &error,
+            COMPLETION_TRANSPORT_ATTEMPTS,
+        ));
+        assert!(!should_retry_superseded_completion("provider failed", 1));
     }
 }


### PR DESCRIPTION
## Summary

- retry claim-fenced completion streams when a reconnect replay is superseded
- terminalize the run and reconcile executor jobs if recovery is exhausted
- keep internal supersession sentinels in logs and show users a clean failure message
- add regression coverage for the bounded retry behavior

## Root cause

An authentication or protocol reconnect can replay an in-flight Convex completion action. The completion fence correctly rejects the stale replay as superseded, but the agent treated that outcome as a successful exit. The run therefore remained non-terminal and its tool call stayed permanently marked as running.

## Impact

Reconnect replays now recover through a fresh fenced stream. If recovery cannot succeed, the run is durably finalized so the thread remains usable and tool state is reconciled.

## Validation

- `nix develop -c cargo test -p sprocket-convex-provider -p sprocket-agent`
- `nix develop -c prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR recovers agent runs when completion replays are superseded. The main changes are:

- Retries superseded completion actions with fresh stream IDs and bounded backoff.
- Terminalizes runs and reconciles executor jobs when recovery is exhausted.
- Keeps internal errors in logs while storing a clean user-facing failure message.
- Adds tests for supersession classification and retry limits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code. Retries remain bounded by the existing transport attempt limit. Claim checks prevent stale workers from finalizing runs owned by replacement workers.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The transcript records every exact command, the /home/user/repo working directory, verbose Cargo output, and exit statuses.
- Focused tests and affected-package validation all returned exit code 0.
- Live Convex service replay was not attempted because deployment/auth configuration is unavailable.

<a href="https://app.greptile.com/trex/runs/14950673/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-convex-provider/src/client.rs | Adds bounded supersession retries, fresh stream tracking, shared backoff handling, and retry-limit tests. |
| crates/sprocket-agent/src/provider.rs | Carries the original supersession error into run finalization for internal logging. |
| crates/sprocket-agent/src/run.rs | Finalizes exhausted recovery through claim-fenced cleanup and reports rejected stale cleanup attempts. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Agent
participant Completion as Convex completion action
participant Runtime as Run runtime
Agent->>Completion: Complete with claim and fresh stream ID
Completion-->>Agent: Superseded sentinel
alt Retry budget remains
    Agent->>Agent: Record old stream ID and back off
    Agent->>Completion: Retry with fresh stream ID
else Retry budget exhausted
    Agent->>Runtime: Finalize claim failure
    alt Claim is still owned
        Runtime->>Runtime: Mark failed and reconcile jobs
    else Claim changed or run is terminal
        Runtime-->>Agent: Reject stale cleanup
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Agent
participant Completion as Convex completion action
participant Runtime as Run runtime
Agent->>Completion: Complete with claim and fresh stream ID
Completion-->>Agent: Superseded sentinel
alt Retry budget remains
    Agent->>Agent: Record old stream ID and back off
    Agent->>Completion: Retry with fresh stream ID
else Retry budget exhausted
    Agent->>Runtime: Finalize claim failure
    alt Claim is still owned
        Runtime->>Runtime: Mark failed and reconcile jobs
    else Claim changed or run is terminal
        Runtime-->>Agent: Reject stale cleanup
    end
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Recover superseded completio..."](https://github.com/spikonado/sprocket/commit/bad6b37295e3fa676fad3f6a5676b079605d435d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45319191)</sub>

<!-- /greptile_comment -->