### PR TITLE
feat(web): Add admin usage tier with manual Convex grants

### DIFF
--- a/apps/web/src/convex/billing.ts
+++ b/apps/web/src/convex/billing.ts
@@ -5,10 +5,21 @@ import {
 } from '@dodopayments/convex';
 import type { ComponentApi } from '@dodopayments/convex/_generated/component';
 import { v } from 'convex/values';
-import { action, internalMutation, internalQuery, query } from '@convex/_generated/server';
+import {
+	action,
+	internalMutation,
+	internalQuery,
+	mutation,
+	query
+} from '@convex/_generated/server';
 import { components, internal } from '@convex/_generated/api';
 import { getUserId } from '@convex/lib/auth';
-import { getSubscriptionTier, tierProductIds } from '@convex/lib/tiers';
+import {
+	ensureSubscription,
+	getSubscriptionDocExclusive,
+	getSubscriptionTier,
+	tierProductIds
+} from '@convex/lib/tiers';
 import { vSubscriptionStatus, vSubscriptionTier } from '@convex/lib/validators';
 
 export const getBillingCustomer = internalQuery({
@@ -40,6 +51,14 @@ export const getMySubscription = query({
 	handler: async (ctx) => {
 		const userId = await getUserId(ctx);
 		return { tier: await getSubscriptionTier(ctx, userId) };
+	}
+});
+
+export const ensureMySubscription = mutation({
+	args: {},
+	handler: async (ctx) => {
+		const userId = await getUserId(ctx);
+		await ensureSubscription(ctx, userId);
 	}
 });
 
@@ -79,10 +98,26 @@ export const upsertSubscription = internalMutation({
 		eventAt: v.number()
 	},
 	handler: async (ctx, args) => {
-		const existing = await ctx.db
-			.query('subscriptions')
-			.withIndex('by_userId', (q) => q.eq('userId', args.userId))
-			.unique();
+		const existing = await getSubscriptionDocExclusive(ctx, args.userId);
+
+		const syncBillingCustomer = async () => {
+			const customer = await ctx.db
+				.query('billingCustomers')
+				.withIndex('by_userId', (q) => q.eq('userId', args.userId))
+				.unique();
+			if (customer) await ctx.db.patch(customer._id, { dodoCustomerId: args.dodoCustomerId });
+			else
+				await ctx.db.insert('billingCustomers', {
+					userId: args.userId,
+					dodoCustomerId: args.dodoCustomerId
+				});
+		};
+
+		// Manual admin grants must not be clobbered by Dodo lifecycle events.
+		if (existing?.status === 'active' && existing.tier === 'admin' && args.tier !== 'admin') {
+			if (args.eventAt >= existing.eventAt) await syncBillingCustomer();
+			return;
+		}
 		// Ignore out-of-order webhook events; retries (equal eventAt) still apply.
 		if (existing && args.eventAt < existing.eventAt) return;
 		// A non-active event for a different subscription than the stored one is
@@ -105,16 +140,6 @@ export const upsertSubscription = internalMutation({
 		};
 		if (existing) await ctx.db.replace(existing._id, subscription);
 		else await ctx.db.insert('subscriptions', subscription);
-
-		const customer = await ctx.db
-			.query('billingCustomers')
-			.withIndex('by_userId', (q) => q.eq('userId', args.userId))
-			.unique();
-		if (customer) await ctx.db.patch(customer._id, { dodoCustomerId: args.dodoCustomerId });
-		else
-			await ctx.db.insert('billingCustomers', {
-				userId: args.userId,
-				dodoCustomerId: args.dodoCustomerId
-			});
+		await syncBillingCustomer();
 	}
 });

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -19,7 +19,7 @@ import {
 	type SupportedModelId,
 	type SupportedServiceTier
 } from '@convex/lib/models';
-import { getSubscriptionTier, tierLimits, type TierLimits } from '@convex/lib/tiers';
+import { ensureSubscription, tierLimits, type TierLimits } from '@convex/lib/tiers';
 import { vModelId, vServiceTier } from '@convex/lib/validators';
 
 const MONTH = 30 * DAY;
@@ -153,14 +153,16 @@ export async function getMeterWindow(
 }
 
 async function chargeWebTools(ctx: MutationCtx, userId: string, count: number): Promise<void> {
-	const tier = await getSubscriptionTier(ctx, userId);
+	const tier = await ensureSubscription(ctx, userId);
+	if (tier === 'admin') return;
 	await chargeMeterLimits(ctx, 'webTools', userId, tierLimits[tier], count);
 }
 
 export const checkWebToolsLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
-		const tier = await getSubscriptionTier(ctx, userId);
+		const tier = await ensureSubscription(ctx, userId);
+		if (tier === 'admin') return;
 		await checkMeterLimits(ctx, 'webTools', userId, tierLimits[tier]);
 	}
 });
