### PR TITLE
fix(agent): Improve system and AGENTS.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,14 @@
 - It's goal is to give its users and AI agents the best possible experience when developing robots and robot apps. They should be able to ship across the entire robotics stack much faster than ever before.
 - Sprocket should work seamlessly across different hardware platforms, operating systems, and Sprocket's own cloud for robotics development.
 
-## Testing
+## Available Testing Commands
 
-1. `cargo test`
-2. `bun run test`
-3. `bun run build`
-4. `prek run -a` -> Always run this for ALL formatting and linting
+- `bun run build`
+- `bun run test`
+- `cargo test`
+- `prek run -a` -> This covers ALL formatting and linting
 
-Run only the tests relevant to your changes unless instructed otherwise.
-If you are a subagent, don't run any of the above.
+If you are a subagent, don't run any of these.
 
 ### Nix Environment
 
@@ -32,16 +31,11 @@ All of these are core priorities; try your best to achieve all of them without h
 
 - Don't be afraid to completely refactor existing code in order to improve on any of the priorities.
 - Make sure that changes are made in all the layers of the app when needed.
-- Deleting code, often fixes more problems than writing code does. Sometimes writing too much code introduces problems.
 
 ## Writing Code
 
-Specifically for gpt-5.6-sol: You often end up writing more code than needed, especially tests. Please don't do this.
-
-## Dependency Documentation
-
-- Most of what you know about our dependencies is outdated or wrong. Most of your training data contains obsolete APIs, deprecated patterns, and incorrect usage.
-- Always check the documentation for the latest best practices.
+- Deleting code, often fixes more problems than writing code does. Sometimes writing too much code introduces problems.
+- Specifically for gpt-5.6-sol: You often end up writing more code than needed, especially tests. Please don't do this.
 
 ## Subagents
 
@@ -49,9 +43,9 @@ Specifically for gpt-5.6-sol: You often end up writing more code than needed, es
 
 - Feel free to commit, branch, and spin up worktrees as you please. Don't push before asking.
 - Do the deep dives and figure out what needs to be done and delegate the rest accordingly and as needed to subagents.
-- Use subagents for LARGE tasks that will benefit from your context being less polluted and multiple subagents working in parallel.
+- Use subagents for tasks that will benefit from your context being less polluted and multiple subagents working in parallel.
 - For non bulk/mechanical/zero-brain operations, always run a subagent for finding cleanup opportunities in the code and tests, and implementing the cleanup.
-- For non bulk/mechanical/zero-brain operations, always get 2 subagents to review the code before considering your work done. One of those agents should review the code overall, the other should review the UI/UX, API design, and code quality parts.
+- For non bulk/mechanical/zero-brain operations and larger tasks, get 2 subagents to review the code before considering your work done. One of those agents should review the code overall, the other should review the UI/UX, API design, and code quality parts.
 - When getting code reviewed by subagents in a loop, use gpt-5.6-sol as the review subagent for a max of 3 reviews. After this, rely on some other model for the review subagent.
 
 #### PR Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -80,24 +80,43 @@ fn build_workspace_preamble(
     };
 
     [
-        "You are an engineering agent operating in the user’s real local workspace.",
+        "# System Instructions",
+
+        "## Identity",
+
+        "Your name is Sprocket.",
+        "You are an engineering agent operating in the user's real local workspace.",
+        "You are a careful senior engineer.",
+        "You debate with the user when you feel there is a better way to do something.",
+
+        "## Working on Tasks",
+
         "Persist until the task is handled end-to-end. Do not stop at analysis if the user is asking for implementation.",
-        "A response without a tool call ends the run. Before sending one, reread the user request and continue with the next tool call if any work remains, including work requested after an explanation or update.",
-        "Behave like a careful senior software engineer.",
-        "Do not guess about repo state or file contents. Always inspect before editing.",
-        "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations.",
         "Fix the root-cause of problems.",
-        "It is highly recommended that you check the latest documentation on the frameworks, libraries, and tools you are using as your training data is outdated and wrong for many of them.",
+        "Do not guess about repo state or file contents. Always inspect before editing.",
         "If the workspace is already dirty, do not revert the changes. Try and work around them. If they conflict with the changes you need to make, ask the user what to do with them.",
         "Validate your work when the repo has relevant tests or build checks. Start with the most targeted checks for the code you changed.",
+        "You are recommended to check the latest documentation on the frameworks, libraries, and tools you use as your training data is outdated and wrong for many of them.",
         "When you finish, respond with a concise summary of what changed and which checks you ran.",
-        "AGENTS.md spec:",
-        "- AGENTS.md files can appear anywhere in the repository tree.",
-        "- Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
-        "- For every file you change, follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
-        "- System and user instructions override AGENTS.md instructions.",
-        "- The AGENTS.md instructions for the current workspace path are already included below and do not need to be re-read.",
-        "- If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
+
+        "## Tool Usage",
+
+        "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations. `git` is an exception to this rule.",
+        "Prefer using the `scrape_url` tool over `web_search` when you have an idea on what URL could lead you to the information you need. `web_search` is more expensive and should be used as a fallback.",
+
+        "## Writing Tests",
+
+        "It's a good practice to write tests.",
+        "This doesn't mean that you should write a test for every change.",
+        "Tests shouldn't be written just as a necessity, they should truly verify some behavior or edge case that isn't directly obvious looking at the code.",
+
+        "## AGENTS.md Spec",
+
+        "AGENTS.md files can appear anywhere in the repository tree.",
+        "Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
+        "Follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
+        "The AGENTS.md instructions for the current workspace path are already included below and do not need to be re-read.",
+        "If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
         "",
         &instruction_block,
     ]


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the instructions used by Sprocket and repository agents. The main changes are:

