### PR TITLE
refactor(web): Share one usage quota across web tools

### DIFF
--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -51,7 +51,13 @@ export type UsagePeriod = (typeof usagePeriods)[number];
 
 const periodDurations: Record<UsagePeriod, number> = { weekly: WEEK, monthly: MONTH };
 
-function meterLimitName(meterId: UsageMeterId, period: UsagePeriod): string {
+// Pre-shared-quota meter names/rates. Counted until those windows expire.
+const legacyWebToolMeters = [
+	{ name: 'webSearch', rates: { weekly: 250, monthly: 750 } },
+	{ name: 'urlScrape', rates: { weekly: 250, monthly: 750 } }
+] as const;
+
+function meterLimitName(meterId: string, period: UsagePeriod): string {
 	return `${meterId}${period === 'weekly' ? 'Weekly' : 'Monthly'}`;
 }
 
@@ -130,15 +136,19 @@ async function chargeMeterLimits(
 	}
 }
 
-export async function getMeterWindow(
+async function getNamedMeterWindow(
 	ctx: RunQueryCtx,
-	meterId: UsageMeterId,
+	name: string,
 	period: UsagePeriod,
 	userId: string,
-	limits: TierLimits
+	rate: number
 ): Promise<{ used: number; limit: number; resetsAt: number | null }> {
-	const config = meterLimitConfig(meterId, period, limits);
-	const stored = await rateLimiter.getValue(ctx, meterLimitName(meterId, period), {
+	const config: RateLimitConfig = {
+		kind: 'fixed window',
+		period: periodDurations[period],
+		rate
+	};
+	const stored = await rateLimiter.getValue(ctx, meterLimitName(name, period), {
 		key: userId,
 		config
 	});
@@ -152,6 +162,57 @@ export async function getMeterWindow(
 	};
 }
 
+async function getWebToolsWindow(
+	ctx: RunQueryCtx,
+	period: UsagePeriod,
+	userId: string,
+	limits: TierLimits
+): Promise<{ used: number; limit: number; resetsAt: number | null }> {
+	const windows = await Promise.all([
+		getNamedMeterWindow(ctx, 'webTools', period, userId, limits.webTools[period]),
+		...legacyWebToolMeters.map((meter) =>
+			getNamedMeterWindow(ctx, meter.name, period, userId, meter.rates[period])
+		)
+	]);
+	const used = windows.reduce((total, window) => total + window.used, 0);
+	const resetsAt =
+		windows
+			.map((window) => window.resetsAt)
+			.filter((value): value is number => value !== null)
+			.sort((a, b) => a - b)[0] ?? null;
+	return { used, limit: limits.webTools[period], resetsAt };
+}
+
+export async function getMeterWindow(
+	ctx: RunQueryCtx,
+	meterId: UsageMeterId,
+	period: UsagePeriod,
+	userId: string,
+	limits: TierLimits
+): Promise<{ used: number; limit: number; resetsAt: number | null }> {
+	if (meterId === 'webTools') return getWebToolsWindow(ctx, period, userId, limits);
+	return getNamedMeterWindow(ctx, meterId, period, userId, limits[meterId][period]);
+}
+
+async function checkWebToolsMeterLimits(
+	ctx: MutationCtx,
+	userId: string,
+	limits: TierLimits
+): Promise<void> {
+	const windows = await Promise.all(
+		usagePeriods.map(async (period) => ({
+			period,
+			window: await getWebToolsWindow(ctx, period, userId, limits)
+		}))
+	);
+	const blocked = windows
+		.filter(({ window }) => window.used >= window.limit)
+		.sort((a, b) => (b.window.resetsAt ?? 0) - (a.window.resetsAt ?? 0))[0];
+	if (!blocked) return;
+	const retryAfter = Math.max(SECOND, (blocked.window.resetsAt ?? Date.now()) - Date.now());
+	throw rateLimitError(meterLimitLabel('webTools', blocked.period), retryAfter);
+}
+
 async function chargeWebTools(ctx: MutationCtx, userId: string, count: number): Promise<void> {
 	const tier = await getSubscriptionTier(ctx, userId);
 	await chargeMeterLimits(ctx, 'webTools', userId, tierLimits[tier], count);
@@ -161,7 +222,7 @@ export const checkWebToolsLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await checkMeterLimits(ctx, 'webTools', userId, tierLimits[tier]);
+		await checkWebToolsMeterLimits(ctx, userId, tierLimits[tier]);
 	}
 });
 
@@ -173,7 +234,9 @@ export const chargeUrlScrapeLimits = internalMutation({
 });
 
 export const chargeWebSearchLimits = internalMutation({
-	args: { userId: v.string() },
+	// numResults kept optional so durable charges queued before the flat-cost
+	// rollout still validate after deploy.
+	args: { userId: v.string(), numResults: v.optional(v.number()) },
 	handler: async (ctx, { userId }) => {
 		await chargeWebTools(ctx, userId, WEB_SEARCH_USAGE_UNITS);
 	}

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -51,13 +51,7 @@ export type UsagePeriod = (typeof usagePeriods)[number];
 
 const periodDurations: Record<UsagePeriod, number> = { weekly: WEEK, monthly: MONTH };
 
-// Pre-shared-quota meter names/rates. Counted until those windows expire.
-const legacyWebToolMeters = [
-	{ name: 'webSearch', rates: { weekly: 250, monthly: 750 } },
-	{ name: 'urlScrape', rates: { weekly: 250, monthly: 750 } }
-] as const;
-
-function meterLimitName(meterId: string, period: UsagePeriod): string {
+function meterLimitName(meterId: UsageMeterId, period: UsagePeriod): string {
 	return `${meterId}${period === 'weekly' ? 'Weekly' : 'Monthly'}`;
 }
 
@@ -136,19 +130,15 @@ async function chargeMeterLimits(
 	}
 }
 
-async function getNamedMeterWindow(
+export async function getMeterWindow(
 	ctx: RunQueryCtx,
-	name: string,
+	meterId: UsageMeterId,
 	period: UsagePeriod,
 	userId: string,
-	rate: number
+	limits: TierLimits
 ): Promise<{ used: number; limit: number; resetsAt: number | null }> {
-	const config: RateLimitConfig = {
-		kind: 'fixed window',
-		period: periodDurations[period],
-		rate
-	};
-	const stored = await rateLimiter.getValue(ctx, meterLimitName(name, period), {
+	const config = meterLimitConfig(meterId, period, limits);
+	const stored = await rateLimiter.getValue(ctx, meterLimitName(meterId, period), {
 		key: userId,
 		config
 	});
@@ -162,57 +152,6 @@ async function getNamedMeterWindow(
 	};
 }
 
-async function getWebToolsWindow(
-	ctx: RunQueryCtx,
-	period: UsagePeriod,
-	userId: string,
-	limits: TierLimits
-): Promise<{ used: number; limit: number; resetsAt: number | null }> {
-	const windows = await Promise.all([
-		getNamedMeterWindow(ctx, 'webTools', period, userId, limits.webTools[period]),
-		...legacyWebToolMeters.map((meter) =>
-			getNamedMeterWindow(ctx, meter.name, period, userId, meter.rates[period])
-		)
-	]);
-	const used = windows.reduce((total, window) => total + window.used, 0);
-	const resetsAt =
-		windows
-			.map((window) => window.resetsAt)
-			.filter((value): value is number => value !== null)
-			.sort((a, b) => a - b)[0] ?? null;
-	return { used, limit: limits.webTools[period], resetsAt };
-}
-
-export async function getMeterWindow(
-	ctx: RunQueryCtx,
-	meterId: UsageMeterId,
-	period: UsagePeriod,
-	userId: string,
-	limits: TierLimits
-): Promise<{ used: number; limit: number; resetsAt: number | null }> {
-	if (meterId === 'webTools') return getWebToolsWindow(ctx, period, userId, limits);
-	return getNamedMeterWindow(ctx, meterId, period, userId, limits[meterId][period]);
-}
-
-async function checkWebToolsMeterLimits(
-	ctx: MutationCtx,
-	userId: string,
-	limits: TierLimits
-): Promise<void> {
-	const windows = await Promise.all(
-		usagePeriods.map(async (period) => ({
-			period,
-			window: await getWebToolsWindow(ctx, period, userId, limits)
-		}))
-	);
-	const blocked = windows
-		.filter(({ window }) => window.used >= window.limit)
-		.sort((a, b) => (b.window.resetsAt ?? 0) - (a.window.resetsAt ?? 0))[0];
-	if (!blocked) return;
-	const retryAfter = Math.max(SECOND, (blocked.window.resetsAt ?? Date.now()) - Date.now());
-	throw rateLimitError(meterLimitLabel('webTools', blocked.period), retryAfter);
-}
-
 async function chargeWebTools(ctx: MutationCtx, userId: string, count: number): Promise<void> {
 	const tier = await getSubscriptionTier(ctx, userId);
 	await chargeMeterLimits(ctx, 'webTools', userId, tierLimits[tier], count);
@@ -222,7 +161,7 @@ export const checkWebToolsLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await checkWebToolsMeterLimits(ctx, userId, tierLimits[tier]);
+		await checkMeterLimits(ctx, 'webTools', userId, tierLimits[tier]);
 	}
 });
 
@@ -234,9 +173,7 @@ export const chargeUrlScrapeLimits = internalMutation({
 });
 
 export const chargeWebSearchLimits = internalMutation({
-	// numResults kept optional so durable charges queued before the flat-cost
-	// rollout still validate after deploy.
-	args: { userId: v.string(), numResults: v.optional(v.number()) },
+	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		await chargeWebTools(ctx, userId, WEB_SEARCH_USAGE_UNITS);
 	}

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -11,7 +11,7 @@ import {
 	type RunQueryCtx
 } from '@convex-dev/rate-limiter';
 import { components, internal } from '@convex/_generated/api';
-import { internalMutation, type ActionCtx } from '@convex/_generated/server';
+import { internalMutation, type ActionCtx, type MutationCtx } from '@convex/_generated/server';
 import { getFunctionName, type FunctionArgs, type FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
 import {
@@ -23,15 +23,25 @@ import { getSubscriptionTier, tierLimits, type TierLimits } from '@convex/lib/ti
 import { vModelId, vServiceTier } from '@convex/lib/validators';
 
 const MONTH = 30 * DAY;
-const URL_SCRAPE_USAGE_UNITS = 1.5;
-const EXA_SEARCH_USAGE_UNITS = 7;
-const EXA_CONTENT_USAGE_UNITS = 1;
+/** Flat web-tools meter cost for one URL scrape. */
+export const URL_SCRAPE_USAGE_UNITS = 1.5;
+/** Flat web-tools meter cost for one web search (independent of result count). */
+export const WEB_SEARCH_USAGE_UNITS = 7;
 export const rateLimiter = new RateLimiter(components.rateLimiter, {});
 
 export const usageMeters = [
-	{ id: 'modelUsage', label: 'Model usage', noun: 'model usage' },
-	{ id: 'webSearch', label: 'Web searches', noun: 'web search' },
-	{ id: 'urlScrape', label: 'URL scrapes', noun: 'URL scrape' }
+	{
+		id: 'modelUsage',
+		label: 'Model usage',
+		noun: 'model usage',
+		description: 'More expensive models use up more usage.'
+	},
+	{
+		id: 'webTools',
+		label: 'Web tools',
+		noun: 'web tools',
+		description: 'Web search and URL scrape share this quota.'
+	}
 ] as const;
 
 export type UsageMeterId = (typeof usageMeters)[number]['id'];
@@ -142,36 +152,30 @@ export async function getMeterWindow(
 	};
 }
 
-export const checkUrlScrapeLimits = internalMutation({
+async function chargeWebTools(ctx: MutationCtx, userId: string, count: number): Promise<void> {
+	const tier = await getSubscriptionTier(ctx, userId);
+	await chargeMeterLimits(ctx, 'webTools', userId, tierLimits[tier], count);
+}
+
+export const checkWebToolsLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
 		const tier = await getSubscriptionTier(ctx, userId);
-		await checkMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier]);
+		await checkMeterLimits(ctx, 'webTools', userId, tierLimits[tier]);
 	}
 });
 
 export const chargeUrlScrapeLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
-		const tier = await getSubscriptionTier(ctx, userId);
-		await chargeMeterLimits(ctx, 'urlScrape', userId, tierLimits[tier], URL_SCRAPE_USAGE_UNITS);
-	}
-});
-
-export const checkWebSearchLimits = internalMutation({
-	args: { userId: v.string() },
-	handler: async (ctx, { userId }) => {
-		const tier = await getSubscriptionTier(ctx, userId);
-		await checkMeterLimits(ctx, 'webSearch', userId, tierLimits[tier]);
+		await chargeWebTools(ctx, userId, URL_SCRAPE_USAGE_UNITS);
 	}
 });
 
 export const chargeWebSearchLimits = internalMutation({
-	args: { userId: v.string(), numResults: v.number() },
-	handler: async (ctx, { userId, numResults }) => {
-		const tier = await getSubscriptionTier(ctx, userId);
-		const count = EXA_SEARCH_USAGE_UNITS + numResults * EXA_CONTENT_USAGE_UNITS;
-		await chargeMeterLimits(ctx, 'webSearch', userId, tierLimits[tier], count);
+	args: { userId: v.string() },
+	handler: async (ctx, { userId }) => {
+		await chargeWebTools(ctx, userId, WEB_SEARCH_USAGE_UNITS);
 	}
 });
 
@@ -241,25 +245,14 @@ export async function chargeModelUsage(
 	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeModelUsageLimits, args);
 }
 