@@ -182,7 +184,8 @@ export const chargeWebSearchLimits = internalMutation({
 export const checkModelUsageLimits = internalMutation({
 	args: { userId: v.string() },
 	handler: async (ctx, { userId }) => {
-		const tier = await getSubscriptionTier(ctx, userId);
+		const tier = await ensureSubscription(ctx, userId);
+		if (tier === 'admin') return;
 		await checkMeterLimits(ctx, 'modelUsage', userId, tierLimits[tier]);
 	}
 });
@@ -200,7 +203,8 @@ export const chargeModelUsageLimits = internalMutation({
 		})
 	},
 	handler: async (ctx, args) => {
-		const tier = await getSubscriptionTier(ctx, args.userId);
+		const tier = await ensureSubscription(ctx, args.userId);
+		if (tier === 'admin') return;
 		const count = completionUsageUnits(args.modelId, args.serviceTier, args.tokens);
 		await chargeMeterLimits(ctx, 'modelUsage', args.userId, tierLimits[tier], count);
 	}

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -38,10 +38,9 @@ export function tierForProductId(productId: string): SubscriptionTier | undefine
 	return subscriptionTierIds.find((tier) => tierProductIds[tier] === productId);
 }
 
+/** Active admin grants are manual and outrank every Dodo-driven row. */
 function subscriptionRank(subscription: Doc<'subscriptions'>): number {
-	if (subscription.status === 'active' && subscription.tier === 'admin') return 3;
-	if (subscription.status === 'active') return 2;
-	return 1;
+	return subscription.status === 'active' && subscription.tier === 'admin' ? 1 : 0;
 }
 
 function pickSubscription(rows: Doc<'subscriptions'>[]): Doc<'subscriptions'> | null {
@@ -50,7 +49,13 @@ function pickSubscription(rows: Doc<'subscriptions'>[]): Doc<'subscriptions'> | 
 		const bestRank = subscriptionRank(best);
 		const rowRank = subscriptionRank(row);
 		if (rowRank !== bestRank) return rowRank > bestRank ? row : best;
-		return row.eventAt >= best.eventAt ? row : best;
+		// Recency wins so a newer cancellation supersedes an older active row.
+		if (row.eventAt !== best.eventAt) return row.eventAt > best.eventAt ? row : best;
+		// Same event time (e.g. webhook retries): keep an active row over a lapsed one.
+		const rowActive = row.status === 'active';
+		const bestActive = best.status === 'active';
+		if (rowActive !== bestActive) return rowActive ? row : best;
+		return best;
 	});
 }
 

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -1,10 +1,14 @@
 import type { GenericMutationCtx, GenericQueryCtx } from 'convex/server';
-import type { DataModel } from '@convex/_generated/dataModel';
+import type { DataModel, Doc } from '@convex/_generated/dataModel';
 
-export const subscriptionTierIds = ['free', 'pro'] as const;
+export const subscriptionTierIds = ['free', 'pro', 'admin'] as const;
 export type SubscriptionTier = (typeof subscriptionTierIds)[number];
 
