### PR TITLE
perf(web): Bound Convex transcript reads to history and live queries

### DIFF
--- a/apps/web/src/convex/lib/threadTranscript.ts
+++ b/apps/web/src/convex/lib/threadTranscript.ts
@@ -100,30 +100,6 @@ export async function hydrateTranscriptMessages(
 	return transcriptMessages;
 }
 
-/** Hydrate already-loaded threadMessages, resolving their runs (legacy pagination). */
-export async function hydrateTranscriptMessagesFromDocs(
-	ctx: MutationCtx | QueryCtx,
-	messages: Doc<'threadMessages'>[]
-): Promise<ThreadTranscriptMessage[]> {
-	const runIds = [...new Set(messages.map((message) => message.runId))];
-	const runsById = new Map<Id<'runs'>, Doc<'runs'>>();
-	for (const run of await Promise.all(runIds.map((runId) => ctx.db.get(runId)))) {
-		if (run) {
-			runsById.set(run._id, run);
-		}
-	}
-
-	const transcriptMessages: ThreadTranscriptMessage[] = [];
-	for (const message of messages) {
-		const run = runsById.get(message.runId);
-		if (!run) {
-			continue;
-		}
-		transcriptMessages.push(await toTranscriptMessage(ctx, message, run));
-	}
-	return transcriptMessages;
-}
-
 export async function buildThreadTranscript(
 	ctx: MutationCtx | QueryCtx,
 	threadId: Id<'threadRecords'>

--- a/apps/web/src/convex/lib/threadTranscript.ts
+++ b/apps/web/src/convex/lib/threadTranscript.ts
@@ -16,14 +16,72 @@ export type ThreadTranscriptMessage = Doc<'threadMessages'> & {
 	runCompletedAt?: number;
 };
 
-export async function buildThreadTranscript(
+export function compareTranscriptMessages(
+	left: ThreadTranscriptMessage,
+	right: ThreadTranscriptMessage
+): number {
+	if (left.runStartedAt !== right.runStartedAt) {
+		return left.runStartedAt - right.runStartedAt;
+	}
+	if (left._creationTime !== right._creationTime) {
+		return left._creationTime - right._creationTime;
+	}
+	// Prompts precede responses within the same run.
+	if (left.type !== right.type) {
+		return left.type === 'prompt' ? -1 : 1;
+	}
+	return left._id.localeCompare(right._id);
+}
+
+async function hydrateMessageAttachments(
 	ctx: MutationCtx | QueryCtx,
-	threadId: Id<'threadRecords'>
+	message: Doc<'threadMessages'>
+): Promise<ThreadTranscriptAttachment[]> {
+	return (
+		await Promise.all(
+			(message.imageUploadIds ?? []).map(async (imageUploadId) => {
+				const upload = await ctx.db.get(imageUploadId);
+				if (
+					!upload ||
+					upload.userId !== message.userId ||
+					!upload.messageIds.includes(message._id)
+				) {
+					return null;
+				}
+				const url = await ctx.storage.getUrl(upload.storageId);
+				return url
+					? {
+							imageUploadId: upload._id,
+							name: upload.name,
+							mediaType: upload.mediaType,
+							size: upload.size,
+							url
+						}
+					: null;
+			})
+		)
+	).filter((attachment) => attachment !== null);
+}
+
+async function toTranscriptMessage(
+	ctx: MutationCtx | QueryCtx,
+	message: Doc<'threadMessages'>,
+	run: Doc<'runs'>
+): Promise<ThreadTranscriptMessage> {
+	return {
+		...message,
+		attachments: await hydrateMessageAttachments(ctx, message),
+		runStatus: run.status,
+		runStartedAt: run.startedAt,
+		runCompletedAt: run.completedAt
+	};
+}
+
+/** Hydrate messages for the supplied runs (prompt then response per run). */
+export async function hydrateTranscriptMessages(
+	ctx: MutationCtx | QueryCtx,
+	runs: Doc<'runs'>[]
 ): Promise<ThreadTranscriptMessage[]> {
-	const runs: Doc<'runs'>[] = await ctx.db
-		.query('runs')
-		.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
-		.collect();
 	const transcriptMessages: ThreadTranscriptMessage[] = [];
 
 	for (const run of runs) {
@@ -31,45 +89,48 @@ export async function buildThreadTranscript(
 			if (!messageId) {
 				continue;
 			}
-			const message: Doc<'threadMessages'> | null = await ctx.db.get(messageId);
+			const message = await ctx.db.get(messageId);
 			if (!message) {
 				continue;
 			}
-
-			const attachments = (
-				await Promise.all(
-					(message.imageUploadIds ?? []).map(async (imageUploadId) => {
-						const upload = await ctx.db.get(imageUploadId);
-						if (
-							!upload ||
-							upload.userId !== message.userId ||
-							!upload.messageIds.includes(message._id)
-						) {
-							return null;
-						}
-						const url = await ctx.storage.getUrl(upload.storageId);
-						return url
-							? {
-									imageUploadId: upload._id,
-									name: upload.name,
-									mediaType: upload.mediaType,
-									size: upload.size,
-									url
-								}
-							: null;
-					})
-				)
-			).filter((attachment) => attachment !== null);
-
-			transcriptMessages.push({
-				...message,
-				attachments,
-				runStatus: run.status,
-				runStartedAt: run.startedAt,
-				runCompletedAt: run.completedAt
-			});
+			transcriptMessages.push(await toTranscriptMessage(ctx, message, run));
 		}
 	}
 
 	return transcriptMessages;
+}
+
+/** Hydrate already-loaded threadMessages, resolving their runs (legacy pagination). */
+export async function hydrateTranscriptMessagesFromDocs(
+	ctx: MutationCtx | QueryCtx,
+	messages: Doc<'threadMessages'>[]
+): Promise<ThreadTranscriptMessage[]> {
+	const runIds = [...new Set(messages.map((message) => message.runId))];
+	const runsById = new Map<Id<'runs'>, Doc<'runs'>>();
+	for (const run of await Promise.all(runIds.map((runId) => ctx.db.get(runId)))) {
+		if (run) {
+			runsById.set(run._id, run);
+		}
+	}
+
+	const transcriptMessages: ThreadTranscriptMessage[] = [];
+	for (const message of messages) {
+		const run = runsById.get(message.runId);
+		if (!run) {
+			continue;
+		}
+		transcriptMessages.push(await toTranscriptMessage(ctx, message, run));
+	}
+	return transcriptMessages;
+}
+
+export async function buildThreadTranscript(
+	ctx: MutationCtx | QueryCtx,
+	threadId: Id<'threadRecords'>
+): Promise<ThreadTranscriptMessage[]> {
+	const runs = await ctx.db
+		.query('runs')
+		.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
+		.collect();
+	return hydrateTranscriptMessages(ctx, runs);
 }

--- a/apps/web/src/convex/messages.test.ts
+++ b/apps/web/src/convex/messages.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+async function createQueuedRun(
+	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
+	threadId: Id<'threadRecords'>,
+	submissionId: string,
+	prompt = `Prompt ${submissionId}`
+) {
+	return await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId,
+		threadId,
+		prompt,
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard'
+	});
+}
+
+async function completeRun(
+	t: ReturnType<typeof initConvexTest>,
+	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
+	args: {
+		runId: Id<'runs'>;
+		status: 'completed' | 'failed' | 'cancelled';
+		responseText?: string;
+		startedAt?: number;
+	}
+) {
+	await asUser.mutation(api.agentRuntime.start, {
+		claimId: `claim-${args.runId}`,
+		runId: args.runId
+	});
+	await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId: args.runId });
+	await asUser.mutation(api.agentRuntime.finalizeRun, {
+		runId: args.runId,
+		text: args.responseText ?? `Response for ${args.runId}`,
+		status: args.status,
+		...(args.status === 'failed' ? { lastError: 'failed' } : {})
+	});
+	if (args.startedAt !== undefined) {
+		await t.run(async (ctx) => {
+			await ctx.db.patch(args.runId, { startedAt: args.startedAt });
+		});
+	}
+}
+
+describe('messages transcript queries', () => {
+	it('requires authentication and ownership', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_owner');
+		await createQueuedRun(asUser, threadId, 'sub-auth');
+		const stranger = t.withIdentity({ subject: 'user_stranger' });
+		const legacyArgs = { threadId, paginationOpts: { cursor: null, numItems: 40 } };
+
+		for (const client of [t, stranger]) {
+			const expected = client === t ? 'Authentication required.' : 'Thread not found.';
+			await expect(client.query(api.messages.listHistoryForThread, { threadId })).rejects.toThrow(
+				expected
+			);
+			await expect(client.query(api.messages.listLiveForThread, { threadId })).rejects.toThrow(
+				expected
+			);
+			await expect(client.query(api.messages.listForThread, legacyArgs)).rejects.toThrow(expected);
+		}
+	});
+
+	it('keeps active runs in live and excludes them from history', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const active = await createQueuedRun(asUser, threadId, 'sub-active', 'Live prompt');
+
+		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
+		const live = await asUser.query(api.messages.listLiveForThread, { threadId });
+
+		expect(history.messages).toEqual([]);
+		expect(live.messages).toHaveLength(1);
+		expect(live.messages[0]).toMatchObject({
+			_id: active.promptMessageId,
+			type: 'prompt',
+			text: 'Live prompt',
+			runStatus: 'queued'
+		});
+	});
+
+	it('streams live responses then moves terminal runs into history', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-stream', 'Stream me');
+
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-stream', runId });
+		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId });
+
+		const beforeStream = await asUser.query(api.messages.listLiveForThread, { threadId });
+		expect(beforeStream.messages.map((message) => message.type)).toEqual(['prompt', 'response']);
+		expect(beforeStream.messages[1]?.text).toBe('');
+
+		const responseMessageId = await t.run(async (ctx) => {
+			const run = await ctx.db.get(runId);
+			if (!run?.responseMessageId) {
+				throw new Error('Expected response message');
+			}
+			await ctx.db.patch(run.responseMessageId, {
+				text: 'partial answer',
+				parts: [{ type: 'text', id: 't1', text: 'partial answer', turnId: 'turn-1' }],
+				streamSequence: 1,
+				streamAttemptId: 'stream-1'
+			});
+			return run.responseMessageId;
+		});
+
+		const streaming = await asUser.query(api.messages.listLiveForThread, { threadId });
+		expect(streaming.messages[1]).toMatchObject({
+			_id: responseMessageId,
+			text: 'partial answer',
+			runStatus: 'running'
+		});
+		expect((await asUser.query(api.messages.listHistoryForThread, { threadId })).messages).toEqual(
+			[]
+		);
+
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId,
+			text: 'final answer',
+			status: 'completed'
+		});
+
+		expect((await asUser.query(api.messages.listLiveForThread, { threadId })).messages).toEqual([]);
+		const historyAfter = await asUser.query(api.messages.listHistoryForThread, { threadId });
+		// finalizeRun prefers already-streamed assistant text when parts exist.
+		expect(historyAfter.messages.map((message) => [message.type, message.text])).toEqual([
+			['prompt', 'Stream me'],
+			['response', 'partial answer']
+		]);
+		expect(historyAfter.messages.every((message) => message.runStatus === 'completed')).toBe(true);
+	});
+
+	it('moves failed and cancelled runs from live into history', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		const failed = await createQueuedRun(asUser, threadId, 'sub-fail', 'Fail prompt');
+		await completeRun(t, asUser, { runId: failed.runId, status: 'failed', responseText: 'boom' });
+
+		const cancelled = await createQueuedRun(asUser, threadId, 'sub-cancel', 'Cancel prompt');
+		await completeRun(t, asUser, {
+			runId: cancelled.runId,
+			status: 'cancelled',
+			responseText: 'stopped'
+		});
+
+		expect((await asUser.query(api.messages.listLiveForThread, { threadId })).messages).toEqual([]);
+		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
+		expect(history.messages.map((message) => [message.text, message.runStatus])).toEqual([
+			['Fail prompt', 'failed'],
+			['boom', 'failed'],
+			['Cancel prompt', 'cancelled'],
+			['stopped', 'cancelled']
+		]);
+	});
+
+	it('orders history chronologically across terminal statuses and bounds to newest 20 runs', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const statuses = ['completed', 'failed', 'cancelled'] as const;
+
+		for (let index = 0; index < 25; index += 1) {
+			const created = await createQueuedRun(asUser, threadId, `sub-bound-${index}`, `P${index}`);
+			await completeRun(t, asUser, {
+				runId: created.runId,
+				status: statuses[index % statuses.length]!,
+				responseText: `R${index}`,
+				startedAt: 1_000 + index
+			});
+		}
+
+		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
+		const promptTexts = history.messages
+			.filter((message) => message.type === 'prompt')
+			.map((message) => message.text);
+		expect(promptTexts).toEqual(Array.from({ length: 20 }, (_, index) => `P${index + 5}`));
+		expect(history.messages).toHaveLength(40);
+		expect(history.messages.map((message) => message.text)).toEqual(
+			promptTexts.flatMap((prompt, index) => [prompt, `R${index + 5}`])
+		);
+	});
+
+	it('hydrates authorized attachments and skips unauthorized or missing uploads', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, subject } = await seedOwnedThread(t);
+		const created = await createQueuedRun(asUser, threadId, 'sub-attach', 'With images');
+
+		const { validUploadId, orphanUploadId, missingUploadId } = await t.run(async (ctx) => {
+			const storageId = await ctx.storage.store(new Blob(['image-bytes'], { type: 'image/png' }));
+			const validUploadId = await ctx.db.insert('imageUploads', {
+				userId: subject,
+				storageId,
+				name: 'shot.png',
+				mediaType: 'image/png',
+				size: 11,
+				messageIds: [created.promptMessageId],
+				attached: true
+			});
+			const orphanStorageId = await ctx.storage.store(new Blob(['other'], { type: 'image/jpeg' }));
+			const orphanUploadId = await ctx.db.insert('imageUploads', {
+				userId: 'someone-else',
+				storageId: orphanStorageId,
+				name: 'other.jpg',
+				mediaType: 'image/jpeg',
+				size: 5,
+				messageIds: [created.promptMessageId],
+				attached: true
+			});
+			const missingStorageId = await ctx.storage.store(new Blob(['gone'], { type: 'image/gif' }));
+			const missingUploadId = await ctx.db.insert('imageUploads', {
+				userId: subject,
+				storageId: missingStorageId,
+				name: 'gone.gif',
+				mediaType: 'image/gif',
+				size: 4,
+				messageIds: [created.promptMessageId],
+				attached: true
+			});
+			await ctx.db.patch(created.promptMessageId, {
+				imageUploadIds: [validUploadId, orphanUploadId, missingUploadId]
+			});
+			await ctx.db.delete(missingUploadId);
+			return { validUploadId, orphanUploadId, missingUploadId };
+		});
+
+		await completeRun(t, asUser, {
+			runId: created.runId,
+			status: 'completed',
+			responseText: 'done'
+		});
+
+		await t.run(async (ctx) => {
+			const run = await ctx.db.get(created.runId);
+			if (run?.responseMessageId) {
+				await ctx.db.delete(run.responseMessageId);
+			}
+		});
+
+		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
+		expect(history.messages).toHaveLength(1);
+		expect(history.messages[0]?.attachments).toEqual([
+			expect.objectContaining({
+				imageUploadId: validUploadId,
+				name: 'shot.png',
+				mediaType: 'image/png',
+				size: 11,
+				url: expect.any(String)
+			})
+		]);
+		expect(
+			history.messages[0]?.attachments.some(
+				(attachment) =>
+					attachment.imageUploadId === orphanUploadId ||
+					attachment.imageUploadId === missingUploadId
+			)
+		).toBe(false);
+	});
+
+	it('returns at most 40 indexed messages from legacy listForThread', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		for (let index = 0; index < 25; index += 1) {
+			const created = await createQueuedRun(asUser, threadId, `sub-legacy-${index}`, `LP${index}`);
+			await completeRun(t, asUser, {
+				runId: created.runId,
+				status: 'completed',
+				responseText: `LR${index}`,
+				startedAt: 2_000 + index
+			});
+		}
+
+		const page = await asUser.query(api.messages.listForThread, {
+			threadId,
+			paginationOpts: { cursor: null, numItems: 100 }
+		});
+		expect(page.page).toHaveLength(40);
+		expect(page.page[0]?.text).toBe('LP5');
+		expect(page.page.at(-1)?.text).toBe('LR24');
+		expect(page.isDone).toBe(false);
+		expect(page.continueCursor).toEqual(expect.any(String));
+	});
+});

