### PR TITLE
fix(web): Keep usage meter UI off Convex server modules

### DIFF
--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -33,6 +33,7 @@ import type * as lib_runs from "../lib/runs.js";
 import type * as lib_threadMessages from "../lib/threadMessages.js";
 import type * as lib_threadTranscript from "../lib/threadTranscript.js";
 import type * as lib_tiers from "../lib/tiers.js";
+import type * as lib_usageMeters from "../lib/usageMeters.js";
 import type * as lib_validators from "../lib/validators.js";
 import type * as lib_workspaceConnection from "../lib/workspaceConnection.js";
 import type * as messages from "../messages.js";
@@ -74,6 +75,7 @@ declare const fullApi: ApiFromModules<{
   "lib/threadMessages": typeof lib_threadMessages;
   "lib/threadTranscript": typeof lib_threadTranscript;
   "lib/tiers": typeof lib_tiers;
+  "lib/usageMeters": typeof lib_usageMeters;
   "lib/validators": typeof lib_validators;
   "lib/workspaceConnection": typeof lib_workspaceConnection;
   messages: typeof messages;

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -20,34 +20,27 @@ import {
 	type SupportedServiceTier
 } from '@convex/lib/models';
 import { ensureSubscription, tierLimits, type TierLimits } from '@convex/lib/tiers';
+import {
+	URL_SCRAPE_USAGE_UNITS,
+	WEB_SEARCH_USAGE_UNITS,
+	usageMeters,
+	usagePeriods,
+	type UsageMeterId,
+	type UsagePeriod
+} from '@convex/lib/usageMeters';
 import { vModelId, vServiceTier } from '@convex/lib/validators';
 
+export {
+	URL_SCRAPE_USAGE_UNITS,
+	WEB_SEARCH_USAGE_UNITS,
+	usageMeters,
+	usagePeriods,
+	type UsageMeterId,
+	type UsagePeriod
+};
+
 const MONTH = 30 * DAY;
-/** Flat web-tools meter cost for one URL scrape. */
-export const URL_SCRAPE_USAGE_UNITS = 1.5;
-/** Flat web-tools meter cost for one web search (independent of result count). */
-export const WEB_SEARCH_USAGE_UNITS = 7;
 export const rateLimiter = new RateLimiter(components.rateLimiter, {});
-
-export const usageMeters = [
-	{
-		id: 'modelUsage',
-		label: 'Model usage',
-		noun: 'model usage',
-		description: 'More expensive models use up more usage.'
-	},
-	{
-		id: 'webTools',
-		label: 'Web tools',
-		noun: 'web tools',
-		description: 'Web search and URL scrape share this quota.'
-	}
-] as const;
-
-export type UsageMeterId = (typeof usageMeters)[number]['id'];
-
-export const usagePeriods = ['weekly', 'monthly'] as const;
-export type UsagePeriod = (typeof usagePeriods)[number];
 
 const periodDurations: Record<UsagePeriod, number> = { weekly: WEEK, monthly: MONTH };
 

--- a/apps/web/src/convex/lib/usageMeters.ts
+++ b/apps/web/src/convex/lib/usageMeters.ts
@@ -1,0 +1,24 @@
+/** Flat web-tools meter cost for one URL scrape. */
+export const URL_SCRAPE_USAGE_UNITS = 1.5;
+/** Flat web-tools meter cost for one web search (independent of result count). */
+export const WEB_SEARCH_USAGE_UNITS = 7;
+
+export const usageMeters = [
+	{
+		id: 'modelUsage',
+		label: 'Model usage',
+		noun: 'model usage',
+		description: 'More expensive models use up more usage.'
+	},
+	{
+		id: 'webTools',
+		label: 'Web tools',
+		noun: 'web tools',
+		description: 'Web search and URL scrape share this quota.'
+	}
+] as const;
+
+export type UsageMeterId = (typeof usageMeters)[number]['id'];
+
+export const usagePeriods = ['weekly', 'monthly'] as const;
+export type UsagePeriod = (typeof usagePeriods)[number];

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { useAuth, useQuery } from 'convex-svelte';
 	import { api } from '$convex/_generated/api';
-	import { usageMeters, usagePeriods } from '$convex/lib/rateLimits';
+	import { usageMeters, usagePeriods } from '$convex/lib/usageMeters';
 	import { tierLabels } from '$convex/lib/tiers';
 
 	const convexAuth = useAuth();


### PR DESCRIPTION
## Summary
- Move client-safe usage meter constants into `$convex/lib/usageMeters` so the settings UI no longer imports Convex server modules in Vite dev
- Prevents the localhost `500 Internal Error` caused by top-level `process.env` in `_generated/server.js`

## Test plan
- [ ] `bun dev`, open `http://localhost:5173`, confirm the app loads (pairing/home) instead of a 500
- [ ] Open Settings → Usage and confirm meters/periods still render
- [ ] `bun run --cwd apps/web test`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves usage-meter metadata into a client-safe module. The main changes are:

- Extract usage constants, meter definitions, periods, and types into `usageMeters.ts`.
- Re-export the extracted values from `rateLimits.ts` for existing server consumers.
- Import meter metadata directly from the new module in the settings UI.
- Register the new module in the generated Convex API types.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues were found in the changed code. The new client module has no imports or runtime side effects, and existing server consumers retain the same exports and values.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before-change and after-change outcomes to confirm the system now returns the expected meter and period constants.
- Documented the reference location for the original condition as src/convex/\_generated/server.js:98.
- Verified that the after-change path loads the client-safe module and exposes the expected UI constants.
- Concluded that the UI blocker stems from environmental or local-service configuration rather than the code path.
- Collected before-change and after-change videos and poster-frame images to document the behavior transition.

<a href="https://app.greptile.com/trex/runs/15242355/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/usageMeters.ts | Adds a dependency-free module containing the unchanged usage-meter constants, metadata, and types. |
| apps/web/src/convex/lib/rateLimits.ts | Imports and re-exports the extracted definitions while preserving existing server imports. |
| apps/web/src/lib/components/home/settings-usage.svelte | Switches the usage-meter UI to the client-safe module without changing rendered data. |
| apps/web/src/convex/_generated/api.d.ts | Adds the new constants-only module to the generated type-level API map. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Keep usage meter UI off Convex..."](https://github.com/spikonado/sprocket/commit/38adf8ba55ceb467ab9237b1b2d77de8dc01eb1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45952786)</sub>

<!-- /greptile_comment -->