### PR TITLE
fix(models): Retry transient provider limits

### DIFF
--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -41,6 +41,9 @@ type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
 
 const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 1_000;
+// AI SDK retries only retryable provider failures and honors Retry-After headers.
+// Allow a longer recovery window for short provider rate-limit bursts.
+const MODEL_PROVIDER_MAX_RETRIES = 5;
 
 export const complete = action({
 	args: {
@@ -557,6 +560,7 @@ function buildSharedCompletionRequest(
 	const serviceTier = args.serviceTier ?? defaultServiceTier;
 	return {
 		model: resolveLanguageModel(args.modelId, serviceTier, promptCacheKey),
+		maxRetries: MODEL_PROVIDER_MAX_RETRIES,
 		...(args.instructions !== undefined ? { instructions: args.instructions } : {}),
 		...(args.tools?.length ? { tools } : {}),
 		...(toolChoice !== undefined ? { toolChoice } : {}),


### PR DESCRIPTION
## Summary
- Raise AI SDK `maxRetries` from the default of 2 to 5 on Convex completion requests so short OpenAI rate-limit bursts can recover instead of failing the agent run.
- Retries remain limited to retryable provider failures and continue to honor `Retry-After` headers.

## Test plan
- [ ] Trigger a completion under a brief provider rate-limit / 429 and confirm the run recovers instead of finalizing as failed
- [ ] Confirm non-retryable provider/developer errors still fail without extra retries
- [ ] Spot-check a normal streaming completion still succeeds end-to-end

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends recovery from transient model-provider failures. The main changes are:

- Raises completion request retries to five.
- Applies the retry limit to the shared streaming request.
- Documents the intended rate-limit recovery behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The retry change is mergeable after bounding its total wait time.

Short provider rate limits can now recover as intended. Long repeated retry delays can exceed the action runtime limit. Existing cancellation and completion-acceptance checks remain in place.

apps/web/src/convex/completion.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The run started with a repository build configured for two retries, and the trace showed three 429 attempts with a maxRetriesExceeded condition.
- The repository was reconfigured to allow five retries and the tests were re-run; the trace now shows four 429s followed by HTTP 200 and streamed-ok.
- All three focused tests completed and exited with code 0.
- Source was restored after the before-run and the configuration was verified with MODEL\_PROVIDER\_MAX\_RETRIES = 5 and no remaining diffs.

<a href="https://app.greptile.com/trex/runs/15251540/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/completion.ts | Adds a shared five-retry limit, which can extend provider backoff beyond the action deadline when no cumulative timeout is set. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/convex/completion.ts:563
**Retries Can Outlive Action Deadline**

When repeated retryable responses include long `Retry-After` delays, five retries can keep `streamText` waiting beyond the Convex action's runtime limit because this request has no cumulative timeout. The action can then be terminated with a generic timeout after holding resources and persisting partial stream work, rather than returning the provider failure through the normal completion path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): Retry transient provider li..."](https://github.com/spikonado/sprocket/commit/a997ab6bb8641d625a533d2ab8019e2f80237ce8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45971877)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->