--- a/apps/web/src/convex/messages.test.ts
+++ b/apps/web/src/convex/messages.test.ts
@@ -49,23 +49,6 @@ async function completeRun(
 }
 
 describe('messages transcript queries', () => {
-	it('requires authentication and ownership', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t, 'user_owner');
-		await createQueuedRun(asUser, threadId, 'sub-auth');
-		const stranger = t.withIdentity({ subject: 'user_stranger' });
-
-		for (const client of [t, stranger]) {
-			const expected = client === t ? 'Authentication required.' : 'Thread not found.';
-			await expect(client.query(api.messages.listHistoryForThread, { threadId })).rejects.toThrow(
-				expected
-			);
-			await expect(client.query(api.messages.listLiveForThread, { threadId })).rejects.toThrow(
-				expected
-			);
-		}
-	});
-
 	it('keeps active runs in live and excludes them from history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
@@ -92,10 +75,6 @@ describe('messages transcript queries', () => {
 		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-stream', runId });
 		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId });
 
-		const beforeStream = await asUser.query(api.messages.listLiveForThread, { threadId });
-		expect(beforeStream.messages.map((message) => message.type)).toEqual(['prompt', 'response']);
-		expect(beforeStream.messages[1]?.text).toBe('');
-
 		const responseMessageId = await t.run(async (ctx) => {
 			const run = await ctx.db.get(runId);
 			if (!run?.responseMessageId) {
@@ -111,6 +90,7 @@ describe('messages transcript queries', () => {
 		});
 
 		const streaming = await asUser.query(api.messages.listLiveForThread, { threadId });
+		expect(streaming.messages.map((message) => message.type)).toEqual(['prompt', 'response']);
 		expect(streaming.messages[1]).toMatchObject({
 			_id: responseMessageId,
 			text: 'partial answer',
@@ -128,35 +108,11 @@ describe('messages transcript queries', () => {
 
 		expect((await asUser.query(api.messages.listLiveForThread, { threadId })).messages).toEqual([]);
 		const historyAfter = await asUser.query(api.messages.listHistoryForThread, { threadId });
-		// finalizeRun prefers already-streamed assistant text when parts exist.
-		expect(historyAfter.messages.map((message) => [message.type, message.text])).toEqual([
-			['prompt', 'Stream me'],
-			['response', 'partial answer']
-		]);
-		expect(historyAfter.messages.every((message) => message.runStatus === 'completed')).toBe(true);
-	});
-
-	it('moves failed and cancelled runs from live into history', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-
-		const failed = await createQueuedRun(asUser, threadId, 'sub-fail', 'Fail prompt');
-		await completeRun(t, asUser, { runId: failed.runId, status: 'failed', responseText: 'boom' });
-
-		const cancelled = await createQueuedRun(asUser, threadId, 'sub-cancel', 'Cancel prompt');
-		await completeRun(t, asUser, {
-			runId: cancelled.runId,
-			status: 'cancelled',
-			responseText: 'stopped'
-		});
-
-		expect((await asUser.query(api.messages.listLiveForThread, { threadId })).messages).toEqual([]);
-		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
-		expect(history.messages.map((message) => [message.text, message.runStatus])).toEqual([
-			['Fail prompt', 'failed'],
-			['boom', 'failed'],
-			['Cancel prompt', 'cancelled'],
-			['stopped', 'cancelled']
+		expect(
+			historyAfter.messages.map((message) => [message.type, message.text, message.runStatus])
+		).toEqual([
+			['prompt', 'Stream me', 'completed'],
+			['response', 'partial answer', 'completed']
 		]);
 	});
 
@@ -184,81 +140,5 @@ describe('messages transcript queries', () => {
 		expect(history.messages.map((message) => message.text)).toEqual(
 			promptTexts.flatMap((prompt, index) => [prompt, `R${index + 5}`])
 		);
-	});
-
-	it('hydrates authorized attachments and skips unauthorized or missing uploads', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId, subject } = await seedOwnedThread(t);
-		const created = await createQueuedRun(asUser, threadId, 'sub-attach', 'With images');
-
-		const { validUploadId, orphanUploadId, missingUploadId } = await t.run(async (ctx) => {
-			const storageId = await ctx.storage.store(new Blob(['image-bytes'], { type: 'image/png' }));
-			const validUploadId = await ctx.db.insert('imageUploads', {
-				userId: subject,
-				storageId,
-				name: 'shot.png',
-				mediaType: 'image/png',
-				size: 11,
-				messageIds: [created.promptMessageId],
-				attached: true
-			});
-			const orphanStorageId = await ctx.storage.store(new Blob(['other'], { type: 'image/jpeg' }));
-			const orphanUploadId = await ctx.db.insert('imageUploads', {
-				userId: 'someone-else',
-				storageId: orphanStorageId,
-				name: 'other.jpg',
-				mediaType: 'image/jpeg',
-				size: 5,
-				messageIds: [created.promptMessageId],
-				attached: true
-			});
-			const missingStorageId = await ctx.storage.store(new Blob(['gone'], { type: 'image/gif' }));
-			const missingUploadId = await ctx.db.insert('imageUploads', {
-				userId: subject,
-				storageId: missingStorageId,
-				name: 'gone.gif',
-				mediaType: 'image/gif',
-				size: 4,
-				messageIds: [created.promptMessageId],
-				attached: true
-			});
-			await ctx.db.patch(created.promptMessageId, {
-				imageUploadIds: [validUploadId, orphanUploadId, missingUploadId]
-			});
-			await ctx.db.delete(missingUploadId);
-			return { validUploadId, orphanUploadId, missingUploadId };
-		});
-
-		await completeRun(t, asUser, {
-			runId: created.runId,
-			status: 'completed',
-			responseText: 'done'
-		});
-
-		await t.run(async (ctx) => {
-			const run = await ctx.db.get(created.runId);
-			if (run?.responseMessageId) {
-				await ctx.db.delete(run.responseMessageId);
-			}
-		});
-
-		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
-		expect(history.messages).toHaveLength(1);
-		expect(history.messages[0]?.attachments).toEqual([
-			expect.objectContaining({
-				imageUploadId: validUploadId,
-				name: 'shot.png',
-				mediaType: 'image/png',
-				size: 11,
-				url: expect.any(String)
-			})
-		]);
-		expect(
-			history.messages[0]?.attachments.some(
-				(attachment) =>
-					attachment.imageUploadId === orphanUploadId ||
-					attachment.imageUploadId === missingUploadId
-			)
-		).toBe(false);
 	});
 });

--- a/apps/web/src/convex/messages.test.ts
+++ b/apps/web/src/convex/messages.test.ts
@@ -54,7 +54,6 @@ describe('messages transcript queries', () => {
 		const { asUser, threadId } = await seedOwnedThread(t, 'user_owner');
 		await createQueuedRun(asUser, threadId, 'sub-auth');
 		const stranger = t.withIdentity({ subject: 'user_stranger' });
-		const legacyArgs = { threadId, paginationOpts: { cursor: null, numItems: 40 } };
 
 		for (const client of [t, stranger]) {
 			const expected = client === t ? 'Authentication required.' : 'Thread not found.';
@@ -64,7 +63,6 @@ describe('messages transcript queries', () => {
 			await expect(client.query(api.messages.listLiveForThread, { threadId })).rejects.toThrow(
 				expected
 			);
-			await expect(client.query(api.messages.listForThread, legacyArgs)).rejects.toThrow(expected);
 		}
 	});
 
@@ -262,30 +260,5 @@ describe('messages transcript queries', () => {
 					attachment.imageUploadId === missingUploadId
 			)
 		).toBe(false);
-	});
-
-	it('returns at most 40 indexed messages from legacy listForThread', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-
-		for (let index = 0; index < 25; index += 1) {
-			const created = await createQueuedRun(asUser, threadId, `sub-legacy-${index}`, `LP${index}`);
-			await completeRun(t, asUser, {
-				runId: created.runId,
-				status: 'completed',
-				responseText: `LR${index}`,
-				startedAt: 2_000 + index
-			});
-		}
-
-		const page = await asUser.query(api.messages.listForThread, {
-			threadId,
-			paginationOpts: { cursor: null, numItems: 100 }
-		});
-		expect(page.page).toHaveLength(40);
-		expect(page.page[0]?.text).toBe('LP5');
-		expect(page.page.at(-1)?.text).toBe('LR24');
-		expect(page.isDone).toBe(false);
-		expect(page.continueCursor).toEqual(expect.any(String));
 	});
 });

