### PR TITLE
fix(web): Accept deeply nested scrape metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
   },
   "patchedDependencies": {
     "@exalabs/convex-exa@0.1.0": "patches/@exalabs%2Fconvex-exa@0.1.0.patch",
+    "@context-dot-dev/convex@1.0.1": "patches/@context-dot-dev%2Fconvex@1.0.1.patch",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"packages/*"
 	],
 	"patchedDependencies": {
-		"@exalabs/convex-exa@0.1.0": "patches/@exalabs%2Fconvex-exa@0.1.0.patch"
+		"@exalabs/convex-exa@0.1.0": "patches/@exalabs%2Fconvex-exa@0.1.0.patch",
+		"@context-dot-dev/convex@1.0.1": "patches/@context-dot-dev%2Fconvex@1.0.1.patch"
 	}
 }

--- a/patches/@context-dot-dev%2Fconvex@1.0.1.patch
+++ b/patches/@context-dot-dev%2Fconvex@1.0.1.patch
@@ -10,7 +10,7 @@ index c7b77a8638df14dac23a5091e7452d657076d2a7..9d064995b46709c3acbda2bdd51c4ba5
 +// Patched: /web/scrape/markdown returns a stable envelope on success, so validate
 +// it precisely instead of the finite-depth apiResponse shared by other endpoints.
 +const scrapeMarkdownResponse = v.object({
-+    success: v.literal(true),
++    success: v.boolean(),
 +    markdown: v.string(),
 +    url: v.string(),
 +    metadata: v.record(v.string(), v.any()),

--- a/patches/@context-dot-dev%2Fconvex@1.0.1.patch
+++ b/patches/@context-dot-dev%2Fconvex@1.0.1.patch
@@ -1,0 +1,30 @@
+diff --git a/dist/component/web.js b/dist/component/web.js
+index c7b77a8638df14dac23a5091e7452d657076d2a7..9d064995b46709c3acbda2bdd51c4ba5954ff96d 100644
+--- a/dist/component/web.js
++++ b/dist/component/web.js
+@@ -1,6 +1,16 @@
+ import { action } from "./_generated/server.js";
+ import { contextRequest } from "./lib/http.js";
+ import { apiResponse, args as validators } from "./lib/validators.js";
++import { v } from "convex/values";
++// Patched: /web/scrape/markdown returns a stable envelope on success, so validate
++// it precisely instead of the finite-depth apiResponse shared by other endpoints.
++const scrapeMarkdownResponse = v.object({
++    success: v.literal(true),
++    markdown: v.string(),
++    url: v.string(),
++    metadata: v.record(v.string(), v.any()),
++    key_metadata: v.optional(v.record(v.string(), v.any())),
++});
+ export const scrapeHtml = action({
+     args: validators.scrapeHtml,
+     returns: apiResponse,
+@@ -8,7 +18,7 @@ export const scrapeHtml = action({
+ });
+ export const scrapeMarkdown = action({
+     args: validators.scrapeMarkdown,
+-    returns: apiResponse,
++    returns: scrapeMarkdownResponse,
+     handler: async (_, args) => contextRequest("get", "/web/scrape/markdown", args),
+ });
+ export const scrapeImages = action({


### PR DESCRIPTION
## Summary

- patch the Context.dev Convex component with a dedicated `scrapeMarkdown` return validator
- validate the stable response envelope while allowing arbitrary nesting only inside metadata
- register the versioned Bun dependency patch in the workspace manifest and lockfile

## Root cause

`@context-dot-dev/convex@1.0.1` validates all API responses with a JSON validator manually unrolled to six levels. Pages with deeper JSON-LD metadata fail inside the component with `ReturnsValidationError` before Sprocket can read the returned markdown.

## Validation

- forced a frozen dependency reinstall and verified `apps/web` resolves the patched component
- `bun run test` in `apps/web` — 141 tests passed
- `bun run build` in `apps/web`
- `bun run check` in `apps/web`
- `bun run lint` in `apps/web`
- pre-commit hooks, including Cargo checks, ESLint, Svelte check, and Prettier

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Context.dev Convex component to accept deeply nested scrape metadata. The main changes are:

- Adds a dedicated return validator for scrape-markdown responses.
- Allows arbitrary nesting inside metadata fields.
- Registers the versioned Bun patch in the workspace manifest and lockfile.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before patch, the same mocked response was rejected by the former finite-depth validator with the message $.metadata: no union member matched.
- After installing the patched validator, the run reported patchedReturnsType=object, metadata values as any, and accepted the deep leaf.
- Both runs completed by sending exactly one mocked request through the installed handler and exiting with status 0.

<a href="https://app.greptile.com/trex/runs/15259843/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patches/@context-dot-dev%2Fconvex@1.0.1.patch | Replaces the generic finite-depth validator for scrape-markdown responses with a dedicated response envelope. |
| package.json | Registers the Context.dev component patch in the workspace configuration. |
| bun.lock | Records the Context.dev component patch in the lockfile. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Update @context-dot-dev%2Fconvex@1.0.1.p..."](https://github.com/spikonado/sprocket/commit/cd5a48fa10782f0d2a15d750f478779da081206f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45680644)</sub>

<!-- /greptile_comment -->