### PR TITLE
feat(web): Add automatic context compaction

### DIFF
--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -99,7 +99,7 @@ describe('agentRuntime context accounting', () => {
 
 	it('carries a compacted prefix into later runs without replaying covered history', async () => {
 		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
+		const { asUser, threadId, workspaceSessionId } = await seedOwnedThread(t);
 		const first = await asUser.mutation(api.agentRuntime.createRun, {
 			submissionId: 'context-first',
 			threadId,
@@ -133,6 +133,20 @@ describe('agentRuntime context accounting', () => {
 			claimId: 'claim-2',
 			attemptSeq: 1
 		});
+		await t.run(async (ctx) => {
+			await ctx.db.insert('runs', {
+				threadId,
+				userId: 'user_alice',
+				submissionId: 'context-concurrent-later',
+				workspaceSessionId,
+				status: 'completed',
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				startedAt: Date.now() + 1_000,
+				completedAt: Date.now() + 1_001
+			});
+		});
 		await asUser.mutation(api.agentRuntime.saveContextCompaction, {
 			runId: second.runId,
 			claimId: 'claim-2',
@@ -142,6 +156,9 @@ describe('agentRuntime context accounting', () => {
 			processedTokens: 100,
 			persistForFutureRuns: true
 		});
+		expect(
+			await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextSummaryThroughRunId)
+		).toBe(first.runId);
 		await asUser.mutation(api.agentRuntime.finalizeRun, {
 			runId: second.runId,
 			expectedStatus: 'running',

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('agentRuntime context accounting', () => {
+	it('fences compaction and usage writes to the current completion attempt', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'context-run',
+			threadId,
+			prompt: 'Continue the long task',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		await asUser.mutation(api.agentRuntime.start, { runId, claimId: 'claim-a' });
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId,
+			claimId: 'claim-a',
+			attemptSeq: 1
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.saveContextCompaction, {
+				runId,
+				claimId: 'claim-a',
+				attemptSeq: 1,
+				summary: 'The setup is complete; implementation remains.',
+				messageCount: 12,
+				processedTokens: 250_000,
+				persistForFutureRuns: false
+			})
+		).resolves.toBe(true);
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				attemptSeq: 1,
+				contextTokens: 8_000,
+				processedTokens: 9_000
+			})
+		).resolves.toBe(true);
+
+		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
+		expect(thread).toMatchObject({
+			contextTokens: 8_000,
+			totalTokensProcessed: 259_000
+		});
+
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId,
+			claimId: 'claim-a',
+			attemptSeq: 2
+		});
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				attemptSeq: 1,
+				contextTokens: 99_000,
+				processedTokens: 99_000
+			})
+		).resolves.toBe(false);
+		expect(await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextTokens)).toBe(8_000);
+	});
+
+	it('rejects invalid token accounting values', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'invalid-context-usage',
+			threadId,
+			prompt: 'Continue',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		await asUser.mutation(api.agentRuntime.start, { runId, claimId: 'claim-a' });
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId,
+			claimId: 'claim-a',
+			attemptSeq: 1
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				attemptSeq: 1,
+				contextTokens: -1,
+				processedTokens: 10
+			})
+		).rejects.toThrow('Invalid token count.');
+		expect(await t.run(async (ctx) => ctx.db.get(threadId))).not.toHaveProperty('contextTokens');
+	});
+
+	it('carries a compacted prefix into later runs without replaying covered history', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const first = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'context-first',
+			threadId,
+			prompt: 'Old prompt that should be covered',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		await asUser.mutation(api.agentRuntime.start, { runId: first.runId, claimId: 'claim-1' });
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId: first.runId,
+			expectedStatus: 'running',
+			expectedClaimId: 'claim-1',
+			text: 'Old work completed',
+			status: 'completed'
+		});
+
+		const second = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'context-second',
+			threadId,
+			prompt: 'New prompt',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		await asUser.mutation(api.agentRuntime.start, { runId: second.runId, claimId: 'claim-2' });
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId: second.runId,
+			claimId: 'claim-2',
+			attemptSeq: 1
+		});
+		await asUser.mutation(api.agentRuntime.saveContextCompaction, {
+			runId: second.runId,
+			claimId: 'claim-2',
+			attemptSeq: 1,
+			summary: 'The old work is complete.',
+			messageCount: 2,
+			processedTokens: 100,
+			persistForFutureRuns: true
+		});
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId: second.runId,
+			expectedStatus: 'running',
+			expectedClaimId: 'claim-2',
+			text: 'Second work completed',
+			status: 'completed'
+		});
+
+		const third = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'context-third',
+			threadId,
+			prompt: 'Third prompt',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		const context = await asUser.query(api.agentRuntime.getContext, { runId: third.runId });
+		const serialized = JSON.stringify(context.agentHistory);
+		expect(serialized).toContain('The old work is complete.');
+		expect(serialized).not.toContain('Old prompt that should be covered');
+		expect(serialized).toContain('New prompt');
+	});
+});

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,25 +1,50 @@
 import { describe, expect, it } from 'vitest';
 import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { executionSecretHash } from '@convex/lib/auth';
 import { initConvexTest, seedOwnedThread } from './test.setup';