-export const tierLabels: Record<SubscriptionTier, string> = { free: 'Free', pro: 'Pro' };
+export const tierLabels: Record<SubscriptionTier, string> = {
+	free: 'Free',
+	pro: 'Pro',
+	admin: 'Admin'
+};
 
 export type TierLimits = {
 	modelUsage: { weekly: number; monthly: number };
@@ -16,25 +20,92 @@ const sharedLimits: TierLimits = {
 	webTools: { weekly: 500, monthly: 1_500 }
 };
 
+const adminQuota = 1_000_000_000;
+
 export const tierLimits: Record<SubscriptionTier, TierLimits> = {
 	free: sharedLimits,
-	pro: sharedLimits
+	pro: sharedLimits,
+	admin: {
+		modelUsage: { weekly: adminQuota, monthly: adminQuota },
+		webTools: { weekly: adminQuota, monthly: adminQuota }
+	}
 };
 
-/** Dodo product id per paid tier; 'free' never has one. */
+/** Dodo product id per paid tier; 'free' and 'admin' never have one. */
 export const tierProductIds: Partial<Record<SubscriptionTier, string>> = {};
 
 export function tierForProductId(productId: string): SubscriptionTier | undefined {
 	return subscriptionTierIds.find((tier) => tierProductIds[tier] === productId);
 }
 
+function subscriptionRank(subscription: Doc<'subscriptions'>): number {
+	if (subscription.status === 'active' && subscription.tier === 'admin') return 3;
+	if (subscription.status === 'active') return 2;
+	return 1;
+}
+
+function pickSubscription(rows: Doc<'subscriptions'>[]): Doc<'subscriptions'> | null {
+	if (rows.length === 0) return null;
+	return rows.reduce((best, row) => {
+		const bestRank = subscriptionRank(best);
+		const rowRank = subscriptionRank(row);
+		if (rowRank !== bestRank) return rowRank > bestRank ? row : best;
+		return row.eventAt >= best.eventAt ? row : best;
+	});
+}
+
+async function listSubscriptions(
+	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<Doc<'subscriptions'>[]> {
+	return await ctx.db
+		.query('subscriptions')
+		.withIndex('by_userId', (query) => query.eq('userId', userId))
+		.collect();
+}
+
+export async function getSubscriptionDoc(
+	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<Doc<'subscriptions'> | null> {
+	return pickSubscription(await listSubscriptions(ctx, userId));
+}
+
+/** Mutation-only: collapse concurrent ensure races onto one row. */
+export async function getSubscriptionDocExclusive(
+	ctx: GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<Doc<'subscriptions'> | null> {
+	const rows = await listSubscriptions(ctx, userId);
+	const keep = pickSubscription(rows);
+	if (!keep) return null;
+	for (const row of rows) {
+		if (row._id !== keep._id) await ctx.db.delete(row._id);
+	}
+	return keep;
+}
+
 export async function getSubscriptionTier(
 	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
 	userId: string
 ): Promise<SubscriptionTier> {
-	const subscription = await ctx.db
-		.query('subscriptions')
-		.withIndex('by_userId', (query) => query.eq('userId', userId))
-		.unique();
+	const subscription = await getSubscriptionDoc(ctx, userId);
 	return subscription?.status === 'active' ? subscription.tier : 'free';
+}
+
+/** Insert a free/active row when missing; never overwrites an existing grant. */
+export async function ensureSubscription(
+	ctx: GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<SubscriptionTier> {
+	const existing = await getSubscriptionDocExclusive(ctx, userId);
+	if (existing) return existing.status === 'active' ? existing.tier : 'free';
+	// eventAt 0 so bootstrap rows never win ordering over Dodo webhooks.
+	await ctx.db.insert('subscriptions', {
+		userId,
+		tier: 'free',
+		status: 'active',
+		eventAt: 0
+	});
+	return 'free';
 }

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -25,8 +25,8 @@ export default defineSchema({
 	subscriptions: defineTable({
 		userId: v.string(),
 		tier: vSubscriptionTier,
-		dodoSubscriptionId: v.string(),
-		dodoProductId: v.string(),
+		dodoSubscriptionId: v.optional(v.string()),
+		dodoProductId: v.optional(v.string()),
 		status: vSubscriptionStatus,
 		eventAt: v.number()
 	}).index('by_userId', ['userId']),

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -82,6 +82,35 @@ describe('subscription and usage backend', () => {
 		expect(await currentTier()).toBe('free');
 	});
 
+	it('dedupes to the newest event so a cancellation beats an older active row', async () => {
+		const t = initConvexTest();
+		const userId = 'user_dedup';
+		const asUser = t.withIdentity({ subject: userId });
+		const shared = {
+			userId,
+			tier: 'pro',
+			dodoSubscriptionId: 'sub_dup',
+			dodoProductId: 'prod_dup'
+		} as const;
+		await t.run(async (ctx) => {
+			await ctx.db.insert('subscriptions', { ...shared, status: 'active', eventAt: 1_000 });
+			await ctx.db.insert('subscriptions', { ...shared, status: 'cancelled', eventAt: 2_000 });
+		});
+
+		expect((await asUser.query(api.usage.getMyUsage, {})).tier).toBe('free');
+
+		// Ensuring collapses the duplicates onto the newer cancellation.
+		await asUser.mutation(api.billing.ensureMySubscription, {});
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('subscriptions')
+				.withIndex('by_userId', (query) => query.eq('userId', userId))
+				.collect()
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ status: 'cancelled', eventAt: 2_000 });
+	});
+
 	it('ensures a free subscription row and leaves existing grants alone', async () => {
 		const t = initConvexTest();
 		const userId = 'user_ensure_free';

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -81,4 +81,135 @@ describe('subscription and usage backend', () => {
 		});
 		expect(await currentTier()).toBe('free');
 	});
+
+	it('ensures a free subscription row and leaves existing grants alone', async () => {
+		const t = initConvexTest();
+		const userId = 'user_ensure_free';
+		const asUser = t.withIdentity({ subject: userId });
+		const readSubscription = () =>
+			t.run(async (ctx) =>
+				ctx.db
+					.query('subscriptions')
+					.withIndex('by_userId', (query) => query.eq('userId', userId))
+					.unique()
+			);
+
+		expect(await readSubscription()).toBeNull();
+		await asUser.mutation(api.billing.ensureMySubscription, {});
+		const created = await readSubscription();
+		expect(created).toMatchObject({ userId, tier: 'free', status: 'active', eventAt: 0 });
+		expect(created?.dodoSubscriptionId).toBeUndefined();
+		expect(created?.dodoProductId).toBeUndefined();
+
+		await t.run(async (ctx) => {
+			if (!created) throw new Error('Expected subscription row');
+			await ctx.db.patch(created._id, { tier: 'admin', eventAt: 5_000 });
+		});
+		await asUser.mutation(api.billing.ensureMySubscription, {});
+		expect(await readSubscription()).toMatchObject({
+			userId,
+			tier: 'admin',
+			status: 'active',
+			eventAt: 5_000
+		});
+	});
+
+	it('lets paid webhooks replace a bootstrap free row', async () => {
+		const t = initConvexTest();
+		const userId = 'user_bootstrap_upgrade';
+		const asUser = t.withIdentity({ subject: userId });
+		await asUser.mutation(api.billing.ensureMySubscription, {});
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			userId,
+			tier: 'pro',
+			dodoSubscriptionId: 'sub_upgrade',
+			dodoProductId: 'prod_upgrade',
+			dodoCustomerId: 'customer_upgrade',
+			status: 'active',
+			eventAt: 1
+		});
+		expect(await asUser.query(api.usage.getMyUsage, {})).toMatchObject({ tier: 'pro' });
+	});
+
+	it('keeps admin grants above Dodo webhook upserts', async () => {
+		const t = initConvexTest();
+		const userId = 'user_admin_grant';
+		const asUser = t.withIdentity({ subject: userId });
+		const currentTier = async () => (await asUser.query(api.usage.getMyUsage, {})).tier;
+		await t.run(async (ctx) => {
+			await ctx.db.insert('subscriptions', {
+				userId,
+				tier: 'admin',
+				status: 'active',
+				eventAt: 1_000
+			});
+		});
+		const webhook = {
+			userId,
+			tier: 'pro' as const,
+			dodoSubscriptionId: 'sub_admin',
+			dodoProductId: 'prod_admin',
+			dodoCustomerId: 'customer_admin'
+		};
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			...webhook,
+			status: 'active',
+			eventAt: 2_000
+		});
+		expect(await currentTier()).toBe('admin');
+		const customer = await t.run(async (ctx) =>
+			ctx.db
+				.query('billingCustomers')
+				.withIndex('by_userId', (query) => query.eq('userId', userId))
+				.unique()
+		);
+		expect(customer?.dodoCustomerId).toBe('customer_admin');
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			...webhook,
+			status: 'cancelled',
+			eventAt: 3_000
+		});
+		expect(await currentTier()).toBe('admin');
+	});
+
+	it('lets admin bypass meters after free overdraft', async () => {
+		const t = initConvexTest();
+		const userId = 'user_admin_bypass';
+		const asUser = t.withIdentity({ subject: userId });
+		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
+			userId,
+			modelId: 'gpt-5.6-sol',
+			serviceTier: 'standard',
+			tokens: { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 }
+		});
+		await expect(
+			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
+		).rejects.toThrow('Monthly model usage limit reached');
+
+		await t.run(async (ctx) => {
+			const existing = await ctx.db
+				.query('subscriptions')
+				.withIndex('by_userId', (query) => query.eq('userId', userId))
+				.unique();
+			if (!existing) throw new Error('Expected subscription row');
+			await ctx.db.patch(existing._id, { tier: 'admin' });
+		});
+
+		await t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId });
+		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
+			userId,
+			modelId: 'gpt-5.6-sol',
+			serviceTier: 'standard',
+			tokens: { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 }
+		});
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		expect(usage.tier).toBe('admin');
+		const weekly = usage.meters
+			.find((meter) => meter.id === 'modelUsage')
+			?.windows.find((window) => window.period === 'weekly');
+		expect(weekly).toMatchObject({ used: 0 });
+	});
 });

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -4,7 +4,6 @@ import contextDevTest from '@context-dot-dev/convex/test';
 import rateLimiterTest from '@convex-dev/rate-limiter/test';
 import exaTest from '@exalabs/convex-exa/test';
 import { convexTest, type TestConvex } from 'convex-test';