--- a/apps/web/src/convex/messages.ts
+++ b/apps/web/src/convex/messages.ts
@@ -1,32 +1,128 @@
 import { paginationOptsValidator } from 'convex/server';
-import { query } from '@convex/_generated/server';
+import type { Doc, Id } from '@convex/_generated/dataModel';
+import { query, type QueryCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
-import { buildThreadTranscript, type ThreadTranscriptMessage } from '@convex/lib/threadTranscript';
+import {
+	compareTranscriptMessages,
+	hydrateTranscriptMessages,
+	hydrateTranscriptMessagesFromDocs,
+	type ThreadTranscriptMessage
+} from '@convex/lib/threadTranscript';
+import { isRunFinalStatus, runFinalStatus } from '@convex/lib/validators';
 
+const HISTORY_RUN_LIMIT = 20;
+const LEGACY_PAGE_MESSAGE_LIMIT = 40;
+
+type ThreadTranscriptQueryResult = {
+	threadId: Id<'threadRecords'>;
+	messages: ThreadTranscriptMessage[];
+};
+
+function compareRunsNewestFirst(left: Doc<'runs'>, right: Doc<'runs'>): number {
+	if (right.startedAt !== left.startedAt) {
+		return right.startedAt - left.startedAt;
+	}
+	return right._creationTime - left._creationTime;
+}
+
+async function requireOwnedThread(ctx: QueryCtx, threadId: Id<'threadRecords'>): Promise<void> {
+	const userId = await getUserId(ctx);
+	await getOwnedThreadRecord(ctx.db, userId, threadId);
+}
+
+async function loadNewestTerminalRuns(
+	ctx: QueryCtx,
+	threadId: Id<'threadRecords'>,
+	limit: number
+): Promise<Doc<'runs'>[]> {
+	const perStatus = await Promise.all(
+		runFinalStatus.map((status) =>
+			ctx.db
+				.query('runs')
+				.withIndex('by_threadId_status_startedAt', (query) =>
+					query.eq('threadId', threadId).eq('status', status)
+				)
+				.order('desc')
+				.take(limit)
+		)
+	);
+
+	return perStatus.flat().sort(compareRunsNewestFirst).slice(0, limit);
+}
+
+async function hydrateSortedTranscript(
+	ctx: QueryCtx,
+	threadId: Id<'threadRecords'>,
+	runs: Doc<'runs'>[]
+): Promise<ThreadTranscriptQueryResult> {
+	const messages = (await hydrateTranscriptMessages(ctx, runs)).sort(compareTranscriptMessages);
+	return { threadId, messages };
+}
+
+export const listHistoryForThread = query({
+	args: {
+		threadId: v.id('threadRecords')
+	},
+	handler: async (ctx, args): Promise<ThreadTranscriptQueryResult> => {
+		await requireOwnedThread(ctx, args.threadId);
+		const terminalRuns = await loadNewestTerminalRuns(ctx, args.threadId, HISTORY_RUN_LIMIT);
+		return hydrateSortedTranscript(ctx, args.threadId, terminalRuns);
+	}
+});
+
+export const listLiveForThread = query({
+	args: {
+		threadId: v.id('threadRecords')
+	},
+	handler: async (ctx, args): Promise<ThreadTranscriptQueryResult> => {
+		await requireOwnedThread(ctx, args.threadId);
+
+		const latestRun = await ctx.db
+			.query('runs')
+			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', args.threadId))
+			.order('desc')
+			.first();
+
+		if (!latestRun || isRunFinalStatus(latestRun.status)) {
+			return { threadId: args.threadId, messages: [] };
+		}
+
+		return hydrateSortedTranscript(ctx, args.threadId, [latestRun]);
+	}
+});
+
+/** @deprecated Prefer listHistoryForThread + listLiveForThread. Kept for older released clients. */
 export const listForThread = query({
 	args: {
 		threadId: v.id('threadRecords'),
 		paginationOpts: paginationOptsValidator
 	},
 	handler: async (ctx, args) => {
-		const userId: string = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		const allMessages: ThreadTranscriptMessage[] = await buildThreadTranscript(ctx, args.threadId);
-		const total: number = allMessages.length;
-		const requested: number = Math.max(1, args.paginationOpts.numItems);
-		const endExclusive: number =
-			args.paginationOpts.cursor == null ? total : Math.max(0, Number(args.paginationOpts.cursor));
-		const start: number = Math.max(0, endExclusive - requested);
-		const page: ThreadTranscriptMessage[] = allMessages.slice(start, endExclusive);
+		await requireOwnedThread(ctx, args.threadId);
+
+		const numItems = Math.min(LEGACY_PAGE_MESSAGE_LIMIT, Math.max(1, args.paginationOpts.numItems));
+		const pageResult = await ctx.db
+			.query('threadMessages')
+			.withIndex('by_threadId', (query) => query.eq('threadId', args.threadId))
+			.order('desc')
+			.paginate({
+				...args.paginationOpts,
+				numItems
+			});
+
+		const messages = (await hydrateTranscriptMessagesFromDocs(ctx, pageResult.page)).sort(
+			compareTranscriptMessages
+		);
+
 		return {
 			threadId: args.threadId,
-			page,
-			isDone: start === 0,
-			continueCursor: start === 0 ? null : String(start),
-			pageStatus: null,
-			splitCursor: null
+			page: messages,
+			isDone: pageResult.isDone,
+			continueCursor: pageResult.continueCursor,
+			pageStatus: pageResult.pageStatus ?? null,
+			splitCursor: pageResult.splitCursor ?? null
 		};
 	}
 });

--- a/apps/web/src/convex/messages.ts
+++ b/apps/web/src/convex/messages.ts
@@ -1,4 +1,3 @@
-import { paginationOptsValidator } from 'convex/server';
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { query, type QueryCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
@@ -7,13 +6,11 @@ import { getUserId } from '@convex/lib/auth';
 import {
 	compareTranscriptMessages,
 	hydrateTranscriptMessages,
-	hydrateTranscriptMessagesFromDocs,
 	type ThreadTranscriptMessage
 } from '@convex/lib/threadTranscript';
 import { isRunFinalStatus, runFinalStatus } from '@convex/lib/validators';
 
 const HISTORY_RUN_LIMIT = 20;
-const LEGACY_PAGE_MESSAGE_LIMIT = 40;
 
 type ThreadTranscriptQueryResult = {
 	threadId: Id<'threadRecords'>;
@@ -90,39 +87,5 @@ export const listLiveForThread = query({
 		}
 
 		return hydrateSortedTranscript(ctx, args.threadId, [latestRun]);
-	}
-});
-
-/** @deprecated Prefer listHistoryForThread + listLiveForThread. Kept for older released clients. */
-export const listForThread = query({
-	args: {
-		threadId: v.id('threadRecords'),
-		paginationOpts: paginationOptsValidator
-	},
-	handler: async (ctx, args) => {
-		await requireOwnedThread(ctx, args.threadId);
-
-		const numItems = Math.min(LEGACY_PAGE_MESSAGE_LIMIT, Math.max(1, args.paginationOpts.numItems));
-		const pageResult = await ctx.db
-			.query('threadMessages')
-			.withIndex('by_threadId', (query) => query.eq('threadId', args.threadId))
-			.order('desc')
-			.paginate({
-				...args.paginationOpts,
-				numItems
-			});
-
-		const messages = (await hydrateTranscriptMessagesFromDocs(ctx, pageResult.page)).sort(
-			compareTranscriptMessages
-		);
-
-		return {
-			threadId: args.threadId,
-			page: messages,
-			isDone: pageResult.isDone,
-			continueCursor: pageResult.continueCursor,
-			pageStatus: pageResult.pageStatus ?? null,
-			splitCursor: pageResult.splitCursor ?? null
-		};
 	}
 });

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -79,6 +79,7 @@ export default defineSchema({
 		responseMessageId: v.optional(v.id('threadMessages'))
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
+		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])
 		.index('by_userId_submissionId', ['userId', 'submissionId'])
 		.index('by_workspaceSessionId', ['workspaceSessionId'])
 		.index('by_userId_startedAt', ['userId', 'startedAt']),
@@ -92,7 +93,7 @@ export default defineSchema({
 		parts: v.optional(v.array(vAssistantMessagePart)),
 		streamSequence: v.optional(v.number()),
 		streamAttemptId: v.optional(v.string())
-	}),
+	}).index('by_threadId', ['threadId']),
 	imageUploads: defineTable({
 		userId: v.string(),
 		storageId: v.id('_storage'),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -93,7 +93,7 @@ export default defineSchema({
 		parts: v.optional(v.array(vAssistantMessagePart)),
 		streamSequence: v.optional(v.number()),
 		streamAttemptId: v.optional(v.string())
-	}).index('by_threadId', ['threadId']),
+	}),
 	imageUploads: defineTable({
 		userId: v.string(),
 		storageId: v.id('_storage'),

--- a/apps/web/src/lib/workspace/transcript.test.ts
+++ b/apps/web/src/lib/workspace/transcript.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { Id } from '$convex/_generated/dataModel';
+import type { ThreadMessage } from '$lib/types/sprocket';
+import {
+	mergeThreadTranscriptMessages,
+	VISIBLE_TRANSCRIPT_MESSAGE_LIMIT
+} from '$lib/workspace/transcript';
+
+function message(
+	overrides: Partial<ThreadMessage> & Pick<ThreadMessage, '_id' | 'type'>
+): ThreadMessage {
+	return {
+		threadId: 'thread-1' as Id<'threadRecords'>,
+		runId: 'run-1' as Id<'runs'>,
+		userId: 'user_1',
+		text: '',
+		attachments: [],
+		runStatus: 'completed',
+		runStartedAt: 1,
+		...overrides
+	};
+}
+
+describe('mergeThreadTranscriptMessages', () => {
+	it('merges history and live in chronological order with live winning duplicates', () => {
+		const history = [
+			message({
+				_id: 'm1' as Id<'threadMessages'>,
+				type: 'prompt',
+				runStartedAt: 10,
+				text: 'stale',
+				runStatus: 'completed'
+			}),
+			message({
+				_id: 'm2' as Id<'threadMessages'>,
+				type: 'response',
+				runStartedAt: 10,
+				_creationTime: 2,
+				text: 'b'
+			})
+		];
+		const live = [
+			message({
+				_id: 'm1' as Id<'threadMessages'>,
+				type: 'prompt',
+				runStartedAt: 10,
+				text: 'fresh',
+				runStatus: 'running'
+			}),
+			message({
+				_id: 'm3' as Id<'threadMessages'>,
+				type: 'prompt',
+				runStartedAt: 20,
+				runStatus: 'running',
+				text: 'c'
+			})
+		];
+
+		expect(mergeThreadTranscriptMessages({ historyMessages: history, liveMessages: live })).toEqual(
+			[live[0], history[1], live[1]]
+		);
+	});
+
+	it('retains only the newest messages within the visible limit', () => {
+		const history = Array.from({ length: VISIBLE_TRANSCRIPT_MESSAGE_LIMIT + 5 }, (_, index) =>
+			message({
+				_id: `m${index}` as Id<'threadMessages'>,
+				type: index % 2 === 0 ? 'prompt' : 'response',
+				runId: `run-${Math.floor(index / 2)}` as Id<'runs'>,
+				runStartedAt: Math.floor(index / 2),
+				text: String(index)
+			})
+		);
+
+		const merged = mergeThreadTranscriptMessages({
+			historyMessages: history,
+			liveMessages: []
+		});
+		// 45 messages → drop oldest whole runs (2 msgs each) until <= 40 → 39 messages.
+		expect(merged).toHaveLength(39);
+		expect(merged[0]?.text).toBe('6');
+		expect(merged.at(-1)?.text).toBe(String(VISIBLE_TRANSCRIPT_MESSAGE_LIMIT + 4));
+	});
+
+	it('drops whole oldest runs instead of orphaning a response when live exceeds the window', () => {
+		const history = Array.from({ length: VISIBLE_TRANSCRIPT_MESSAGE_LIMIT }, (_, index) =>
+			message({
+				_id: `h${index}` as Id<'threadMessages'>,
+				type: index % 2 === 0 ? 'prompt' : 'response',
+				runId: `run-${Math.floor(index / 2)}` as Id<'runs'>,
+				runStartedAt: Math.floor(index / 2),
+				text: `h${index}`
+			})
+		);
+		const live = [
+			message({
+				_id: 'live-prompt' as Id<'threadMessages'>,
+				type: 'prompt',
+				runId: 'run-live' as Id<'runs'>,
+				runStartedAt: 100,
+				runStatus: 'queued',
+				text: 'new'
+			})
+		];
+
+		const merged = mergeThreadTranscriptMessages({
+			historyMessages: history,
+			liveMessages: live
+		});
+		expect(merged.map((entry) => entry._id)).not.toContain(history[0]?._id);
+		expect(merged.map((entry) => entry._id)).not.toContain(history[1]?._id);
+		expect(merged[0]?.type).toBe('prompt');
+		expect(merged.at(-1)?.text).toBe('new');
+		expect(merged).toHaveLength(39);
+	});
+
+	it('treats null and undefined sources as empty', () => {
+		expect(
+			mergeThreadTranscriptMessages({
+				historyMessages: undefined,
+				liveMessages: null
+			})
+		).toEqual([]);
+	});
+});

--- a/apps/web/src/lib/workspace/transcript.test.ts
+++ b/apps/web/src/lib/workspace/transcript.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
 import type { ThreadMessage } from '$lib/types/sprocket';
-import {
-	mergeThreadTranscriptMessages,
-	VISIBLE_TRANSCRIPT_MESSAGE_LIMIT
-} from '$lib/workspace/transcript';
+import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
 
 function message(
 	overrides: Partial<ThreadMessage> & Pick<ThreadMessage, '_id' | 'type'>
@@ -61,29 +58,8 @@ describe('mergeThreadTranscriptMessages', () => {
 		);
 	});
 
-	it('retains only the newest messages within the visible limit', () => {
-		const history = Array.from({ length: VISIBLE_TRANSCRIPT_MESSAGE_LIMIT + 5 }, (_, index) =>
-			message({
-				_id: `m${index}` as Id<'threadMessages'>,
-				type: index % 2 === 0 ? 'prompt' : 'response',
-				runId: `run-${Math.floor(index / 2)}` as Id<'runs'>,
-				runStartedAt: Math.floor(index / 2),
-				text: String(index)
-			})
-		);
-
-		const merged = mergeThreadTranscriptMessages({
-			historyMessages: history,
-			liveMessages: []
-		});
-		// 45 messages → drop oldest whole runs (2 msgs each) until <= 40 → 39 messages.
-		expect(merged).toHaveLength(39);
-		expect(merged[0]?.text).toBe('6');
-		expect(merged.at(-1)?.text).toBe(String(VISIBLE_TRANSCRIPT_MESSAGE_LIMIT + 4));
-	});
-
 	it('drops whole oldest runs instead of orphaning a response when live exceeds the window', () => {
-		const history = Array.from({ length: VISIBLE_TRANSCRIPT_MESSAGE_LIMIT }, (_, index) =>
+		const history = Array.from({ length: 40 }, (_, index) =>
 			message({
 				_id: `h${index}` as Id<'threadMessages'>,
 				type: index % 2 === 0 ? 'prompt' : 'response',
@@ -112,14 +88,5 @@ describe('mergeThreadTranscriptMessages', () => {
 		expect(merged[0]?.type).toBe('prompt');
 		expect(merged.at(-1)?.text).toBe('new');
 		expect(merged).toHaveLength(39);
-	});
-
-	it('treats null and undefined sources as empty', () => {
-		expect(
-			mergeThreadTranscriptMessages({
-				historyMessages: undefined,
-				liveMessages: null
-			})
-		).toEqual([]);
 	});
 });

--- a/apps/web/src/lib/workspace/transcript.test.ts
+++ b/apps/web/src/lib/workspace/transcript.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
 import type { ThreadMessage } from '$lib/types/sprocket';
-import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
+import {
+	holdLiveMessagesUntilHistoryAbsorbs,
+	mergeThreadTranscriptMessages
+} from '$lib/workspace/transcript';
 
 function message(
 	overrides: Partial<ThreadMessage> & Pick<ThreadMessage, '_id' | 'type'>
@@ -88,5 +91,54 @@ describe('mergeThreadTranscriptMessages', () => {
 		expect(merged[0]?.type).toBe('prompt');
 		expect(merged.at(-1)?.text).toBe('new');
 		expect(merged).toHaveLength(39);
+	});
+});
+
+describe('holdLiveMessagesUntilHistoryAbsorbs', () => {
+	it('holds departing live messages until history contains them', () => {
+		const live = [
+			message({
+				_id: 'p' as Id<'threadMessages'>,
+				type: 'prompt',
+				runStartedAt: 20,
+				runStatus: 'running',
+				text: 'go'
+			}),
+			message({
+				_id: 'r' as Id<'threadMessages'>,
+				type: 'response',
+				runStartedAt: 20,
+				_creationTime: 2,
+				runStatus: 'running',
+				text: 'ok'
+			})
+		];
+		const held = holdLiveMessagesUntilHistoryAbsorbs({
+			historyMessages: [],
+			liveMessages: live,
+			heldLiveMessages: []
+		});
+		expect(held).toEqual(live);
+
+		const duringHandoff = holdLiveMessagesUntilHistoryAbsorbs({
+			historyMessages: [],
+			liveMessages: [],
+			heldLiveMessages: held
+		});
+		expect(duringHandoff).toEqual(live);
+		expect(
+			mergeThreadTranscriptMessages({
+				historyMessages: [],
+				liveMessages: duringHandoff
+			}).map((entry) => entry._id)
+		).toEqual(['p', 'r']);
+
+		expect(
+			holdLiveMessagesUntilHistoryAbsorbs({
+				historyMessages: live.map((entry) => ({ ...entry, runStatus: 'completed' })),
+				liveMessages: [],
+				heldLiveMessages: duringHandoff
+			})
+		).toEqual([]);
 	});
 });

--- a/apps/web/src/lib/workspace/transcript.ts
+++ b/apps/web/src/lib/workspace/transcript.ts
@@ -42,6 +42,28 @@ export function truncateTranscriptToNewestRuns(
 	return truncated.length > limit ? truncated.slice(-limit) : truncated;
 }
 
+/**
+ * Keep departing live messages until history absorbs them so independent
+ * subscription updates cannot blank the finishing turn.
+ */
+export function holdLiveMessagesUntilHistoryAbsorbs(args: {
+	historyMessages: ThreadMessage[];
+	liveMessages: ThreadMessage[];
+	heldLiveMessages: ThreadMessage[];
+}): ThreadMessage[] {
+	if (args.liveMessages.length > 0) {
+		return args.liveMessages;
+	}
+	if (args.heldLiveMessages.length === 0) {
+		return [];
+	}
+	const historyIds = new Set(args.historyMessages.map((message) => message._id));
+	if (args.heldLiveMessages.every((message) => historyIds.has(message._id))) {
+		return [];
+	}
+	return args.heldLiveMessages;
+}
+
 /** Merge history + live pages; live wins on ID collisions. Keeps the newest visible window. */
 export function mergeThreadTranscriptMessages(args: {
 	historyMessages: ThreadMessage[] | null | undefined;

--- a/apps/web/src/lib/workspace/transcript.ts
+++ b/apps/web/src/lib/workspace/transcript.ts
@@ -1,0 +1,60 @@
+import type { ThreadMessage } from '$lib/types/sprocket';
+
+export const VISIBLE_TRANSCRIPT_MESSAGE_LIMIT = 40;
+
+function compareMessagesChronologically(left: ThreadMessage, right: ThreadMessage): number {
+	if (left.runStartedAt !== right.runStartedAt) {
+		return left.runStartedAt - right.runStartedAt;
+	}
+	const leftCreated = left._creationTime ?? 0;
+	const rightCreated = right._creationTime ?? 0;
+	if (leftCreated !== rightCreated) {
+		return leftCreated - rightCreated;
+	}
+	if (left.type !== right.type) {
+		return left.type === 'prompt' ? -1 : 1;
+	}
+	return left._id.localeCompare(right._id);
+}
+
+/** Drop oldest whole runs until the window fits; never leave a response without its prompt. */
+export function truncateTranscriptToNewestRuns(
+	messages: ThreadMessage[],
+	limit = VISIBLE_TRANSCRIPT_MESSAGE_LIMIT
+): ThreadMessage[] {
+	if (messages.length <= limit) {
+		return messages;
+	}
+
+	let start = 0;
+	while (messages.length - start > limit) {
+		const runId = messages[start]?.runId;
+		if (!runId) {
+			start += 1;
+			continue;
+		}
+		while (start < messages.length && messages[start]?.runId === runId) {
+			start += 1;
+		}
+	}
+
+	const truncated = messages.slice(start);
+	return truncated.length > limit ? truncated.slice(-limit) : truncated;
+}
+
+/** Merge history + live pages; live wins on ID collisions. Keeps the newest visible window. */
+export function mergeThreadTranscriptMessages(args: {
+	historyMessages: ThreadMessage[] | null | undefined;
+	liveMessages: ThreadMessage[] | null | undefined;
+}): ThreadMessage[] {
+	const byId = new Map<ThreadMessage['_id'], ThreadMessage>();
+
+	for (const message of args.historyMessages ?? []) {
+		byId.set(message._id, message);
+	}
+	for (const message of args.liveMessages ?? []) {
+		byId.set(message._id, message);
+	}
+
+	return truncateTranscriptToNewestRuns([...byId.values()].sort(compareMessagesChronologically));
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -70,6 +70,7 @@
 		resolveWorkspaceThreadSelection,
 		type PendingAgentLaunches
 	} from '$lib/workspace/threads';
+	import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
 	import {
 		clearLaunchHash,
 		readWorkspaceLaunchFromHash,
@@ -178,7 +179,6 @@
 	let composerAttachments = $state<ComposerAttachment[]>([]);
 	let currentError = $state<string | null>(null);
 	let executorClientId = $state<string | null>(null);
-	let visibleMessages = $state<ThreadMessage[]>([]);
 	let elapsedSeconds = $state(0);
 	const submittingPromptScopes = new SvelteMap<string, number>();
 	const composerRecoveries = new SvelteMap<string, ComposerRecovery>();
@@ -363,31 +363,25 @@
 	);
 	const threadsQuery = useQuery(api.threads.listMine, getAuthenticatedQueryArgs);
 	const uiPreferencesQuery = useQuery(api.uiPreferences.getMine, getAuthenticatedQueryArgs);
-	const activeThreadQuery = useQuery(api.threads.getByThreadId, () => {
-		return currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
+	const authenticatedThreadQueryArgs = () =>
+		currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
 			? { threadId: currentThreadId }
 			: 'skip';
-	});
-	const messagesQuery = useQuery(api.messages.listForThread, () => {
-		return currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
-			? {
-					threadId: currentThreadId,
-					paginationOpts: { cursor: null, numItems: 40 }
-				}
-			: 'skip';
-	});
-	const latestRunQuery = useQuery(api.chat.latestRunForThread, () => {
-		return currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
-			? { threadId: currentThreadId }
-			: 'skip';
-	});
+	const activeThreadQuery = useQuery(api.threads.getByThreadId, authenticatedThreadQueryArgs);
+	const historyMessagesQuery = useQuery(
+		api.messages.listHistoryForThread,
+		authenticatedThreadQueryArgs
+	);
+	const liveMessagesQuery = useQuery(api.messages.listLiveForThread, authenticatedThreadQueryArgs);
+	const latestRunQuery = useQuery(api.chat.latestRunForThread, authenticatedThreadQueryArgs);
 	const queryError = $derived.by(() => {
 		for (const query of [
 			workspaceSessionsQuery,
 			threadsQuery,
 			uiPreferencesQuery,
 			activeThreadQuery,
-			messagesQuery,
+			historyMessagesQuery,
+			liveMessagesQuery,
 			latestRunQuery
 		]) {
 			if (query.error) {
@@ -413,7 +407,21 @@
 	const threads = $derived((threadsQuery.data ?? []) as ThreadSummary[]);
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
 	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
-	const currentMessagesData = $derived(dataForThread(messagesQuery.data, currentThreadId));
+	const currentHistoryMessagesData = $derived(
+		dataForThread(historyMessagesQuery.data, currentThreadId)
+	);
+	const currentLiveMessagesData = $derived(dataForThread(liveMessagesQuery.data, currentThreadId));
+	// Wait for both subscriptions so thread switches and finalization handoff do not
+	// briefly show live-only or history-only windows.
+	const visibleMessages = $derived.by(() => {
+		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
+			return [] as ThreadMessage[];
+		}
+		return mergeThreadTranscriptMessages({
+			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
+			liveMessages: currentLiveMessagesData.messages as ThreadMessage[]
+		});
+	});
 
 	const currentWorkspaceSession = $derived.by<WorkspaceSessionState | null>(() => {
 		if (!currentWorkspaceName) {
@@ -1298,7 +1306,6 @@
 		prompt = '';
 		clearComposerAttachments({ discard: true });
 		currentError = null;
-		visibleMessages = [];
 		elapsedSeconds = 0;
 		selectedModel = defaultModelId;
 		selectedReasoningEffort = defaultReasoningEffort;
@@ -1354,16 +1361,6 @@
 		selectedModel = thread.selectedModel;
 		selectedReasoningEffort = thread.reasoningEffort;
 		selectedServiceTier = thread.serviceTier;
-	});
-
-	$effect(() => {
-		const data = currentMessagesData;
-		if (!data) {
-			visibleMessages = [];
-			return;
-		}
-
-		visibleMessages = [...(data.page ?? [])];
 	});
 
 	$effect(() => {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -70,7 +70,10 @@
 		resolveWorkspaceThreadSelection,
 		type PendingAgentLaunches
 	} from '$lib/workspace/threads';
-	import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
+	import {
+		holdLiveMessagesUntilHistoryAbsorbs,
+		mergeThreadTranscriptMessages
+	} from '$lib/workspace/transcript';
 	import {
 		clearLaunchHash,
 		readWorkspaceLaunchFromHash,
@@ -411,15 +414,27 @@
 		dataForThread(historyMessagesQuery.data, currentThreadId)
 	);
 	const currentLiveMessagesData = $derived(dataForThread(liveMessagesQuery.data, currentThreadId));
-	// Wait for both subscriptions so thread switches and finalization handoff do not
-	// briefly show live-only or history-only windows.
+	// Hold the last live page across finalization until history absorbs those IDs.
+	let heldLiveMessages = $state<ThreadMessage[]>([]);
+	$effect(() => {
+		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
+			heldLiveMessages = [];
+			return;
+		}
+		heldLiveMessages = holdLiveMessagesUntilHistoryAbsorbs({
+			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
+			liveMessages: currentLiveMessagesData.messages as ThreadMessage[],
+			heldLiveMessages
+		});
+	});
+	// Wait for both subscriptions so thread switches do not briefly show one side alone.
 	const visibleMessages = $derived.by(() => {
 		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
 			return [] as ThreadMessage[];
 		}
 		return mergeThreadTranscriptMessages({
 			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
-			liveMessages: currentLiveMessagesData.messages as ThreadMessage[]
+			liveMessages: heldLiveMessages
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Split thread transcript loading into `listHistoryForThread` (newest terminal runs) and `listLiveForThread` (active run only) so streaming no longer rereads the full thread
- Merge the two query results on the client with run-boundary truncation and a both-ready gate to avoid handoff flashes
- Drop the unused legacy `listForThread` pagination path and keep full-history `buildThreadTranscript` only for agent model context

## Test plan
- [ ] Open a thread with existing history and confirm the newest ~40 messages still render
- [ ] Start a new run and confirm the prompt appears immediately while history does not refetch on each stream patch
- [ ] Watch streaming response text update live, then confirm the completed turn lands in history without duplicates
- [ ] Cancel/fail a run and confirm it moves from live into history
- [ ] Switch threads / sign out and confirm previous-thread messages do not flash
- [ ] After deploy, compare Convex DB bandwidth/invocation graphs for message queries before vs after

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds transcript reads and separates active messages from terminal history. The main changes are:

- Adds bounded history and active-run Convex queries.
- Merges history and live messages into a 40-message client window.
- Retains live messages until terminal history contains them.
- Adds tests for streaming handoff, ordering, deduplication, and truncation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The live transcript remains visible until all retained message IDs appear in history. Thread changes and sign-out clear retained transcript state. No blocking issues were found in the updated handoff flow.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - The thread-lifecycle-startup.log records the exact missing WorkOS startup blocker.
- - Before/after browser captures show the repository app failing to load runtime configuration, with browser logs containing the /api/config 502 and a stack trace.
- - The thread-lifecycle-02-after-test.log records all three narrow transcript tests passing with exit code 0.

<a href="https://app.greptile.com/trex/runs/15256190/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/messages.ts | Splits transcript loading into bounded terminal history and active-run queries. |
| apps/web/src/lib/workspace/transcript.ts | Adds chronological merging, whole-run truncation, and live-to-history retention. |
| apps/web/src/routes/+page.svelte | Combines both transcript subscriptions and preserves the finishing turn during handoff. |
| apps/web/src/convex/messages.test.ts | Tests active and terminal query behavior, ordering, and history bounds. |
| apps/web/src/lib/workspace/transcript.test.ts | Tests merging, deduplication, whole-run truncation, and terminal handoff. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): Hold live transcript through h..."](https://github.com/spikonado/sprocket/commit/5defbd7cb241515904b4720700921c4ccde5fef8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45978070)</sub>

<!-- /greptile_comment -->