+
+async function createQueuedRun(
+	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
+	threadId: Id<'threadRecords'>,
+	submissionId: string,
+	executionSecret: string,
+	prompt: string
+) {
+	return await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId,
+		threadId,
+		prompt,
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard',
+		executionSecret
+	});
+}
 
 describe('agentRuntime context accounting', () => {
 	it('fences compaction and usage writes to the current completion attempt', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
-			submissionId: 'context-run',
+		const executionSecret = 'context-run-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
 			threadId,
-			prompt: 'Continue the long task',
-			imageUploadIds: [],
-			selectedModel: 'gpt-5.6-sol',
-			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			'context-run',
+			executionSecret,
+			'Continue the long task'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
 		});
-		await asUser.mutation(api.agentRuntime.start, { runId, claimId: 'claim-a' });
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId,
 			claimId: 'claim-a',
-			attemptSeq: 1
+			attemptSeq: 1,
+			executionSecret
 		});
 
 		await expect(
@@ -52,7 +77,8 @@ describe('agentRuntime context accounting', () => {
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId,
 			claimId: 'claim-a',
-			attemptSeq: 2
+			attemptSeq: 2,
+			executionSecret
 		});
 		await expect(
 			asUser.mutation(api.agentRuntime.recordContextUsage, {
@@ -69,20 +95,24 @@ describe('agentRuntime context accounting', () => {
 	it('rejects invalid token accounting values', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
-			submissionId: 'invalid-context-usage',
+		const executionSecret = 'invalid-context-usage-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
 			threadId,
-			prompt: 'Continue',
-			imageUploadIds: [],
-			selectedModel: 'gpt-5.6-sol',
-			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			'invalid-context-usage',
+			executionSecret,
+			'Continue'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
 		});
-		await asUser.mutation(api.agentRuntime.start, { runId, claimId: 'claim-a' });
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId,
 			claimId: 'claim-a',
-			attemptSeq: 1
+			attemptSeq: 1,
+			executionSecret
 		});
 
 		await expect(
@@ -100,16 +130,19 @@ describe('agentRuntime context accounting', () => {
 	it('carries a compacted prefix into later runs without replaying covered history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId, workspaceSessionId } = await seedOwnedThread(t);
-		const first = await asUser.mutation(api.agentRuntime.createRun, {
-			submissionId: 'context-first',
+		const firstSecret = 'context-first-secret';
+		const first = await createQueuedRun(
+			asUser,
 			threadId,
-			prompt: 'Old prompt that should be covered',
-			imageUploadIds: [],
-			selectedModel: 'gpt-5.6-sol',
-			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			'context-first',
+			firstSecret,
+			'Old prompt that should be covered'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId: first.runId,
+			claimId: 'claim-1',
+			executionSecret: firstSecret
 		});
-		await asUser.mutation(api.agentRuntime.start, { runId: first.runId, claimId: 'claim-1' });
 		await asUser.mutation(api.agentRuntime.finalizeRun, {
 			runId: first.runId,
 			expectedStatus: 'running',
@@ -118,20 +151,24 @@ describe('agentRuntime context accounting', () => {
 			status: 'completed'
 		});
 
-		const second = await asUser.mutation(api.agentRuntime.createRun, {
-			submissionId: 'context-second',
+		const secondSecret = 'context-second-secret';
+		const second = await createQueuedRun(
+			asUser,
 			threadId,
-			prompt: 'New prompt',
-			imageUploadIds: [],
-			selectedModel: 'gpt-5.6-sol',
-			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			'context-second',
+			secondSecret,
+			'New prompt'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId: second.runId,
+			claimId: 'claim-2',
+			executionSecret: secondSecret
 		});
-		await asUser.mutation(api.agentRuntime.start, { runId: second.runId, claimId: 'claim-2' });
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId: second.runId,
 			claimId: 'claim-2',
-			attemptSeq: 1
+			attemptSeq: 1,
+			executionSecret: secondSecret
 		});
 		await t.run(async (ctx) => {
 			await ctx.db.insert('runs', {
@@ -140,6 +177,7 @@ describe('agentRuntime context accounting', () => {
 				submissionId: 'context-concurrent-later',
 				workspaceSessionId,
 				status: 'completed',
+				executionSecretHash: await executionSecretHash('context-concurrent-later-secret'),
 				selectedModel: 'gpt-5.6-sol',
 				reasoningEffort: 'medium',
 				serviceTier: 'standard',
@@ -167,16 +205,18 @@ describe('agentRuntime context accounting', () => {
 			status: 'completed'
 		});
 
-		const third = await asUser.mutation(api.agentRuntime.createRun, {
-			submissionId: 'context-third',
+		const thirdSecret = 'context-third-secret';
+		const third = await createQueuedRun(
+			asUser,
 			threadId,
-			prompt: 'Third prompt',
-			imageUploadIds: [],
-			selectedModel: 'gpt-5.6-sol',
-			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			'context-third',
+			thirdSecret,
+			'Third prompt'
+		);
+		const context = await asUser.query(api.agentRuntime.getContext, {
+			runId: third.runId,
+			executionSecret: thirdSecret
 		});
-		const context = await asUser.query(api.agentRuntime.getContext, { runId: third.runId });
 		const serialized = JSON.stringify(context.agentHistory);
 		expect(serialized).toContain('The old work is complete.');
 		expect(serialized).not.toContain('Old prompt that should be covered');

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -565,7 +565,13 @@ export const saveContextCompaction = mutation({
 				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', run.threadId))
 				.collect();
 			const previousRun = runs
-				.filter((candidate) => candidate._id !== run._id && isRunFinalStatus(candidate.status))
+				.filter(
+					(candidate) =>
+						isRunFinalStatus(candidate.status) &&
+						(candidate.startedAt < run.startedAt ||
+							(candidate.startedAt === run.startedAt &&
+								candidate._creationTime < run._creationTime))
+				)
 				.sort(
 					(left, right) =>
 						right.startedAt - left.startedAt || right._creationTime - left._creationTime

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -9,6 +9,7 @@ import {
 	type SupportedServiceTier
 } from '@convex/lib/models';
 import { buildCanonicalAgentHistory } from '@convex/lib/agentHistory';
+import { contextSummaryText } from '@convex/lib/contextCompaction';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import {
 	areImageUploadIdsEqual,
@@ -350,7 +351,13 @@ export const start = mutation({
 			status: isSameClaimRenewal ? run.status : 'running',
 			lastError: undefined,
 			...(isSameClaimRenewal ? {} : { completionAttemptSeq: 0 }),
-			...(isTakeover ? { activeJobId: undefined } : {})
+			...(isTakeover
+				? {
+						activeJobId: undefined,
+						contextSummary: undefined,
+						contextSummaryMessageCount: undefined
+					}
+				: {})
 		});
 
 		return { claimed: true, claimExpiresAt: nextClaimExpiresAt };
@@ -412,10 +419,41 @@ export const getContext = query({
 			.query('executorJobs')
 			.withIndex('by_threadId_sequence', (query) => query.eq('threadId', run.threadId))
 			.collect();
-		const agentHistory: AgentHistoryMessage[] = buildCanonicalAgentHistory({
-			messages: messages.filter((message) => message.runId !== run._id),
-			jobs: jobs.filter((job) => job.runId !== run._id)
-		});
+		let historyRunIds: Set<Id<'runs'>> | undefined;
+		if (threadRecord.contextSummaryThroughRunId) {
+			const runs = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', run.threadId))
+				.collect();
+			const ordered = runs.sort(
+				(left, right) =>
+					left.startedAt - right.startedAt || left._creationTime - right._creationTime
+			);
+			const cutoffIndex = ordered.findIndex(
+				(candidate) => candidate._id === threadRecord.contextSummaryThroughRunId
+			);
+			if (cutoffIndex >= 0) {
+				historyRunIds = new Set(ordered.slice(cutoffIndex + 1).map((candidate) => candidate._id));
+			}
+		}
+		const includeInHistory = (candidateRunId: Id<'runs'>) =>
+			candidateRunId !== run._id && (!historyRunIds || historyRunIds.has(candidateRunId));
+		const agentHistory: AgentHistoryMessage[] = [
+			...(threadRecord.contextSummary
+				? [
+						{
+							role: 'user' as const,
+							contents: [
+								{ type: 'text' as const, text: contextSummaryText(threadRecord.contextSummary) }
+							]
+						}
+					]
+				: []),
+			...buildCanonicalAgentHistory({
+				messages: messages.filter((message) => includeInHistory(message.runId)),
+				jobs: jobs.filter((job) => includeInHistory(job.runId))
+			})
+		];
 		const promptMessage = messages.find(
 			(message) => message.runId === run._id && message.type === 'prompt'
 		);
@@ -469,10 +507,15 @@ export const completionActor = query({
 		completionAttemptSeq: number;
 		streamSequence: number;
 		streamAttemptId?: string;
+		contextTokens: number;
+		totalTokensProcessed: number;
+		contextSummary?: string;
+		contextSummaryMessageCount?: number;
 	}> => {
 		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const userId = run.userId;
 		const streamState = await getCompletionStreamState(ctx, run);
+		const thread = await getOwnedThreadRecord(ctx.db, userId, run.threadId);
 		return {
 			userId,
 			threadId: run.threadId,
@@ -481,10 +524,100 @@ export const completionActor = query({
 			...(run.claimExpiresAt ? { claimExpiresAt: run.claimExpiresAt } : {}),
 			completionAttemptSeq: run.completionAttemptSeq ?? 0,
 			streamSequence: streamState.sequence,
-			...(streamState.streamAttemptId ? { streamAttemptId: streamState.streamAttemptId } : {})
+			...(streamState.streamAttemptId ? { streamAttemptId: streamState.streamAttemptId } : {}),
+			contextTokens: thread.contextTokens ?? 0,
+			totalTokensProcessed: thread.totalTokensProcessed ?? 0,
+			...(run.contextSummary ? { contextSummary: run.contextSummary } : {}),
+			...(run.contextSummaryMessageCount !== undefined
+				? { contextSummaryMessageCount: run.contextSummaryMessageCount }
+				: {})
 		};
 	}
 });
+
+export const saveContextCompaction = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		attemptSeq: v.number(),
+		summary: v.string(),
+		messageCount: v.number(),
+		processedTokens: v.number(),
+		persistForFutureRuns: v.boolean()
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const userId = await getUserId(ctx);
+		const run = await getOwnedRun(ctx.db, userId, args.runId);
+		if (!isCurrentCompletionAttempt(run, args.claimId, args.attemptSeq)) return false;
+		if (!args.summary.trim() || !Number.isSafeInteger(args.messageCount) || args.messageCount < 0) {
+			throw new Error('Invalid context compaction.');
+		}
+		assertValidTokenCount(args.processedTokens);
+		const thread = await getOwnedThreadRecord(ctx.db, userId, run.threadId);
+		await ctx.db.patch(run._id, {
+			contextSummary: args.summary,
+			contextSummaryMessageCount: args.messageCount
+		});
+		let contextSummaryThroughRunId = thread.contextSummaryThroughRunId;
+		if (args.persistForFutureRuns) {
+			const runs = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', run.threadId))
+				.collect();
+			const previousRun = runs
+				.filter((candidate) => candidate._id !== run._id && isRunFinalStatus(candidate.status))
+				.sort(
+					(left, right) =>
+						right.startedAt - left.startedAt || right._creationTime - left._creationTime
+				)[0];
+			contextSummaryThroughRunId = previousRun?._id;
+		}
+		await ctx.db.patch(thread._id, {
+			...(args.persistForFutureRuns
+				? { contextSummary: args.summary, contextSummaryThroughRunId }
+				: {}),
+			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed ?? 0, args.processedTokens)
+		});
+		return true;
+	}
+});
+
+export const recordContextUsage = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		attemptSeq: v.number(),
+		contextTokens: v.number(),
+		processedTokens: v.number()
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const userId = await getUserId(ctx);
+		const run = await getOwnedRun(ctx.db, userId, args.runId);
+		if (!isCurrentCompletionAttempt(run, args.claimId, args.attemptSeq)) return false;
+		assertValidTokenCount(args.contextTokens);
+		assertValidTokenCount(args.processedTokens);
+		const thread = await getOwnedThreadRecord(ctx.db, userId, run.threadId);
+		await ctx.db.patch(thread._id, {
+			contextTokens: args.contextTokens,
+			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed ?? 0, args.processedTokens)
+		});
+		return true;
+	}
+});
+
+function assertValidTokenCount(value: number): void {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error('Invalid token count.');
+	}
+}
+
+function addTokenCounts(left: number, right: number): number {
+	assertValidTokenCount(left);
+	assertValidTokenCount(right);
+	const total = left + right;
+	assertValidTokenCount(total);
+	return total;
+}
 
 export const registerCompletionAttempt = mutation({
 	args: {

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -14,6 +14,7 @@ import { vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators
 import {
 	assertSupportedModelConfiguration,
 	defaultServiceTier,
+	getModelDefinition,
 	normalizeCompletionUsage,
 	type SupportedModelId,
 	type SupportedReasoningEffort,
@@ -28,6 +29,12 @@ import {
 	upsertCompletionReasoningEvent,
 	upsertCompletionTextEvent
 } from '@convex/lib/completionStream';
+import {
+	applyContextCompaction,
+	CONTEXT_COMPACTION_INSTRUCTIONS,
+	estimateContextTokens,
+	shouldCompactContext
+} from '@convex/lib/contextCompaction';
 
 type JsonSchema = Parameters<typeof jsonSchema>[0];
 type ToolChoice = NonNullable<Parameters<typeof generateText>[0]['toolChoice']>;
@@ -46,6 +53,7 @@ const COMPLETION_STREAM_FLUSH_INTERVAL_MS = 250;
 // AI SDK retries only retryable provider failures and honors Retry-After headers.
 // Allow a longer recovery window for short provider rate-limit bursts.
 const MODEL_PROVIDER_MAX_RETRIES = 5;
+const COMPACTION_MAX_OUTPUT_TOKENS = 12_000;
 
 export const complete = action({
 	args: {
@@ -132,17 +140,109 @@ export const complete = action({
 			args.streamRunId,
 			args.executionSecret
 		);
+		const completionAttempt: CompletionAttempt = {
+			runId: args.streamRunId,
+			claimId: args.claimId,
+			attemptSeq: args.attemptSeq,
+			streamId: args.streamId,
+			executionSecret: args.executionSecret,
+			initialSequence: completionContext.streamSequence
+		};
 		const sharedArgs = buildSharedCompletionRequest(
 			{ ...args, modelId, serviceTier },
 			tools,
 			toolChoice,
 			completionContext.promptCacheKey
 		);
+		let effectiveMessages =
+			messages === undefined
+				? undefined
+				: applyContextCompaction(
+						messages,
+						completionContext.contextSummary !== undefined &&
+							completionContext.contextSummaryMessageCount !== undefined
+							? {
+									summary: completionContext.contextSummary,
+									messageCount: completionContext.contextSummaryMessageCount
+								}
+							: undefined
+					);
+		const autoCompactTokenLimit = getModelDefinition(modelId).autoCompactTokenLimit;
+		if (
+			effectiveMessages &&
+			shouldCompactContext({
+				inputTokens: completionContext.contextTokens,
+				autoCompactTokenLimit,
+				messages: effectiveMessages
+			})
+		) {
+			let messagesToCompact = effectiveMessages;
+			let compactedMessageCount = messages?.length ?? 0;
+			let persistForFutureRuns = false;
+			if (completionContext.contextSummary === undefined && messages) {
+				const currentRunStart = messages.findLastIndex((message) => message.role === 'user');
+				const currentRunMessages = messages.slice(currentRunStart);
+				if (
+					currentRunStart > 0 &&
+					estimateContextTokens(currentRunMessages) + COMPACTION_MAX_OUTPUT_TOKENS <
+						autoCompactTokenLimit
+				) {
+					messagesToCompact = messages.slice(0, currentRunStart);
+					compactedMessageCount = currentRunStart;
+					persistForFutureRuns = true;
+				}
+			}
+			const compactionAbortController = new AbortController();
+			const compaction = await waitForCompletionWithAcceptance(
+				ctx,
+				generateText({
+					model: resolveLanguageModel(modelId, serviceTier, completionContext.promptCacheKey),
+					instructions: CONTEXT_COMPACTION_INSTRUCTIONS,
+					messages: messagesToCompact,
+					maxOutputTokens: COMPACTION_MAX_OUTPUT_TOKENS,
+					maxRetries: MODEL_PROVIDER_MAX_RETRIES,
+					providerOptions: resolveProviderOptions(
+						modelId,
+						args.reasoningEffort,
+						serviceTier,
+						completionContext.promptCacheKey
+					),
+					abortSignal: compactionAbortController.signal
+				}),
+				completionAttempt,
+				compactionAbortController
+			);
+			const summary = compaction.text.trim();
+			if (!summary) throw new Error('The model returned an empty context summary.');
+			const compactionTokens = normalizeCompletionUsage(compaction.usage);
+			await assertCompletionStillAccepted(ctx, completionAttempt);
+			await chargeModelUsage(ctx, {
+				userId: completionContext.userId,
+				modelId,
+				serviceTier,
+				tokens: compactionTokens
+			});
+			const saved = await ctx.runMutation(api.agentRuntime.saveContextCompaction, {
+				runId: args.streamRunId,
+				claimId: args.claimId,
+				attemptSeq: args.attemptSeq,
+				summary,
+				messageCount: compactedMessageCount,
+				processedTokens: totalProcessedTokens(compactionTokens),
+				persistForFutureRuns
+			});
+			if (!saved) throw new Error(COMPLETION_STREAM_SUPERSEDED);
+			await checkModelUsageLimit(ctx, completionContext.userId);
+			effectiveMessages = applyContextCompaction(messages ?? [], {
+				summary,
+				messageCount: compactedMessageCount
+			});
+		}
 		let request: CompletionRequest;
 		if (args.prompt !== undefined) {
 			request = buildCompletionRequest(sharedArgs, args.prompt, undefined);
-		} else if (messages !== undefined) {
-			request = buildCompletionRequest(sharedArgs, undefined, messages);
+		} else if (effectiveMessages !== undefined) {
+			request = buildCompletionRequest(sharedArgs, undefined, effectiveMessages);
 		} else {
 			throw new Error('Either prompt or messagesJson is required.');
 		}
@@ -153,26 +253,28 @@ export const complete = action({
 			result = await collectStreamingCompletion(
 				ctx,
 				streamText({ ...request, abortSignal: abortController.signal }),
-				{
-					runId: args.streamRunId,
-					claimId: args.claimId,
-					attemptSeq: args.attemptSeq,
-					streamId: args.streamId,
-					executionSecret: args.executionSecret,
-					initialSequence: completionContext.streamSequence
-				},
+				completionAttempt,
 				abortController
 			);
 		} catch (error) {
 			abortController.abort(error);
 			throw error;
 		}
+		const completionTokens = normalizeCompletionUsage(result.usage);
 		await chargeModelUsage(ctx, {
 			userId: completionContext.userId,
 			modelId,
 			serviceTier,
-			tokens: normalizeCompletionUsage(result.usage)
+			tokens: completionTokens
 		});
+		const usageRecorded = await ctx.runMutation(api.agentRuntime.recordContextUsage, {
+			runId: args.streamRunId,
+			claimId: args.claimId,
+			attemptSeq: args.attemptSeq,
+			contextTokens: totalProcessedTokens(completionTokens),
+			processedTokens: totalProcessedTokens(completionTokens)
+		});
+		if (!usageRecorded) throw new Error(COMPLETION_STREAM_SUPERSEDED);
 
 		return {
 			text: result.text,
@@ -542,6 +644,27 @@ async function assertCompletionStillAccepted(
 	}
 }
 
+async function waitForCompletionWithAcceptance<T>(
+	ctx: ActionCtx,
+	completion: Promise<T>,
+	attempt: CompletionAttempt,
+	abortController: AbortController
+): Promise<T> {
+	while (true) {
+		const outcome = await Promise.race([
+			completion.then((value) => ({ type: 'completed' as const, value })),
+			delay(COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS).then(() => ({ type: 'check' as const }))
+		]);
+		if (outcome.type === 'completed') return outcome.value;
+		try {
+			await assertCompletionStillAccepted(ctx, attempt);
+		} catch (error) {
+			abortController.abort(error);
+			throw error;
+		}
+	}
+}
+
 function toolPartId(streamId: string, toolCallId: string): string {
 	return `${streamId}:tool:${toolCallId}`;
 }
@@ -561,7 +684,14 @@ async function prepareCompletionContext(
 	ctx: ActionCtx,
 	runId: Id<'runs'>,
 	executionSecret: string
-): Promise<{ promptCacheKey: string; streamSequence: number; userId: string }> {
+): Promise<{
+	promptCacheKey: string;
+	streamSequence: number;
+	userId: string;
+	contextTokens: number;
+	contextSummary?: string;
+	contextSummaryMessageCount?: number;
+}> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
 		runId,
 		executionSecret
@@ -571,8 +701,22 @@ async function prepareCompletionContext(
 	return {
 		promptCacheKey: `thread:${actor.threadId}`,
 		streamSequence: actor.streamSequence,
-		userId: actor.userId
+		userId: actor.userId,
+		contextTokens: actor.contextTokens,
+		...(actor.contextSummary ? { contextSummary: actor.contextSummary } : {}),
+		...(actor.contextSummaryMessageCount !== undefined
+			? { contextSummaryMessageCount: actor.contextSummaryMessageCount }
+			: {})
 	};
+}
+
+function totalProcessedTokens(tokens: {
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	output: number;
+}): number {
+	return tokens.input + tokens.cacheRead + tokens.cacheWrite + tokens.output;
 }
 
 function buildSharedCompletionRequest(

--- a/apps/web/src/convex/lib/contextCompaction.test.ts
+++ b/apps/web/src/convex/lib/contextCompaction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { applyContextCompaction, shouldCompactContext } from './contextCompaction';
+
+describe('context compaction', () => {
+	it('replaces the compacted prefix and retains later turns', () => {
+		const messages = [
+			{ role: 'user' as const, content: 'old request' },
+			{ role: 'assistant' as const, content: 'old response' },
+			{ role: 'user' as const, content: 'new request' }
+		];
+		const compacted = applyContextCompaction(messages, {
+			summary: 'The old request is complete.',
+			messageCount: 2
+		});
+
+		expect(compacted).toHaveLength(2);
+		expect(compacted[0]).toMatchObject({ role: 'user' });
+		expect(JSON.stringify(compacted[0])).toContain('The old request is complete.');
+		expect(compacted[1]).toEqual(messages[2]);
+	});
+
+	it('uses reported usage and a conservative preflight estimate', () => {
+		expect(
+			shouldCompactContext({ inputTokens: 90, autoCompactTokenLimit: 100, messages: [] })
+		).toBe(false);
+		expect(
+			shouldCompactContext({ inputTokens: 100, autoCompactTokenLimit: 100, messages: [] })
+		).toBe(true);
+		expect(
+			shouldCompactContext({
+				inputTokens: 0,
+				autoCompactTokenLimit: 100,
+				messages: [{ role: 'user', content: 'x'.repeat(400) }]
+			})
+		).toBe(true);
+	});
+});

--- a/apps/web/src/convex/lib/contextCompaction.ts
+++ b/apps/web/src/convex/lib/contextCompaction.ts
@@ -1,0 +1,57 @@
+import type { ModelMessage } from 'ai';
+
+export type ContextCompaction = {
+	summary: string;
+	messageCount: number;
+};
+
+const COMPACTED_CONTEXT_PREAMBLE =
+	'The conversation context was automatically compacted. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.';
+
+export function contextSummaryText(summary: string): string {
+	return `${COMPACTED_CONTEXT_PREAMBLE}\n\n<conversation_summary>\n${summary}\n</conversation_summary>`;
+}
+
+export function applyContextCompaction(
+	messages: ModelMessage[],
+	compaction: ContextCompaction | undefined
+): ModelMessage[] {
+	if (!compaction) return messages;
+	if (compaction.messageCount < 0 || compaction.messageCount > messages.length) {
+		throw new Error('Stored context compaction does not match the current conversation.');
+	}
+	return [
+		{
+			role: 'user',
+			content: contextSummaryText(compaction.summary)
+		},
+		...messages.slice(compaction.messageCount)
+	];
+}
+
+export function shouldCompactContext(args: {
+	inputTokens: number;
+	autoCompactTokenLimit: number;
+	messages: ModelMessage[];
+}): boolean {
+	if (args.inputTokens >= args.autoCompactTokenLimit) return true;
+	// Provider usage is available only after a request. This conservative preflight
+	// catches a single large prompt or tool result before it can overflow the model.
+	const estimatedTokens = estimateContextTokens(args.messages);
+	return estimatedTokens >= args.autoCompactTokenLimit;
+}
+
+export function estimateContextTokens(messages: ModelMessage[]): number {
+	return Math.ceil(JSON.stringify(messages).length / 3);
+}
+
+export const CONTEXT_COMPACTION_INSTRUCTIONS = `Summarize the supplied coding-agent conversation so another agent can continue without the original messages.
+
+Preserve:
+- every user request and the current objective
+- decisions, constraints, plans, and unresolved questions
+- files inspected or changed and the important technical details
+- tool results, errors, tests, and commands that still matter
+- completed work and the exact next steps
+
+Be dense and factual. Do not address the user, continue the task, call tools, or add commentary. Output only the summary.`;

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	assertSupportedModelConfiguration,
 	completionUsageUnits,
+	getModelDefinition,
 	modelIds
 } from '@convex/lib/models';
 
@@ -14,6 +15,23 @@ describe('model configuration', () => {
 			'claude-fable-5',
 			'grok-4.5'
 		]);
+	});
+
+	it('uses the coding-agent context and compaction budgets', () => {
+		expect(getModelDefinition('gpt-5.6-sol')).toMatchObject({
+			contextWindowTokens: 258_400,
+			autoCompactTokenLimit: 244_800
+		});
+		expect(getModelDefinition('gpt-5.6-terra').contextWindowTokens).toBe(258_400);
+		expect(getModelDefinition('gpt-5.6-luna').contextWindowTokens).toBe(258_400);
+		expect(getModelDefinition('claude-fable-5')).toMatchObject({
+			contextWindowTokens: 980_000,
+			autoCompactTokenLimit: 967_000
+		});
+		expect(getModelDefinition('grok-4.5')).toMatchObject({
+			contextWindowTokens: 500_000,
+			autoCompactTokenLimit: 400_000
+		});
 	});
 
 	it('rejects reasoning efforts unsupported by a model', () => {

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -19,6 +19,10 @@ type ModelDefinition = {
 	id: SupportedModelId;
 	label: string;
 	provider: ModelProvider;
+	/** Context budget exposed by the provider's coding-agent harness. */
+	contextWindowTokens: number;
+	/** Input-token count at which the harness automatically compacts. */
+	autoCompactTokenLimit: number;
 	reasoningEfforts: readonly SupportedReasoningEffort[];
 	defaultReasoningEffort: SupportedReasoningEffort;
 	serviceTiers: readonly SupportedServiceTier[];
@@ -36,6 +40,10 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-sol',
 		label: 'GPT-5.6 Sol',
 		provider: 'openai',
+		// https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json
+		// Codex reserves 5% of its 272k catalog window and compacts at 90%.
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -53,6 +61,8 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-terra',
 		label: 'GPT-5.6 Terra',
 		provider: 'openai',
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -75,6 +85,8 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-luna',
 		label: 'GPT-5.6 Luna',
 		provider: 'openai',
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -92,6 +104,10 @@ export const modelDefinitions = [
 		id: 'claude-fable-5',
 		label: 'Claude Fable 5',
 		provider: 'anthropic',
+		// https://code.claude.com/docs/en/model-config#work-with-fable-5
+		// Claude Code reserves 20k output tokens, then a further 13k for compaction.
+		contextWindowTokens: 980_000,
+		autoCompactTokenLimit: 967_000,
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,
@@ -104,6 +120,10 @@ export const modelDefinitions = [
 		id: 'grok-4.5',
 		label: 'Grok 4.5',
 		provider: 'xai',
+		// https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-models/default_models.json
+		// Grok Build's model catalog sets an 80% threshold on the 500k window.
+		contextWindowTokens: 500_000,
+		autoCompactTokenLimit: 400_000,
 		reasoningEfforts: ['low', 'medium', 'high'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -53,6 +53,10 @@ export default defineSchema({
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
+		contextTokens: v.optional(v.number()),
+		totalTokensProcessed: v.optional(v.number()),
+		contextSummary: v.optional(v.string()),
+		contextSummaryThroughRunId: v.optional(v.id('runs')),
 		lastMessageAt: v.number(),
 		archivedAt: v.optional(v.number())
 	})
@@ -70,6 +74,8 @@ export default defineSchema({
 		claimId: v.optional(v.string()),
 		claimExpiresAt: v.optional(v.number()),
 		completionAttemptSeq: v.optional(v.number()),
+		contextSummary: v.optional(v.string()),
+		contextSummaryMessageCount: v.optional(v.number()),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -35,6 +35,12 @@
 		isStarting: boolean;
 		isRunning: boolean;
 		elapsedLabel: string | null;
+		contextUsage: {
+			inputTokens: number;
+			totalTokensProcessed: number;
+			contextWindowTokens: number;
+			autoCompactTokenLimit: number;
+		};
 		onSubmit: () => void;
 		onCancel: () => void;
 	};
@@ -52,6 +58,7 @@
 		isStarting,
 		isRunning,
 		elapsedLabel,
+		contextUsage,
 		onSubmit,
 		onCancel
 	}: Props = $props();
@@ -69,6 +76,12 @@
 	);
 	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
 	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
+	const contextPercent = $derived(
+		Math.min(100, Math.round((contextUsage.inputTokens / contextUsage.contextWindowTokens) * 100))
+	);
+	const contextCompactPercent = $derived(
+		Math.round((contextUsage.autoCompactTokenLimit / contextUsage.contextWindowTokens) * 100)
+	);
 
 	const COMPOSER_MIN_HEIGHT_PX = 68;
 	const COMPOSER_MAX_HEIGHT_PX = 160;
@@ -139,6 +152,16 @@
 
 	function handleModelChange(modelId: SupportedModelId) {
 		selectedReasoningEffort = getModelDefinition(modelId).defaultReasoningEffort;
+	}
+
+	function formatTokens(value: number): string {
+		if (value >= 1_000_000) {
+			return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1).replace(/\.0$/, '')}m`;
+		}
+		if (value >= 1_000) {
+			return `${Math.round(value / 1_000)}k`;
+		}
+		return String(value);
 	}
 
 	$effect(() => {
@@ -299,6 +322,48 @@
 						</div>
 
 						<div class="flex shrink-0 flex-nowrap items-center justify-end gap-2.5">
+							<div class="group/context relative">
+								<button
+									type="button"
+									class="relative flex size-8 cursor-help items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
+									aria-label={`Context window ${contextPercent}% full`}
+									aria-describedby="context-window-details"
+									style={`background: conic-gradient(rgb(59 130 246) ${contextPercent * 3.6}deg, rgb(255 255 255 / 0.08) 0deg);`}
+									onkeydown={(event) => {
+										if (event.key === 'Escape') event.currentTarget.blur();
+									}}
+								>
+									<span class="size-5.5 rounded-full bg-[#202023]"></span>
+								</button>
+								<div
+									id="context-window-details"
+									class="invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border border-white/9 bg-[#19191b] p-4 opacity-0 shadow-[0_18px_55px_rgba(0,0,0,0.45)] transition duration-150 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100"
+									role="tooltip"
+								>
+									<div class="flex items-center justify-between gap-4 text-[13px]">
+										<span class="font-medium text-slate-200">Context window</span>
+										<span class="text-slate-400"
+											>{contextPercent}% · {formatTokens(contextUsage.inputTokens)}/{formatTokens(
+												contextUsage.contextWindowTokens
+											)}</span
+										>
+									</div>
+									<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-white/5">
+										<div
+											class="h-full rounded-full bg-blue-500 transition-[width] duration-300"
+											style={`width: ${contextPercent}%`}
+										></div>
+									</div>
+									<div class="mt-3 flex items-center justify-between text-[12px] text-slate-500">
+										<span>Total processed</span>
+										<span>{formatTokens(contextUsage.totalTokensProcessed)}</span>
+									</div>
+									<p class="mt-4 text-[12px] leading-5 text-slate-500">
+										Sprocket automatically compacts context at about {contextCompactPercent}% so
+										long-running work can continue.
+									</p>
+								</div>
+							</div>
 							{#if isRunning}
 								<button
 									type="button"

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -48,6 +48,7 @@
 		defaultModelId,
 		defaultReasoningEffort,
 		defaultServiceTier,
+		getModelDefinition,
 		type SupportedModelId,
 		type SupportedReasoningEffort,
 		type SupportedServiceTier
@@ -438,6 +439,15 @@
 		});
 	});
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
+	const contextUsage = $derived.by(() => {
+		const model = getModelDefinition(selectedModel);
+		return {
+			inputTokens: currentActiveThread?.contextTokens ?? 0,
+			totalTokensProcessed: currentActiveThread?.totalTokensProcessed ?? 0,
+			contextWindowTokens: model.contextWindowTokens,
+			autoCompactTokenLimit: model.autoCompactTokenLimit
+		};
+	});
 	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
 	const currentHistoryMessagesData = $derived(
 		dataForThread(historyMessagesQuery.data, currentThreadId)
@@ -1803,6 +1813,7 @@
 						isStarting={hasPendingAgentLaunch}
 						{isRunning}
 						elapsedLabel={isRunning ? formatElapsedDuration(elapsedSeconds) : null}
+						{contextUsage}
 						onSubmit={() => {
 							void submitPrompt();
 						}}


### PR DESCRIPTION
## Summary

- automatically compact long agent contexts with persisted summaries, provider usage accounting, quota checks, and claim/attempt fencing
- use coding-agent context budgets researched from OpenAI Codex, Claude Code, and xAI Grok Build for every supported model
- add an accessible filling-circle context meter beside the send button with current and total processed token details
- preserve compacted context across runs and add focused regression coverage

## Context budgets

- GPT-5.6 Sol/Terra/Luna: 258.4k usable, compact at 244.8k
- Claude Fable 5: 980k usable, compact at 967k
- Grok 4.5: 500k, compact at 400k

## Validation

- `bun run test`
- `bun run --cwd apps/web build`
- `bun run --cwd apps/web check`
- `prek run -a`
- targeted context compaction and model budget tests

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic context compaction for long agent sessions. The main changes are:

- Persisted context summaries with attempt fencing and token accounting.
- Model-specific context windows and compaction thresholds.
- Context restoration across later runs.
- A context usage meter beside the prompt controls.
- Focused tests for compaction, accounting, and model budgets.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes appear safe to merge.

No additional distinct blocking issue qualifies for concern.

No new incomplete fix or separate production failure was identified in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The exact Bun command was run from the specified working directory and completed with exit code 0.
- Two missing-source sourcemap warnings appeared for @exalabs/convex-exa, but they did not affect test execution.

<a href="https://app.greptile.com/trex/runs/15509573/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Adds persisted summaries, context accounting, attempt fencing, and run-based history filtering. |
| apps/web/src/convex/completion.ts | Adds automatic compaction, usage charging, quota checks, and summary reuse. |
| apps/web/src/convex/lib/contextCompaction.ts | Adds context estimation, compaction decisions, summary formatting, and prefix replacement. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Adds an accessible context-window meter with processed-token details. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): Adapt context compaction tests..."](https://github.com/spikonado/sprocket/commit/c3f1588ffc9b44da50bf0486f908c2beea191d93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46275254)</sub>

<!-- /greptile_comment -->