- Restructured Sprocket's workspace system prompt.
- Revised testing, coding, and subagent guidance in `AGENTS.md`.
- Removed the Claude and Gemini instruction aliases.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Prose-only progress updates can terminate unfinished runs, and filename-specific external agents can lose repository instructions.

The rewritten preamble drops a runtime-critical continuation warning. Removing the compatibility aliases disables instruction discovery for affected Claude and Gemini sessions. The remaining instruction edits do not show a concrete code failure.

`crates/sprocket-agent/src/run.rs`, `CLAUDE.md`, and `GEMINI.md`
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the prose updates end active runs using a focused Rust harness and verified the terminal-warning is absent.
- Reproduced Claude instructions stop loading by running a CLAUDE.md repository-guidance discovery harness that found no root CLAUDE.md despite AGENTS.md existing and exited with code 1.
- Reproduced Gemini instructions stop loading by running a GEMINI.md discovery harness that reported GEMINI.md missing while AGENTS.md existed and exited with code 1.
- Ran the sprocket-agent test suite before and after the instruction-preamble revision; both revisions completed with 14 passing tests and no failures.

<a href="https://app.greptile.com/trex/runs/14988978/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/run.rs | Restructures the workspace preamble but removes the warning that a response without a tool call ends the run. |
| AGENTS.md | Reorganizes repository testing, coding, documentation, and subagent guidance. |
| CLAUDE.md | Removes the compatibility alias that exposes `AGENTS.md` to Claude tooling. |
| GEMINI.md | Removes the compatibility alias that exposes `AGENTS.md` to Gemini tooling. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `CLAUDE.md` 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Claude Instructions Stop Loading**

   Claude tooling that discovers repository guidance through the root `CLAUDE.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: executable Claude repository-guidance discovery harness](https://app.greptile.com/trex/artifacts/6fe1fdb7-adca-4988-9659-b55b65227931)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: failing discovery output showing AGENTS.md guidance was not loaded](https://app.greptile.com/trex/artifacts/7ce2328b-3e10-4656-b2b5-cb649b24d58b)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14988978/artifacts?artifact=6fe1fdb7-adca-4988-9659-b55b65227931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: CLAUDE.md
   Line: 1

   Comment:
   **Claude Instructions Stop Loading**

   Claude tooling that discovers repository guidance through the root `CLAUDE.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%201%0A%0AComment%3A%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%201%0A%0AComment%3A%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%201%0A%0AComment%3A%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%201%0A%0AComment%3A%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>


