### PR TITLE
perf(web): Reduce Convex database I/O

### DIFF
--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -112,16 +112,22 @@ describe('agentRuntime.start', () => {
 
 		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId, executionSecret });
 
-		const { responseMessageId, pendingJobId, completedJobId } = await t.run(async (ctx) => {
+		const seeded = await t.run(async (ctx) => {
+			const run = await ctx.db.get(runId);
+			if (!run?.completionStreamStateId) {
+				throw new Error('Expected completion stream state');
+			}
+			await ctx.db.patch(run.completionStreamStateId, {
+				sequence: 3,
+				streamAttemptId: 'attempt-a'
+			});
 			const responseMessageId = await ctx.db.insert('threadMessages', {
 				threadId,
 				runId,
 				userId: 'user_alice',
 				type: 'response',
 				text: 'partial',
-				parts: [{ type: 'text', id: 'text-1', text: 'partial', turnId: 'turn-1' }],
-				streamSequence: 3,
-				streamAttemptId: 'attempt-a'
+				parts: [{ type: 'text', id: 'text-1', text: 'partial', turnId: 'turn-1' }]
 			});
 			const pendingJobId = await ctx.db.insert('executorJobs', {
 				workspaceSessionId,
@@ -164,7 +170,12 @@ describe('agentRuntime.start', () => {
 				completionAttemptSeq: 4,
 				claimExpiresAt: Date.now() - 1
 			});
-			return { responseMessageId, pendingJobId, completedJobId };
+			return {
+				responseMessageId,
+				streamStateId: run.completionStreamStateId,
+				pendingJobId,
+				completedJobId
+			};
 		});
 
 		const takeover = await asUser.mutation(api.agentRuntime.start, {
@@ -177,10 +188,11 @@ describe('agentRuntime.start', () => {
 
 		const state = await t.run(async (ctx) => {
 			const run = await ctx.db.get(runId);
-			const response = await ctx.db.get(responseMessageId);
-			const pending = await ctx.db.get(pendingJobId);
-			const completed = await ctx.db.get(completedJobId);
-			return { run, response, pending, completed };
+			const response = await ctx.db.get(seeded.responseMessageId);
+			const stream = await ctx.db.get(seeded.streamStateId);
+			const pending = await ctx.db.get(seeded.pendingJobId);
+			const completed = await ctx.db.get(seeded.completedJobId);
+			return { run, response, stream, pending, completed };
 		});
 
 		expect(state.run).toMatchObject({
@@ -192,10 +204,12 @@ describe('agentRuntime.start', () => {
 		expect(state.run?.claimExpiresAt).toBe(takeover.claimExpiresAt);
 		expect(state.response).toMatchObject({
 			text: '',
-			parts: [],
-			streamSequence: 0
+			parts: []
 		});
-		expect(state.response?.streamAttemptId ?? undefined).toBeUndefined();
+		expect(state.stream).toMatchObject({
+			sequence: 0
+		});
+		expect(state.stream?.streamAttemptId ?? undefined).toBeUndefined();
 		expect(state.pending).toMatchObject({
 			hidden: true,
 			status: 'cancelled',

--- a/apps/web/src/convex/agentRuntime.stream.test.ts
+++ b/apps/web/src/convex/agentRuntime.stream.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('agentRuntime completion stream state', () => {
+	it('tracks the stream cursor outside the growing response message', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-stream-state',
+			threadId,
+			prompt: 'Stream a response',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-stream', runId });
+		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId });
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId,
+			claimId: 'claim-stream',
+			attemptSeq: 1
+		});
+		await expect(
+			asUser.mutation(api.agentRuntime.mergeAssistantStreamEvents, {
+				runId,
+				claimId: 'claim-stream',
+				attemptSeq: 1,
+				streamId: 'stream-1',
+				sequence: 1,
+				events: [{ type: 'text', id: 'text-1', text: 'Hello' }]
+			})
+		).resolves.toBe('merged');
+
+		const stored = await t.run(async (ctx) => {
+			const run = await ctx.db.get(runId);
+			if (!run?.responseMessageId || !run.completionStreamStateId) {
+				throw new Error('Expected response and stream state records');
+			}
+			return {
+				message: await ctx.db.get(run.responseMessageId),
+				state: await ctx.db.get(run.completionStreamStateId)
+			};
+		});
+		expect(stored.message).toMatchObject({ text: 'Hello' });
+		expect(stored.state).toMatchObject({
+			runId,
+			sequence: 1,
+			streamAttemptId: 'stream-1'
+		});
+		expect(await asUser.query(api.agentRuntime.completionActor, { runId })).toMatchObject({
+			streamSequence: 1,
+			streamAttemptId: 'stream-1'
+		});
+	});
+});

--- a/apps/web/src/convex/agentRuntime.stream.test.ts
+++ b/apps/web/src/convex/agentRuntime.stream.test.ts
@@ -6,6 +6,7 @@ describe('agentRuntime completion stream state', () => {
 	it('tracks the stream cursor outside the growing response message', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'stream-state-secret';
 		const { runId } = await asUser.mutation(api.agentRuntime.createRun, {
 			submissionId: 'sub-stream-state',
 			threadId,
@@ -13,15 +14,21 @@ describe('agentRuntime completion stream state', () => {
 			imageUploadIds: [],
 			selectedModel: 'gpt-5.6-sol',
 			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			serviceTier: 'standard',
+			executionSecret
 		});
 
-		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-stream', runId });
-		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId });
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-stream',
+			runId,
+			executionSecret
+		});
+		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId, executionSecret });
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId,
 			claimId: 'claim-stream',
-			attemptSeq: 1
+			attemptSeq: 1,
+			executionSecret
 		});
 		await expect(
 			asUser.mutation(api.agentRuntime.mergeAssistantStreamEvents, {
@@ -30,7 +37,8 @@ describe('agentRuntime completion stream state', () => {
 				attemptSeq: 1,
 				streamId: 'stream-1',
 				sequence: 1,
-				events: [{ type: 'text', id: 'text-1', text: 'Hello' }]
+				events: [{ type: 'text', id: 'text-1', text: 'Hello' }],
+				executionSecret
 			})
 		).resolves.toBe('merged');
 
@@ -50,7 +58,9 @@ describe('agentRuntime completion stream state', () => {
 			sequence: 1,
 			streamAttemptId: 'stream-1'
 		});
-		expect(await asUser.query(api.agentRuntime.completionActor, { runId })).toMatchObject({
+		expect(
+			await asUser.query(api.agentRuntime.completionActor, { runId, executionSecret })
+		).toMatchObject({
 			streamSequence: 1,
 			streamAttemptId: 'stream-1'
 		});

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -1,5 +1,5 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { mutation, query, type MutationCtx } from '@convex/_generated/server';
+import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
 import { getOwnedRun, getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
 import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
@@ -62,6 +62,25 @@ type FinalizeRunArgs = {
 };
 
 type RuntimePromptAttachment = Pick<ThreadTranscriptAttachment, 'mediaType' | 'url'>;
+
+async function getCompletionStreamState(
+	ctx: MutationCtx | QueryCtx,
+	run: Doc<'runs'>
+): Promise<Doc<'completionStreamStates'>> {
+	if (!run.completionStreamStateId) {
+		throw new Error('Run does not contain completion stream state.');
+	}
+	const state = await ctx.db.get(run.completionStreamStateId);
+	if (!state || state.runId !== run._id || state.userId !== run.userId) {
+		throw new Error('Completion stream state is invalid.');
+	}
+	return state;
+}
+
+export const authenticatedUserId = query({
+	args: {},
+	handler: async (ctx): Promise<string> => await getUserId(ctx)
+});
 
 async function finalizeRunRecord(
 	ctx: MutationCtx,
@@ -202,7 +221,8 @@ export const createRun = mutation({
 				existingRun.selectedModel !== args.selectedModel ||
 				existingRun.reasoningEffort !== args.reasoningEffort ||
 				existingRun.serviceTier !== args.serviceTier ||
-				!existingRun.promptMessageId
+				!existingRun.promptMessageId ||
+				!existingRun.completionStreamStateId
 			) {
 				throw new Error('Submission belongs to a different or incomplete run.');
 			}
@@ -240,6 +260,11 @@ export const createRun = mutation({
 			serviceTier: args.serviceTier,
 			startedAt: Date.now()
 		});
+		const completionStreamStateId = await ctx.db.insert('completionStreamStates', {
+			runId,
+			userId,
+			sequence: 0
+		});
 		const promptMessageId: Id<'threadMessages'> = await appendThreadMessage(ctx, {
 			threadId: args.threadId,
 			runId,
@@ -250,7 +275,8 @@ export const createRun = mutation({
 		});
 		await attachImageUploads(ctx, imageUploads, promptMessageId);
 		await ctx.db.patch(runId, {
-			promptMessageId
+			promptMessageId,
+			completionStreamStateId
 		});
 		await ctx.db.patch(threadRecord._id, {
 			title: threadRecord.title ?? (prompt || imageUploads[0]?.name || 'New thread').slice(0, 72),
@@ -306,11 +332,14 @@ export const start = mutation({
 			if (run.responseMessageId) {
 				await ctx.db.patch(run.responseMessageId, {
 					text: '',
-					parts: [],
-					streamSequence: 0,
-					streamAttemptId: undefined
+					parts: []
 				});
 			}
+			const streamState = await getCompletionStreamState(ctx, run);
+			await ctx.db.patch(streamState._id, {
+				sequence: 0,
+				streamAttemptId: undefined
+			});
 		}
 
 		const nextClaimExpiresAt = claimExpiresAt(now);
@@ -443,9 +472,7 @@ export const completionActor = query({
 	}> => {
 		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const userId = run.userId;
-		const message = run.responseMessageId
-			? await getThreadMessage(ctx, run.responseMessageId)
-			: null;
+		const streamState = await getCompletionStreamState(ctx, run);
 		return {
 			userId,
 			threadId: run.threadId,
@@ -453,8 +480,8 @@ export const completionActor = query({
 			...(run.claimId ? { claimId: run.claimId } : {}),
 			...(run.claimExpiresAt ? { claimExpiresAt: run.claimExpiresAt } : {}),
 			completionAttemptSeq: run.completionAttemptSeq ?? 0,
-			streamSequence: message?.streamSequence ?? 0,
-			...(message?.streamAttemptId ? { streamAttemptId: message.streamAttemptId } : {})
+			streamSequence: streamState.sequence,
+			...(streamState.streamAttemptId ? { streamAttemptId: streamState.streamAttemptId } : {})
 		};
 	}
 });
@@ -507,10 +534,8 @@ export const beginAssistantMessage = mutation({
 		if (isRunFinalStatus(run.status)) {
 			return;
 		}
-		const assistantMessage: Doc<'threadMessages'> | null = run.responseMessageId
-			? await ctx.db.get(run.responseMessageId)
-			: null;
-		if (assistantMessage) {
+		await getCompletionStreamState(ctx, run);
+		if (run.responseMessageId) {
 			return;
 		}
 
@@ -555,11 +580,11 @@ export const mergeAssistantStreamEvents = mutation({
 			return 'merged';
 		}
 
+		const streamState = await getCompletionStreamState(ctx, run);
 		const message: Doc<'threadMessages'> = await getThreadMessage(ctx, run.responseMessageId);
-		const lastSequence = message.streamSequence ?? 0;
 		const classification = classifyCompletionStreamBatch({
-			lastSequence,
-			lastStreamId: message.streamAttemptId,
+			lastSequence: streamState.sequence,
+			lastStreamId: streamState.streamAttemptId,
 			sequence: args.sequence,
 			streamId: args.streamId
 		});
@@ -637,8 +662,10 @@ export const mergeAssistantStreamEvents = mutation({
 
 		await ctx.db.patch(run.responseMessageId, {
 			text: joinAssistantTextParts(parts),
-			parts,
-			streamSequence: args.sequence,
+			parts
+		});
+		await ctx.db.patch(streamState._id, {
+			sequence: args.sequence,
 			streamAttemptId: args.streamId
 		});
 		return 'merged';

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -38,8 +38,11 @@ export const latestRunForThread = query({
 
 		const jobs: Doc<'executorJobs'>[] = await ctx.db
 			.query('executorJobs')
-			.withIndex('by_runId_sequence', (query) => query.eq('runId', latestRun._id))
-			.collect();
+			.withIndex('by_runId_hidden_sequence', (query) =>
+				query.eq('runId', latestRun._id).eq('hidden', false)
+			)
+			.order('desc')
+			.take(60);
 		const promptMessage = latestRun.promptMessageId
 			? await ctx.db.get(latestRun.promptMessageId)
 			: null;
@@ -47,7 +50,7 @@ export const latestRunForThread = query({
 		return {
 			threadId: args.threadId,
 			run: latestRun,
-			jobs: jobs.filter((job) => !job.hidden).sort((left, right) => left.sequence - right.sequence),
+			jobs: jobs.reverse(),
 			...(promptMessage?.type === 'prompt'
 				? {
 						prompt: promptMessage.text,

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -40,6 +40,9 @@ type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
 
 const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 1_000;
+// Persisting a growing message rewrites and reactively rereads the whole document.
+// Keep the UI responsive without paying that cost for every token-sized provider delta.
+const COMPLETION_STREAM_FLUSH_INTERVAL_MS = 250;
 // AI SDK retries only retryable provider failures and honors Retry-After headers.
 // Allow a longer recovery window for short provider rate-limit bursts.
 const MODEL_PROVIDER_MAX_RETRIES = 5;
@@ -211,6 +214,7 @@ async function collectStreamingCompletion(
 		{ partId: string; providerMetadata?: JsonValue; finalized: boolean }
 	>();
 	let nextBatchSequence = initialSequence + 1;
+	let nextFlushAt: number | undefined;
 
 	const flush = async (): Promise<void> => {
 		if (pendingEvents.length === 0) {
@@ -234,6 +238,9 @@ async function collectStreamingCompletion(
 					throw new Error(COMPLETION_STREAM_SUPERSEDED);
 				}
 				pendingEvents.splice(0, events.length);
+				nextFlushAt = pendingEvents.length
+					? Date.now() + COMPLETION_STREAM_FLUSH_INTERVAL_MS
+					: undefined;
 				nextBatchSequence += 1;
 				return;
 			} catch (error) {
@@ -246,6 +253,9 @@ async function collectStreamingCompletion(
 	};
 
 	const queuePersisted = (event: CompletionStreamEvent): void => {
+		if (pendingEvents.length === 0) {
+			nextFlushAt = Date.now() + COMPLETION_STREAM_FLUSH_INTERVAL_MS;
+		}
 		if (event.type === 'text') {
 			upsertCompletionTextEvent(pendingEvents, event);
 		} else {
@@ -284,6 +294,10 @@ async function collectStreamingCompletion(
 		let nextPart = iterator.next();
 		let nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
 		while (true) {
+			if (pendingEvents.length > 0 && nextFlushAt !== undefined && Date.now() >= nextFlushAt) {
+				await flush();
+				continue;
+			}
 			let next:
 				| { type: 'part'; value: Awaited<typeof nextPart> }
 				| { type: 'flush' }
@@ -301,7 +315,10 @@ async function collectStreamingCompletion(
 			];
 			if (pendingEvents.length > 0) {
 				const flushDeadline = new Promise<{ type: 'flush' }>((resolve) => {
-					flushTimer = setTimeout(() => resolve({ type: 'flush' }), 80);
+					flushTimer = setTimeout(
+						() => resolve({ type: 'flush' }),
+						Math.max(0, (nextFlushAt ?? Date.now()) - Date.now())
+					);
 				});
 				waits.push(flushDeadline);
 			}

--- a/apps/web/src/convex/messages.test.ts
+++ b/apps/web/src/convex/messages.test.ts
@@ -106,9 +106,7 @@ describe('messages transcript queries', () => {
 			}
 			await ctx.db.patch(run.responseMessageId, {
 				text: 'partial answer',
-				parts: [{ type: 'text', id: 't1', text: 'partial answer', turnId: 'turn-1' }],
-				streamSequence: 1,
-				streamAttemptId: 'stream-1'
+				parts: [{ type: 'text', id: 't1', text: 'partial answer', turnId: 'turn-1' }]
 			});
 			return run.responseMessageId;
 		});

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -78,7 +78,8 @@ export default defineSchema({
 		lastError: v.optional(v.string()),
 		activeJobId: v.optional(v.id('executorJobs')),
 		promptMessageId: v.optional(v.id('threadMessages')),
-		responseMessageId: v.optional(v.id('threadMessages'))
+		responseMessageId: v.optional(v.id('threadMessages')),
+		completionStreamStateId: v.optional(v.id('completionStreamStates'))
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
 		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])
@@ -93,8 +94,12 @@ export default defineSchema({
 		type: vThreadMessageType,
 		text: v.string(),
 		imageUploadIds: v.optional(v.array(v.id('imageUploads'))),
-		parts: v.optional(v.array(vAssistantMessagePart)),
-		streamSequence: v.optional(v.number()),
+		parts: v.optional(v.array(vAssistantMessagePart))
+	}),
+	completionStreamStates: defineTable({
+		runId: v.id('runs'),
+		userId: v.string(),
+		sequence: v.number(),
 		streamAttemptId: v.optional(v.string())
 	}),
 	imageUploads: defineTable({
@@ -128,4 +133,5 @@ export default defineSchema({
 		.index('by_workspaceSessionId_sequence', ['workspaceSessionId', 'sequence'])
 		.index('by_threadId_sequence', ['threadId', 'sequence'])
 		.index('by_runId_sequence', ['runId', 'sequence'])
+		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence'])
 });

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -93,23 +93,13 @@ export const listMine = query({
 	args: {},
 	handler: async (ctx) => {
 		const userId: string = await getUserId(ctx);
-		const [records, workspaceSessions] = await Promise.all([
-			ctx.db
-				.query('threadRecords')
-				.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
-				.order('desc')
-				.collect(),
-			ctx.db
-				.query('workspaceSessions')
-				.withIndex('by_userId', (query) => query.eq('userId', userId))
-				.collect()
-		]);
-		const workspaceSessionLookup = new Map(
-			workspaceSessions.map((workspaceSession) => [workspaceSession._id, workspaceSession])
-		);
+		const records = await ctx.db
+			.query('threadRecords')
+			.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
+			.order('desc')
+			.collect();
 		return await Promise.all(
 			records.map(async (record) => {
-				const workspaceSession = workspaceSessionLookup.get(record.workspaceSessionId);
 				const latestRun = await ctx.db
 					.query('runs')
 					.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', record._id))
@@ -121,7 +111,6 @@ export const listMine = query({
 					title: record.title?.trim() || 'New thread',
 					threadStatus:
 						record.archivedAt !== undefined ? ('archived' as const) : ('active' as const),
-					workspaceName: workspaceSession?.workspaceName ?? 'Unknown workspace',
 					latestRunStatus: latestRun?.status ?? null,
 					latestRunId: latestRun?._id ?? null,
 					latestRunStartedAt: latestRun?.startedAt,

--- a/apps/web/src/convex/workspaceSessions.ts
+++ b/apps/web/src/convex/workspaceSessions.ts
@@ -67,18 +67,16 @@ export const heartbeatAttached = mutation({
 		const userId: string = await getUserId(ctx);
 		const now = Date.now();
 		const requestedIds = new Set(args.workspaceSessionIds);
-
-		for (const workspaceSessionId of args.workspaceSessionIds) {
-			const workspaceSession = await ctx.db.get(workspaceSessionId);
-			if (!workspaceSession || workspaceSession.userId !== userId) {
-				throw new Error('Workspace session not found.');
-			}
-		}
-
 		const sessions = await ctx.db
 			.query('workspaceSessions')
 			.withIndex('by_userId', (query) => query.eq('userId', userId))
 			.collect();
+		const ownedSessionIds = new Set(sessions.map((session) => session._id));
+		for (const workspaceSessionId of requestedIds) {
+			if (!ownedSessionIds.has(workspaceSessionId)) {
+				throw new Error('Workspace session not found.');
+			}
+		}
 		const detachedSessionIds = getDetachedWorkspaceSessionIdsForClient(
 			sessions,
 			args.clientId,

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -226,6 +226,8 @@
 	function getCurrentUserId() {
 		return $authState.user?.id ?? null;
 	}
+	const workspaceNameCache = new SvelteMap<Id<'workspaceSessions'>, string>();
+	let workspaceNameCacheUserId: string | null = null;
 
 	function updateComposerAttachment(localId: string, patch: Partial<ComposerAttachment>) {
 		const attachment = composerAttachments.find((entry) => entry.localId === localId);
@@ -404,7 +406,30 @@
 			};
 		})
 	);
-	const threads = $derived((threadsQuery.data ?? []) as ThreadSummary[]);
+	$effect(() => {
+		const userId = getCurrentUserId();
+		if (workspaceNameCacheUserId !== userId) {
+			workspaceNameCache.clear();
+			workspaceNameCacheUserId = userId;
+		}
+		for (const workspaceSession of workspaceSessions) {
+			workspaceNameCache.set(workspaceSession._id, workspaceSession.workspaceName);
+		}
+	});
+	const threads = $derived.by<ThreadSummary[]>(() => {
+		const workspaceNames = new Map(
+			workspaceSessions.map((workspaceSession) => [
+				workspaceSession._id,
+				workspaceSession.workspaceName
+			])
+		);
+		return (threadsQuery.data ?? []).flatMap((thread) => {
+			const workspaceName =
+				workspaceNames.get(thread.workspaceSessionId) ??
+				workspaceNameCache.get(thread.workspaceSessionId);
+			return workspaceName === undefined ? [] : ([{ ...thread, workspaceName }] as ThreadSummary[]);
+		});
+	});
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
 	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
 	const currentHistoryMessagesData = $derived(

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -412,6 +412,10 @@
 			workspaceNameCache.clear();
 			workspaceNameCacheUserId = userId;
 		}
+		if (workspaceSessionsQuery.data === undefined) {
+			return;
+		}
+		workspaceNameCache.clear();
 		for (const workspaceSession of workspaceSessions) {
 			workspaceNameCache.set(workspaceSession._id, workspaceSession.workspaceName);
 		}
@@ -423,11 +427,14 @@
 				workspaceSession.workspaceName
 			])
 		);
-		return (threadsQuery.data ?? []).flatMap((thread) => {
+		return (threadsQuery.data ?? []).map((thread) => {
 			const workspaceName =
 				workspaceNames.get(thread.workspaceSessionId) ??
-				workspaceNameCache.get(thread.workspaceSessionId);
-			return workspaceName === undefined ? [] : ([{ ...thread, workspaceName }] as ThreadSummary[]);
+				(workspaceSessionsQuery.data === undefined
+					? workspaceNameCache.get(thread.workspaceSessionId)
+					: undefined) ??
+				'Unknown workspace';
+			return { ...thread, workspaceName } as ThreadSummary;
 		});
 	});
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));


### PR DESCRIPTION
## Summary
- throttle assistant stream persistence and move stream cursors into dedicated small records
- bound latest-run job reads and avoid heartbeat-driven thread query invalidations
- remove duplicate workspace heartbeat reads and join workspace names client-side
- intentionally require stream state for all runs, with no legacy message-cursor fallback or migration path

## Validation
- `bun run --cwd apps/web test` (149 tests)
- `bun run --cwd apps/web check`
- `bun run --cwd apps/web build`
- Convex TypeScript typecheck
- changed-file ESLint and Prettier checks

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces Convex database work for streaming, run queries, heartbeats, and thread navigation. The main changes are:

- Moves completion stream cursors into dedicated records.
- Throttles assistant stream persistence.
- Bounds latest-run job reads with a composite index.
- Consolidates workspace heartbeat ownership reads.
- Joins workspace names on the client with cache and fallback handling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

Unresolved threads now remain visible under the fallback name. Removed sessions no longer retain stale cached names. No blocking issues related to the earlier workspace-name failures remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran bun run --cwd apps/web test to execute the web test suite, and the command completed with exit status 0, reporting 24 passed test files and 148 passed tests.
- I reviewed the web-test.log artifact to verify the test run results.

<a href="https://app.greptile.com/trex/runs/15506917/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/routes/+page.svelte | Preserves unresolved threads with an unknown-workspace fallback and refreshes cached names from authoritative session data. |
| apps/web/src/convex/threads.ts | Removes the server-side workspace-session join from thread listing. |
| apps/web/src/convex/agentRuntime.ts | Moves completion cursor reads, writes, and takeover resets to dedicated stream-state records. |
| apps/web/src/convex/completion.ts | Throttles stream flushes while retaining immediate flushes at completion boundaries. |
| apps/web/src/convex/chat.ts | Uses an indexed query to return the latest visible jobs in ascending order. |
| apps/web/src/convex/workspaceSessions.ts | Validates heartbeat session ownership from one user-scoped query. |
| apps/web/src/convex/schema.ts | Adds stream-state storage and the composite executor-job index. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(web): Pass executionSecret in stream..."](https://github.com/spikonado/sprocket/commit/b1043d1d69789a46739ed7ee50b086b3ac764473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46284818)</sub>

<!-- /greptile_comment -->