### PR TITLE
fix(web): Settle tool calls and command sessions after crashed runs

### DIFF
--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -532,13 +532,17 @@ describe('partitionWorkSectionTools', () => {
 		const claimedTool = tool('patch-1', 'apply_patch', {
 			job: executorJob('job-patch', 1, { status: 'claimed', kind: 'apply_patch' })
 		});
+		const claimedToolWithResult = tool('patch-2', 'apply_patch', {
+			output: { changedFiles: ['a.txt'] },
+			job: executorJob('job-patch-2', 2, { status: 'claimed', kind: 'apply_patch' })
+		});
 		const yieldedCommand = tool('exec-1', 'exec_command', {
 			input: { cmd: 'npm run dev' },
 			output: { sessionId: '7', running: true },
-			job: executorJob('job-exec', 2, { status: 'completed', kind: 'exec_command' })
+			job: executorJob('job-exec', 3, { status: 'completed', kind: 'exec_command' })
 		});
 		const blocks: AssistantTimelineWorkBlock[] = [
-			{ type: 'tool-group', toolKey: 'apply_patch', tools: [claimedTool] },
+			{ type: 'tool-group', toolKey: 'apply_patch', tools: [claimedTool, claimedToolWithResult] },
 			{ type: 'tool-group', toolKey: 'exec_command', tools: [yieldedCommand] }
 		];
 
@@ -550,6 +554,7 @@ describe('partitionWorkSectionTools', () => {
 		expect(assistantTimelineToolError(claimedTool, false)).toBe(
 			'The agent stopped before this tool call finished.'
 		);
+		expect(assistantTimelineToolFailureKind(claimedToolWithResult, false)).toBeUndefined();
 		expect(assistantTimelineToolFailureKind(yieldedCommand, false)).toBeUndefined();
 	});
 });

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -139,7 +139,7 @@ describe('assistant timeline', () => {
 
 		expect(tool).toMatchObject({ type: 'tool' });
 		if (tool?.type !== 'tool') throw new Error('Expected a tool timeline item.');
-		expect(assistantTimelineToolError(tool)).toBe('command failed');
+		expect(assistantTimelineToolError(tool, true)).toBe('command failed');
 	});
 
 	it('exposes the error or cancelled state for live cancelled jobs', () => {
@@ -156,10 +156,12 @@ describe('assistant timeline', () => {
 		if (cancelled?.type !== 'tool' || cancelledWithError?.type !== 'tool') {
 			throw new Error('Expected tool timeline items.');
 		}
-		expect(assistantTimelineToolError(cancelled)).toBe('Executor job cancelled before completion.');
-		expect(assistantTimelineToolError(cancelledWithError)).toBe('stopped by user');
-		expect(assistantTimelineToolFailureKind(cancelled)).toBe('cancelled');
-		expect(assistantTimelineToolFailureKind(cancelledWithError)).toBe('cancelled');
+		expect(assistantTimelineToolError(cancelled, true)).toBe(
+			'Executor job cancelled before completion.'
+		);
+		expect(assistantTimelineToolError(cancelledWithError, true)).toBe('stopped by user');
+		expect(assistantTimelineToolFailureKind(cancelled, true)).toBe('cancelled');
+		expect(assistantTimelineToolFailureKind(cancelledWithError, true)).toBe('cancelled');
 	});
 
 	it('falls back to the failed state when a failed live job has no error', () => {
@@ -167,8 +169,8 @@ describe('assistant timeline', () => {
 
 		expect(failed).toMatchObject({ type: 'tool' });
 		if (failed?.type !== 'tool') throw new Error('Expected a tool timeline item.');
-		expect(assistantTimelineToolError(failed)).toBe('Executor job failed.');
-		expect(assistantTimelineToolFailureKind(failed)).toBe('failed');
+		expect(assistantTimelineToolError(failed, true)).toBe('Executor job failed.');
+		expect(assistantTimelineToolFailureKind(failed, true)).toBe('failed');
 	});
 
 	it('labels persisted tool-result errors as failed, not cancelled', () => {
@@ -186,7 +188,7 @@ describe('assistant timeline', () => {
 
 		expect(tool).toMatchObject({ type: 'tool' });
 		if (tool?.type !== 'tool') throw new Error('Expected a tool timeline item.');
-		expect(assistantTimelineToolFailureKind(tool)).toBe('failed');
+		expect(assistantTimelineToolFailureKind(tool, true)).toBe('failed');
 	});
 
 	it('preserves cancelled vs failed from persisted tool-result status after jobs leave the timeline', () => {
@@ -213,10 +215,10 @@ describe('assistant timeline', () => {
 		if (cancelled?.type !== 'tool' || failed?.type !== 'tool') {
 			throw new Error('Expected tool timeline items.');
 		}
-		expect(assistantTimelineToolFailureKind(cancelled)).toBe('cancelled');
-		expect(assistantTimelineToolError(cancelled)).toBe('stopped by user');
-		expect(assistantTimelineToolFailureKind(failed)).toBe('failed');
-		expect(assistantTimelineToolError(failed)).toBe('command failed');
+		expect(assistantTimelineToolFailureKind(cancelled, true)).toBe('cancelled');
+		expect(assistantTimelineToolError(cancelled, true)).toBe('stopped by user');
+		expect(assistantTimelineToolFailureKind(failed, true)).toBe('failed');
+		expect(assistantTimelineToolError(failed, true)).toBe('command failed');
 	});
 });
 
@@ -366,6 +368,15 @@ describe('groupAssistantTimelineSections', () => {
 });
 
 describe('partitionWorkSectionTools', () => {
+	function partition(blocks: AssistantTimelineWorkBlock[], isStreaming: boolean) {
+		const tools = blocks.flatMap((block) => (block.type === 'tool-group' ? block.tools : []));
+		return partitionWorkSectionTools(
+			blocks,
+			isStreaming,
+			buildOpenExecCommandSessions(tools, isStreaming)
+		);
+	}
+
 	it('pulls running tools out and leaves settled reasoning/tools behind', () => {
 		const blocks: AssistantTimelineWorkBlock[] = [
 			{ type: 'reasoning', id: 'r1', text: 'plan' },
@@ -385,7 +396,7 @@ describe('partitionWorkSectionTools', () => {
 			}
 		];
 
-		const { settledBlocks, runningTools } = partitionWorkSectionTools(blocks, true);
+		const { settledBlocks, runningTools } = partition(blocks, true);
 
 		expect(runningTools.map((item) => item.callId)).toEqual(['live']);
 		expect(settledBlocks).toEqual([
@@ -428,7 +439,7 @@ describe('partitionWorkSectionTools', () => {
 			}
 		];
 
-		const { settledBlocks, runningTools } = partitionWorkSectionTools(blocks, true);
+		const { settledBlocks, runningTools } = partition(blocks, true);
 
 		expect(runningTools.map((item) => item.callId)).toEqual(['exec-1']);
 		expect(settledBlocks).toEqual([]);
@@ -464,7 +475,7 @@ describe('partitionWorkSectionTools', () => {
 			}
 		];
 
-		const { settledBlocks, runningTools } = partitionWorkSectionTools(blocks, true);
+		const { settledBlocks, runningTools } = partition(blocks, true);
 
 		expect(runningTools).toEqual([]);
 		expect(settledBlocks).toEqual([
@@ -496,7 +507,7 @@ describe('partitionWorkSectionTools', () => {
 				payload: { sessionId: '7' }
 			})
 		});
-		const openSessions = buildOpenExecCommandSessions([exec, monitor]);
+		const openSessions = buildOpenExecCommandSessions([exec, monitor], true);
 		const earlierSection: AssistantTimelineWorkBlock[] = [
 			{ type: 'tool-group', toolKey: 'exec_command', tools: [exec] }
 		];
@@ -515,6 +526,31 @@ describe('partitionWorkSectionTools', () => {
 				tools: [expect.objectContaining({ callId: 'exec-1' })]
 			})
 		]);
+	});
+
+	it('settles in-flight tools and yielded commands after the run stops', () => {
+		const claimedTool = tool('patch-1', 'apply_patch', {
+			job: executorJob('job-patch', 1, { status: 'claimed', kind: 'apply_patch' })
+		});
+		const yieldedCommand = tool('exec-1', 'exec_command', {
+			input: { cmd: 'npm run dev' },
+			output: { sessionId: '7', running: true },
+			job: executorJob('job-exec', 2, { status: 'completed', kind: 'exec_command' })
+		});
+		const blocks: AssistantTimelineWorkBlock[] = [
+			{ type: 'tool-group', toolKey: 'apply_patch', tools: [claimedTool] },
+			{ type: 'tool-group', toolKey: 'exec_command', tools: [yieldedCommand] }
+		];
+
+		const { settledBlocks, runningTools } = partition(blocks, false);
+
+		expect(runningTools).toEqual([]);
+		expect(settledBlocks).toEqual(blocks);
+		expect(assistantTimelineToolFailureKind(claimedTool, false)).toBe('interrupted');
+		expect(assistantTimelineToolError(claimedTool, false)).toBe(
+			'The agent stopped before this tool call finished.'
+		);
+		expect(assistantTimelineToolFailureKind(yieldedCommand, false)).toBeUndefined();
 	});
 });
 

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -213,12 +213,15 @@ export function workSectionTimingAnchor(
 	return { startedAtMs, completedAtMs };
 }
 
-/** Whether a tool call never reached a durable result (job still pending/claimed, or no output). */
+/** Whether a tool call never reached a durable result (no output and no finished job). */
 function isAssistantTimelineToolUnresolved(tool: AssistantTimelineTool): boolean {
+	if (tool.output !== undefined) {
+		return false;
+	}
 	if (tool.job) {
 		return tool.job.status === 'pending' || tool.job.status === 'claimed';
 	}
-	return tool.output === undefined;
+	return true;
 }
 
 /** Whether a tool call is still in flight while the run is streaming. */

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -37,7 +37,7 @@ export type AssistantTimelineSection =
 	  }
 	| Extract<AssistantTimelineBlock, { type: 'text' }>;
 
-export type AssistantTimelineToolFailureKind = 'cancelled' | 'failed';
+export type AssistantTimelineToolFailureKind = 'cancelled' | 'failed' | 'interrupted';
 
 /** Tool type used for grouping: prefer streamed call name so groups stay stable as jobs attach. */
 export function assistantTimelineToolKey(tool: AssistantTimelineTool): string {
@@ -213,15 +213,20 @@ export function workSectionTimingAnchor(
 	return { startedAtMs, completedAtMs };
 }
 
-/** Whether a tool call is still in flight (pending/claimed, or unresolved while streaming). */
+/** Whether a tool call never reached a durable result (job still pending/claimed, or no output). */
+function isAssistantTimelineToolUnresolved(tool: AssistantTimelineTool): boolean {
+	if (tool.job) {
+		return tool.job.status === 'pending' || tool.job.status === 'claimed';
+	}
+	return tool.output === undefined;
+}
+
+/** Whether a tool call is still in flight while the run is streaming. */
 export function isAssistantTimelineToolRunning(
 	tool: AssistantTimelineTool,
 	isStreaming: boolean
 ): boolean {
-	if (tool.job) {
-		return tool.job.status === 'pending' || tool.job.status === 'claimed';
-	}
-	return isStreaming && tool.output === undefined;
+	return isStreaming && isAssistantTimelineToolUnresolved(tool);
 }
 
 function jsonStringProp(value: JsonValue | undefined, key: string): string | undefined {
@@ -276,10 +281,18 @@ export function resolveCommandSessionLabel(
 
 /**
  * Sessions still running that also have an exec_command row.
+ * Returns empty when the run is not streaming so yielded commands settle after a crash/stop.
  * Later tool outputs win on the running flag (write_stdin completion clears the session).
  * Pass the full message tool list so monitors after text section breaks still close sessions.
  */
-export function buildOpenExecCommandSessions(tools: readonly AssistantTimelineTool[]): Set<string> {
+export function buildOpenExecCommandSessions(
+	tools: readonly AssistantTimelineTool[],
+	isStreaming: boolean
+): Set<string> {
+	if (!isStreaming) {
+		return new Set();
+	}
+
 	const sessionRunning = new Map<string, boolean>();
 	const execSessions = new Set<string>();
 
@@ -299,10 +312,6 @@ export function buildOpenExecCommandSessions(tools: readonly AssistantTimelineTo
 	return new Set([...execSessions].filter((sessionId) => sessionRunning.get(sessionId) === true));
 }
 
-function collectWorkSectionTools(blocks: AssistantTimelineWorkBlock[]): AssistantTimelineTool[] {
-	return blocks.flatMap((block) => (block.type === 'tool-group' ? block.tools : []));
-}
-
 /**
  * Split a work section's blocks into settled content (reasoning + finished tools) and
  * currently running tools pulled out for a separate Running dropdown.
@@ -314,7 +323,7 @@ function collectWorkSectionTools(blocks: AssistantTimelineWorkBlock[]): Assistan
 export function partitionWorkSectionTools(
 	blocks: AssistantTimelineWorkBlock[],
 	isStreaming: boolean,
-	openSessions: ReadonlySet<string> = buildOpenExecCommandSessions(collectWorkSectionTools(blocks))
+	openSessions: ReadonlySet<string>
 ): {
 	settledBlocks: AssistantTimelineWorkBlock[];
 	runningTools: AssistantTimelineTool[];
@@ -372,8 +381,12 @@ export function partitionWorkSectionTools(
 }
 
 export function assistantTimelineToolFailureKind(
-	item: AssistantTimelineTool
+	item: AssistantTimelineTool,
+	isStreaming: boolean
 ): AssistantTimelineToolFailureKind | undefined {
+	if (!isStreaming && isAssistantTimelineToolUnresolved(item)) {
+		return 'interrupted';
+	}
 	if (item.job?.status === 'cancelled' || item.job?.status === 'failed') {
 		return item.job.status;
 	}
@@ -381,7 +394,13 @@ export function assistantTimelineToolFailureKind(
 	return parseAssistantToolResultError(item.output)?.status;
 }
 
-export function assistantTimelineToolError(item: AssistantTimelineTool): string | undefined {
+export function assistantTimelineToolError(
+	item: AssistantTimelineTool,
+	isStreaming: boolean
+): string | undefined {
+	if (!isStreaming && isAssistantTimelineToolUnresolved(item)) {
+		return 'The agent stopped before this tool call finished.';
+	}
 	const outputError = parseAssistantToolResultError(item.output)?.error;
 
 	if (item.job) {

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -31,6 +31,7 @@
 		runError: string | null;
 		messages: ThreadMessage[];
 		actions: ExecutorJob[];
+		activeRunId: ThreadMessage['runId'] | null;
 		workspaceSession: WorkspaceSession | null;
 		emptyStateMessage?: string;
 		emptyStateHint?: string | null;
@@ -41,6 +42,7 @@
 		runError,
 		messages,
 		actions,
+		activeRunId,
 		workspaceSession,
 		emptyStateMessage = workspaceSession
 			? 'Start a thread and ask Sprocket to inspect code, edit files, or run project commands.'
@@ -264,7 +266,7 @@
 		if (isAssistantTimelineToolRunning(toolLog, isStreaming)) {
 			return `${summary} (running)`;
 		}
-		const error = assistantTimelineToolError(toolLog);
+		const error = assistantTimelineToolError(toolLog, isStreaming);
 		return error ? `${summary} (${error})` : summary;
 	}
 
@@ -441,15 +443,16 @@
 								(item): item is AssistantTimelineTool => item.type === 'tool'
 							)}
 							{@const sessionCommands = buildCommandSessionCommandMap(timelineTools)}
-							{@const openSessions = buildOpenExecCommandSessions(timelineTools)}
 							{@const blocks = groupAssistantTimeline(timeline)}
 							{@const sections = groupAssistantTimelineSections(blocks)}
 							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
 								workSectionTimingIndexes(sections)}
 							{@const isStreaming =
+								message.runId === activeRunId &&
 								message.runStatus !== 'completed' &&
 								message.runStatus !== 'failed' &&
 								message.runStatus !== 'cancelled'}
+							{@const openSessions = buildOpenExecCommandSessions(timelineTools, isStreaming)}
 							{@const hasPersistedAssistantContent = timeline.some(
 								(part) => part.type === 'text' || part.type === 'reasoning'
 							)}
@@ -510,8 +513,11 @@
 																	: undefined}
 															>
 																{#snippet toolRow(tool)}
-																	{@const toolError = assistantTimelineToolError(tool)}
-																	{@const toolFailureKind = assistantTimelineToolFailureKind(tool)}
+																	{@const toolError = assistantTimelineToolError(tool, isStreaming)}
+																	{@const toolFailureKind = assistantTimelineToolFailureKind(
+																		tool,
+																		isStreaming
+																	)}
 																	{@const toolSummary = toolItemSummary(tool, sessionCommands)}
 																	{#if toolError && toolFailureKind}
 																		<details class="min-w-0">
@@ -521,18 +527,18 @@
 																			>
 																				<span class={toolSummaryClass(tool)}>{toolSummary}</span>
 																				<span
-																					class={toolFailureKind === 'cancelled'
-																						? 'text-amber-200'
-																						: 'text-rose-200'}
+																					class={toolFailureKind === 'failed'
+																						? 'text-rose-200'
+																						: 'text-amber-200'}
 																				>
 																					({toolFailureKind})
 																				</span>
 																			</summary>
 																			<p
 																				class="mt-1.5 whitespace-pre-wrap wrap-break-word text-xs leading-5 {toolFailureKind ===
-																				'cancelled'
-																					? 'text-amber-200'
-																					: 'text-rose-200'}"
+																				'failed'
+																					? 'text-rose-200'
+																					: 'text-amber-200'}"
 																				role="status"
 																			>
 																				{toolError}
@@ -565,7 +571,7 @@
 														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
 														<p
 															class="flex min-w-0 items-start gap-1.5"
-															title={fullToolSummary(tool, isStreaming, sessionCommands)}
+															title={`${toolSummary} (running)`}
 														>
 															<ToolIcon
 																class="mt-1.5 size-3 shrink-0 text-slate-500"

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1737,6 +1737,7 @@
 						runError={runState?.lastError ?? null}
 						messages={visibleMessages}
 						actions={visibleActions}
+						activeRunId={isRunning ? (runState?._id ?? null) : null}
 						workspaceSession={currentWorkspaceSession}
 					/>
 


### PR DESCRIPTION
## Problem

When the local agent process crashes (or otherwise dies without finalizing), its run stays `running`/`awaiting_executor` with executor jobs stuck in `pending`/`claimed`. The transcript UI treated any pending/claimed job — and any command session whose last output said `running: true` — as still running, so spinners and the "Running" dropdown persisted forever even though the run's claim lease had long expired.

## Fix

- Pass `activeRunId` into `ThreadTranscript`: the latest run's id only while its lease is actually live (reusing the existing `isRunBlockingAgentLaunch` server-clock estimate).
- Derive per-message `isStreaming` from `activeRunId` in addition to run status, so lease-expired runs render as settled.
- Gate `isAssistantTimelineToolRunning` and `buildOpenExecCommandSessions` on `isStreaming`, so stuck jobs and yielded `exec_command` sessions leave the "Running" dropdown once the run is dead.
- Label unresolved tool calls on stopped runs as amber `(interrupted)` ("The agent stopped before this tool call finished.") instead of silently rendering them like successes.
- Make `openSessions` a required parameter of `partitionWorkSectionTools`; the section-local default silently reintroduced the stuck-Running bug for text-separated sections.

## Testing

- `bun run --cwd apps/web test` (132 tests, includes a new test for the crash path)
- `svelte-check`
- `prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR settles stale tool calls and command sessions after an agent run stops. The main changes are:

- Uses the lease-backed active run ID to determine streaming state.
- Removes unresolved tools and yielded commands from the Running view after a stopped run.
- Marks unfinished tool calls as interrupted while preserving durable results.
- Passes message-wide open command sessions into timeline partitioning.
- Adds tests for crashed-run behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

Durable tool results take precedence over stale pending or claimed job state. Unresolved calls without output are marked interrupted after the run stops.

No blocking issues found in the updated code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused test ran and exited with code 0, directly exercising the crash-settlement behavior.
- A separate web check step completed and exited with code 0.
- I inspected the two logs to confirm they record the exact command, working directory, exit status, and captured output.

<a href="https://app.greptile.com/trex/runs/14951751/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/chat/assistant-timeline.ts | Adds streaming-aware running and interrupted states while preserving persisted tool results. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Uses the active run ID for tool rendering and command-session state. |
| apps/web/src/routes/+page.svelte | Passes the lease-aware active run ID into the transcript. |
| apps/web/src/lib/chat/assistant-timeline.test.ts | Covers interrupted calls, durable results, and yielded commands after a stopped run. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): Keep durable tool results visi..."](https://github.com/spikonado/sprocket/commit/bcb480d99c0dde2da6f5162728c6f02e232619b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45320711)</sub>

<!-- /greptile_comment -->