2. `GEMINI.md` 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Gemini Instructions Stop Loading**

   Gemini tooling that discovers repository guidance through the root `GEMINI.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: executable default GEMINI.md discovery harness](https://app.greptile.com/trex/artifacts/979a32d8-a442-4fe4-ba10-f90c1975423b)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: failing discovery output showing AGENTS.md guidance was not loaded](https://app.greptile.com/trex/artifacts/eb8093dc-cfa6-4e2a-b616-cf8e0908c749)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14988978/artifacts?artifact=979a32d8-a442-4fe4-ba10-f90c1975423b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: GEMINI.md
   Line: 1

   Comment:
   **Gemini Instructions Stop Loading**

   Gemini tooling that discovers repository guidance through the root `GEMINI.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20GEMINI.md%0ALine%3A%201%0A%0AComment%3A%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20GEMINI.md%0ALine%3A%201%0A%0AComment%3A%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20GEMINI.md%0ALine%3A%201%0A%0AComment%3A%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20GEMINI.md%0ALine%3A%201%0A%0AComment%3A%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fsprocket-agent%2Fsrc%2Frun.rs%3A94-95%0A**Prose%20Updates%20End%20Active%20Runs**%0A%0ADuring%20an%20implementation%20task%2C%20the%20model%20can%20send%20a%20progress%20update%20without%20a%20tool%20call.%20The%20runtime%20then%20ends%20the%20run%20with%20work%20still%20pending%20because%20the%20rewritten%20prompt%20no%20longer%20explains%20that%20a%20prose-only%20response%20is%20terminal.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22Persist%20until%20the%20task%20is%20handled%20end-to-end.%20Do%20not%20stop%20at%20analysis%20if%20the%20user%20is%20asking%20for%20implementation.%22%2C%0A%20%20%20%20%20%20%20%20%22A%20response%20without%20a%20tool%20call%20ends%20the%20run.%20Before%20sending%20one%2C%20reread%20the%20user%20request%20and%20continue%20with%20the%20next%20tool%20call%20if%20any%20work%20remains%2C%20including%20work%20requested%20after%20an%20explanation%20or%20update.%22%2C%0A%20%20%20%20%20%20%20%20%22Fix%20the%20root-cause%20of%20problems.%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACLAUDE.md%3A1%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A%23%23%23%20Issue%203%20of%203%0AGEMINI.md%3A1%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fsprocket-agent%2Fsrc%2Frun.rs%3A94-95%0A**Prose%20Updates%20End%20Active%20Runs**%0A%0ADuring%20an%20implementation%20task%2C%20the%20model%20can%20send%20a%20progress%20update%20without%20a%20tool%20call.%20The%20runtime%20then%20ends%20the%20run%20with%20work%20still%20pending%20because%20the%20rewritten%20prompt%20no%20longer%20explains%20that%20a%20prose-only%20response%20is%20terminal.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22Persist%20until%20the%20task%20is%20handled%20end-to-end.%20Do%20not%20stop%20at%20analysis%20if%20the%20user%20is%20asking%20for%20implementation.%22%2C%0A%20%20%20%20%20%20%20%20%22A%20response%20without%20a%20tool%20call%20ends%20the%20run.%20Before%20sending%20one%2C%20reread%20the%20user%20request%20and%20continue%20with%20the%20next%20tool%20call%20if%20any%20work%20remains%2C%20including%20work%20requested%20after%20an%20explanation%20or%20update.%22%2C%0A%20%20%20%20%20%20%20%20%22Fix%20the%20root-cause%20of%20problems.%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACLAUDE.md%3A1%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A%23%23%23%20Issue%203%20of%203%0AGEMINI.md%3A1%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fsprocket-agent%2Fsrc%2Frun.rs%3A94-95%0A**Prose%20Updates%20End%20Active%20Runs**%0A%0ADuring%20an%20implementation%20task%2C%20the%20model%20can%20send%20a%20progress%20update%20without%20a%20tool%20call.%20The%20runtime%20then%20ends%20the%20run%20with%20work%20still%20pending%20because%20the%20rewritten%20prompt%20no%20longer%20explains%20that%20a%20prose-only%20response%20is%20terminal.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22Persist%20until%20the%20task%20is%20handled%20end-to-end.%20Do%20not%20stop%20at%20analysis%20if%20the%20user%20is%20asking%20for%20implementation.%22%2C%0A%20%20%20%20%20%20%20%20%22A%20response%20without%20a%20tool%20call%20ends%20the%20run.%20Before%20sending%20one%2C%20reread%20the%20user%20request%20and%20continue%20with%20the%20next%20tool%20call%20if%20any%20work%20remains%2C%20including%20work%20requested%20after%20an%20explanation%20or%20update.%22%2C%0A%20%20%20%20%20%20%20%20%22Fix%20the%20root-cause%20of%20problems.%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACLAUDE.md%3A1%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A%23%23%23%20Issue%203%20of%203%0AGEMINI.md%3A1%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A&repo=spikonado%2Fsprocket&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22spikonado%2Fsprocket%22%20on%20the%20existing%20branch%20%22fix%2Fupdate-system-prompt%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupdate-system-prompt%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fsprocket-agent%2Fsrc%2Frun.rs%3A94-95%0A**Prose%20Updates%20End%20Active%20Runs**%0A%0ADuring%20an%20implementation%20task%2C%20the%20model%20can%20send%20a%20progress%20update%20without%20a%20tool%20call.%20The%20runtime%20then%20ends%20the%20run%20with%20work%20still%20pending%20because%20the%20rewritten%20prompt%20no%20longer%20explains%20that%20a%20prose-only%20response%20is%20terminal.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%22Persist%20until%20the%20task%20is%20handled%20end-to-end.%20Do%20not%20stop%20at%20analysis%20if%20the%20user%20is%20asking%20for%20implementation.%22%2C%0A%20%20%20%20%20%20%20%20%22A%20response%20without%20a%20tool%20call%20ends%20the%20run.%20Before%20sending%20one%2C%20reread%20the%20user%20request%20and%20continue%20with%20the%20next%20tool%20call%20if%20any%20work%20remains%2C%20including%20work%20requested%20after%20an%20explanation%20or%20update.%22%2C%0A%20%20%20%20%20%20%20%20%22Fix%20the%20root-cause%20of%20problems.%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ACLAUDE.md%3A1%0A**Claude%20Instructions%20Stop%20Loading**%0A%0AClaude%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60CLAUDE.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A%23%23%23%20Issue%203%20of%203%0AGEMINI.md%3A1%0A**Gemini%20Instructions%20Stop%20Loading**%0A%0AGemini%20tooling%20that%20discovers%20repository%20guidance%20through%20the%20root%20%60GEMINI.md%60%20filename%20will%20no%20longer%20load%20%60AGENTS.md%60.%20Those%20sessions%20silently%20lose%20the%20repository's%20testing%20and%20workflow%20instructions.%0A%0A&repo=spikonado%2Fsprocket"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/sprocket-agent/src/run.rs:94-95
**Prose Updates End Active Runs**

During an implementation task, the model can send a progress update without a tool call. The runtime then ends the run with work still pending because the rewritten prompt no longer explains that a prose-only response is terminal.

```suggestion
        "Persist until the task is handled end-to-end. Do not stop at analysis if the user is asking for implementation.",
        "A response without a tool call ends the run. Before sending one, reread the user request and continue with the next tool call if any work remains, including work requested after an explanation or update.",
        "Fix the root-cause of problems.",
```

### Issue 2 of 3
CLAUDE.md:1
**Claude Instructions Stop Loading**

Claude tooling that discovers repository guidance through the root `CLAUDE.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.

### Issue 3 of 3
GEMINI.md:1
**Gemini Instructions Stop Loading**

Gemini tooling that discovers repository guidance through the root `GEMINI.md` filename will no longer load `AGENTS.md`. Those sessions silently lose the repository's testing and workflow instructions.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Remove CLAUDE.md and GEMINI.md"](https://github.com/spikonado/sprocket/commit/e135f7cdea30d0dc93e75906a068408f4a568a0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45400837)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->