### PR TITLE
fix(web): Remove transcript hold effect freezing UI reactivity

### DIFF
--- a/apps/web/src/lib/workspace/transcript.test.ts
+++ b/apps/web/src/lib/workspace/transcript.test.ts
@@ -113,10 +113,11 @@ describe('holdLiveMessagesUntilHistoryAbsorbs', () => {
 				text: 'ok'
 			})
 		];
+		const emptyHeld: ThreadMessage[] = [];
 		const held = holdLiveMessagesUntilHistoryAbsorbs({
 			historyMessages: [],
 			liveMessages: live,
-			heldLiveMessages: []
+			heldLiveMessages: emptyHeld
 		});
 		expect(held).toEqual(live);
 
@@ -125,7 +126,7 @@ describe('holdLiveMessagesUntilHistoryAbsorbs', () => {
 			liveMessages: [],
 			heldLiveMessages: held
 		});
-		expect(duringHandoff).toEqual(live);
+		expect(duringHandoff).toBe(held);
 		expect(
 			mergeThreadTranscriptMessages({
 				historyMessages: [],
@@ -140,5 +141,16 @@ describe('holdLiveMessagesUntilHistoryAbsorbs', () => {
 				heldLiveMessages: duringHandoff
 			})
 		).toEqual([]);
+	});
+
+	it('returns the same empty held array so effects do not infinite-loop', () => {
+		const emptyHeld: ThreadMessage[] = [];
+		expect(
+			holdLiveMessagesUntilHistoryAbsorbs({
+				historyMessages: [],
+				liveMessages: [],
+				heldLiveMessages: emptyHeld
+			})
+		).toBe(emptyHeld);
 	});
 });

--- a/apps/web/src/lib/workspace/transcript.test.ts
+++ b/apps/web/src/lib/workspace/transcript.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
 import type { ThreadMessage } from '$lib/types/sprocket';
-import {
-	holdLiveMessagesUntilHistoryAbsorbs,
-	mergeThreadTranscriptMessages
-} from '$lib/workspace/transcript';
+import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
 
 function message(
 	overrides: Partial<ThreadMessage> & Pick<ThreadMessage, '_id' | 'type'>
@@ -91,66 +88,5 @@ describe('mergeThreadTranscriptMessages', () => {
 		expect(merged[0]?.type).toBe('prompt');
 		expect(merged.at(-1)?.text).toBe('new');
 		expect(merged).toHaveLength(39);
-	});
-});
-
-describe('holdLiveMessagesUntilHistoryAbsorbs', () => {
-	it('holds departing live messages until history contains them', () => {
-		const live = [
-			message({
-				_id: 'p' as Id<'threadMessages'>,
-				type: 'prompt',
-				runStartedAt: 20,
-				runStatus: 'running',
-				text: 'go'
-			}),
-			message({
-				_id: 'r' as Id<'threadMessages'>,
-				type: 'response',
-				runStartedAt: 20,
-				_creationTime: 2,
-				runStatus: 'running',
-				text: 'ok'
-			})
-		];
-		const emptyHeld: ThreadMessage[] = [];
-		const held = holdLiveMessagesUntilHistoryAbsorbs({
-			historyMessages: [],
-			liveMessages: live,
-			heldLiveMessages: emptyHeld
-		});
-		expect(held).toEqual(live);
-
-		const duringHandoff = holdLiveMessagesUntilHistoryAbsorbs({
-			historyMessages: [],
-			liveMessages: [],
-			heldLiveMessages: held
-		});
-		expect(duringHandoff).toBe(held);
-		expect(
-			mergeThreadTranscriptMessages({
-				historyMessages: [],
-				liveMessages: duringHandoff
-			}).map((entry) => entry._id)
-		).toEqual(['p', 'r']);
-
-		expect(
-			holdLiveMessagesUntilHistoryAbsorbs({
-				historyMessages: live.map((entry) => ({ ...entry, runStatus: 'completed' })),
-				liveMessages: [],
-				heldLiveMessages: duringHandoff
-			})
-		).toEqual([]);
-	});
-
-	it('returns the same empty held array so effects do not infinite-loop', () => {
-		const emptyHeld: ThreadMessage[] = [];
-		expect(
-			holdLiveMessagesUntilHistoryAbsorbs({
-				historyMessages: [],
-				liveMessages: [],
-				heldLiveMessages: emptyHeld
-			})
-		).toBe(emptyHeld);
 	});
 });

--- a/apps/web/src/lib/workspace/transcript.ts
+++ b/apps/web/src/lib/workspace/transcript.ts
@@ -1,7 +1,6 @@
 import type { ThreadMessage } from '$lib/types/sprocket';
 
 export const VISIBLE_TRANSCRIPT_MESSAGE_LIMIT = 40;