-import type { GenericSchema, SchemaDefinition } from 'convex/server';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import schema from './schema';
@@ -22,7 +21,7 @@ export const modules = import.meta.glob([
 	'!./**/test.setup.ts'
 ]);
 
-export type ConvexTestInstance = TestConvex<SchemaDefinition<GenericSchema, boolean>>;
+export type ConvexTestInstance = TestConvex<typeof schema>;
 
 type AuthenticatedTest = ReturnType<ConvexTestInstance['withIdentity']>;
 

--- a/apps/web/src/convex/usage.ts
+++ b/apps/web/src/convex/usage.ts
@@ -17,10 +17,21 @@ export const getMyUsage = query({
 					label: meter.label,
 					description: meter.description,
 					windows: await Promise.all(
-						usagePeriods.map(async (period) => ({
-							period,
-							...(await getMeterWindow(ctx, meter.id, period, userId, limits))
-						}))
+						usagePeriods.map(async (period) => {
+							// Admin skips meters; don't project free/pro remaining onto admin rates.
+							if (tier === 'admin') {
+								return {
+									period,
+									used: 0,
+									limit: limits[meter.id][period],
+									resetsAt: null
+								};
+							}
+							return {
+								period,
+								...(await getMeterWindow(ctx, meter.id, period, userId, limits))
+							};
+						})
 					)
 				}))
 			)

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -130,6 +130,33 @@
 	const registerImageUpload = useMutation(api.imageUploads.register);
 	const discardImageUpload = useMutation(api.imageUploads.discard);
 	const heartbeatAttached = useMutation(api.workspaceSessions.heartbeatAttached);
