### PR TITLE
feat(agent): Increase agent turn limit

### DIFF
--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -12,7 +12,7 @@ use crate::hooks::{AgentPromptHook, ToolCallTracker};
 use crate::tools::agent_tools;
 use crate::types::RunContextResponse;
 
-const AGENT_MAX_TURNS: usize = 75;
+const AGENT_MAX_TURNS: usize = 1_000;
 const MAX_INVALID_TOOL_CALL_RETRIES: usize = 3;
 
 /// Must match `RUN_CANCELLED_BY_USER` in `apps/web/src/convex/lib/agentErrors.ts`.


### PR DESCRIPTION
## Summary
- Raise the agent maximum turn limit from 75 to 1,000.

## Testing
- `nix develop -c cargo test -p sprocket-agent`
- pre-commit hooks (`cargo-fmt`, `cargo-check`, ESLint, svelte-check, Prettier)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR allows agent runs to continue for substantially more turns. The main change is:

- Raises the maximum agent turn count from 75 to 1,000.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is mergeable after adding a guard for conversation growth.

Long tool-heavy runs can exceed the model context window before reaching the new turn limit.

crates/sprocket-agent/src/provider.rs; existing cancellation, lease renewal, and provider error handling remain unchanged.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the narrow agent-max-turns package test and observed an exit status of 0.
- Reviewed the command transcript and test summary in the agent-max-turns-package-test-02-after log to confirm the results.
- Concluded validation stopped after the narrow package test produced a passing proof.

<a href="https://app.greptile.com/trex/runs/15342638/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/provider.rs | Raises the agent turn limit to 1,000 without adding a token-aware bound for accumulated conversation history. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
crates/sprocket-agent/src/provider.rs:15
**Conversation History Exceeds Context Limit**

When a tool-heavy run continues beyond the old 75-turn limit, each response and tool result remains in the conversation history. Without a token-aware limit or history compaction, the growing prompt can exceed the model's context window well before turn 1,000, causing an otherwise valid run to fail after consuming many prior completions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Increase agent turn limit"](https://github.com/spikonado/sprocket/commit/20fb57f625e42a581fb0bf5567d3109cc1156a80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46153171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->