-const EMPTY_TRANSCRIPT_MESSAGES: ThreadMessage[] = [];
 
 function compareMessagesChronologically(left: ThreadMessage, right: ThreadMessage): number {
 	if (left.runStartedAt !== right.runStartedAt) {
@@ -41,31 +40,6 @@ export function truncateTranscriptToNewestRuns(
 
 	const truncated = messages.slice(start);
 	return truncated.length > limit ? truncated.slice(-limit) : truncated;
-}
-
-/**
- * Keep departing live messages until history absorbs them so independent
- * subscription updates cannot blank the finishing turn.
- *
- * Stable empty references are required: returning a fresh `[]` from an effect
- * that writes `$state` will infinite-loop under Svelte 5 equality checks.
- */
-export function holdLiveMessagesUntilHistoryAbsorbs(args: {
-	historyMessages: ThreadMessage[];
-	liveMessages: ThreadMessage[];
-	heldLiveMessages: ThreadMessage[];
-}): ThreadMessage[] {
-	if (args.liveMessages.length > 0) {
-		return args.liveMessages;
-	}
-	if (args.heldLiveMessages.length === 0) {
-		return args.heldLiveMessages;
-	}
-	const historyIds = new Set(args.historyMessages.map((message) => message._id));
-	if (args.heldLiveMessages.every((message) => historyIds.has(message._id))) {
-		return EMPTY_TRANSCRIPT_MESSAGES;
-	}
-	return args.heldLiveMessages;
 }
 
 /** Merge history + live pages; live wins on ID collisions. Keeps the newest visible window. */

--- a/apps/web/src/lib/workspace/transcript.ts
+++ b/apps/web/src/lib/workspace/transcript.ts
@@ -1,6 +1,7 @@
 import type { ThreadMessage } from '$lib/types/sprocket';
 
 export const VISIBLE_TRANSCRIPT_MESSAGE_LIMIT = 40;
+const EMPTY_TRANSCRIPT_MESSAGES: ThreadMessage[] = [];
 
 function compareMessagesChronologically(left: ThreadMessage, right: ThreadMessage): number {
 	if (left.runStartedAt !== right.runStartedAt) {
@@ -45,6 +46,9 @@ export function truncateTranscriptToNewestRuns(
 /**
  * Keep departing live messages until history absorbs them so independent
  * subscription updates cannot blank the finishing turn.
+ *
+ * Stable empty references are required: returning a fresh `[]` from an effect
+ * that writes `$state` will infinite-loop under Svelte 5 equality checks.
  */
 export function holdLiveMessagesUntilHistoryAbsorbs(args: {
 	historyMessages: ThreadMessage[];
@@ -55,11 +59,11 @@ export function holdLiveMessagesUntilHistoryAbsorbs(args: {
 		return args.liveMessages;
 	}
 	if (args.heldLiveMessages.length === 0) {
-		return [];
+		return args.heldLiveMessages;
 	}
 	const historyIds = new Set(args.historyMessages.map((message) => message._id));
 	if (args.heldLiveMessages.every((message) => historyIds.has(message._id))) {
-		return [];
+		return EMPTY_TRANSCRIPT_MESSAGES;
 	}
 	return args.heldLiveMessages;
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -415,26 +415,35 @@
 	);
 	const currentLiveMessagesData = $derived(dataForThread(liveMessagesQuery.data, currentThreadId));
 	// Hold the last live page across finalization until history absorbs those IDs.
+	// Only assign when the held page identity changes — a fresh `[]` each effect
+	// tick would infinite-loop under Svelte 5 and freeze UI reactivity.
 	let heldLiveMessages = $state<ThreadMessage[]>([]);
 	$effect(() => {
 		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
-			heldLiveMessages = [];
+			if (heldLiveMessages.length > 0) {
+				heldLiveMessages = [];
+			}
 			return;
 		}
-		heldLiveMessages = holdLiveMessagesUntilHistoryAbsorbs({
+		const nextHeld = holdLiveMessagesUntilHistoryAbsorbs({
 			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
 			liveMessages: currentLiveMessagesData.messages as ThreadMessage[],
 			heldLiveMessages
 		});
+		if (nextHeld !== heldLiveMessages) {
+			heldLiveMessages = nextHeld;
+		}
 	});
 	// Wait for both subscriptions so thread switches do not briefly show one side alone.
+	// Prefer live query data while present so streaming stays synchronous with Convex.
 	const visibleMessages = $derived.by(() => {
 		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
 			return [] as ThreadMessage[];
 		}
+		const liveMessages = currentLiveMessagesData.messages as ThreadMessage[];
 		return mergeThreadTranscriptMessages({
 			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
-			liveMessages: heldLiveMessages
+			liveMessages: liveMessages.length > 0 ? liveMessages : heldLiveMessages
 		});
 	});
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -70,10 +70,7 @@
 		resolveWorkspaceThreadSelection,
 		type PendingAgentLaunches
 	} from '$lib/workspace/threads';
-	import {
-		holdLiveMessagesUntilHistoryAbsorbs,
-		mergeThreadTranscriptMessages
-	} from '$lib/workspace/transcript';
+	import { mergeThreadTranscriptMessages } from '$lib/workspace/transcript';
 	import {
 		clearLaunchHash,
 		readWorkspaceLaunchFromHash,
@@ -414,36 +411,16 @@
 		dataForThread(historyMessagesQuery.data, currentThreadId)
 	);
 	const currentLiveMessagesData = $derived(dataForThread(liveMessagesQuery.data, currentThreadId));
-	// Hold the last live page across finalization until history absorbs those IDs.
-	// Only assign when the held page identity changes — a fresh `[]` each effect
-	// tick would infinite-loop under Svelte 5 and freeze UI reactivity.
-	let heldLiveMessages = $state<ThreadMessage[]>([]);
-	$effect(() => {
-		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
-			if (heldLiveMessages.length > 0) {
-				heldLiveMessages = [];
-			}
-			return;
-		}
-		const nextHeld = holdLiveMessagesUntilHistoryAbsorbs({
-			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
-			liveMessages: currentLiveMessagesData.messages as ThreadMessage[],
-			heldLiveMessages
-		});
-		if (nextHeld !== heldLiveMessages) {
-			heldLiveMessages = nextHeld;
-		}
-	});
-	// Wait for both subscriptions so thread switches do not briefly show one side alone.
-	// Prefer live query data while present so streaming stays synchronous with Convex.
+	// Pure derived merge only — no $effect/$state hold. Convex delivers history+live in one
+	// client transition; a held-live effect previously infinite-looped and froze all UI updates
+	// (messages, run timer, working state) until hard reload.
 	const visibleMessages = $derived.by(() => {
 		if (!currentHistoryMessagesData || !currentLiveMessagesData) {
 			return [] as ThreadMessage[];
 		}
-		const liveMessages = currentLiveMessagesData.messages as ThreadMessage[];
 		return mergeThreadTranscriptMessages({
 			historyMessages: currentHistoryMessagesData.messages as ThreadMessage[],
-			liveMessages: liveMessages.length > 0 ? liveMessages : heldLiveMessages
+			liveMessages: currentLiveMessagesData.messages as ThreadMessage[]
 		});
 	});
 


### PR DESCRIPTION
## Summary
- The held-live `$effect` returned a fresh `[]` whenever live/held were empty, which retriggered itself under Svelte 5 and froze UI reactivity until reload
- Keep stable empty references from `holdLiveMessagesUntilHistoryAbsorbs`, only assign held state when the reference changes, and merge live query data directly while streaming

## Test plan
- [ ] Load the app without a hard refresh and confirm workspace/thread UI stays reactive
- [ ] Open a completed thread and confirm history messages appear without reload
- [ ] Start a run and confirm the prompt/response stream updates live
- [ ] Finish a run and confirm the turn remains visible through history handoff
- [ ] Switch threads and confirm messages update without freezing

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the transcript hold effect that could freeze Svelte reactivity. The main changes are:

- Derive visible messages directly from history and live query data.
- Remove the held-live state and effect.
- Delete the unused hold helper and its tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The startup sequence was run to reproduce the missing WORKOS\_CLIENT\_ID blocker.
- The browser/server logs captured Chromium navigation and the /api/config request being refused, confirming the runtime connection issue.
- Focused before/after test runs were executed to provide comparable evidence of behavior, establishing a baseline before changes.
- The after-change checks showed the Svelte code passes type-checking, validating the contract after updates.

<a href="https://app.greptile.com/trex/runs/15273210/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/routes/+page.svelte | Replaces the stateful transcript hold effect with a direct derived merge. |
| apps/web/src/lib/workspace/transcript.ts | Removes the unused live-message hold helper. |
| apps/web/src/lib/workspace/transcript.test.ts | Removes tests for the deleted hold helper while retaining merge coverage. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): Remove held-live transcript ef..."](https://github.com/spikonado/sprocket/commit/6084dca80c6e935041ec1c4b0dd1e387e6a036d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46013772)</sub>

<!-- /greptile_comment -->