### PR TITLE
ci(npm-release): Publish root package from its directory

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -257,5 +257,8 @@ jobs:
           if npm view "$name@$VERSION" version >/dev/null 2>&1; then
             echo "$name@$VERSION is already published; skipping"
           else
-            npm publish npm-dist/sprocket --tag "$NPM_TAG"
+            (
+              cd npm-dist/sprocket
+              npm publish --tag "$NPM_TAG"
+            )
           fi


### PR DESCRIPTION
## Summary
- Root `@spikonado/sprocket` publish was failing because `npm publish npm-dist/sprocket` is parsed as a GitHub package shorthand, not a local folder.
- Publish from inside `npm-dist/sprocket` (same pattern as native packages) so the `dev` dist-tag is applied correctly.

## Test plan
- [ ] Merge and let the next successful **Build and Test** on `main` trigger npm Release
- [ ] Confirm `@spikonado/sprocket` gains a `dev` dist-tag (`npm view @spikonado/sprocket dist-tags`)
- [ ] Confirm `npx @spikonado/sprocket@dev --version` resolves to the new `0.0.0-dev.<sha>` build

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes publication of the root npm package. The main change is:

- Publishes `@spikonado/sprocket` from inside `npm-dist/sprocket` while preserving the selected dist-tag.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof to outline the sequence of invocations, including the baseline repository-root run and the corrected path.
- Checked the root-publish-path-01-before.log to verify the previous invocation at the repository root.
- Reviewed the trex-artifacts/root-publish-path-harness.sh to confirm the harmless fake npm/git fixture used for both executions.
- Checked the root-publish-path-02-after.log to verify the corrected package-directory invocation and preserved dev tag.
- Reviewed the package-assembly-tests.log and confirmed the focused assembly test run completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15263219/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Publishes the generated root package from its directory, matching the existing validation and native-package publish pattern. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(npm-release): Publish root package fr..."](https://github.com/spikonado/sprocket/commit/420e24ea49170c68f66b22413f64a7aa33e41152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45996916)</sub>

<!-- /greptile_comment -->