### PR TITLE
fix(agent): Recover completions after auth refresh

### DIFF
--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -18,7 +18,7 @@ use rig::message::{ReasoningContent, ToolCall as RigToolCall, ToolChoice, ToolFu
 use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
 use rustls::crypto::ring::default_provider;
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 use tokio::time::{sleep, timeout};
 
 use crate::messages::{build_model_messages, instructions_text, normalize_convex_json_numbers};
@@ -26,6 +26,7 @@ use crate::messages::{build_model_messages, instructions_text, normalize_convex_
 const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 const COMPLETION_TRANSPORT_ATTEMPTS: u32 = 3;
 const COMPLETION_TRANSPORT_RETRY_DELAY: Duration = Duration::from_millis(400);
+const AUTH_REFRESH_CORRELATION_GRACE: Duration = Duration::from_millis(500);
 
 pub const COMPLETION_STREAM_SUPERSEDED: &str = "SPROCKET_COMPLETION_STREAM_SUPERSEDED";
 
@@ -39,6 +40,8 @@ pub fn is_completion_stream_superseded(error: &(impl std::fmt::Display + ?Sized)
 #[derive(Clone)]
 pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
+    auth_refresh_generation: Arc<AtomicU32>,
+    auth_refresh_notify: Arc<Notify>,
     completion_action: Arc<str>,
     default_reasoning_effort: Option<Arc<str>>,
     default_service_tier: Option<Arc<str>>,
@@ -58,6 +61,8 @@ impl Client {
             .context("failed to initialize Convex client")?;
         Ok(Self {
             inner: Arc::new(Mutex::new(client)),
+            auth_refresh_generation: Arc::new(AtomicU32::new(0)),
+            auth_refresh_notify: Arc::new(Notify::new()),
             completion_action: completion_action.into().into(),
             default_reasoning_effort: None,
             default_service_tier: None,
@@ -68,8 +73,14 @@ impl Client {
     }
 
     pub async fn set_auth_token_fetcher(&self, fetcher: AuthTokenFetcher) {
+        let auth_refresh_generation = self.auth_refresh_generation.clone();
+        let auth_refresh_notify = self.auth_refresh_notify.clone();
         let convex_fetcher: convex::AuthTokenFetcher = Box::new(move |force_refresh| {
             let fetcher = fetcher.clone();
+            if force_refresh {
+                auth_refresh_generation.fetch_add(1, Ordering::Release);
+                auth_refresh_notify.notify_waiters();
+            }
             Box::pin(async move { fetcher(force_refresh).await.map(AuthenticationToken::User) })
         });
         self.inner
@@ -496,6 +507,10 @@ async fn call_completion_action(
         let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let stream_id = uuid::Uuid::new_v4().to_string();
         let mut convex = clone_locked(&client.inner).await;
+        // Register before taking the generation snapshot so a refresh starting
+        // while this action is in flight cannot be missed by the grace wait.
+        let auth_refresh_started = client.auth_refresh_notify.notified();
+        let auth_refresh_generation = client.auth_refresh_generation.load(Ordering::Acquire);
         eprintln!(
             "sprocket-convex-provider: action start {} attempt {attempt_seq}",
             client.completion_action
@@ -536,7 +551,7 @@ async fn call_completion_action(
             }
         };
 
-        let provider_error = match result {
+        let (provider_error, is_error_message) = match result {
             Ok(FunctionResult::Value(value)) => {
                 eprintln!(
                     "sprocket-convex-provider: action done {}",
@@ -544,8 +559,8 @@ async fn call_completion_action(
                 );
                 return Ok(value);
             }
-            Ok(FunctionResult::ErrorMessage(message)) => message,
-            Ok(FunctionResult::ConvexError(error)) => error.message,
+            Ok(FunctionResult::ErrorMessage(message)) => (message, true),
+            Ok(FunctionResult::ConvexError(error)) => (error.message, false),
             Err(error) => {
                 if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
                     return Err(to_completion_error(error));
@@ -569,12 +584,87 @@ async fn call_completion_action(
             backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
             continue;
         }
+        let auth_refresh_started = if attempt < COMPLETION_TRANSPORT_ATTEMPTS
+            && is_error_message
+            && is_redacted_convex_server_error(&provider_error)
+        {
+            auth_refresh_observed(
+                &client.auth_refresh_generation,
+                auth_refresh_generation,
+                auth_refresh_started,
+                AUTH_REFRESH_CORRELATION_GRACE,
+            )
+            .await
+        } else {
+            false
+        };
+        if should_retry_transient_server_error(
+            &provider_error,
+            is_error_message,
+            auth_refresh_started,
+            attempt,
+        ) {
+            // An expired identity interrupts in-flight actions with Convex's
+            // redacted server error. If a forced refresh began during the
+            // attempt, replay through the same stream-fencing path as transport
+            // failures. Requiring that correlation avoids retrying developer
+            // errors, which Convex redacts to the same text in production.
+            eprintln!(
+                "sprocket-convex-provider: action {} attempt {attempt} was interrupted by auth refresh; retrying with a fresh stream: {provider_error}",
+                client.completion_action,
+            );
+            backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
+            continue;
+        }
         return Err(CompletionError::ProviderError(provider_error));
     }
 }
 
 fn should_retry_superseded_completion(message: &str, attempt: u32) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS && is_completion_stream_superseded(message)
+}
+
+fn should_retry_transient_server_error(
+    message: &str,
+    is_error_message: bool,
+    auth_refresh_started: bool,
+    attempt: u32,
+) -> bool {
+    attempt < COMPLETION_TRANSPORT_ATTEMPTS
+        && is_error_message
+        && auth_refresh_started
+        && is_redacted_convex_server_error(message)
+}
+
+async fn auth_refresh_observed(
+    generation: &AtomicU32,
+    generation_at_start: u32,
+    refresh_started: impl Future<Output = ()>,
+    grace: Duration,
+) -> bool {
+    if generation.load(Ordering::Acquire) != generation_at_start {
+        return true;
+    }
+
+    // Convex can deliver the action error immediately before its background
+    // worker starts the reconnect auth callback. Give that callback one short
+    // reconnect window, then preserve redacted developer errors as fatal.
+    let _ = timeout(grace, refresh_started).await;
+    generation.load(Ordering::Acquire) != generation_at_start
+}
+
+/// Convex production failures are redacted to this exact shape. This alone
+/// does not distinguish infrastructure failures from developer errors; callers
+/// must also correlate the response with a forced authentication refresh.
+fn is_redacted_convex_server_error(message: &str) -> bool {
+    let Some((request_id, suffix)) = message
+        .trim()
+        .strip_prefix("[Request ID: ")
+        .and_then(|rest| rest.split_once(']'))
+    else {
+        return false;
+    };
+    !request_id.is_empty() && suffix == " Server Error"
 }
 
 async fn backoff_completion_retry(
@@ -751,14 +841,17 @@ where
 mod tests {
     use super::{
         COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
-        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, clone_locked, completion_choice,
-        is_completion_stream_superseded, reasoning_stream_choices,
-        should_retry_superseded_completion, text_stream_choices,
+        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, auth_refresh_observed,
+        clone_locked, completion_choice, is_completion_stream_superseded,
+        is_redacted_convex_server_error, reasoning_stream_choices,
+        should_retry_superseded_completion, should_retry_transient_server_error,
+        text_stream_choices,
     };
     use rig::completion::{CompletionError, GetTokenUsage};
     use rig::message::AssistantContent;
     use rig::streaming::RawStreamingChoice;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
     use tokio::sync::Mutex;
     use tokio::time::timeout;
@@ -790,6 +883,21 @@ mod tests {
         }
 
         assert_eq!(*inner.lock().await, 1);
+    }
+
+    #[tokio::test]
+    async fn observes_auth_refresh_when_notification_is_lost() {
+        let generation = AtomicU32::new(0);
+        let refresh_started = std::future::poll_fn(|_| {
+            // Simulate a refresh starting after the first generation check but
+            // before the notification future registers its waiter.
+            generation.fetch_add(1, Ordering::Release);
+            std::task::Poll::<()>::Pending
+        });
+
+        assert!(
+            auth_refresh_observed(&generation, 0, refresh_started, Duration::from_millis(1),).await
+        );
     }
 
     #[test]
@@ -941,5 +1049,61 @@ mod tests {
             COMPLETION_TRANSPORT_ATTEMPTS,
         ));
         assert!(!should_retry_superseded_completion("provider failed", 1));
+    }
+
+    #[test]
+    fn recognizes_redacted_convex_server_errors() {
+        assert!(is_redacted_convex_server_error(
+            "[Request ID: b79af67f8bcd57b2] Server Error"
+        ));
+        assert!(is_redacted_convex_server_error(
+            " [Request ID: abc] Server Error "
+        ));
+
+        // Other error formats must stay fatal. Even the matching redacted
+        // shape is retried only when correlated with a forced auth refresh.
+        assert!(!is_redacted_convex_server_error("Server Error"));
+        assert!(!is_redacted_convex_server_error(
+            "[Request ID: ] Server Error"
+        ));
+        assert!(!is_redacted_convex_server_error(
+            "[Request ID: abc] Uncaught Error: insufficient credits"
+        ));
+        assert!(!is_redacted_convex_server_error(
+            "Server Error: something specific"
+        ));
+        assert!(!is_redacted_convex_server_error("rate limited"));
+    }
+
+    #[test]
+    fn retries_redacted_server_errors_until_the_transport_attempt_limit() {
+        let message = "[Request ID: b79af67f8bcd57b2] Server Error";
+
+        assert!(should_retry_transient_server_error(
+            message,
+            true,
+            true,
+            COMPLETION_TRANSPORT_ATTEMPTS - 1,
+        ));
+        assert!(!should_retry_transient_server_error(
+            message,
+            true,
+            true,
+            COMPLETION_TRANSPORT_ATTEMPTS,
+        ));
+        // ConvexError results are application data, never retried as transient.
+        assert!(!should_retry_transient_server_error(
+            message, false, true, 1
+        ));
+        // The same redacted text can represent a developer error in prod.
+        assert!(!should_retry_transient_server_error(
+            message, true, false, 1
+        ));
+        assert!(!should_retry_transient_server_error(
+            "insufficient credits",
+            true,
+            true,
+            1,
+        ));
     }
 }

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -40,6 +40,7 @@ pub fn is_completion_stream_superseded(error: &(impl std::fmt::Display + ?Sized)
 #[derive(Clone)]
 pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
+    completion_inner: Arc<Mutex<ConvexClient>>,
     auth_refresh_generation: Arc<AtomicU32>,
     auth_refresh_notify: Arc<Notify>,
     completion_action_lock: Arc<Mutex<()>>,
@@ -60,8 +61,12 @@ impl Client {
         let client = ConvexClient::new(deployment_url)
             .await
             .context("failed to initialize Convex client")?;
+        let completion_client = ConvexClient::new(deployment_url)
+            .await
+            .context("failed to initialize Convex completion client")?;
         Ok(Self {
             inner: Arc::new(Mutex::new(client)),
+            completion_inner: Arc::new(Mutex::new(completion_client)),
             auth_refresh_generation: Arc::new(AtomicU32::new(0)),
             auth_refresh_notify: Arc::new(Notify::new()),
             completion_action_lock: Arc::new(Mutex::new(())),
@@ -75,20 +80,21 @@ impl Client {
     }
 
     pub async fn set_auth_token_fetcher(&self, fetcher: AuthTokenFetcher) {
-        let auth_refresh_generation = self.auth_refresh_generation.clone();
-        let auth_refresh_notify = self.auth_refresh_notify.clone();
-        let convex_fetcher: convex::AuthTokenFetcher = Box::new(move |force_refresh| {
-            let fetcher = fetcher.clone();
-            if force_refresh {
-                auth_refresh_generation.fetch_add(1, Ordering::Release);
-                auth_refresh_notify.notify_waiters();
-            }
-            Box::pin(async move { fetcher(force_refresh).await.map(AuthenticationToken::User) })
-        });
         self.inner
             .lock()
             .await
-            .set_auth_callback(Some(convex_fetcher))
+            .set_auth_callback(Some(convex_auth_fetcher(fetcher.clone(), None)))
+            .await;
+        self.completion_inner
+            .lock()
+            .await
+            .set_auth_callback(Some(convex_auth_fetcher(
+                fetcher,
+                Some((
+                    self.auth_refresh_generation.clone(),
+                    self.auth_refresh_notify.clone(),
+                )),
+            )))
             .await;
     }
 
@@ -486,6 +492,20 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
+fn convex_auth_fetcher(
+    fetcher: AuthTokenFetcher,
+    refresh_tracking: Option<(Arc<AtomicU32>, Arc<Notify>)>,
+) -> convex::AuthTokenFetcher {
+    Box::new(move |force_refresh| {
+        let fetcher = fetcher.clone();
+        if force_refresh && let Some((generation, notify)) = &refresh_tracking {
+            generation.fetch_add(1, Ordering::Release);
+            notify.notify_waiters();
+        }
+        Box::pin(async move { fetcher(force_refresh).await.map(AuthenticationToken::User) })
+    })
+}
+
 async fn call_completion_action(
     client: &Client,
     args: &ConvexActionArgs,
@@ -498,10 +518,9 @@ async fn call_completion_action(
     let claim_id = args.claim_id.as_ref().ok_or_else(|| {
         CompletionError::ProviderError("claimId is required for completion:complete".to_string())
     })?;
-    // A forced auth refresh belongs to the shared Convex connection, not an
-    // individual action. Keep completion actions on that connection serial so
-    // a redacted error can be correlated without crossing action boundaries.
-    // Queries and mutations use only `inner` clones and remain concurrent.
+    // A forced auth refresh belongs to a Convex connection, not an individual
+    // action. Completion actions use a dedicated connection and run serially on
+    // it, so refresh correlation cannot cross action or runtime RPC boundaries.
     let _completion_action_guard = client.completion_action_lock.lock().await;
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
@@ -513,7 +532,7 @@ async fn call_completion_action(
         // ids let the backend drop their partial output on the next try.
         let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let stream_id = uuid::Uuid::new_v4().to_string();
-        let mut convex = clone_locked(&client.inner).await;
+        let mut convex = clone_locked(&client.completion_inner).await;
         // Register before taking the generation snapshot so a refresh starting
         // while this action is in flight cannot be missed by the grace wait.
         let auth_refresh_started = client.auth_refresh_notify.notified();
@@ -849,7 +868,7 @@ mod tests {
     use super::{
         COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
         CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, auth_refresh_observed,
-        clone_locked, completion_choice, is_completion_stream_superseded,
+        clone_locked, completion_choice, convex_auth_fetcher, is_completion_stream_superseded,
         is_redacted_convex_server_error, reasoning_stream_choices,
         should_retry_superseded_completion, should_retry_transient_server_error,
         text_stream_choices,
@@ -905,6 +924,22 @@ mod tests {
         assert!(
             auth_refresh_observed(&generation, 0, refresh_started, Duration::from_millis(1),).await
         );
+    }
+
+    #[tokio::test]
+    async fn runtime_auth_refresh_does_not_correlate_to_completion() {
+        let fetcher: super::AuthTokenFetcher =
+            Arc::new(|_| Box::pin(async { Ok("token".to_string()) }));
+        let generation = Arc::new(AtomicU32::new(0));
+        let notify = Arc::new(tokio::sync::Notify::new());
+
+        let runtime_fetcher = convex_auth_fetcher(fetcher.clone(), None);
+        runtime_fetcher(true).await.expect("runtime token");
+        assert_eq!(generation.load(Ordering::Acquire), 0);
+
+        let completion_fetcher = convex_auth_fetcher(fetcher, Some((generation.clone(), notify)));
+        completion_fetcher(true).await.expect("completion token");
+        assert_eq!(generation.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -42,8 +42,7 @@ pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
     auth_refresh_generation: Arc<AtomicU32>,
     auth_refresh_notify: Arc<Notify>,
-    active_completion_actions: Arc<AtomicU32>,
-    completion_overlap_generation: Arc<AtomicU32>,
+    completion_action_lock: Arc<Mutex<()>>,
     completion_action: Arc<str>,
     default_reasoning_effort: Option<Arc<str>>,
     default_service_tier: Option<Arc<str>>,
@@ -65,8 +64,7 @@ impl Client {
             inner: Arc::new(Mutex::new(client)),
             auth_refresh_generation: Arc::new(AtomicU32::new(0)),
             auth_refresh_notify: Arc::new(Notify::new()),
-            active_completion_actions: Arc::new(AtomicU32::new(0)),
-            completion_overlap_generation: Arc::new(AtomicU32::new(0)),
+            completion_action_lock: Arc::new(Mutex::new(())),
             completion_action: completion_action.into().into(),
             default_reasoning_effort: None,
             default_service_tier: None,
@@ -488,43 +486,6 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
-struct CompletionConcurrencyGuard<'a> {
-    active: &'a AtomicU32,
-    overlap_generation: &'a AtomicU32,
-    generation_before_start: u32,
-    overlapped_on_start: bool,
-}
-
-impl<'a> CompletionConcurrencyGuard<'a> {
-    fn new(active: &'a AtomicU32, overlap_generation: &'a AtomicU32) -> Self {
-        // Snapshot before becoming active so a concurrently starting action
-        // either observes us or advances the generation that we later check.
-        let generation_before_start = overlap_generation.load(Ordering::Acquire);
-        let overlapped_on_start = active.fetch_add(1, Ordering::AcqRel) > 0;
-        if overlapped_on_start {
-            overlap_generation.fetch_add(1, Ordering::AcqRel);
-        }
-        Self {
-            active,
-            overlap_generation,
-            generation_before_start,
-            overlapped_on_start,
-        }
-    }
-
-    fn remained_exclusive(&self) -> bool {
-        !self.overlapped_on_start
-            && self.overlap_generation.load(Ordering::Acquire) == self.generation_before_start
-    }
-}
-
-impl Drop for CompletionConcurrencyGuard<'_> {
-    fn drop(&mut self) {
-        let previous = self.active.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "completion action count underflowed");
-    }
-}
-
 async fn call_completion_action(
     client: &Client,
     args: &ConvexActionArgs,
@@ -537,10 +498,11 @@ async fn call_completion_action(
     let claim_id = args.claim_id.as_ref().ok_or_else(|| {
         CompletionError::ProviderError("claimId is required for completion:complete".to_string())
     })?;
-    let completion_concurrency = CompletionConcurrencyGuard::new(
-        &client.active_completion_actions,
-        &client.completion_overlap_generation,
-    );
+    // A forced auth refresh belongs to the shared Convex connection, not an
+    // individual action. Keep completion actions on that connection serial so
+    // a redacted error can be correlated without crossing action boundaries.
+    // Queries and mutations use only `inner` clones and remain concurrent.
+    let _completion_action_guard = client.completion_action_lock.lock().await;
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
     let mut superseded_stream_ids: Vec<String> = Vec::new();
@@ -632,7 +594,6 @@ async fn call_completion_action(
         let auth_refresh_started = if attempt < COMPLETION_TRANSPORT_ATTEMPTS
             && is_error_message
             && is_redacted_convex_server_error(&provider_error)
-            && completion_concurrency.remained_exclusive()
         {
             auth_refresh_observed(
                 &client.auth_refresh_generation,
@@ -648,7 +609,6 @@ async fn call_completion_action(
             &provider_error,
             is_error_message,
             auth_refresh_started,
-            completion_concurrency.remained_exclusive(),
             attempt,
         ) {
             // An expired identity interrupts in-flight actions with Convex's
@@ -675,13 +635,11 @@ fn should_retry_transient_server_error(
     message: &str,
     is_error_message: bool,
     auth_refresh_started: bool,
-    completion_was_exclusive: bool,
     attempt: u32,
 ) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS
         && is_error_message
         && auth_refresh_started
-        && completion_was_exclusive
         && is_redacted_convex_server_error(message)
 }
 
@@ -889,9 +847,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionConcurrencyGuard,
-        CompletionOutput, CompletionStreamEvent, InputTokenDetails, ToolCall, Usage,
-        auth_refresh_observed, clone_locked, completion_choice, is_completion_stream_superseded,
+        COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
+        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, auth_refresh_observed,
+        clone_locked, completion_choice, is_completion_stream_superseded,
         is_redacted_convex_server_error, reasoning_stream_choices,
         should_retry_superseded_completion, should_retry_transient_server_error,
         text_stream_choices,
@@ -947,27 +905,6 @@ mod tests {
         assert!(
             auth_refresh_observed(&generation, 0, refresh_started, Duration::from_millis(1),).await
         );
-    }
-
-    #[test]
-    fn concurrent_completion_overlap_remains_sticky() {
-        let active = AtomicU32::new(0);
-        let overlap_generation = AtomicU32::new(0);
-        let first = CompletionConcurrencyGuard::new(&active, &overlap_generation);
-        assert!(first.remained_exclusive());
-
-        {
-            let second = CompletionConcurrencyGuard::new(&active, &overlap_generation);
-            assert!(!first.remained_exclusive());
-            assert!(!second.remained_exclusive());
-        }
-
-        // The first action must remain ineligible even after its overlap ends.
-        assert!(!first.remained_exclusive());
-        drop(first);
-
-        let later = CompletionConcurrencyGuard::new(&active, &overlap_generation);
-        assert!(later.remained_exclusive());
     }
 
     #[test]
@@ -1153,31 +1090,24 @@ mod tests {
             message,
             true,
             true,
-            true,
             COMPLETION_TRANSPORT_ATTEMPTS - 1,
         ));
         assert!(!should_retry_transient_server_error(
             message,
             true,
             true,
-            true,
             COMPLETION_TRANSPORT_ATTEMPTS,
         ));
         // ConvexError results are application data, never retried as transient.
         assert!(!should_retry_transient_server_error(
-            message, false, true, true, 1
+            message, false, true, 1
         ));
         // The same redacted text can represent a developer error in prod.
         assert!(!should_retry_transient_server_error(
-            message, true, false, true, 1
-        ));
-        // A shared connection refresh is ambiguous while actions overlap.
-        assert!(!should_retry_transient_server_error(
-            message, true, true, false, 1
+            message, true, false, 1
         ));
         assert!(!should_retry_transient_server_error(
             "insufficient credits",
-            true,
             true,
             true,
             1,

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -42,6 +42,8 @@ pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
     auth_refresh_generation: Arc<AtomicU32>,
     auth_refresh_notify: Arc<Notify>,
+    active_completion_actions: Arc<AtomicU32>,
+    completion_overlap_generation: Arc<AtomicU32>,
     completion_action: Arc<str>,
     default_reasoning_effort: Option<Arc<str>>,
     default_service_tier: Option<Arc<str>>,
@@ -63,6 +65,8 @@ impl Client {
             inner: Arc::new(Mutex::new(client)),
             auth_refresh_generation: Arc::new(AtomicU32::new(0)),
             auth_refresh_notify: Arc::new(Notify::new()),
+            active_completion_actions: Arc::new(AtomicU32::new(0)),
+            completion_overlap_generation: Arc::new(AtomicU32::new(0)),
             completion_action: completion_action.into().into(),
             default_reasoning_effort: None,
             default_service_tier: None,
@@ -484,6 +488,43 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
+struct CompletionConcurrencyGuard<'a> {
+    active: &'a AtomicU32,
+    overlap_generation: &'a AtomicU32,
+    generation_before_start: u32,
+    overlapped_on_start: bool,
+}
+
+impl<'a> CompletionConcurrencyGuard<'a> {
+    fn new(active: &'a AtomicU32, overlap_generation: &'a AtomicU32) -> Self {
+        // Snapshot before becoming active so a concurrently starting action
+        // either observes us or advances the generation that we later check.
+        let generation_before_start = overlap_generation.load(Ordering::Acquire);
+        let overlapped_on_start = active.fetch_add(1, Ordering::AcqRel) > 0;
+        if overlapped_on_start {
+            overlap_generation.fetch_add(1, Ordering::AcqRel);
+        }
+        Self {
+            active,
+            overlap_generation,
+            generation_before_start,
+            overlapped_on_start,
+        }
+    }
+
+    fn remained_exclusive(&self) -> bool {
+        !self.overlapped_on_start
+            && self.overlap_generation.load(Ordering::Acquire) == self.generation_before_start
+    }
+}
+
+impl Drop for CompletionConcurrencyGuard<'_> {
+    fn drop(&mut self) {
+        let previous = self.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "completion action count underflowed");
+    }
+}
+
 async fn call_completion_action(
     client: &Client,
     args: &ConvexActionArgs,
@@ -496,6 +537,10 @@ async fn call_completion_action(
     let claim_id = args.claim_id.as_ref().ok_or_else(|| {
         CompletionError::ProviderError("claimId is required for completion:complete".to_string())
     })?;
+    let completion_concurrency = CompletionConcurrencyGuard::new(
+        &client.active_completion_actions,
+        &client.completion_overlap_generation,
+    );
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
     let mut superseded_stream_ids: Vec<String> = Vec::new();
@@ -587,6 +632,7 @@ async fn call_completion_action(
         let auth_refresh_started = if attempt < COMPLETION_TRANSPORT_ATTEMPTS
             && is_error_message
             && is_redacted_convex_server_error(&provider_error)
+            && completion_concurrency.remained_exclusive()
         {
             auth_refresh_observed(
                 &client.auth_refresh_generation,
@@ -602,6 +648,7 @@ async fn call_completion_action(
             &provider_error,
             is_error_message,
             auth_refresh_started,
+            completion_concurrency.remained_exclusive(),
             attempt,
         ) {
             // An expired identity interrupts in-flight actions with Convex's
@@ -628,11 +675,13 @@ fn should_retry_transient_server_error(
     message: &str,
     is_error_message: bool,
     auth_refresh_started: bool,
+    completion_was_exclusive: bool,
     attempt: u32,
 ) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS
         && is_error_message
         && auth_refresh_started
+        && completion_was_exclusive
         && is_redacted_convex_server_error(message)
 }
 
@@ -840,9 +889,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
-        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, auth_refresh_observed,
-        clone_locked, completion_choice, is_completion_stream_superseded,
+        COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionConcurrencyGuard,
+        CompletionOutput, CompletionStreamEvent, InputTokenDetails, ToolCall, Usage,
+        auth_refresh_observed, clone_locked, completion_choice, is_completion_stream_superseded,
         is_redacted_convex_server_error, reasoning_stream_choices,
         should_retry_superseded_completion, should_retry_transient_server_error,
         text_stream_choices,
@@ -898,6 +947,27 @@ mod tests {
         assert!(
             auth_refresh_observed(&generation, 0, refresh_started, Duration::from_millis(1),).await
         );
+    }
+
+    #[test]
+    fn concurrent_completion_overlap_remains_sticky() {
+        let active = AtomicU32::new(0);
+        let overlap_generation = AtomicU32::new(0);
+        let first = CompletionConcurrencyGuard::new(&active, &overlap_generation);
+        assert!(first.remained_exclusive());
+
+        {
+            let second = CompletionConcurrencyGuard::new(&active, &overlap_generation);
+            assert!(!first.remained_exclusive());
+            assert!(!second.remained_exclusive());
+        }
+
+        // The first action must remain ineligible even after its overlap ends.
+        assert!(!first.remained_exclusive());
+        drop(first);
+
+        let later = CompletionConcurrencyGuard::new(&active, &overlap_generation);
+        assert!(later.remained_exclusive());
     }
 
     #[test]
@@ -1083,24 +1153,31 @@ mod tests {
             message,
             true,
             true,
+            true,
             COMPLETION_TRANSPORT_ATTEMPTS - 1,
         ));
         assert!(!should_retry_transient_server_error(
             message,
             true,
             true,
+            true,
             COMPLETION_TRANSPORT_ATTEMPTS,
         ));
         // ConvexError results are application data, never retried as transient.
         assert!(!should_retry_transient_server_error(
-            message, false, true, 1
+            message, false, true, true, 1
         ));
         // The same redacted text can represent a developer error in prod.
         assert!(!should_retry_transient_server_error(
-            message, true, false, 1
+            message, true, false, true, 1
+        ));
+        // A shared connection refresh is ambiguous while actions overlap.
+        assert!(!should_retry_transient_server_error(
+            message, true, true, false, 1
         ));
         assert!(!should_retry_transient_server_error(
             "insufficient credits",
+            true,
             true,
             true,
             1,


### PR DESCRIPTION
## Summary

- track forced Convex authentication refreshes on the shared completion client
- retry redacted completion action failures only when they correlate with an auth refresh
- preserve the existing attempt sequence and stream fencing when replaying the interrupted action
- cover redacted error classification and refresh notification races with focused tests

## Root cause

Convex detected that the run's token identity had expired while `completion:complete` was in flight. The Rust client refreshed authentication and rebuilt its protocol state, but it only replays queries and mutations after reconnecting; actions are not replayed. The interrupted completion therefore returned `[Request ID: …] Server Error`, and Sprocket treated that function result as a terminal provider failure because its retry loop only handled transport errors and superseded streams.

## Validation

- `cargo test -p sprocket-convex-provider` — 16 tests passed
- `cargo test` — all workspace tests passed
- `cargo fmt --all -- --check`
- `prek run -a` — all hooks passed, including Cargo checks, ESLint, Svelte check, and Prettier

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR recovers completion actions interrupted by authentication refreshes. The main changes are:

- A dedicated Convex client for completion actions.
- Serialized completion actions to isolate refresh correlation.
- Refresh-correlated retries for redacted server errors.
- Stream fencing and focused tests for retry races.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

Completion actions now use an isolated connection and run serially. Runtime refreshes no longer cross completion request boundaries.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The package validation run shows the parent revision had 16 tests pass and the changed revision had 17 passes, including the added runtime\_auth\_refresh\_does\_not\_correlate\_to\_completion coverage.
- Auth-refresh tests were evaluated, with 1 test passing before and 2 passing after, and the changed-revision race/correlation tests passed.
- Redacted classification and retry tests passed on both revisions.
- All Cargo commands exited with code 0 and were executed offline against a warmed local cache.

<a href="https://app.greptile.com/trex/runs/15242109/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-convex-provider/src/client.rs | Separates completion transport, tracks forced authentication refreshes, and retries correlated redacted action failures. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(agent): Isolate completion transport"](https://github.com/spikonado/sprocket/commit/f19a34fc1647ca625aa24f23b3f6313d8aea3ef8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45910254)</sub>

<!-- /greptile_comment -->