### PR TITLE
fix(web): Prioritize running project threads

### DIFF
--- a/apps/web/src/lib/workspace/threads.test.ts
+++ b/apps/web/src/lib/workspace/threads.test.ts
@@ -150,6 +150,37 @@ describe('workspace thread helpers', () => {
 		expect(groups[0]?.threads[0]?.threadId).toBe('thread-record-1');
 	});
 
+	it('lists running threads before newer completed threads in each project', () => {
+		const groups = getWorkspaceThreadGroups(
+			[],
+			[
+				makeThreadSummary({
+					_id: 'thread-record-completed-newer' as ThreadSummary['_id'],
+					threadId: 'thread-record-completed-newer' as ThreadSummary['threadId'],
+					lastMessageAt: 30
+				}),
+				makeThreadSummary({
+					_id: 'thread-record-running-older' as ThreadSummary['_id'],
+					threadId: 'thread-record-running-older' as ThreadSummary['threadId'],
+					lastMessageAt: 10,
+					hasActiveRun: true
+				}),
+				makeThreadSummary({
+					_id: 'thread-record-running-newer' as ThreadSummary['_id'],
+					threadId: 'thread-record-running-newer' as ThreadSummary['threadId'],
+					lastMessageAt: 20,
+					hasActiveRun: true
+				})
+			]
+		);
+
+		expect(groups[0]?.threads.map((thread) => thread.threadId)).toEqual([
+			'thread-record-running-newer',
+			'thread-record-running-older',
+			'thread-record-completed-newer'
+		]);
+	});
+
 	it('finds a workspace session by exact name', () => {
 		const session = findWorkspaceSessionByName(
 			[

--- a/apps/web/src/lib/workspace/threads.ts
+++ b/apps/web/src/lib/workspace/threads.ts
@@ -72,7 +72,7 @@ export function getWorkspaceThreadGroups(
 		.map((group) => ({
 			...group,
 			activeThreadCount: countActiveThreads(group.threads),
-			threads: [...group.threads].sort((left, right) => right.lastMessageAt - left.lastMessageAt)
+			threads: sortThreadsRunningFirst(group.threads)
 		}))
 		.sort((left, right) => {
 			const leftSortKey = left.latestThreadAt || left.lastSeenAt;
@@ -83,6 +83,16 @@ export function getWorkspaceThreadGroups(
 
 			return left.workspaceName.localeCompare(right.workspaceName);
 		});
+}
+
+function sortThreadsRunningFirst(threads: ThreadSummary[]) {
+	return [...threads].sort((left, right) => {
+		if (left.hasActiveRun !== right.hasActiveRun) {
+			return Number(right.hasActiveRun) - Number(left.hasActiveRun);
+		}
+
+		return right.lastMessageAt - left.lastMessageAt;
+	});
 }
 
 function countActiveThreads(threads: ThreadSummary[]) {


### PR DESCRIPTION
## Summary
- show running threads before completed threads within each project
- preserve recency ordering within each state
- add regression coverage for the project thread ordering

## Validation
- `nix develop -c bun --filter @sprocket/web test -- src/lib/workspace/threads.test.ts`
- `nix develop -c bun --filter @sprocket/web check`
- `nix develop -c bunx prettier --check apps/web/src/lib/workspace/threads.ts apps/web/src/lib/workspace/threads.test.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prioritizes running threads within each project. The main changes are:

- Sort running threads before completed threads.
- Preserve descending recency within each state.
- Add tests for the updated ordering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the focused Vitest run completed with exit status 0.
- Captured the complete focused Vitest output in the log artifact to enable review of the test results.
- Confirmed validation stopped after the HEAD command passed, with no unrelated suites or services started.

<a href="https://app.greptile.com/trex/runs/15338899/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/workspace/threads.ts | Adds a non-mutating comparator that prioritizes active runs before sorting by message recency. |
| apps/web/src/lib/workspace/threads.test.ts | Tests running-first ordering and recency ordering within the running state. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Prioritize running project thr..."](https://github.com/spikonado/sprocket/commit/3ab608df7e600a5c0aa30fc546634c3f0f66b7e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46146153)</sub>

<!-- /greptile_comment -->