### PR TITLE
docs: Refine README.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/sprocket.png filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **Goal**: To make the world's best platform for developing hardware and software, while making it the world's best platform for robotics development.
 
 Sprocket is currently a coding agent that can operate in your local workspace, surf the web better than any other agent out there, and write high-quality code.
- 
+
+![Sprocket](./assets/sprocket.png)
 
 ## Using Sprocket
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Sprocket
 
-**Goal**: To make the world's best platform for developing hardware and software, and thus become THE platform for robotics development.<br>
-Because as they say, _"Robotics is the true jack of all trades field."_
+**Goal**: To make the world's best platform for developing hardware and software, while making it the world's best platform for robotics development.
+
+Sprocket is currently a coding agent that can operate in your local workspace, surf the web better than any other agent out there, and write high-quality code.
  
 
 ## Using Sprocket

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Sprocket
 
-Sprocket is an agentic workspace for building robots and robot applications. It
-connects an AI coding agent to a local project while keeping filesystem and
-command execution on your machine.
+**Goal**: To make the world's best platform for developing hardware and software, and thus become THE platform for robotics development.<br>
+Because as they say, _"Robotics is the true jack of all trades field."_
+ 
 
 ## Using Sprocket
 
@@ -10,6 +10,13 @@ To directly launch Sprocket in the browser without having to install anything:
 
 ```sh
 npx @spikonado/sprocket --web
+```
+
+Installing the `sprocket` CLI and using it:
+
+```sh
+npm i -g @spikonado/sprocket
+sprocket --web
 ```
 
 After installing the Sprocket desktop application and the `sprocket` CLI, launch it from a terminal:

--- a/assets/sprocket.png
+++ b/assets/sprocket.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d6c53b173eed71daca14b9445e5cc3a5addd1f1bf6358fd95863ce9ee3f374f
+size 1367016


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the README and adds product artwork. The main changes are:

- Revised product goals and description.
- Added browser and global CLI usage instructions.
- Added a Git LFS-managed Sprocket image.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the latest changes.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I confirmed the before/after integrity captures pass, and the after capture verifies the image path exists and has the expected LFS tracking rule.
- I documented the formatting improvement, noting the pre-change trailing whitespace issue is resolved and the codebase now passes Prettier and git diff --check.
- I verified that assets/sprocket.png is tracked with LFS filter/diff/merge attributes in Git metadata, and noted that the PNG could not be materialized due to an environmental limitation (Git LFS unavailable).
- I reviewed the related logs to corroborate the validation results and the environmental constraint.

<a href="https://app.greptile.com/trex/runs/15214301/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Updates the product description, installation instructions, and artwork. |
| .gitattributes | Configures the new PNG asset for Git LFS. |
| assets/sprocket.png | Adds the Sprocket artwork as a Git LFS object. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **README.md does not pass the repository formatter check**

   - **Bug**
     - The requested README-only validation fails: `bunx prettier --check README.md` exits with status 1 and identifies README.md as improperly formatted.
   - **Cause**
     - The changed Markdown differs from Prettier's expected formatting.
   - **Fix**
     - Format README.md with the repository's Prettier configuration, commit the resulting Markdown changes, and rerun `bunx prettier --check README.md`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **README contains trailing whitespace and fails formatting validation**

   - **Bug**
     - The changed README does not satisfy the stated whitespace-clean formatting expectation. Prettier reports code-style issues, while Git identifies trailing whitespace on `README.md:6`.
   - **Cause**
     - The newly changed blank line at `README.md:6` contains a space (`+ `) rather than being empty.
   - **Fix**
     - Remove the trailing space from `README.md:6`, then rerun `./node_modules/.bin/prettier --check README.md` and `git diff --check 1a5670308e5f06e9c2fef74f1deb4a2f3954fbac...48d8e9e4080312657c2fd9a12c1f121280ee0234 -- README.md`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["add images"](https://github.com/spikonado/sprocket/commit/ca864a40473d4e73785b5158eb4774013d3c59bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45817103)</sub>

<!-- /greptile_comment -->