### PR TITLE
fix(ci): npm-release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -73,8 +73,6 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.source-sha }}
       - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
       - run: bun install --frozen-lockfile
       - run: bun run --cwd apps/web build
       - uses: actions/upload-artifact@v6
@@ -180,7 +178,10 @@ jobs:
       - name: Validate package contents
         run: |
           for package in npm-dist/*; do
-            npm pack "$package" --dry-run
+            (
+              cd "$package"
+              npm pack --dry-run
+            )
           done
       - uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts package validation in the npm release workflow. The main changes are:

- Resolves Bun from the repository's package manager metadata.
- Runs each npm package dry-run from its assembled directory.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The repository metadata resolves the same Bun version that was previously explicit, and the package builder creates directories compatible with the revised validation loop.

No blocking issues were found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial package assembly completed successfully and produced the root package plus five platform packages under npm-dist.
- The package-argument loop for that run failed with exit 128 because npm interpreted paths as GitHub shorthand.
- A revised packaging loop completed with exit 0, yielding six package markers and six successful tarball summaries, with complete verbose per-package output captured separately.
- No publishing was attempted during this work.

<a href="https://app.greptile.com/trex/runs/15059284/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Removes the redundant Bun version input and validates generated package directories from their own working directories. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): npm-release workflow"](https://github.com/spikonado/sprocket/commit/6519483d459566a3bd657581915034cd2a378173) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45575917)</sub>

<!-- /greptile_comment -->