### PR TITLE
ci(npm-release): Switch to GitHub hosted runners

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   prepare:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
       npm-tag: ${{ steps.version.outputs.npm-tag }}
@@ -67,7 +67,7 @@ jobs:
 
   web:
     needs: prepare
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -88,12 +88,12 @@ jobs:
       matrix:
         include:
           - id: linux-x64-gnu
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-latest
             executable: sprocket
             rust-target: x86_64-unknown-linux-gnu
             glibc-version: '2.17'
           - id: linux-arm64-gnu
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-latest
             executable: sprocket
             rust-target: aarch64-unknown-linux-gnu
             glibc-version: '2.17'
@@ -150,7 +150,7 @@ jobs:
 
   package:
     needs: [prepare, web, native]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -192,7 +192,7 @@ jobs:
   publish:
     if: github.event_name == 'push' || github.event_name == 'workflow_run' || inputs.publish
     needs: [prepare, package]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the npm release workflow to GitHub-hosted Linux runners. The main changes are:

- Use `ubuntu-latest` for preparation and web builds.
- Use `ubuntu-latest` for Linux x64 and ARM64 native builds.
- Use `ubuntu-latest` for package assembly and npm publishing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues were found. The workflow explicitly installs the Bun, Node.js, Rust, Zig, and cross-compilation tools it needs. GitHub-hosted runners support the artifact and npm publishing paths used here.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The contract validator compared the before and after runner wiring and confirmed the wiring change from 6 Blacksmith references to 6 ubuntu-latest references, with the wiring check exiting 0.
- The Prettier formatting step ran and completed successfully (exit code 0).
- The negative-control path was executed and rejected the wrong expected runner, exiting with code 1, demonstrating mismatch detection.
- Artifacts documenting the validation run were collected and organized for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/15242053/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Replaces Blacksmith runner labels with `ubuntu-latest` across the Linux release jobs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(npm-release): Switch to GitHub hosted..."](https://github.com/spikonado/sprocket/commit/80f66401e1bb04d398520887386c848cbac3f851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45951901)</sub>

<!-- /greptile_comment -->