-export async function checkUrlScrapeLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.checkUrlScrapeLimits, { userId });
+export async function checkWebToolsLimit(ctx: ActionCtx, userId: string): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.checkWebToolsLimits, { userId });
 }
 
 export async function chargeUrlScrapeUsage(ctx: ActionCtx, userId: string): Promise<void> {
 	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
 }
 
-export async function checkWebSearchLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.checkWebSearchLimits, { userId });
-}
-
-export async function chargeWebSearchUsage(
-	ctx: ActionCtx,
-	userId: string,
-	numResults: number
-): Promise<void> {
-	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeWebSearchLimits, {
-		userId,
-		numResults
-	});
+export async function chargeWebSearchUsage(ctx: ActionCtx, userId: string): Promise<void> {
+	await chargeUsageDurably(ctx, internal.lib.rateLimits.chargeWebSearchLimits, { userId });
 }

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -8,14 +8,12 @@ export const tierLabels: Record<SubscriptionTier, string> = { free: 'Free', pro:
 
 export type TierLimits = {
 	modelUsage: { weekly: number; monthly: number };
-	urlScrape: { weekly: number; monthly: number };
-	webSearch: { weekly: number; monthly: number };
+	webTools: { weekly: number; monthly: number };
 };
 
 const sharedLimits: TierLimits = {
 	modelUsage: { weekly: 2_500, monthly: 7_500 },
-	urlScrape: { weekly: 250, monthly: 750 },
-	webSearch: { weekly: 250, monthly: 750 }
+	webTools: { weekly: 500, monthly: 1_500 }
 };
 
 export const tierLimits: Record<SubscriptionTier, TierLimits> = {

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -1,11 +1,6 @@
-import { WEEK } from '@convex-dev/rate-limiter';
 import { describe, expect, it } from 'vitest';
 import { api, internal } from '@convex/_generated/api';
-import {
-	rateLimiter,
-	URL_SCRAPE_USAGE_UNITS,
-	WEB_SEARCH_USAGE_UNITS
-} from '@convex/lib/rateLimits';
+import { URL_SCRAPE_USAGE_UNITS, WEB_SEARCH_USAGE_UNITS } from '@convex/lib/rateLimits';
 import { initConvexTest } from './test.setup';
 
 describe('subscription and usage backend', () => {
@@ -46,42 +41,8 @@ describe('subscription and usage backend', () => {
 		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + WEB_SEARCH_USAGE_UNITS);
 
 		// Same flat search cost again (not scaled by result count).
-		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, {
-			userId,
-			numResults: 10
-		});
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId });
 		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + 2 * WEB_SEARCH_USAGE_UNITS);
-	});
-
-	it('counts legacy web search and scrape usage toward the shared quota', async () => {
-		const t = initConvexTest();
-		const userId = 'user_legacy_web_tools';
-		const asUser = t.withIdentity({ subject: userId });
-		const weekly = { kind: 'fixed window' as const, period: WEEK, rate: 250 };
-
-		await t.run(async (ctx) => {
-			await rateLimiter.limit(ctx, 'webSearchWeekly', {
-				key: userId,
-				config: weekly,
-				count: 250,
-				reserve: true
-			});
-			await rateLimiter.limit(ctx, 'urlScrapeWeekly', {
-				key: userId,
-				config: weekly,
-				count: 250,
-				reserve: true
-			});
-		});
-
-		const usage = await asUser.query(api.usage.getMyUsage, {});
-		const meter = usage.meters.find((meter) => meter.id === 'webTools');
-		const window = meter?.windows.find((window) => window.period === 'weekly');
-		expect(window?.used).toBe(500);
-		expect(window?.limit).toBe(500);
-		await expect(
-			t.mutation(internal.lib.rateLimits.checkWebToolsLimits, { userId })
-		).rejects.toThrow('Weekly web tools limit reached');
 	});
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -1,6 +1,11 @@
+import { WEEK } from '@convex-dev/rate-limiter';
 import { describe, expect, it } from 'vitest';
 import { api, internal } from '@convex/_generated/api';
