### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,35 @@ How to apply:
 - The produced code meeting the priorities in "Priorities in Order" is much more important than what it costed.
 - For bulk/mechanical/zero-brain operations, always use the cheapest model first and only switch to a better model if the output doesn't meet the bar.
 - For user-facing UI/UX and APIs, use a model with good taste (>=7). If making those UIs/APIs is highly complicated, get a model with higher intelligence to complete the work after the core UI/API has been decided by the model with good taste.
+
+## Cursor Cloud specific instructions
+
+The startup update script already ran `bun install` inside the Nix dev shell, and the Nix store is prewarmed in the VM snapshot. Notes below are the non-obvious gotchas for this environment.
+
+### Nix daemon (no systemd)
+
+- This VM's init is `tini`, not systemd. The multi-user Nix daemon is auto-started from the agent's `~/.bashrc`. If a shell reports `nix` missing or `cannot connect to socket at '/nix/var/nix/daemon-socket/socket'`, start it once with:
+  `sudo sh -c 'nohup /nix/var/nix/profiles/default/bin/nix-daemon >/tmp/nix-daemon.log 2>&1 &'`
+- The Nix binary cache config in `flake.nix` (cachix) is ignored because this user isn't a trusted Nix user; everything is fetched from `cache.nixos.org`, so those warnings are harmless.
+
+### Running toolchain commands
+
+- Run every toolchain command as `nix develop --accept-flake-config -c <command>` (e.g. `nix develop --accept-flake-config -c bun run test`).
+- Do NOT wrap it in a login shell (`bash -lc`). `~/.bashrc` prepends the system `cargo 1.83` to `PATH`, which lacks `edition2024` and breaks all cargo builds. Plain `nix develop -c ...` keeps the Nix toolchain (cargo/rustc 1.96, bun 1.3.x, node 24) first.
+
+### Services and ports
+
+- `nix develop --accept-flake-config -c bun dev` starts the whole dev stack: Rust API (`:7731`), an anonymous local Convex backend (`:3210`), and Vite (`:5173`). `bun dev:desktop` swaps Vite for Electron.
+- `convex dev` (invoked by `bun dev`) provisions a fully local, no-account Convex deployment and writes `apps/web/.env.local`. The browser's `PUBLIC_CONVEX_URL` comes from the Rust server's `/api/config`, which `bun dev` points at the local backend via that `.env.local`.
+- The local Convex push fails until deployment env vars exist. Set placeholders once (they persist in the local deployment): `cd apps/web && nix develop --accept-flake-config -c node node_modules/convex/bin/main.js env set WORKOS_CLIENT_ID <val>` and likewise for `CONTEXT_DEV_API_KEY` and `EXA_API_KEY`.
+- Full sign-in and agent runs additionally require a real WorkOS AuthKit app (`WORKOS_CLIENT_ID`) and a model-provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY`) set on the Convex deployment. Without them the app renders the sign-in screen but cannot authenticate or run the agent.
+
+### Local server (works fully offline)
+
+- The Rust server can run standalone: `nix develop --accept-flake-config -c cargo run -p sprocket-cli -- serve --port 7731 --data-dir .sprocket-dev --api-only`.
+- Pair a client by POSTing the credential from `<data-dir>/pairing-credential` to `/api/auth/bootstrap` (returns a session cookie), then use `/api/workspace/{browse,resolve,sessions}` for local filesystem access and workspace attachment.
+
+### Dev-mode web UI caveat
+
+- `bun dev`'s Vite browser bundle currently throws `ReferenceError: process is not defined` (from `apps/web/src/convex/lib/rateLimits.ts` value-importing `internalMutation` from `_generated/server.js`, which pulls `process.env` into the client via `+page.svelte` -> `settings-usage.svelte`). This shows a client-side "500 Internal Error" page.
+- The production build tree-shakes that import, so `bun run build` output renders correctly. To view the UI, serve the build with the Rust server: `SPROCKET_STATIC_DIR=/workspace/apps/web/dist PUBLIC_CONVEX_URL=http://127.0.0.1:3210 nix develop --accept-flake-config -c cargo run -p sprocket-cli -- serve --port 17731 --data-dir .sprocket-web`, then open `http://127.0.0.1:17731/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the Cursor Cloud development environment for this repo. No application code is changed — this only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious startup/run caveats discovered while setting up and running the full stack.

## What was set up and verified

- Installed Nix (multi-user) and materialized the `flake.nix` dev shell: `bun 1.3.13`, `node 24.18`, `rustc/cargo 1.96`, `prek 0.4.4`, `commitlint 21`.
- `bun install` (1229 packages) and `cargo build` (all 5 crates) succeed.
- Lint/format: `prek run -a` — all hooks pass.
- Tests: `cargo test` (36 pass) and `bun run test` (136 pass).
- Build: `bun run build` (web + desktop) succeeds.
- Ran the full dev stack `bun dev`: Rust API (`:7731`) + anonymous local Convex backend (`:3210`) + Vite (`:5173`).
- Hello-world (local execution plane): paired a client, browsed the local filesystem, and resolved + attached a workspace via the local API.
- Served the production web build via the Rust server (`:17731`) and confirmed the Sprocket sign-in UI renders.

## Notable caveats captured in AGENTS.md

- No systemd on the VM; the Nix daemon is auto-started from `~/.bashrc`.
- Always run toolchain commands as `nix develop --accept-flake-config -c <cmd>` — a login-shell wrapper re-prepends the system `cargo 1.83` which lacks `edition2024`.
- `convex dev` runs a local, no-account deployment and writes `apps/web/.env.local`; its push needs `WORKOS_CLIENT_ID`, `CONTEXT_DEV_API_KEY`, `EXA_API_KEY` set via `convex env set`.
- Full sign-in / agent runs additionally require a real WorkOS app and a model-provider API key on the Convex deployment.
- `bun dev`'s Vite browser bundle currently crashes with `process is not defined` (a convex server module leaks into the client via `rateLimits.ts`); the production build tree-shakes it and renders fine.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fa69ea7-ba27-45ee-8fbd-4d5918aa06f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fa69ea7-ba27-45ee-8fbd-4d5918aa06f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Cursor Cloud development notes to `AGENTS.md`. The main changes are:

- Nix daemon and dev-shell startup guidance.
- Commands for running the web, desktop, and Rust services.
- Convex environment and authentication requirements.
- A production-build workaround for the Vite development error.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed documentation. The documented commands, ports, routes, and environment variables match the repository configuration.

AGENTS.md requires no additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Completed the build verification and confirmed 4,045 transformed client modules and static adapter output written to dist with all tasks succeeding.
- Validated the server lifecycle by confirming startup, HTTP readiness, and pairing URL generation followed by a clean shutdown.
- Verified the UI loads from the real repository-built UI at the internal URL, not a mockup or error page.
- Compared before/after videos and confirmed they are equivalent, validating that documentation changes do not affect production behavior.
- Reviewed the evidence artifacts (videos, posters, and logs) to confirm end-to-end verification and readiness signals.

<a href="https://app.greptile.com/trex/runs/15045932/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds Cursor Cloud setup, service, authentication, and troubleshooting instructions that match the repository configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Cursor Cloud dev environment s..."](https://github.com/spikonado/sprocket/commit/946c3539966be804f581f61980205e81fcd22121) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45546804)</sub>

<!-- /greptile_comment -->