+	const ensureMySubscription = useMutation(api.billing.ensureMySubscription);
+	let ensuredSubscriptionUserId: string | null = null;
+	let ensureSubscriptionInFlightFor: string | null = null;
+
+	$effect(() => {
+		if (!authReady) return;
+		const userId = getCurrentUserId();
+		if (
+			!userId ||
+			ensuredSubscriptionUserId === userId ||
+			ensureSubscriptionInFlightFor === userId
+		) {
+			return;
+		}
+		ensureSubscriptionInFlightFor = userId;
+		void ensureMySubscription({})
+			.then(() => {
+				if (getCurrentUserId() === userId) {
+					ensuredSubscriptionUserId = userId;
+				}
+			})
+			.finally(() => {
+				if (ensureSubscriptionInFlightFor === userId) {
+					ensureSubscriptionInFlightFor = null;
+				}
+			});
+	});
 	const localServerRequiredMessage = 'Connect to a running Sprocket server to use this workspace.';
 	const agentLaunchTimeoutMs = 30_000;
 	type ComposerRecovery = {
@@ -1277,6 +1304,8 @@
 		pendingAgentLaunches = {};
 		restoredWorkspaceSessionIdToAttach = null;
 		lastSavedThreadId = null;
+		ensuredSubscriptionUserId = null;
+		ensureSubscriptionInFlightFor = null;
 		lastSyncedComposerThreadId = null;
 		workspaceSelectionGeneration += 1;
 		prompt = '';

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -131,31 +131,19 @@
 	const discardImageUpload = useMutation(api.imageUploads.discard);
 	const heartbeatAttached = useMutation(api.workspaceSessions.heartbeatAttached);
 	const ensureMySubscription = useMutation(api.billing.ensureMySubscription);
-	let ensuredSubscriptionUserId: string | null = null;
-	let ensureSubscriptionInFlightFor: string | null = null;
+	let ensureSubscriptionAttemptedFor: string | null = null;
 
 	$effect(() => {
 		if (!authReady) return;
 		const userId = getCurrentUserId();
-		if (
-			!userId ||
-			ensuredSubscriptionUserId === userId ||
-			ensureSubscriptionInFlightFor === userId
-		) {
+		if (!userId || ensureSubscriptionAttemptedFor === userId) {
 			return;
 		}
-		ensureSubscriptionInFlightFor = userId;
-		void ensureMySubscription({})
-			.then(() => {
-				if (getCurrentUserId() === userId) {
-					ensuredSubscriptionUserId = userId;
-				}
-			})
-			.finally(() => {
-				if (ensureSubscriptionInFlightFor === userId) {
-					ensureSubscriptionInFlightFor = null;
-				}
-			});
+		// Attempt once per signed-in user. This is a best-effort bootstrap: the
+		// backend also ensures a row on first metered usage, so a failure is safe
+		// to swallow and must not re-trigger the effect into a tight retry loop.
+		ensureSubscriptionAttemptedFor = userId;
+		void ensureMySubscription({}).catch(() => {});
 	});
 	const localServerRequiredMessage = 'Connect to a running Sprocket server to use this workspace.';
 	const agentLaunchTimeoutMs = 30_000;
@@ -1304,8 +1292,7 @@
 		pendingAgentLaunches = {};
 		restoredWorkspaceSessionIdToAttach = null;
 		lastSavedThreadId = null;
-		ensuredSubscriptionUserId = null;
-		ensureSubscriptionInFlightFor = null;
+		ensureSubscriptionAttemptedFor = null;
 		lastSyncedComposerThreadId = null;
 		workspaceSelectionGeneration += 1;
 		prompt = '';


### PR DESCRIPTION
## Summary
- Add an `admin` subscription tier that bypasses usage meters and can be granted by editing the Convex `subscriptions` table
- Ensure every user (including free) gets a `subscriptions` row on sign-in / first usage, with optional Dodo fields for non-paid grants
- Protect active admin grants from Dodo webhook overwrites while still syncing billing customer linkage

## Test plan
- [ ] Sign in as a new user and confirm a free/active `subscriptions` row appears in Convex
- [ ] Patch that row to `tier: admin`, `status: active` and confirm Account/Usage show Admin
- [ ] Confirm admin users can continue after free-tier overdraft
- [ ] Confirm a Dodo webhook cannot downgrade an active admin grant
- [ ] `bun run test` in `apps/web` for `subscriptionUsage.test.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a manually managed admin subscription tier and subscription bootstrap flow. The main changes are:

- Admin grants bypass model and web-tool usage meters.
- Missing subscription rows are created during sign-in or first metered usage.
- Active admin grants are preserved during billing webhook updates.
- Duplicate subscription rows are reconciled by grant priority and event time.
- Subscription and usage views display the admin tier.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

Newer cancellations supersede older active paid rows, and failed sign-in bootstrap attempts are handled without immediate reactive retries.

No blocking issues remain in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification to validate the proofs.
- T-Rex did not upload local artifact references for the verification.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/tiers.ts | Adds the admin tier, default subscription creation, and event-aware duplicate-row reconciliation. |
| apps/web/src/convex/billing.ts | Adds the subscription bootstrap mutation and preserves active admin grants during webhook updates. |
| apps/web/src/convex/lib/rateLimits.ts | Creates missing subscription rows during metered operations and bypasses meters for admins. |
| apps/web/src/convex/usage.ts | Returns admin usage views without projecting ordinary metered consumption. |
| apps/web/src/routes/+page.svelte | Attempts subscription bootstrap once per signed-in user and handles mutation failures. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): type convex test instance with..."](https://github.com/spikonado/sprocket/commit/3cdce65577484fb545858ee4a6cbb98665aebf00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45538458)</sub>

<!-- /greptile_comment -->