-import { URL_SCRAPE_USAGE_UNITS, WEB_SEARCH_USAGE_UNITS } from '@convex/lib/rateLimits';
+import {
+	rateLimiter,
+	URL_SCRAPE_USAGE_UNITS,
+	WEB_SEARCH_USAGE_UNITS
+} from '@convex/lib/rateLimits';
 import { initConvexTest } from './test.setup';
 
 describe('subscription and usage backend', () => {
@@ -41,8 +46,42 @@ describe('subscription and usage backend', () => {
 		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + WEB_SEARCH_USAGE_UNITS);
 
 		// Same flat search cost again (not scaled by result count).
-		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId });
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, {
+			userId,
+			numResults: 10
+		});
 		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + 2 * WEB_SEARCH_USAGE_UNITS);
+	});
+
+	it('counts legacy web search and scrape usage toward the shared quota', async () => {
+		const t = initConvexTest();
+		const userId = 'user_legacy_web_tools';
+		const asUser = t.withIdentity({ subject: userId });
+		const weekly = { kind: 'fixed window' as const, period: WEEK, rate: 250 };
+
+		await t.run(async (ctx) => {
+			await rateLimiter.limit(ctx, 'webSearchWeekly', {
+				key: userId,
+				config: weekly,
+				count: 250,
+				reserve: true
+			});
+			await rateLimiter.limit(ctx, 'urlScrapeWeekly', {
+				key: userId,
+				config: weekly,
+				count: 250,
+				reserve: true
+			});
+		});
+
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		const meter = usage.meters.find((meter) => meter.id === 'webTools');
+		const window = meter?.windows.find((window) => window.period === 'weekly');
+		expect(window?.used).toBe(500);
+		expect(window?.limit).toBe(500);
+		await expect(
+			t.mutation(internal.lib.rateLimits.checkWebToolsLimits, { userId })
+		).rejects.toThrow('Weekly web tools limit reached');
 	});
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { api, internal } from '@convex/_generated/api';
+import { URL_SCRAPE_USAGE_UNITS, WEB_SEARCH_USAGE_UNITS } from '@convex/lib/rateLimits';
 import { initConvexTest } from './test.setup';
 
 describe('subscription and usage backend', () => {
@@ -23,24 +24,25 @@ describe('subscription and usage backend', () => {
 		).rejects.toThrow('Monthly model usage limit reached');
 	});
 
-	it('weights web tool usage by request size', async () => {
+	it('charges scrape and search against one shared web tools quota', async () => {
 		const t = initConvexTest();
 		const userId = 'user_web_tools';
 		const asUser = t.withIdentity({ subject: userId });
-		const used = async (meterId: string) => {
+		const used = async () => {
 			const usage = await asUser.query(api.usage.getMyUsage, {});
-			const meter = usage.meters.find((meter) => meter.id === meterId);
+			const meter = usage.meters.find((meter) => meter.id === 'webTools');
 			return meter?.windows.find((window) => window.period === 'monthly')?.used ?? 0;
 		};
 
 		await t.mutation(internal.lib.rateLimits.chargeUrlScrapeLimits, { userId });
-		expect(await used('urlScrape')).toBeGreaterThan(0);
+		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS);
 
-		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults: 1 });
-		const smallSearch = await used('webSearch');
-		expect(smallSearch).toBeGreaterThan(0);
-		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId, numResults: 10 });
-		expect(await used('webSearch')).toBeGreaterThan(smallSearch * 2);
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId });
+		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + WEB_SEARCH_USAGE_UNITS);
+
+		// Same flat search cost again (not scaled by result count).
+		await t.mutation(internal.lib.rateLimits.chargeWebSearchLimits, { userId });
+		expect(await used()).toBe(URL_SCRAPE_USAGE_UNITS + 2 * WEB_SEARCH_USAGE_UNITS);
 	});
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {

--- a/apps/web/src/convex/usage.ts
+++ b/apps/web/src/convex/usage.ts
@@ -15,6 +15,7 @@ export const getMyUsage = query({
 				usageMeters.map(async (meter) => ({
 					id: meter.id,
 					label: meter.label,
+					description: meter.description,
 					windows: await Promise.all(
 						usagePeriods.map(async (period) => ({
 							period,

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -9,8 +9,7 @@ import { getUserId } from '@convex/lib/auth';
 import {
 	chargeUrlScrapeUsage,
 	chargeWebSearchUsage,
-	checkUrlScrapeLimit,
-	checkWebSearchLimit
+	checkWebToolsLimit
 } from '@convex/lib/rateLimits';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
 
@@ -83,7 +82,7 @@ export const scrapeUrl = action({
 		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 			throw new Error('Only http(s) URLs can be scraped.');
 		}
-		await checkUrlScrapeLimit(ctx, userId);
+		await checkWebToolsLimit(ctx, userId);
 
 		const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
 			contextDev.scrapeMarkdown(ctx, {
@@ -122,7 +121,7 @@ export const webSearch = action({
 			? Math.floor(args.numResults as number)
 			: DEFAULT_SEARCH_RESULTS;
 		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
-		await checkWebSearchLimit(ctx, userId);
+		await checkWebToolsLimit(ctx, userId);
 
 		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
 			exa.search(ctx, {
@@ -132,7 +131,7 @@ export const webSearch = action({
 				contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
 			})
 		);
-		await chargeWebSearchUsage(ctx, userId, numResults);
+		await chargeWebSearchUsage(ctx, userId);
 
 		return {
 			results: response.results.flatMap((result) => {

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { useAuth, useQuery } from 'convex-svelte';
 	import { api } from '$convex/_generated/api';
+	import { usageMeters, usagePeriods } from '$convex/lib/rateLimits';
 	import { tierLabels } from '$convex/lib/tiers';
 
 	const convexAuth = useAuth();
@@ -65,10 +66,10 @@
 			{:else if usageQuery.isLoading || usageQuery.data === undefined}
 				<div class="animate-pulse space-y-10" aria-hidden="true">
 					<div class="h-4 w-24 rounded bg-white/5"></div>
-					{#each ['modelUsage', 'webSearch', 'urlScrape'] as meterId (meterId)}
+					{#each usageMeters as meter (meter.id)}
 						<div class="space-y-5">
 							<div class="h-3 w-28 rounded bg-white/5"></div>
-							{#each ['weekly', 'monthly'] as period (period)}
+							{#each usagePeriods as period (period)}
 								<div class="space-y-2">
 									<div class="h-3.5 w-full rounded bg-white/5"></div>
 									<div class="h-1.5 w-full rounded-full bg-white/5"></div>
@@ -79,19 +80,17 @@
 				</div>
 			{:else}
 				<div>
-					<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Plan</p>
+					<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Subscription Tier</p>
 					<p class="mt-3 text-[15px] text-white">
-						{tierLabels[usageQuery.data.tier]} plan
+						{tierLabels[usageQuery.data.tier]}
 					</p>
 				</div>
 
 				{#each usageQuery.data.meters as meter (meter.id)}
 					<div>
 						<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">{meter.label}</p>
-						{#if meter.id === 'modelUsage'}
-							<p class="mt-1 text-[12px] text-slate-500">
-								Weighted by model and token type — pricier models and output tokens use more.
-							</p>
+						{#if meter.description}
+							<p class="mt-1 text-[12px] text-slate-500">{meter.description}</p>
 						{/if}
 						<div class="mt-4 space-y-6">
 							{#each meter.windows as meterWindow (meterWindow.period)}


### PR DESCRIPTION
## Summary
- Combine web search and URL scrape into a single shared `webTools` usage quota (sum of the previous separate limits)
- Keep per-tool credit costs the same, with web search charged flat per request instead of per result
- Update the usage settings UI to show one Web tools meter

## Test plan
- [ ] Run `bun run test src/convex/subscriptionUsage.test.ts` in `apps/web`
- [ ] Confirm Usage settings shows Model usage + Web tools (not separate search/scrape meters)
- [ ] Confirm scrape and search both deplete the shared Web tools quota
- [ ] Confirm changing search result count does not change the charged amount

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR combines web search and URL scraping under one shared usage quota. The main changes are:

- Adds a shared `webTools` meter with combined limits.
- Keeps flat per-request costs for search and scraping.
- Routes both web actions through the shared quota.
- Updates usage tests and the settings UI for the combined meter.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issues were found in the latest changes.

The examined candidates overlap with existing reported rollout issues.

No separate production failure requiring another fix was identified.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after logs to evaluate the authenticated visual confirmation blocker and concluded it is a setup-only issue, not a product finding.
- Validated test results show the shared scrape/search quota test passed and overall tests report as 3 passed, with non-fatal missing-sourcemap notices from convex-exa.

<a href="https://app.greptile.com/trex/runs/14990649/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/rateLimits.ts | Replaces separate web meters with shared checks and flat charges. |
| apps/web/src/convex/lib/tiers.ts | Combines the previous search and scrape limits into one web-tools quota. |
| apps/web/src/convex/subscriptionUsage.test.ts | Tests shared quota accounting and flat search charges. |
| apps/web/src/convex/usage.ts | Returns meter descriptions with usage data. |
| apps/web/src/convex/webTools.ts | Routes search and scraping through the shared web-tools meter. |
| apps/web/src/lib/components/home/settings-usage.svelte | Displays the combined Web tools meter and shared descriptions. |

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(web): Drop unused web tools quo..."](https://github.com/spikonado/sprocket/commit/fe429e601d2074ce4aa8da8e1fee99d6da35e12f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45402169)</sub>

<!-- /greptile_comment -->