### PR TITLE
ci: Fix npm-release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -232,7 +232,10 @@ jobs:
             if npm view "$name@$VERSION" version >/dev/null 2>&1; then
               echo "$name@$VERSION is already published; skipping"
             else
-              npm publish "$package" --tag "$NPM_TAG"
+              (
+                cd "$package"
+                npm publish --tag "$NPM_TAG"
+              )
             fi
           done
       - name: Publish root package last


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how generated native npm packages are published. The main change is:

- Runs `npm publish` from inside each package directory using an isolated subshell.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code. The subshell keeps each directory change local to one loop iteration. Package manifests, included files, npm configuration, and authentication resolve consistently under the new command.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested contract validation and noted that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Publishes each generated native package from its own directory without changing the working directory of later workflow commands. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: Fix npm-release workflow"](https://github.com/spikonado/sprocket/commit/4c598119e1180eea9431f285441a6fd6b0a1e588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45578087)</sub>

<!-- /greptile_comment -->