### PR TITLE
fix(web): Keep agent auth monitor alive

### DIFF
--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -136,21 +136,61 @@ describe('launchAgentRun', () => {
 		expect(getAccessToken).toHaveBeenCalledWith({ forceRefreshToken: true });
 	});
 
-	it('treats a missing auth session as complete after launch acknowledgement', async () => {
-		const authStatus = deferred<AgentAuthStatus>();
-		const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
-		vi.mocked(desktopApi.waitForAgentAuthRefresh).mockReturnValue(authStatus.promise);
-		const onError = vi.fn();
-		const onStarted = vi.fn();
+	it('rechecks a missing auth session delivered after launch acknowledgement', async () => {
+		vi.useFakeTimers();
+		try {
+			const staleStatus = deferred<AgentAuthStatus>();
+			const activeStatus = deferred<AgentAuthStatus>();
+			const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
+			vi.mocked(desktopApi.waitForAgentAuthRefresh)
+				.mockReturnValueOnce(staleStatus.promise)
+				.mockReturnValueOnce(activeStatus.promise);
+			const getAccessToken = vi.fn().mockResolvedValue('token-2');
+			const onError = vi.fn();
+			const onStarted = vi.fn();
 
-		launchAgentRun(launchArgs({ desktopApi, onError, onStarted }));
+			launchAgentRun(launchArgs({ desktopApi, getAccessToken, onError, onStarted }));
 
-		await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
-		authStatus.resolve('notFound');
-		await authStatus.promise;
-		await Promise.resolve();
+			await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
+			staleStatus.resolve('notFound');
+			await staleStatus.promise;
+			await vi.advanceTimersByTimeAsync(250);
+			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(2);
 
-		expect(onError).not.toHaveBeenCalled();
+			activeStatus.resolve('refreshRequired');
+			await activeStatus.promise;
+			await vi.waitFor(() => {
+				expect(desktopApi.refreshAgentAuth).toHaveBeenCalledWith(expect.any(String), 'token-2');
+			});
+			expect(onError).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('stops polling after a missing session is confirmed following launch', async () => {
+		vi.useFakeTimers();
+		try {
+			const staleStatus = deferred<AgentAuthStatus>();
+			const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
+			vi.mocked(desktopApi.waitForAgentAuthRefresh)
+				.mockReturnValueOnce(staleStatus.promise)
+				.mockResolvedValue('notFound');
+			const onError = vi.fn();
+			const onStarted = vi.fn();
+
+			launchAgentRun(launchArgs({ desktopApi, onError, onStarted }));
+
+			await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
+			staleStatus.resolve('notFound');
+			await staleStatus.promise;
+			await vi.advanceTimersByTimeAsync(4_000);
+
+			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(2);
+			expect(onError).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('keeps polling while launch is pending and the auth session is not ready yet', async () => {
@@ -175,12 +215,14 @@ describe('launchAgentRun', () => {
 		}
 	});
 
-	it('surfaces the launch error when the auth session never appears', async () => {
+	it('surfaces the launch error and stops auth polling when the local API is unavailable', async () => {
 		vi.useFakeTimers();
 		try {
 			const launch = deferred<{ runId: never }>();
 			const desktopApi = createDesktopApi(vi.fn().mockReturnValue(launch.promise));
-			vi.mocked(desktopApi.waitForAgentAuthRefresh).mockResolvedValue('notFound');
+			vi.mocked(desktopApi.waitForAgentAuthRefresh).mockRejectedValue(
+				new Error('local API unavailable')
+			);
 			const onError = vi.fn();
 			const launchError = new Error('desktop launch failed');
 
@@ -191,6 +233,9 @@ describe('launchAgentRun', () => {
 				expect(onError).toHaveBeenCalledWith(launchError);
 			});
 			expect(onError).toHaveBeenCalledOnce();
+			const pollCountAfterFailure = vi.mocked(desktopApi.waitForAgentAuthRefresh).mock.calls.length;
+			await vi.advanceTimersByTimeAsync(4_000);
+			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(pollCountAfterFailure);
 		} finally {
 			vi.useRealTimers();
 		}

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -108,8 +108,12 @@ export function launchAgentRun(args: {
 		args.onError(error);
 	};
 	const handleMonitorError = async (error: unknown) => {
-		if (launchState.status === 'pending') await launchState.settled;
-		if (launchState.status === 'failed') reportError(error);
+		await launchState.settled;
+		if (launchState.status === 'failed') {
+			reportError(error);
+			return;
+		}
+		console.error('Agent authentication monitor stopped', error);
 	};
 
 	void monitorAgentAuthSession({
@@ -159,23 +163,34 @@ async function monitorAgentAuthSession(args: {
 }) {
 	let pendingToken: string | null = null;
 	let retryDelayMs = AGENT_AUTH_INITIAL_RETRY_DELAY_MS;
+	let missingSessionObservedAfterLaunch = false;
+	const launchFailed = () => args.launchState.status === 'failed';
 
 	while (true) {
 		let status: AgentAuthStatus;
 		try {
 			status = await args.desktopApi.waitForAgentAuthRefresh(args.authSessionId);
 		} catch {
+			if (launchFailed()) return;
 			retryDelayMs = await backoff(retryDelayMs);
+			if (launchFailed()) return;
 			continue;
 		}
 
 		if (status === 'complete') return;
 		if (status === 'notFound') {
-			// Pending: session may not be created yet. Otherwise the run already settled.
-			if (args.launchState.status !== 'pending') return;
+			if (args.launchState.status === 'failed') return;
+			if (args.launchState.status === 'acknowledged') {
+				// This response may have been produced before runAgent created the session,
+				// then delivered after the launch acknowledgement. Recheck once so that
+				// race cannot silently disable token refresh for the rest of the run.
+				if (missingSessionObservedAfterLaunch) return;
+				missingSessionObservedAfterLaunch = true;
+			}
 			retryDelayMs = await backoff(retryDelayMs);
 			continue;
 		}
+		missingSessionObservedAfterLaunch = false;
 
 		if (!pendingToken) {
 			assertAgentRunUser(args.expectedUserId, args.getCurrentUserId());


### PR DESCRIPTION
## Summary

- recheck auth sessions when a pre-creation `notFound` response arrives after an agent launch is acknowledged
- keep token refresh monitoring active across the launch race so long-running run claims continue renewing
- stop failed-launch polling loops and log post-launch monitor failures
- cover stale responses, confirmed completion, refresh recovery, and local API failures

## Root cause

The browser starts the auth refresh long-poll concurrently with the local agent launch. A poll can return `notFound` before the server creates the auth session, but be processed after the launch is acknowledged. The UI previously treated that stale response as proof that the run had finished and permanently stopped monitoring. When the delegated token later expired, the server could not request a fresh token, claim renewal stopped, and the UI eventually showed “The previous agent stopped responding.”

## Validation

- `nix develop -c bun run --cwd apps/web test -- src/lib/home/desktop.test.ts` — 22 tests passed
- `nix develop -c bun run --cwd apps/web check` — 0 errors and 0 warnings
- `nix develop -c prek run -a` — all hooks passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps desktop agent authentication monitoring active through the launch race. The main changes are:

- Rechecks a stale `notFound` response after launch acknowledgement.
- Stops polling after a second confirmed missing-session response.
- Stops retrying when the agent launch fails.
- Adds tests for stale responses, refresh recovery, completion, and local API failures.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The confirmation poll matches the sequential request flow and session creation order.
- Launch failures stop the monitor without reporting duplicate errors.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/home/desktop.ts | Adds one confirmation poll for a post-launch missing auth session and terminates retries after launch failure. |
| apps/web/src/lib/home/desktop.test.ts | Covers stale missing-session responses, confirmed completion, token refresh recovery, and local API failure shutdown. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Web
    participant Monitor
    participant Desktop
    par Launch
        Web->>Desktop: Start agent run
        Desktop->>Desktop: Create auth session
        Desktop-->>Web: Launch acknowledged
    and Initial poll
        Monitor->>Desktop: Wait for auth refresh
        Desktop-->>Monitor: notFound (pre-creation response)
    end
    Monitor->>Desktop: Recheck after backoff
    Desktop-->>Monitor: refreshRequired or notFound
    alt Session is active
        Monitor->>Desktop: Send refreshed token
        Monitor->>Desktop: Continue monitoring
    else Session remains missing
        Monitor->>Monitor: Stop polling
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Keep agent auth monitor alive"](https://github.com/spikonado/sprocket/commit/11250ef92b3dca9b44d54a3fc9c9c35ca3e57005) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46253523)</sub>

<!-- /greptile_comment -->