### PR TITLE
fix(agent): Keep runs alive after browser closes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,7 +102,7 @@ Sprocket deliberately separates cloud and machine-local state.
 | Users, workspace identities, threads, messages, runs, and tool-job records | Convex               |
 | Workspace identity to local path mapping                                   | Local server         |
 | Pairing credential and local browser sessions                              | Local server         |
-| Active commands, cancellation tokens, and access-token refresh sessions    | Local process memory |
+| Active commands, cancellation tokens, and run execution capabilities       | Local process memory |
 | Source files and build artifacts                                           | User workspace       |
 | Model and authentication provider secrets                                  | Cloud deployment     |
 
@@ -123,7 +123,7 @@ sequenceDiagram
     UI->>C: Create or recover thread
     UI->>S: Start run with user token and workspace identity
     S->>A: Prepare local run
-    A->>C: Create or recover durable run
+    A->>C: Create or recover durable run and bind execution capability
     A->>C: Claim run and load context
     loop Model and tool turns
         A->>C: Request completion
@@ -158,8 +158,9 @@ Cloud and local authorization solve different problems:
   checks ownership before reading or changing user records.
 - **Local authorization:** a machine-local pairing credential bootstraps a
   local session used for filesystem and agent endpoints.
-- **Agent delegation:** the browser provides a short-lived user token to the
-  local server for a run. Refreshes must remain bound to the same cloud user.
+- **Agent delegation:** the browser provides a fresh user token only to create
+  the run. Convex then binds a random, run-scoped capability to that run, and
+  the local executor uses it without depending on the browser session.
 - **Desktop trust:** Electron isolates the renderer, validates its origin, and
   exposes only a constrained IPC surface.
 
@@ -176,6 +177,7 @@ The distributed run protocol assumes that requests can time out after either
 succeeding or failing. Its main safeguards are:
 
 - idempotent creation keyed by a client submission identifier;
+- request-independent local launch and run-scoped executor capabilities;
 - renewable claims that reject stale workers;
 - durable transcript and tool-job updates;
 - explicit terminal states and failure reconciliation;

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -16,14 +16,15 @@ describe('agentRuntime.createRun', () => {
 				imageUploadIds: [],
 				selectedModel: 'gpt-5.6-sol',
 				reasoningEffort: 'medium',
-				serviceTier: 'standard'
+				serviceTier: 'standard',
+				executionSecret: 'empty-prompt-secret'
 			})
 		).rejects.toThrow('Message cannot be empty.');
 	});
 
 	it('creates a queued run and is idempotent for the same submission', async () => {
 		const t = initConvexTest();
-		const { asUser, threadId, subject } = await seedOwnedThread(t);
+		const { asUser, threadId } = await seedOwnedThread(t);
 		const args = {
 			submissionId: 'sub-1',
 			threadId,
@@ -31,21 +32,18 @@ describe('agentRuntime.createRun', () => {
 			imageUploadIds: [] as Id<'imageUploads'>[],
 			selectedModel: 'gpt-5.6-sol' as const,
 			reasoningEffort: 'medium' as const,
-			serviceTier: 'standard' as const
+			serviceTier: 'standard' as const,
+			executionSecret: 'idempotent-secret'
 		};
 
 		const created = await asUser.mutation(api.agentRuntime.createRun, args);
-		expect(created).toMatchObject({
-			created: true,
-			userId: subject
-		});
+		expect(created).toMatchObject({ created: true });
 
 		const again = await asUser.mutation(api.agentRuntime.createRun, args);
 		expect(again).toEqual({
 			created: false,
 			runId: created.runId,
-			promptMessageId: created.promptMessageId,
-			userId: subject
+			promptMessageId: created.promptMessageId
 		});
 
 		const run = await t.run(async (ctx) => ctx.db.get(created.runId));
@@ -54,6 +52,112 @@ describe('agentRuntime.createRun', () => {
 			submissionId: 'sub-1',
 			promptMessageId: created.promptMessageId
 		});
+	});
+
+	it('lets the local executor continue without a browser identity using its run capability', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'executor-secret';
+		const created = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-capability',
+			threadId,
+			prompt: 'Keep going after the tab closes',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard',
+			executionSecret
+		});
+
+		await expect(
+			t.mutation(api.agentRuntime.start, {
+				runId: created.runId,
+				claimId: 'claim-wrong',
+				executionSecret: 'wrong-secret'
+			})
+		).rejects.toThrow('Run not found.');
+
+		await expect(
+			t.mutation(api.agentRuntime.start, {
+				runId: created.runId,
+				claimId: 'claim-local',
+				executionSecret
+			})
+		).resolves.toMatchObject({ claimed: true });
+		expect(
+			await t.run(async (ctx) => (await ctx.db.get(created.runId))?.executionSecretHash)
+		).not.toBe(executionSecret);
+		await expect(
+			t.query(api.agentRuntime.isFinished, { runId: created.runId, executionSecret })
+		).resolves.toBe(false);
+		await expect(
+			t.mutation(api.agentRuntime.renewClaim, {
+				runId: created.runId,
+				claimId: 'claim-local',
+				executionSecret
+			})
+		).resolves.toMatchObject({ renewed: true });
+	});
+
+	it('rebinds a queued submission when its original local executor was lost', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const args = {
+			submissionId: 'sub-rebind',
+			threadId,
+			prompt: 'Recover this launch',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+		const created = await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret: 'lost-secret'
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				...args,
+				executionSecret: 'replacement-secret'
+			})
+		).resolves.toMatchObject({ created: false, runId: created.runId });
+		await expect(
+			t.mutation(api.agentRuntime.start, {
+				runId: created.runId,
+				claimId: 'replacement-claim',
+				executionSecret: 'replacement-secret'
+			})
+		).resolves.toMatchObject({ claimed: true });
+	});
+
+	it('reconciles a queued run by capability after browser authentication is gone', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'cleanup-secret';
+		const args = {
+			submissionId: 'sub-capability-cleanup',
+			threadId,
+			prompt: 'Reconcile me',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+		const created = await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret
+		});
+
+		await expect(
+			t.mutation(api.agentRuntime.finalizeFailedStart, {
+				...args,
+				executionSecret,
+				text: 'Run failed before the model started.',
+				lastError: 'startup timed out'
+			})
+		).resolves.toBe(true);
+		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('failed');
 	});
 
 	it('rejects a second run while the thread has an active run', async () => {
@@ -67,7 +171,8 @@ describe('agentRuntime.createRun', () => {
 			imageUploadIds: [],
 			selectedModel: 'gpt-5.6-sol',
 			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			serviceTier: 'standard',
+			executionSecret: 'active-first-secret'
 		});
 
 		await expect(
@@ -78,7 +183,8 @@ describe('agentRuntime.createRun', () => {
 				imageUploadIds: [],
 				selectedModel: 'gpt-5.6-sol',
 				reasoningEffort: 'medium',
-				serviceTier: 'standard'
+				serviceTier: 'standard',
+				executionSecret: 'active-second-secret'
 			})
 		).rejects.toThrow('Finish or cancel the active run before sending another message.');
 	});
@@ -94,7 +200,8 @@ describe('agentRuntime.createRun', () => {
 			imageUploadIds: [],
 			selectedModel: 'gpt-5.6-sol',
 			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			serviceTier: 'standard',
+			executionSecret: 'completed-first-secret'
 		});
 		await t.run(async (ctx) => {
 			await ctx.db.patch(first.runId, { status: 'completed', completedAt: Date.now() });
@@ -107,7 +214,8 @@ describe('agentRuntime.createRun', () => {
 			imageUploadIds: [],
 			selectedModel: 'gpt-5.6-sol',
 			reasoningEffort: 'medium',
-			serviceTier: 'standard'
+			serviceTier: 'standard',
+			executionSecret: 'completed-second-secret'
 		});
 		expect(second.created).toBe(true);
 		expect(second.runId).not.toBe(first.runId);

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -97,6 +97,22 @@ describe('agentRuntime.createRun', () => {
 				executionSecret
 			})
 		).resolves.toMatchObject({ renewed: true });
+
+		const expiredAt = await t.run(async (ctx) => {
+			const claimExpiresAt = Date.now() - 1;
+			await ctx.db.patch(created.runId, { claimExpiresAt });
+			return claimExpiresAt;
+		});
+		await expect(
+			t.mutation(api.agentRuntime.renewClaim, {
+				runId: created.runId,
+				claimId: 'claim-local',
+				executionSecret
+			})
+		).resolves.toMatchObject({ renewed: false });
+		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.claimExpiresAt)).toBe(
+			expiredAt
+		);
 	});
 
 	it('rebinds a queued submission when its original local executor was lost', async () => {

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -87,16 +87,6 @@ describe('agentRuntime.createRun', () => {
 		expect(
 			await t.run(async (ctx) => (await ctx.db.get(created.runId))?.executionSecretHash)
 		).not.toBe(executionSecret);
-		await expect(
-			t.query(api.agentRuntime.isFinished, { runId: created.runId, executionSecret })
-		).resolves.toBe(false);
-		await expect(
-			t.mutation(api.agentRuntime.renewClaim, {
-				runId: created.runId,
-				claimId: 'claim-local',
-				executionSecret
-			})
-		).resolves.toMatchObject({ renewed: true });
 
 		const expiredAt = await t.run(async (ctx) => {
 			const claimExpiresAt = Date.now() - 1;

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -7,7 +7,8 @@ import { initConvexTest, seedOwnedThread } from './test.setup';
 async function createQueuedRun(
 	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
 	threadId: Id<'threadRecords'>,
-	submissionId: string
+	submissionId: string,
+	executionSecret: string
 ) {
 	return await asUser.mutation(api.agentRuntime.createRun, {
 		submissionId,
@@ -16,7 +17,8 @@ async function createQueuedRun(
 		imageUploadIds: [],
 		selectedModel: 'gpt-5.6-sol',
 		reasoningEffort: 'medium',
-		serviceTier: 'standard'
+		serviceTier: 'standard',
+		executionSecret
 	});
 }
 
@@ -24,11 +26,13 @@ describe('agentRuntime.start', () => {
 	it('claims a queued run and renews the same claim', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId } = await createQueuedRun(asUser, threadId, 'sub-claim');
+		const executionSecret = 'start-claim-secret';
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-claim', executionSecret);
 
 		const claimed = await asUser.mutation(api.agentRuntime.start, {
 			claimId: 'claim-a',
-			runId
+			runId,
+			executionSecret
 		});
 		expect(claimed.claimed).toBe(true);
 		expect(claimed.claimExpiresAt).toBeTypeOf('number');
@@ -42,7 +46,8 @@ describe('agentRuntime.start', () => {
 
 		const renewed = await asUser.mutation(api.agentRuntime.start, {
 			claimId: 'claim-a',
-			runId
+			runId,
+			executionSecret
 		});
 		expect(renewed.claimed).toBe(true);
 		expect(renewed.claimExpiresAt).toBeGreaterThanOrEqual(claimed.claimExpiresAt ?? 0);
@@ -52,20 +57,60 @@ describe('agentRuntime.start', () => {
 	it('refuses a different claim while the lease is active', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId } = await createQueuedRun(asUser, threadId, 'sub-busy');
+		const executionSecret = 'start-busy-secret';
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-busy', executionSecret);
 
-		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId });
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId, executionSecret });
 		await expect(
-			asUser.mutation(api.agentRuntime.start, { claimId: 'claim-b', runId })
+			asUser.mutation(api.agentRuntime.start, { claimId: 'claim-b', runId, executionSecret })
 		).resolves.toEqual({ claimed: false });
+	});
+
+	it('rejects completion writes and terminal cleanup after a claim expires', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'start-expired-writes-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'sub-expired-writes',
+			executionSecret
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-expired',
+			runId,
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(runId, { claimExpiresAt: Date.now() - 1 });
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+				runId,
+				claimId: 'claim-expired',
+				attemptSeq: 1,
+				executionSecret
+			})
+		).rejects.toThrow('Run is no longer active.');
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
+				runId,
+				claimId: 'claim-expired',
+				text: 'stale failure',
+				lastError: 'claim expired',
+				executionSecret
+			})
+		).resolves.toBe(false);
 	});
 
 	it('takes over an expired claim, hides in-flight jobs, and clears partial response', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId, workspaceSessionId } = await seedOwnedThread(t);
-		const { runId } = await createQueuedRun(asUser, threadId, 'sub-takeover');
+		const executionSecret = 'start-takeover-secret';
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-takeover', executionSecret);
 
-		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId });
+		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-a', runId, executionSecret });
 
 		const { responseMessageId, pendingJobId, completedJobId } = await t.run(async (ctx) => {
 			const responseMessageId = await ctx.db.insert('threadMessages', {
@@ -124,7 +169,8 @@ describe('agentRuntime.start', () => {
 
 		const takeover = await asUser.mutation(api.agentRuntime.start, {
 			claimId: 'claim-b',
-			runId
+			runId,
+			executionSecret
 		});
 		expect(takeover.claimed).toBe(true);
 		expect(takeover.claimExpiresAt).toBeGreaterThan(Date.now());

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -2,7 +2,7 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
 import { getOwnedRun, getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
-import { getUserId } from '@convex/lib/auth';
+import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
 import {
 	assertSupportedModelConfiguration,
 	type SupportedModelId,
@@ -20,7 +20,7 @@ import {
 	type ThreadTranscriptAttachment,
 	type ThreadTranscriptMessage
 } from '@convex/lib/threadTranscript';
-import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
 import { assertThreadCanStartRun, cancelExecutorJobsForTerminalRun } from '@convex/lib/runs';
 import {
 	canRegisterCompletionAttempt,
@@ -61,11 +61,6 @@ type FinalizeRunArgs = {
 };
 
 type RuntimePromptAttachment = Pick<ThreadTranscriptAttachment, 'mediaType' | 'url'>;
-
-export const authenticatedUserId = query({
-	args: {},
-	handler: async (ctx): Promise<string> => await getUserId(ctx)
-});
 
 async function finalizeRunRecord(
 	ctx: MutationCtx,
@@ -155,7 +150,8 @@ export const createRun = mutation({
 		imageUploadIds: v.array(v.id('imageUploads')),
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
-		serviceTier: vServiceTier
+		serviceTier: vServiceTier,
+		executionSecret: v.string()
 	},
 	handler: async (
 		ctx,
@@ -164,7 +160,6 @@ export const createRun = mutation({
 		created: boolean;
 		runId: Id<'runs'>;
 		promptMessageId: Id<'threadMessages'>;
-		userId: string;
 	}> => {
 		assertSupportedModelConfiguration({
 			modelId: args.selectedModel,
@@ -172,6 +167,7 @@ export const createRun = mutation({
 			serviceTier: args.serviceTier
 		});
 		const userId: string = await getUserId(ctx);
+		const secretHash = await executionSecretHash(args.executionSecret);
 		const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecord(
 			ctx.db,
 			userId,
@@ -190,6 +186,16 @@ export const createRun = mutation({
 			)
 			.unique();
 		if (existingRun) {
+			if (existingRun.executionSecretHash !== secretHash) {
+				const canRecoverExecutor =
+					existingRun.status === 'queued' ||
+					(isClaimedRunStatus(existingRun.status) &&
+						!isRunClaimLeaseActive(existingRun, Date.now()));
+				if (!canRecoverExecutor) {
+					throw new Error('Submission belongs to a different active executor.');
+				}
+				await ctx.db.patch(existingRun._id, { executionSecretHash: secretHash });
+			}
 			if (
 				existingRun.threadId !== args.threadId ||
 				existingRun.selectedModel !== args.selectedModel ||
@@ -211,8 +217,7 @@ export const createRun = mutation({
 			return {
 				created: false,
 				runId: existingRun._id,
-				promptMessageId: existingRun.promptMessageId,
-				userId
+				promptMessageId: existingRun.promptMessageId
 			};
 		}
 		const latestRun: Doc<'runs'> | null = await ctx.db
@@ -228,6 +233,7 @@ export const createRun = mutation({
 			submissionId: args.submissionId,
 			workspaceSessionId: threadRecord.workspaceSessionId,
 			status: 'queued',
+			executionSecretHash: secretHash,
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
 			serviceTier: args.serviceTier,
@@ -255,8 +261,7 @@ export const createRun = mutation({
 		return {
 			created: true,
 			runId,
-			promptMessageId,
-			userId
+			promptMessageId
 		};
 	}
 });
@@ -264,11 +269,11 @@ export const createRun = mutation({
 export const start = mutation({
 	args: {
 		claimId: v.string(),
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<{ claimed: boolean; claimExpiresAt?: number }> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const now = Date.now();
 		if (!canStartRunWithClaim(run, args.claimId, now)) {
 			return { claimed: false };
@@ -325,11 +330,11 @@ export const start = mutation({
 export const renewClaim = mutation({
 	args: {
 		claimId: v.string(),
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<{ renewed: boolean; claimExpiresAt?: number }> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		if (!isClaimedRunStatus(run.status) || run.claimId !== args.claimId) {
 			return { renewed: false };
 		}
@@ -342,7 +347,8 @@ export const renewClaim = mutation({
 
 export const getContext = query({
 	args: {
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (
 		ctx,
@@ -358,8 +364,8 @@ export const getContext = query({
 		promptAttachments: RuntimePromptAttachment[];
 		agentHistory: AgentHistoryMessage[];
 	}> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const userId = run.userId;
 		const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecord(
 			ctx.db,
 			userId,
@@ -406,18 +412,19 @@ export const getContext = query({
 
 export const isFinished = query({
 	args: {
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<boolean> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		return isRunFinalStatus(run.status);
 	}
 });
 
 export const completionActor = query({
 	args: {
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (
 		ctx,
@@ -427,12 +434,13 @@ export const completionActor = query({
 		threadId: Id<'threadRecords'>;
 		status: Infer<typeof vRunStatus>;
 		claimId?: string;
+		claimExpiresAt?: number;
 		completionAttemptSeq: number;
 		streamSequence: number;
 		streamAttemptId?: string;
 	}> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const userId = run.userId;
 		const message = run.responseMessageId
 			? await getThreadMessage(ctx, run.responseMessageId)
 			: null;
@@ -441,6 +449,7 @@ export const completionActor = query({
 			threadId: run.threadId,
 			status: run.status,
 			...(run.claimId ? { claimId: run.claimId } : {}),
+			...(run.claimExpiresAt ? { claimExpiresAt: run.claimExpiresAt } : {}),
 			completionAttemptSeq: run.completionAttemptSeq ?? 0,
 			streamSequence: message?.streamSequence ?? 0,
 			...(message?.streamAttemptId ? { streamAttemptId: message.streamAttemptId } : {})
@@ -453,12 +462,15 @@ export const registerCompletionAttempt = mutation({
 		runId: v.id('runs'),
 		claimId: v.string(),
 		attemptSeq: v.number(),
-		supersededStreamIds: v.optional(v.array(v.string()))
+		supersededStreamIds: v.optional(v.array(v.string())),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<void> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		assertRunAcceptsModelCompletion(run.status);
+		if (!isRunClaimLeaseActive(run, Date.now())) {
+			throw new Error(RUN_NO_LONGER_ACTIVE);
+		}
 		if (!canRegisterCompletionAttempt(run, args.claimId, args.attemptSeq)) {
 			throw new Error(COMPLETION_STREAM_SUPERSEDED);
 		}
@@ -484,11 +496,12 @@ export const registerCompletionAttempt = mutation({
 
 export const beginAssistantMessage = mutation({
 	args: {
-		runId: v.id('runs')
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<void> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const userId = run.userId;
 		if (isRunFinalStatus(run.status)) {
 			return;
 		}
@@ -519,15 +532,18 @@ export const mergeAssistantStreamEvents = mutation({
 		attemptSeq: v.number(),
 		streamId: v.string(),
 		sequence: v.number(),
-		events: v.array(vCompletionStreamEvent)
+		events: v.array(vCompletionStreamEvent),
+		executionSecret: v.string()
 	},
 	handler: async (
 		ctx,
 		args
 	): Promise<Exclude<CompletionStreamBatchClassification, 'append'> | 'merged'> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		assertRunAcceptsModelCompletion(run.status);
+		if (!isRunClaimLeaseActive(run, Date.now())) {
+			throw new Error(RUN_NO_LONGER_ACTIVE);
+		}
 		// Fence every write: periodic acceptance checks alone leave a window
 		// where a superseded attempt could still append after a newer one registers.
 		if (!isCurrentCompletionAttempt(run, args.claimId, args.attemptSeq)) {
@@ -637,8 +653,8 @@ export const finalizeRun = mutation({
 		lastError: v.optional(v.string())
 	},
 	handler: async (ctx, args): Promise<boolean> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const userId = await getUserId(ctx);
+		const run = await getOwnedRun(ctx.db, userId, args.runId);
 		if (args.expectedStatus && run.status !== args.expectedStatus) {
 			return false;
 		}
@@ -652,6 +668,31 @@ export const finalizeRun = mutation({
 	}
 });
 
+export const finalizeExecutorRun = mutation({
+	args: {
+		expectedStatus: v.optional(vRunStatus),
+		expectedClaimId: v.optional(v.string()),
+		runId: v.id('runs'),
+		text: v.string(),
+		status: vRunFinalStatus,
+		lastError: v.optional(v.string()),
+		executionSecret: v.string()
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		if (args.expectedStatus && run.status !== args.expectedStatus) {
+			return false;
+		}
+		if (
+			args.expectedClaimId &&
+			(run.claimId !== args.expectedClaimId || !isRunClaimLeaseActive(run, Date.now()))
+		) {
+			return false;
+		}
+		return finalizeRunRecord(ctx, run.userId, run, args);
+	}
+});
+
 export const finalizeFailedStart = mutation({
 	args: {
 		submissionId: v.string(),
@@ -662,15 +703,14 @@ export const finalizeFailedStart = mutation({
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
 		text: v.string(),
-		lastError: v.string()
+		lastError: v.string(),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<boolean> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> | null = await ctx.db
+		const secretHash = await executionSecretHash(args.executionSecret);
+		const run = await ctx.db
 			.query('runs')
-			.withIndex('by_userId_submissionId', (query) =>
-				query.eq('userId', userId).eq('submissionId', args.submissionId)
-			)
+			.withIndex('by_executionSecretHash', (query) => query.eq('executionSecretHash', secretHash))
 			.unique();
 		if (
 			!run ||
@@ -691,7 +731,7 @@ export const finalizeFailedStart = mutation({
 		) {
 			return false;
 		}
-		return finalizeRunRecord(ctx, userId, run, {
+		return finalizeRunRecord(ctx, run.userId, run, {
 			text: args.text,
 			status: 'failed',
 			lastError: args.lastError
@@ -704,12 +744,13 @@ export const finalizeClaimFailure = mutation({
 		claimId: v.string(),
 		runId: v.id('runs'),
 		text: v.string(),
-		lastError: v.string()
+		lastError: v.string(),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<boolean> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
-		if (!canFinalizeAfterClaimFailure(run, args.claimId)) {
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const userId = run.userId;
+		if (!canFinalizeAfterClaimFailure(run, args.claimId, Date.now())) {
 			return false;
 		}
 		return finalizeRunRecord(ctx, userId, run, {
@@ -727,7 +768,8 @@ export const beginToolJob = mutation({
 		kind: vExecutorJobKind,
 		callId: v.optional(v.string()),
 		payload: vExecutorJobPayload,
-		hidden: v.optional(v.boolean())
+		hidden: v.optional(v.boolean()),
+		executionSecret: v.string()
 	},
 	handler: async (
 		ctx,
@@ -736,8 +778,8 @@ export const beginToolJob = mutation({
 		jobId: Id<'executorJobs'>;
 		sequence: number;
 	}> => {
-		const userId: string = await getUserId(ctx);
-		const run: Doc<'runs'> = await getOwnedRun(ctx.db, userId, args.runId);
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const userId = run.userId;
 		assertRunAcceptsModelCompletion(run.status);
 		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
 			throw new Error('Run is no longer active.');

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -29,7 +29,8 @@ import {
 	claimExpiresAt,
 	isClaimedRunStatus,
 	isCurrentCompletionAttempt,
-	isRunClaimLeaseActive
+	isRunClaimLeaseActive,
+	ownsActiveRunClaim
 } from '@convex/lib/runLease';
 import {
 	ensureAssistantToolPartsFromJobs,
@@ -335,7 +336,8 @@ export const renewClaim = mutation({
 	},
 	handler: async (ctx, args): Promise<{ renewed: boolean; claimExpiresAt?: number }> => {
 		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (!isClaimedRunStatus(run.status) || run.claimId !== args.claimId) {
+		// Only active leases renew; expired workers must start/takeover again.
+		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
 			return { renewed: false };
 		}
 

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -7,10 +7,9 @@ import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
-import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
-import { isCurrentCompletionAttempt } from '@convex/lib/runLease';
+import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { isCurrentCompletionAttempt, isRunClaimLeaseActive } from '@convex/lib/runLease';
 import { chargeModelUsage, checkModelUsageLimit } from '@convex/lib/rateLimits';
-import { getUserId } from '@convex/lib/auth';
 import { vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
 import {
 	assertSupportedModelConfiguration,
@@ -57,6 +56,7 @@ export const complete = action({
 		claimId: v.string(),
 		attemptSeq: v.number(),
 		streamId: v.string(),
+		executionSecret: v.string(),
 		supersededStreamIds: v.optional(v.array(v.string())),
 		toolChoiceJson: v.optional(v.string()),
 		tools: v.optional(
@@ -84,13 +84,13 @@ export const complete = action({
 		}>;
 		stream_events: CompletionStreamEvent[];
 	}> => {
-		await getUserId(ctx);
 		// Register before any model work so a reconnect-replayed orphan dies
 		// on the monotonic (claimId, attemptSeq) fence instead of racing the live attempt.
 		await ctx.runMutation(api.agentRuntime.registerCompletionAttempt, {
 			runId: args.streamRunId,
 			claimId: args.claimId,
 			attemptSeq: args.attemptSeq,
+			executionSecret: args.executionSecret,
 			...(args.supersededStreamIds !== undefined
 				? { supersededStreamIds: args.supersededStreamIds }
 				: {})
@@ -124,7 +124,11 @@ export const complete = action({
 		if (args.prompt === undefined && messages === undefined) {
 			throw new Error('Either prompt or messagesJson is required.');
 		}
-		const completionContext = await prepareCompletionContext(ctx, args.streamRunId);
+		const completionContext = await prepareCompletionContext(
+			ctx,
+			args.streamRunId,
+			args.executionSecret
+		);
 		const sharedArgs = buildSharedCompletionRequest(
 			{ ...args, modelId, serviceTier },
 			tools,
@@ -151,6 +155,7 @@ export const complete = action({
 					claimId: args.claimId,
 					attemptSeq: args.attemptSeq,
 					streamId: args.streamId,
+					executionSecret: args.executionSecret,
 					initialSequence: completionContext.streamSequence
 				},
 				abortController
@@ -188,6 +193,7 @@ type CompletionAttempt = {
 	claimId: string;
 	attemptSeq: number;
 	streamId: string;
+	executionSecret: string;
 	initialSequence: number;
 };
 
@@ -197,7 +203,7 @@ async function collectStreamingCompletion(
 	attempt: CompletionAttempt,
 	abortController: AbortController
 ): Promise<CompletionActionResult> {
-	const { runId, claimId, attemptSeq, streamId, initialSequence } = attempt;
+	const { runId, claimId, attemptSeq, streamId, executionSecret, initialSequence } = attempt;
 	const streamEvents: CompletionStreamEvent[] = [];
 	const pendingEvents: CompletionStreamEvent[] = [];
 	const reasoning = new Map<
@@ -221,6 +227,7 @@ async function collectStreamingCompletion(
 					attemptSeq,
 					streamId,
 					sequence,
+					executionSecret,
 					events
 				});
 				if (outcome === 'superseded') {
@@ -496,9 +503,13 @@ async function assertCompletionStillAccepted(
 	attempt: CompletionAttempt
 ): Promise<void> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-		runId: attempt.runId
+		runId: attempt.runId,
+		executionSecret: attempt.executionSecret
 	});
 	assertRunAcceptsModelCompletion(actor.status);
+	if (!isRunClaimLeaseActive(actor, Date.now())) {
+		throw new Error(RUN_NO_LONGER_ACTIVE);
+	}
 	if (!isCurrentCompletionAttempt(actor, attempt.claimId, attempt.attemptSeq)) {
 		throw new Error(COMPLETION_STREAM_SUPERSEDED);
 	}
@@ -531,10 +542,12 @@ function delay(milliseconds: number): Promise<void> {
 
 async function prepareCompletionContext(
 	ctx: ActionCtx,
-	runId: Id<'runs'>
+	runId: Id<'runs'>,
+	executionSecret: string
 ): Promise<{ promptCacheKey: string; streamSequence: number; userId: string }> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-		runId
+		runId,
+		executionSecret
 	});
 	assertRunAcceptsModelCompletion(actor.status);
 	await checkModelUsageLimit(ctx, actor.userId);

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -199,27 +199,6 @@ describe('executor', () => {
 		expect(await t.run(async (ctx) => (await ctx.db.get(mismatched.jobId))?.status)).toBe('failed');
 	});
 
-	it('does not revive a run that is already final', async () => {
-		const t = initConvexTest();
-		const { asUser, runId, jobId, claimId, executionSecret } = await seedRunWithJob(t, {
-			runStatus: 'failed',
-			executionSecret: 'executor-final-secret'
-		});
-
-		await expect(
-			asUser.mutation(api.executor.fail, {
-				jobId,
-				error: 'late failure',
-				runId,
-				claimId,
-				executionSecret
-			})
-		).resolves.toBe(false);
-		expect(await t.run(async (ctx) => (await ctx.db.get(jobId))?.status)).toBe('claimed');
-		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('failed');
-		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.activeJobId)).toBeTruthy();
-	});
-
 	it('rejects tool completion and failure after the claim lease expires', async () => {
 		const t = initConvexTest();
 		const completeCase = await seedRunWithJob(t, {

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -6,11 +6,13 @@ import { initConvexTest, seedOwnedThread, type ConvexTestInstance } from './test
 async function seedRunWithJob(
 	t: ConvexTestInstance,
 	options: {
+		executionSecret: string;
 		runStatus?: 'queued' | 'running' | 'awaiting_executor' | 'failed' | 'completed';
 		jobStatus?: 'pending' | 'claimed' | 'completed' | 'failed' | 'cancelled';
 		activeJobMatches?: boolean;
-	} = {}
+	}
 ) {
+	const executionSecret = options.executionSecret;
 	const { asUser, threadId, workspaceSessionId, subject } = await seedOwnedThread(t);
 	const created = await asUser.mutation(api.agentRuntime.createRun, {
 		submissionId: `sub-job-${Math.random()}`,
@@ -19,7 +21,8 @@ async function seedRunWithJob(
 		imageUploadIds: [],
 		selectedModel: 'gpt-5.6-sol',
 		reasoningEffort: 'medium',
-		serviceTier: 'standard'
+		serviceTier: 'standard',
+		executionSecret
 	});
 
 	const jobId = await t.run(async (ctx) => {
@@ -53,7 +56,7 @@ async function seedRunWithJob(
 		return jobId;
 	});
 
-	return { asUser, subject, runId: created.runId, jobId };
+	return { asUser, subject, runId: created.runId, jobId, executionSecret };
 }
 
 const commandResult = {
@@ -72,10 +75,17 @@ const commandResult = {
 describe('executor', () => {
 	it('completes the active job and releases the run back to running', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId } = await seedRunWithJob(t);
+		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
+			executionSecret: 'executor-complete-secret'
+		});
 
 		await expect(
-			asUser.mutation(api.executor.complete, { jobId, result: commandResult })
+			asUser.mutation(api.executor.complete, {
+				jobId,
+				result: commandResult,
+				runId,
+				executionSecret
+			})
 		).resolves.toBe(true);
 
 		const state = await t.run(async (ctx) => ({
@@ -93,27 +103,39 @@ describe('executor', () => {
 
 	it('is idempotent for an already completed job and ignores terminal runs', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId } = await seedRunWithJob(t, {
+		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
 			jobStatus: 'completed',
-			runStatus: 'running'
+			runStatus: 'running',
+			executionSecret: 'executor-idempotent-secret'
 		});
 		await t.run(async (ctx) => {
 			await ctx.db.patch(jobId, { result: commandResult, completedAt: 1 });
 		});
 
 		await expect(
-			asUser.mutation(api.executor.complete, { jobId, result: commandResult })
+			asUser.mutation(api.executor.complete, {
+				jobId,
+				result: commandResult,
+				runId,
+				executionSecret
+			})
 		).resolves.toBe(true);
 
 		const {
 			asUser: asUser2,
 			runId: terminalRunId,
-			jobId: terminalJobId
-		} = await seedRunWithJob(t, { runStatus: 'completed' });
+			jobId: terminalJobId,
+			executionSecret: terminalSecret
+		} = await seedRunWithJob(t, {
+			runStatus: 'completed',
+			executionSecret: 'executor-terminal-secret'
+		});
 		await expect(
 			asUser2.mutation(api.executor.complete, {
 				jobId: terminalJobId,
-				result: commandResult
+				result: commandResult,
+				runId: terminalRunId,
+				executionSecret: terminalSecret
 			})
 		).resolves.toBe(false);
 		expect(await t.run(async (ctx) => (await ctx.db.get(terminalRunId))?.status)).toBe('completed');
@@ -122,11 +144,16 @@ describe('executor', () => {
 
 	it('fails a job and clears activeJobId only when it matches', async () => {
 		const t = initConvexTest();
-		const matching = await seedRunWithJob(t, { activeJobMatches: true });
+		const matching = await seedRunWithJob(t, {
+			activeJobMatches: true,
+			executionSecret: 'executor-fail-match-secret'
+		});
 		await expect(
 			matching.asUser.mutation(api.executor.fail, {
 				jobId: matching.jobId,
-				error: 'boom'
+				error: 'boom',
+				runId: matching.runId,
+				executionSecret: matching.executionSecret
 			})
 		).resolves.toBe(true);
 		expect(
@@ -142,12 +169,17 @@ describe('executor', () => {
 			(await t.run(async (ctx) => (await ctx.db.get(matching.runId))?.activeJobId)) ?? undefined
 		).toBeUndefined();
 
-		const mismatched = await seedRunWithJob(t, { activeJobMatches: false });
+		const mismatched = await seedRunWithJob(t, {
+			activeJobMatches: false,
+			executionSecret: 'executor-fail-mismatch-secret'
+		});
 		const before = await t.run(async (ctx) => ctx.db.get(mismatched.runId));
 		await expect(
 			mismatched.asUser.mutation(api.executor.fail, {
 				jobId: mismatched.jobId,
-				error: 'boom'
+				error: 'boom',
+				runId: mismatched.runId,
+				executionSecret: mismatched.executionSecret
 			})
 		).resolves.toBe(true);
 		const after = await t.run(async (ctx) => ctx.db.get(mismatched.runId));
@@ -158,10 +190,18 @@ describe('executor', () => {
 
 	it('does not revive a run that is already final', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId } = await seedRunWithJob(t, { runStatus: 'failed' });
+		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
+			runStatus: 'failed',
+			executionSecret: 'executor-final-secret'
+		});
 
 		await expect(
-			asUser.mutation(api.executor.fail, { jobId, error: 'late failure' })
+			asUser.mutation(api.executor.fail, {
+				jobId,
+				error: 'late failure',
+				runId,
+				executionSecret
+			})
 		).resolves.toBe(true);
 		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('failed');
 		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.activeJobId)).toBeTruthy();

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -10,9 +10,12 @@ async function seedRunWithJob(
 		runStatus?: 'queued' | 'running' | 'awaiting_executor' | 'failed' | 'completed';
 		jobStatus?: 'pending' | 'claimed' | 'completed' | 'failed' | 'cancelled';
 		activeJobMatches?: boolean;
+		claimId?: string;
+		claimExpiresAt?: number;
 	}
 ) {
 	const executionSecret = options.executionSecret;
+	const claimId = options.claimId ?? `claim-${Math.random()}`;
 	const { asUser, threadId, workspaceSessionId, subject } = await seedOwnedThread(t);
 	const created = await asUser.mutation(api.agentRuntime.createRun, {
 		submissionId: `sub-job-${Math.random()}`,
@@ -51,12 +54,14 @@ async function seedRunWithJob(
 		});
 		await ctx.db.patch(created.runId, {
 			status: options.runStatus ?? 'awaiting_executor',
+			claimId,
+			claimExpiresAt: options.claimExpiresAt ?? Date.now() + 60_000,
 			activeJobId: options.activeJobMatches === false ? otherJobId : (jobId as Id<'executorJobs'>)
 		});
 		return jobId;
 	});
 
-	return { asUser, subject, runId: created.runId, jobId, executionSecret };
+	return { asUser, subject, runId: created.runId, jobId, claimId, executionSecret };
 }
 
 const commandResult = {
@@ -75,7 +80,7 @@ const commandResult = {
 describe('executor', () => {
 	it('completes the active job and releases the run back to running', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
+		const { asUser, runId, jobId, claimId, executionSecret } = await seedRunWithJob(t, {
 			executionSecret: 'executor-complete-secret'
 		});
 
@@ -84,6 +89,7 @@ describe('executor', () => {
 				jobId,
 				result: commandResult,
 				runId,
+				claimId,
 				executionSecret
 			})
 		).resolves.toBe(true);
@@ -103,7 +109,7 @@ describe('executor', () => {
 
 	it('is idempotent for an already completed job and ignores terminal runs', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
+		const { asUser, runId, jobId, claimId, executionSecret } = await seedRunWithJob(t, {
 			jobStatus: 'completed',
 			runStatus: 'running',
 			executionSecret: 'executor-idempotent-secret'
@@ -117,6 +123,7 @@ describe('executor', () => {
 				jobId,
 				result: commandResult,
 				runId,
+				claimId,
 				executionSecret
 			})
 		).resolves.toBe(true);
@@ -125,6 +132,7 @@ describe('executor', () => {
 			asUser: asUser2,
 			runId: terminalRunId,
 			jobId: terminalJobId,
+			claimId: terminalClaimId,
 			executionSecret: terminalSecret
 		} = await seedRunWithJob(t, {
 			runStatus: 'completed',
@@ -135,6 +143,7 @@ describe('executor', () => {
 				jobId: terminalJobId,
 				result: commandResult,
 				runId: terminalRunId,
+				claimId: terminalClaimId,
 				executionSecret: terminalSecret
 			})
 		).resolves.toBe(false);
@@ -153,6 +162,7 @@ describe('executor', () => {
 				jobId: matching.jobId,
 				error: 'boom',
 				runId: matching.runId,
+				claimId: matching.claimId,
 				executionSecret: matching.executionSecret
 			})
 		).resolves.toBe(true);
@@ -179,6 +189,7 @@ describe('executor', () => {
 				jobId: mismatched.jobId,
 				error: 'boom',
 				runId: mismatched.runId,
+				claimId: mismatched.claimId,
 				executionSecret: mismatched.executionSecret
 			})
 		).resolves.toBe(true);
@@ -190,7 +201,7 @@ describe('executor', () => {
 
 	it('does not revive a run that is already final', async () => {
 		const t = initConvexTest();
-		const { asUser, runId, jobId, executionSecret } = await seedRunWithJob(t, {
+		const { asUser, runId, jobId, claimId, executionSecret } = await seedRunWithJob(t, {
 			runStatus: 'failed',
 			executionSecret: 'executor-final-secret'
 		});
@@ -200,10 +211,55 @@ describe('executor', () => {
 				jobId,
 				error: 'late failure',
 				runId,
+				claimId,
 				executionSecret
 			})
-		).resolves.toBe(true);
+		).resolves.toBe(false);
+		expect(await t.run(async (ctx) => (await ctx.db.get(jobId))?.status)).toBe('claimed');
 		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('failed');
 		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.activeJobId)).toBeTruthy();
+	});
+
+	it('rejects tool completion and failure after the claim lease expires', async () => {
+		const t = initConvexTest();
+		const completeCase = await seedRunWithJob(t, {
+			executionSecret: 'executor-expired-complete-secret',
+			claimExpiresAt: Date.now() - 1
+		});
+		await expect(
+			completeCase.asUser.mutation(api.executor.complete, {
+				jobId: completeCase.jobId,
+				result: commandResult,
+				runId: completeCase.runId,
+				claimId: completeCase.claimId,
+				executionSecret: completeCase.executionSecret
+			})
+		).resolves.toBe(false);
+		expect(
+			await t.run(async (ctx) => ({
+				jobStatus: (await ctx.db.get(completeCase.jobId))?.status,
+				activeJobId: (await ctx.db.get(completeCase.runId))?.activeJobId
+			}))
+		).toEqual({ jobStatus: 'claimed', activeJobId: completeCase.jobId });
+
+		const failCase = await seedRunWithJob(t, {
+			executionSecret: 'executor-expired-fail-secret',
+			claimExpiresAt: Date.now() - 1
+		});
+		await expect(
+			failCase.asUser.mutation(api.executor.fail, {
+				jobId: failCase.jobId,
+				error: 'late tool failure',
+				runId: failCase.runId,
+				claimId: failCase.claimId,
+				executionSecret: failCase.executionSecret
+			})
+		).resolves.toBe(false);
+		expect(
+			await t.run(async (ctx) => ({
+				jobStatus: (await ctx.db.get(failCase.jobId))?.status,
+				activeJobId: (await ctx.db.get(failCase.runId))?.activeJobId
+			}))
+		).toEqual({ jobStatus: 'claimed', activeJobId: failCase.jobId });
 	});
 });

--- a/apps/web/src/convex/executor.ts
+++ b/apps/web/src/convex/executor.ts
@@ -1,26 +1,27 @@
 import { mutation } from '@convex/_generated/server';
 import { v } from 'convex/values';
-import { getOwnedExecutorJob } from '@convex/lib/access';
-import { getUserId } from '@convex/lib/auth';
+import { getExecutionRun } from '@convex/lib/auth';
 import { executorFailureRunPatch } from '@convex/lib/runs';
 import { isRunFinalStatus, vExecutorJobResult } from '@convex/lib/validators';
 
 export const complete = mutation({
 	args: {
 		jobId: v.id('executorJobs'),
-		result: vExecutorJobResult
+		result: vExecutorJobResult,
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args) => {
-		const userId: string = await getUserId(ctx);
-		const job = await getOwnedExecutorJob(ctx.db, userId, args.jobId);
-		const run = await ctx.db.get(job.runId);
+		const job = await ctx.db.get(args.jobId);
+		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+		const run = await getExecutionRun(ctx, job.runId, args.executionSecret);
 		if (job.status === 'cancelled' || job.status === 'failed') {
 			return false;
 		}
 		if (job.status === 'completed') {
 			return true;
 		}
-		if (!run || isRunFinalStatus(run.status)) {
+		if (isRunFinalStatus(run.status)) {
 			return false;
 		}
 
@@ -42,11 +43,14 @@ export const complete = mutation({
 export const fail = mutation({
 	args: {
 		jobId: v.id('executorJobs'),
-		error: v.string()
+		error: v.string(),
+		runId: v.id('runs'),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args) => {
-		const userId: string = await getUserId(ctx);
-		const job = await getOwnedExecutorJob(ctx.db, userId, args.jobId);
+		const job = await ctx.db.get(args.jobId);
+		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+		const run = await getExecutionRun(ctx, job.runId, args.executionSecret);
 		if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
 			return false;
 		}
@@ -57,16 +61,13 @@ export const fail = mutation({
 			error: args.error,
 			completedAt
 		});
-		const run = await ctx.db.get(job.runId);
-		if (run) {
-			const runPatch = executorFailureRunPatch({
-				runStatus: run.status,
-				activeJobId: run.activeJobId,
-				failedJobId: args.jobId
-			});
-			if (runPatch) {
-				await ctx.db.patch(job.runId, runPatch);
-			}
+		const runPatch = executorFailureRunPatch({
+			runStatus: run.status,
+			activeJobId: run.activeJobId,
+			failedJobId: args.jobId
+		});
+		if (runPatch) {
+			await ctx.db.patch(job.runId, runPatch);
 		}
 		return true;
 	}

--- a/apps/web/src/convex/executor.ts
+++ b/apps/web/src/convex/executor.ts
@@ -2,6 +2,7 @@ import { mutation } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getExecutionRun } from '@convex/lib/auth';
 import { executorFailureRunPatch } from '@convex/lib/runs';
+import { ownsActiveRunClaim } from '@convex/lib/runLease';
 import { isRunFinalStatus, vExecutorJobResult } from '@convex/lib/validators';
 
 export const complete = mutation({
@@ -9,6 +10,7 @@ export const complete = mutation({
 		jobId: v.id('executorJobs'),
 		result: vExecutorJobResult,
 		runId: v.id('runs'),
+		claimId: v.string(),
 		executionSecret: v.string()
 	},
 	handler: async (ctx, args) => {
@@ -22,6 +24,9 @@ export const complete = mutation({
 			return true;
 		}
 		if (isRunFinalStatus(run.status)) {
+			return false;
+		}
+		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
 			return false;
 		}
 
@@ -45,6 +50,7 @@ export const fail = mutation({
 		jobId: v.id('executorJobs'),
 		error: v.string(),
 		runId: v.id('runs'),
+		claimId: v.string(),
 		executionSecret: v.string()
 	},
 	handler: async (ctx, args) => {
@@ -52,6 +58,9 @@ export const fail = mutation({
 		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
 		const run = await getExecutionRun(ctx, job.runId, args.executionSecret);
 		if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
+			return false;
+		}
+		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
 			return false;
 		}
 

--- a/apps/web/src/convex/lib/auth.ts
+++ b/apps/web/src/convex/lib/auth.ts
@@ -5,6 +5,7 @@ import type {
 	UserIdentity
 } from 'convex/server';
 import type { DataModel } from '@convex/_generated/dataModel';
+import type { Doc, Id } from '@convex/_generated/dataModel';
 
 export async function getUserId(
 	ctx: GenericActionCtx<DataModel> | GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>
@@ -14,4 +15,36 @@ export async function getUserId(
 		throw new Error('Authentication required.');
 	}
 	return identity.subject;
+}
+
+async function hashExecutionSecret(secret: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+	let difference = left.length ^ right.length;
+	const length = Math.max(left.length, right.length);
+	for (let index = 0; index < length; index += 1) {
+		difference |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+	}
+	return difference === 0;
+}
+
+export async function executionSecretHash(secret: string): Promise<string> {
+	if (!secret.trim()) throw new Error('Execution secret cannot be empty.');
+	return await hashExecutionSecret(secret);
+}
+
+/** Authorize a run using the capability held by its local executor. */
+export async function getExecutionRun(
+	ctx: GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>,
+	runId: Id<'runs'>,
+	executionSecret: string
+): Promise<Doc<'runs'>> {
+	const run = await ctx.db.get(runId);
+	if (!run) throw new Error('Run not found.');
+	const candidateHash = await hashExecutionSecret(executionSecret);
+	if (!constantTimeEqual(candidateHash, run.executionSecretHash)) throw new Error('Run not found.');
+	return run;
 }

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -41,22 +41,31 @@ describe('run claim leases', () => {
 	});
 
 	it('only terminalizes state owned by the same claim after claim uncertainty', () => {
-		expect(canFinalizeAfterClaimFailure({ status: 'queued' }, 'claim-a')).toBe(false);
+		expect(canFinalizeAfterClaimFailure({ status: 'queued' }, 'claim-a', 100)).toBe(false);
 		expect(
 			canFinalizeAfterClaimFailure(
 				{ status: 'running', claimId: 'claim-a', claimExpiresAt: 200 },
-				'claim-a'
+				'claim-a',
+				100
 			)
 		).toBe(true);
 		expect(
 			canFinalizeAfterClaimFailure(
-				{ status: 'awaiting_executor', claimId: 'claim-b', claimExpiresAt: 200 },
-				'claim-a'
+				{ status: 'running', claimId: 'claim-a', claimExpiresAt: 100 },
+				'claim-a',
+				100
 			)
 		).toBe(false);
-		expect(canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a')).toBe(
-			false
-		);
+		expect(
+			canFinalizeAfterClaimFailure(
+				{ status: 'awaiting_executor', claimId: 'claim-b', claimExpiresAt: 200 },
+				'claim-a',
+				100
+			)
+		).toBe(false);
+		expect(
+			canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a', 100)
+		).toBe(false);
 	});
 
 	it('only lets strictly newer completion attempts of the current claim take the stream', () => {

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -3,6 +3,7 @@ import {
 	RUN_CLAIM_LEASE_DURATION_MS,
 	canRegisterCompletionAttempt,
 	canFinalizeAfterClaimFailure,
+	ownsActiveRunClaim,
 	canStartRunWithClaim,
 	claimExpiresAt,
 	isCurrentCompletionAttempt,
@@ -41,28 +42,20 @@ describe('run claim leases', () => {
 	});
 
 	it('only terminalizes state owned by the same claim after claim uncertainty', () => {
-		expect(canFinalizeAfterClaimFailure({ status: 'queued' }, 'claim-a', 100)).toBe(false);
+		const active = { status: 'running', claimId: 'claim-a', claimExpiresAt: 200 };
+		expect(ownsActiveRunClaim({ status: 'queued' }, 'claim-a', 100)).toBe(false);
+		expect(ownsActiveRunClaim(active, 'claim-a', 100)).toBe(true);
+		expect(ownsActiveRunClaim(active, 'claim-b', 100)).toBe(false);
 		expect(
-			canFinalizeAfterClaimFailure(
-				{ status: 'running', claimId: 'claim-a', claimExpiresAt: 200 },
-				'claim-a',
-				100
-			)
-		).toBe(true);
-		expect(
-			canFinalizeAfterClaimFailure(
+			ownsActiveRunClaim(
 				{ status: 'running', claimId: 'claim-a', claimExpiresAt: 100 },
 				'claim-a',
 				100
 			)
 		).toBe(false);
-		expect(
-			canFinalizeAfterClaimFailure(
-				{ status: 'awaiting_executor', claimId: 'claim-b', claimExpiresAt: 200 },
-				'claim-a',
-				100
-			)
-		).toBe(false);
+		expect(canFinalizeAfterClaimFailure(active, 'claim-a', 100)).toBe(
+			ownsActiveRunClaim(active, 'claim-a', 100)
+		);
 		expect(
 			canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a', 100)
 		).toBe(false);

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
 	RUN_CLAIM_LEASE_DURATION_MS,
 	canRegisterCompletionAttempt,
-	canFinalizeAfterClaimFailure,
 	ownsActiveRunClaim,
 	canStartRunWithClaim,
 	claimExpiresAt,
@@ -41,7 +40,7 @@ describe('run claim leases', () => {
 		expect(canStartRunWithClaim(run, 'claim-b', 100)).toBe(true);
 	});
 
-	it('only terminalizes state owned by the same claim after claim uncertainty', () => {
+	it('only treats a matching unexpired claim as active ownership', () => {
 		const active = { status: 'running', claimId: 'claim-a', claimExpiresAt: 200 };
 		expect(ownsActiveRunClaim({ status: 'queued' }, 'claim-a', 100)).toBe(false);
 		expect(ownsActiveRunClaim(active, 'claim-a', 100)).toBe(true);
@@ -53,11 +52,12 @@ describe('run claim leases', () => {
 				100
 			)
 		).toBe(false);
-		expect(canFinalizeAfterClaimFailure(active, 'claim-a', 100)).toBe(
-			ownsActiveRunClaim(active, 'claim-a', 100)
-		);
 		expect(
-			canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a', 100)
+			ownsActiveRunClaim(
+				{ status: 'failed', claimId: 'claim-a', claimExpiresAt: 200 },
+				'claim-a',
+				100
+			)
 		).toBe(false);
 	});
 

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -27,12 +27,16 @@ export function canStartRunWithClaim(run: ClaimableRun, claimId: string, now: nu
 	return !isRunClaimLeaseActive(run, now);
 }
 
+export function ownsActiveRunClaim(run: ClaimableRun, claimId: string, now: number): boolean {
+	return run.claimId === claimId && isRunClaimLeaseActive(run, now);
+}
+
 export function canFinalizeAfterClaimFailure(
 	run: ClaimableRun,
 	claimId: string,
 	now: number
 ): boolean {
-	return run.claimId === claimId && isRunClaimLeaseActive(run, now);
+	return ownsActiveRunClaim(run, claimId, now);
 }
 
 export function claimExpiresAt(now: number): number {

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -27,8 +27,12 @@ export function canStartRunWithClaim(run: ClaimableRun, claimId: string, now: nu
 	return !isRunClaimLeaseActive(run, now);
 }
 
-export function canFinalizeAfterClaimFailure(run: ClaimableRun, claimId: string): boolean {
-	return isClaimedRunStatus(run.status) && run.claimId === claimId;
+export function canFinalizeAfterClaimFailure(
+	run: ClaimableRun,
+	claimId: string,
+	now: number
+): boolean {
+	return run.claimId === claimId && isRunClaimLeaseActive(run, now);
 }
 
 export function claimExpiresAt(now: number): number {

--- a/apps/web/src/convex/messages.test.ts
+++ b/apps/web/src/convex/messages.test.ts
@@ -7,6 +7,7 @@ async function createQueuedRun(
 	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
 	threadId: Id<'threadRecords'>,
 	submissionId: string,
+	executionSecret: string,
 	prompt = `Prompt ${submissionId}`
 ) {
 	return await asUser.mutation(api.agentRuntime.createRun, {
@@ -16,7 +17,8 @@ async function createQueuedRun(
 		imageUploadIds: [],
 		selectedModel: 'gpt-5.6-sol',
 		reasoningEffort: 'medium',
-		serviceTier: 'standard'
+		serviceTier: 'standard',
+		executionSecret
 	});
 }
 
@@ -25,6 +27,7 @@ async function completeRun(
 	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
 	args: {
 		runId: Id<'runs'>;
+		executionSecret: string;
 		status: 'completed' | 'failed' | 'cancelled';
 		responseText?: string;
 		startedAt?: number;
@@ -32,9 +35,13 @@ async function completeRun(
 ) {
 	await asUser.mutation(api.agentRuntime.start, {
 		claimId: `claim-${args.runId}`,
-		runId: args.runId
+		runId: args.runId,
+		executionSecret: args.executionSecret
 	});
-	await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId: args.runId });
+	await asUser.mutation(api.agentRuntime.beginAssistantMessage, {
+		runId: args.runId,
+		executionSecret: args.executionSecret
+	});
 	await asUser.mutation(api.agentRuntime.finalizeRun, {
 		runId: args.runId,
 		text: args.responseText ?? `Response for ${args.runId}`,
@@ -52,7 +59,13 @@ describe('messages transcript queries', () => {
 	it('keeps active runs in live and excludes them from history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const active = await createQueuedRun(asUser, threadId, 'sub-active', 'Live prompt');
+		const active = await createQueuedRun(
+			asUser,
+			threadId,
+			'sub-active',
+			'messages-live-secret',
+			'Live prompt'
+		);
 
 		const history = await asUser.query(api.messages.listHistoryForThread, { threadId });
 		const live = await asUser.query(api.messages.listLiveForThread, { threadId });
@@ -70,10 +83,21 @@ describe('messages transcript queries', () => {
 	it('streams live responses then moves terminal runs into history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId } = await createQueuedRun(asUser, threadId, 'sub-stream', 'Stream me');
+		const executionSecret = 'messages-stream-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'sub-stream',
+			executionSecret,
+			'Stream me'
+		);
 
-		await asUser.mutation(api.agentRuntime.start, { claimId: 'claim-stream', runId });
-		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId });
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-stream',
+			runId,
+			executionSecret
+		});
+		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId, executionSecret });
 
 		const responseMessageId = await t.run(async (ctx) => {
 			const run = await ctx.db.get(runId);
@@ -122,9 +146,17 @@ describe('messages transcript queries', () => {
 		const statuses = ['completed', 'failed', 'cancelled'] as const;
 
 		for (let index = 0; index < 25; index += 1) {
-			const created = await createQueuedRun(asUser, threadId, `sub-bound-${index}`, `P${index}`);
+			const executionSecret = `messages-bound-secret-${index}`;
+			const created = await createQueuedRun(
+				asUser,
+				threadId,
+				`sub-bound-${index}`,
+				executionSecret,
+				`P${index}`
+			);
 			await completeRun(t, asUser, {
 				runId: created.runId,
+				executionSecret,
 				status: statuses[index % statuses.length]!,
 				responseText: `R${index}`,
 				startedAt: 1_000 + index

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -65,6 +65,8 @@ export default defineSchema({
 		submissionId: v.string(),
 		workspaceSessionId: v.id('workspaceSessions'),
 		status: vRunStatus,
+		// Hash of the bearer capability held only by the local executor.
+		executionSecretHash: v.string(),
 		claimId: v.optional(v.string()),
 		claimExpiresAt: v.optional(v.number()),
 		completionAttemptSeq: v.optional(v.number()),
@@ -80,6 +82,7 @@ export default defineSchema({
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
 		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])
+		.index('by_executionSecretHash', ['executionSecretHash'])
 		.index('by_userId_submissionId', ['userId', 'submissionId'])
 		.index('by_workspaceSessionId', ['workspaceSessionId'])
 		.index('by_userId_startedAt', ['userId', 'startedAt']),

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -4,14 +4,14 @@ import { v, type Infer } from 'convex/values';
 import { ContextDev } from '@context-dot-dev/convex';
 import { ExaClient } from '@exalabs/convex-exa';
 import { action } from '@convex/_generated/server';
-import { components } from '@convex/_generated/api';
-import { getUserId } from '@convex/lib/auth';
+import { api, components } from '@convex/_generated/api';
 import {
 	chargeUrlScrapeUsage,
 	chargeWebSearchUsage,
 	checkWebToolsLimit
 } from '@convex/lib/rateLimits';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
+import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 
 const contextDev = new ContextDev(components.contextDev);
 const exa = new ExaClient(components.exa);
@@ -69,10 +69,20 @@ async function callComponent<T>(
 
 export const scrapeUrl = action({
 	args: {
-		url: v.string()
+		url: v.string(),
+		runId: v.id('runs'),
+		claimId: v.string(),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<ScrapeUrlResult> => {
-		const userId: string = await getUserId(ctx);
+		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+			runId: args.runId,
+			executionSecret: args.executionSecret
+		});
+		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+			throw new Error('Run is no longer active.');
+		}
+		const { userId } = actor;
 		let url: URL;
 		try {
 			url = new URL(args.url.trim());
@@ -109,10 +119,20 @@ export const scrapeUrl = action({
 export const webSearch = action({
 	args: {
 		query: v.string(),
-		numResults: v.optional(v.number())
+		numResults: v.optional(v.number()),
+		runId: v.id('runs'),
+		claimId: v.string(),
+		executionSecret: v.string()
 	},
 	handler: async (ctx, args): Promise<WebSearchResult> => {
-		const userId: string = await getUserId(ctx);
+		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+			runId: args.runId,
+			executionSecret: args.executionSecret
+		});
+		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+			throw new Error('Run is no longer active.');
+		}
+		const { userId } = actor;
 		const query = args.query.trim();
 		if (!query) {
 			throw new Error('Search query cannot be empty.');

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -7,12 +7,7 @@ import {
 	resolveDraftRunSubmissionId,
 	resolveSubmissionId
 } from '$lib/home/desktop';
-import type {
-	AgentAuthStatus,
-	DesktopApi,
-	RunState,
-	WorkspaceSessionLocation
-} from '$lib/types/sprocket';
+import type { DesktopApi, RunState, WorkspaceSessionLocation } from '$lib/types/sprocket';
 
 const recoveredSubmission = {
 	prompt: 'Inspect the robot',
@@ -29,9 +24,7 @@ function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 		resolveWorkspacePath: vi.fn(),
 		listWorkspaceSessions: vi.fn(),
 		attachWorkspaceSession: vi.fn(),
-		runAgent,
-		waitForAgentAuthRefresh: vi.fn().mockResolvedValue('complete'),
-		refreshAgentAuth: vi.fn()
+		runAgent
 	} as unknown as DesktopApi;
 }
 
@@ -41,9 +34,6 @@ function launchArgs(
 ): Parameters<typeof launchAgentRun>[0] {
 	return {
 		authToken: 'token-1',
-		expectedUserId: 'user-1',
-		getAccessToken: vi.fn(),
-		getCurrentUserId: () => 'user-1',
 		onError: vi.fn(),
 		onStarted: vi.fn(),
 		threadId: 'thread-1' as never,
@@ -93,7 +83,6 @@ describe('launchAgentRun', () => {
 		launchAgentRun(launchArgs({ desktopApi, onStarted }));
 
 		expect(runAgent).toHaveBeenCalledWith({
-			authSessionId: expect.any(String),
 			authToken: 'token-1',
 			threadId: 'thread-1',
 			prompt: 'Inspect src/lib.rs',
@@ -119,126 +108,6 @@ describe('launchAgentRun', () => {
 		await vi.waitFor(() => {
 			expect(onError).toHaveBeenCalledWith(launchError);
 		});
-	});
-
-	it('force-refreshes the access token when the running agent requests one', async () => {
-		const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
-		vi.mocked(desktopApi.waitForAgentAuthRefresh)
-			.mockResolvedValueOnce('refreshRequired')
-			.mockResolvedValueOnce('complete');
-		const getAccessToken = vi.fn().mockResolvedValue('token-2');
-
-		launchAgentRun(launchArgs({ desktopApi, getAccessToken }));
-
-		await vi.waitFor(() => {
-			expect(desktopApi.refreshAgentAuth).toHaveBeenCalledWith(expect.any(String), 'token-2');
-		});
-		expect(getAccessToken).toHaveBeenCalledWith({ forceRefreshToken: true });
-	});
-
-	it('rechecks a missing auth session delivered after launch acknowledgement', async () => {
-		vi.useFakeTimers();
-		try {
-			const staleStatus = deferred<AgentAuthStatus>();
-			const activeStatus = deferred<AgentAuthStatus>();
-			const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
-			vi.mocked(desktopApi.waitForAgentAuthRefresh)
-				.mockReturnValueOnce(staleStatus.promise)
-				.mockReturnValueOnce(activeStatus.promise);
-			const getAccessToken = vi.fn().mockResolvedValue('token-2');
-			const onError = vi.fn();
-			const onStarted = vi.fn();
-
-			launchAgentRun(launchArgs({ desktopApi, getAccessToken, onError, onStarted }));
-
-			await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
-			staleStatus.resolve('notFound');
-			await staleStatus.promise;
-			await vi.advanceTimersByTimeAsync(250);
-			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(2);
-
-			activeStatus.resolve('refreshRequired');
-			await activeStatus.promise;
-			await vi.waitFor(() => {
-				expect(desktopApi.refreshAgentAuth).toHaveBeenCalledWith(expect.any(String), 'token-2');
-			});
-			expect(onError).not.toHaveBeenCalled();
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it('stops polling after a missing session is confirmed following launch', async () => {
-		vi.useFakeTimers();
-		try {
-			const staleStatus = deferred<AgentAuthStatus>();
-			const desktopApi = createDesktopApi(vi.fn().mockResolvedValue({ runId: 'run-1' }));
-			vi.mocked(desktopApi.waitForAgentAuthRefresh)
-				.mockReturnValueOnce(staleStatus.promise)
-				.mockResolvedValue('notFound');
-			const onError = vi.fn();
-			const onStarted = vi.fn();
-
-			launchAgentRun(launchArgs({ desktopApi, onError, onStarted }));
-
-			await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
-			staleStatus.resolve('notFound');
-			await staleStatus.promise;
-			await vi.advanceTimersByTimeAsync(4_000);
-
-			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(2);
-			expect(onError).not.toHaveBeenCalled();
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it('keeps polling while launch is pending and the auth session is not ready yet', async () => {
-		vi.useFakeTimers();
-		try {
-			const launch = deferred<{ runId: never }>();
-			const desktopApi = createDesktopApi(vi.fn().mockReturnValue(launch.promise));
-			vi.mocked(desktopApi.waitForAgentAuthRefresh).mockResolvedValue('notFound');
-			const onError = vi.fn();
-			const onStarted = vi.fn();
-
-			launchAgentRun(launchArgs({ desktopApi, onError, onStarted }));
-			await vi.advanceTimersByTimeAsync(1_000);
-			expect(onError).not.toHaveBeenCalled();
-			expect(vi.mocked(desktopApi.waitForAgentAuthRefresh).mock.calls.length).toBeGreaterThan(1);
-
-			launch.resolve({ runId: 'run-1' as never });
-			await vi.waitFor(() => expect(onStarted).toHaveBeenCalledWith('run-1'));
-			expect(onError).not.toHaveBeenCalled();
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it('surfaces the launch error and stops auth polling when the local API is unavailable', async () => {
-		vi.useFakeTimers();
-		try {
-			const launch = deferred<{ runId: never }>();
-			const desktopApi = createDesktopApi(vi.fn().mockReturnValue(launch.promise));
-			vi.mocked(desktopApi.waitForAgentAuthRefresh).mockRejectedValue(
-				new Error('local API unavailable')
-			);
-			const onError = vi.fn();
-			const launchError = new Error('desktop launch failed');
-
-			launchAgentRun(launchArgs({ desktopApi, onError }));
-			await vi.advanceTimersByTimeAsync(500);
-			launch.reject(launchError);
-			await vi.waitFor(() => {
-				expect(onError).toHaveBeenCalledWith(launchError);
-			});
-			expect(onError).toHaveBeenCalledOnce();
-			const pollCountAfterFailure = vi.mocked(desktopApi.waitForAgentAuthRefresh).mock.calls.length;
-			await vi.advanceTimersByTimeAsync(4_000);
-			expect(desktopApi.waitForAgentAuthRefresh).toHaveBeenCalledTimes(pollCountAfterFailure);
-		} finally {
-			vi.useRealTimers();
-		}
 	});
 });
 

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -1,6 +1,5 @@
 import type { Id } from '$convex/_generated/dataModel';
 import type {
-	AgentAuthStatus,
 	AgentRunRequest,
 	DesktopApi,
 	LocalWorkspaceAvailability,
@@ -12,9 +11,6 @@ import type {
 import { isRunClaimLeaseActive } from '$convex/lib/runLease';
 import { isRunFinalStatus } from '$convex/lib/validators';
 import { areImageUploadIdsEqual } from '$lib/chat/attachments';
-
-const AGENT_AUTH_INITIAL_RETRY_DELAY_MS = 250;
-const AGENT_AUTH_MAX_RETRY_DELAY_MS = 4_000;
 
 export type WorkspaceSessionState = WorkspaceSession & {
 	localWorkspaceAvailability: LocalWorkspaceAvailability;
@@ -78,9 +74,6 @@ export function isRunBlockingAgentLaunch(
 export function launchAgentRun(args: {
 	authToken: string;
 	desktopApi: DesktopApi;
-	expectedUserId: string;
-	getAccessToken: (options: { forceRefreshToken: boolean }) => Promise<string | null>;
-	getCurrentUserId: () => string | null;
 	onError: (error: unknown) => void;
 	onStarted: (runId: Id<'runs'>) => void;
 	threadId: Id<'threadRecords'>;
@@ -92,42 +85,8 @@ export function launchAgentRun(args: {
 	submissionId: string;
 	workspaceSessionId: Id<'workspaceSessions'>;
 }) {
-	const authSessionId = crypto.randomUUID();
-	let settleLaunch!: () => void;
-	const launchState = {
-		status: 'pending' as 'pending' | 'acknowledged' | 'failed',
-		settled: new Promise<void>((resolve) => {
-			settleLaunch = resolve;
-		})
-	};
-	let errorReported = false;
-	const reportError = (error: unknown) => {
-		if (errorReported) return;
-		errorReported = true;
-		console.error('Failed to run agent', error);
-		args.onError(error);
-	};
-	const handleMonitorError = async (error: unknown) => {
-		await launchState.settled;
-		if (launchState.status === 'failed') {
-			reportError(error);
-			return;
-		}
-		console.error('Agent authentication monitor stopped', error);
-	};
-
-	void monitorAgentAuthSession({
-		authSessionId,
-		desktopApi: args.desktopApi,
-		expectedUserId: args.expectedUserId,
-		getAccessToken: args.getAccessToken,
-		getCurrentUserId: args.getCurrentUserId,
-		launchState
-	}).catch(handleMonitorError);
-
 	void args.desktopApi
 		.runAgent({
-			authSessionId,
 			authToken: args.authToken,
 			threadId: args.threadId,
 			prompt: args.prompt,
@@ -139,92 +98,12 @@ export function launchAgentRun(args: {
 			workspaceSessionId: args.workspaceSessionId
 		})
 		.then(({ runId }) => {
-			launchState.status = 'acknowledged';
-			settleLaunch();
 			args.onStarted(runId);
 		})
 		.catch((error) => {
-			launchState.status = 'failed';
-			settleLaunch();
-			reportError(error);
+			console.error('Failed to run agent', error);
+			args.onError(error);
 		});
-}
-
-async function monitorAgentAuthSession(args: {
-	authSessionId: string;
-	desktopApi: DesktopApi;
-	expectedUserId: string;
-	getAccessToken: (options: { forceRefreshToken: boolean }) => Promise<string | null>;
-	getCurrentUserId: () => string | null;
-	launchState: {
-		status: 'pending' | 'acknowledged' | 'failed';
-		settled: Promise<void>;
-	};
-}) {
-	let pendingToken: string | null = null;
-	let retryDelayMs = AGENT_AUTH_INITIAL_RETRY_DELAY_MS;
-	let missingSessionObservedAfterLaunch = false;
-	const launchFailed = () => args.launchState.status === 'failed';
-
-	while (true) {
-		let status: AgentAuthStatus;
-		try {
-			status = await args.desktopApi.waitForAgentAuthRefresh(args.authSessionId);
-		} catch {
-			if (launchFailed()) return;
-			retryDelayMs = await backoff(retryDelayMs);
-			if (launchFailed()) return;
-			continue;
-		}
-
-		if (status === 'complete') return;
-		if (status === 'notFound') {
-			if (args.launchState.status === 'failed') return;
-			if (args.launchState.status === 'acknowledged') {
-				// This response may have been produced before runAgent created the session,
-				// then delivered after the launch acknowledgement. Recheck once so that
-				// race cannot silently disable token refresh for the rest of the run.
-				if (missingSessionObservedAfterLaunch) return;
-				missingSessionObservedAfterLaunch = true;
-			}
-			retryDelayMs = await backoff(retryDelayMs);
-			continue;
-		}
-		missingSessionObservedAfterLaunch = false;
-
-		if (!pendingToken) {
-			assertAgentRunUser(args.expectedUserId, args.getCurrentUserId());
-			pendingToken = await args.getAccessToken({ forceRefreshToken: true });
-			if (!pendingToken) {
-				throw new Error('Your session ended while the agent was running. Sign in again.');
-			}
-		}
-
-		assertAgentRunUser(args.expectedUserId, args.getCurrentUserId());
-		try {
-			await args.desktopApi.refreshAgentAuth(args.authSessionId, pendingToken);
-			pendingToken = null;
-			retryDelayMs = AGENT_AUTH_INITIAL_RETRY_DELAY_MS;
-		} catch {
-			retryDelayMs = await backoff(retryDelayMs);
-		}
-	}
-}
-
-function assertAgentRunUser(expectedUserId: string, currentUserId: string | null) {
-	if (!currentUserId) {
-		throw new Error('Your session ended while the agent was running. Sign in again.');
-	}
-	if (currentUserId !== expectedUserId) {
-		throw new Error(
-			'Your account changed while the agent was running. Switch back and start again.'
-		);
-	}
-}
-
-async function backoff(retryDelayMs: number): Promise<number> {
-	await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
-	return Math.min(retryDelayMs * 2, AGENT_AUTH_MAX_RETRY_DELAY_MS);
 }
 
 function buildDesktopWorkspaceSessionsById(

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -1,5 +1,4 @@
 import type {
-	AgentAuthStatus,
 	AgentRunStart,
 	DesktopApi,
 	FilesystemBrowseResult,
@@ -224,15 +223,7 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 			request<AgentRunStart>('/api/agent/run', {
 				method: 'POST',
 				body: JSON.stringify(requestBody)
-			}),
-		waitForAgentAuthRefresh: (authSessionId) =>
-			request<AgentAuthStatus>(`/api/agent/auth/${encodeURIComponent(authSessionId)}`),
-		refreshAgentAuth: async (authSessionId, authToken) => {
-			await request(`/api/agent/auth/${encodeURIComponent(authSessionId)}`, {
-				method: 'PUT',
-				body: JSON.stringify({ authToken })
-			});
-		}
+			})
 	};
 }
 

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -128,7 +128,6 @@ export type ThreadMessage = {
 };
 
 export type AgentRunRequest = {
-	authSessionId: string;
 	authToken: string;
 	submissionId: string;
 	threadId: Id<'threadRecords'>;
@@ -143,8 +142,6 @@ export type AgentRunRequest = {
 export type AgentRunStart = {
 	runId: Id<'runs'>;
 };
-
-export type AgentAuthStatus = 'refreshRequired' | 'complete' | 'notFound';
 
 export type FilesystemBrowseEntry = {
 	name: string;
@@ -170,8 +167,6 @@ export type DesktopApi = {
 		session: WorkspaceSessionAttachment
 	) => Promise<WorkspaceSessionLocation>;
 	runAgent: (request: AgentRunRequest) => Promise<AgentRunStart>;
-	waitForAgentAuthRefresh: (authSessionId: string) => Promise<AgentAuthStatus>;
-	refreshAgentAuth: (authSessionId: string, authToken: string) => Promise<void>;
 };
 
 export type WorkspacePathResolution = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1063,7 +1063,10 @@
 				submissionTrackingKey = getComposerRecoveryKey(submittedUserId, recoveryScope);
 				latestSubmissionSequencesByRecoveryScope.set(submissionTrackingKey, submissionSequence);
 			}
-			const authToken = await getAccessToken();
+			// The browser is no longer involved after Convex binds the run-scoped
+			// executor capability. Start with a fresh token so closing the tab during
+			// the detached launch cannot strand it on an expiring browser token.
+			const authToken = await getAccessToken({ forceRefreshToken: true });
 			if (!authToken) {
 				recoverSubmission('Your session ended before the agent started. Sign in again.');
 				return;
@@ -1116,9 +1119,6 @@
 			launchAgentRun({
 				authToken,
 				desktopApi,
-				expectedUserId: submittedUserId,
-				getAccessToken,
-				getCurrentUserId: () => $authState.user?.id ?? null,
 				onError: (error) => {
 					if (!isSubmissionCurrent() || !isSubmittedUserCurrent()) {
 						return;

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -3,7 +3,6 @@ use convex::{FunctionResult, QuerySubscription, Value};
 use serde::Deserialize;
 use sprocket_convex_provider::Client as ConvexProviderClient;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -13,23 +12,6 @@ use crate::types::{
 
 const CREATE_RUN_MAX_ATTEMPTS: usize = 3;
 const CREATE_RUN_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
-
-pub async fn authenticated_user_id(
-    deployment_url: &str,
-    auth_token: String,
-) -> anyhow::Result<String> {
-    let client = ConvexProviderClient::new(deployment_url, "completion:complete").await?;
-    client
-        .set_auth_token_fetcher(Arc::new(move |_| {
-            let auth_token = auth_token.clone();
-            Box::pin(async move { Ok(auth_token) })
-        }))
-        .await;
-    let result = client
-        .query("agentRuntime:authenticatedUserId", BTreeMap::new())
-        .await?;
-    decode_function_result(result, "agentRuntime:authenticatedUserId")
-}
 
 #[derive(Clone)]
 pub(crate) struct RuntimeClient {
@@ -42,8 +24,9 @@ impl RuntimeClient {
             "sprocket-agent: initializing Convex client for thread {}",
             request.thread_id
         );
-        let client =
-            ConvexProviderClient::new(&request.deployment_url, "completion:complete").await?;
+        let client = ConvexProviderClient::new(&request.deployment_url, "completion:complete")
+            .await?
+            .with_execution_secret(request.execution_secret.clone());
         client
             .set_auth_token_fetcher(request.auth_token_fetcher.clone())
             .await;
@@ -61,8 +44,9 @@ impl RuntimeClient {
     pub(crate) async fn query_json<T: for<'de> Deserialize<'de>>(
         &self,
         function: &str,
-        args: BTreeMap<String, Value>,
+        mut args: BTreeMap<String, Value>,
     ) -> anyhow::Result<T> {
+        self.add_execution_secret(&mut args);
         eprintln!("sprocket-agent: query start {function}");
         let result = self.client.query(function, args).await?;
         eprintln!("sprocket-agent: query done {function}");
@@ -72,8 +56,9 @@ impl RuntimeClient {
     pub(crate) async fn mutation_json<T: for<'de> Deserialize<'de>>(
         &self,
         function: &str,
-        args: BTreeMap<String, Value>,
+        mut args: BTreeMap<String, Value>,
     ) -> anyhow::Result<T> {
+        self.add_execution_secret(&mut args);
         eprintln!("sprocket-agent: mutation start {function}");
         let result = self.client.mutation(function, args).await?;
         eprintln!("sprocket-agent: mutation done {function}");
@@ -83,8 +68,9 @@ impl RuntimeClient {
     pub(crate) async fn action_json<T: for<'de> Deserialize<'de>>(
         &self,
         function: &str,
-        args: BTreeMap<String, Value>,
+        mut args: BTreeMap<String, Value>,
     ) -> anyhow::Result<T> {
+        self.add_execution_secret(&mut args);
         eprintln!("sprocket-agent: action start {function}");
         let result = self.client.action(function, args).await?;
         eprintln!("sprocket-agent: action done {function}");
@@ -139,6 +125,7 @@ impl RuntimeClient {
             "serviceTier".to_string(),
             request.service_tier.clone().into(),
         );
+        self.add_execution_secret(&mut args);
 
         let mut retry_delay = CREATE_RUN_INITIAL_RETRY_DELAY;
         let mut last_error = None;
@@ -260,9 +247,9 @@ impl RuntimeClient {
         &self,
         run_id: &str,
     ) -> anyhow::Result<QuerySubscription> {
-        self.client
-            .subscribe("agentRuntime:isFinished", self.run_args(run_id))
-            .await
+        let mut args = self.run_args(run_id);
+        self.add_execution_secret(&mut args);
+        self.client.subscribe("agentRuntime:isFinished", args).await
     }
 
     pub(crate) fn decode_run_finished_update(result: FunctionResult) -> anyhow::Result<bool> {
@@ -319,13 +306,25 @@ impl RuntimeClient {
         if let Some(last_error) = last_error {
             args.insert("lastError".to_string(), last_error.to_string().into());
         }
-        self.mutation_json("agentRuntime:finalizeRun", args).await
+        self.mutation_json("agentRuntime:finalizeExecutorRun", args)
+            .await
     }
 
     fn run_args(&self, run_id: &str) -> BTreeMap<String, Value> {
         let mut args = BTreeMap::new();
         args.insert("runId".to_string(), run_id.to_string().into());
         args
+    }
+
+    fn add_execution_secret(&self, args: &mut BTreeMap<String, Value>) {
+        args.insert(
+            "executionSecret".to_string(),
+            self.client
+                .execution_secret()
+                .expect("runtime client has an execution secret")
+                .to_string()
+                .into(),
+        );
     }
 
     fn run_args_with_claim(&self, run_id: &str, claim_id: &str) -> BTreeMap<String, Value> {

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -5,7 +5,6 @@ mod run;
 mod tools;
 mod types;
 
-pub use convex::authenticated_user_id;
 pub use run::{AgentRun, finalize_failed_start, run_agent, start_agent_run};
 pub use sprocket_convex_provider::AuthTokenFetcher;
 pub use types::{

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -6,6 +6,7 @@ use rig::client::CompletionClient;
 use rig::completion::{CompletionModel, Message};
 use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
 use sprocket_convex_provider::{Client as ConvexProviderClient, is_completion_stream_superseded};
+use sprocket_workspace::CommandSessionManager;
 
 use crate::convex::RuntimeClient;
 use crate::hooks::{AgentPromptHook, ToolCallTracker};
@@ -124,7 +125,7 @@ where
         request.workspace_root.clone(),
         tool_call_tracker.clone(),
     );
-    let command_sessions = tools.command_sessions.clone();
+    let session_shutdown = CommandSessionShutdown::new(tools.command_sessions.clone());
     let agent = completion_client
         .agent(model)
         .preamble(&request.preamble)
@@ -205,8 +206,39 @@ where
         AgentProviderResult::Completed { text: final_text }
     };
 
-    command_sessions.stop_all().await;
+    session_shutdown.finish().await;
     result
+}
+
+/// Stops persistent command sessions on the normal path and if this future is
+/// dropped early (for example when claim lease renewal fails).
+struct CommandSessionShutdown {
+    sessions: Option<CommandSessionManager>,
+}
+
+impl CommandSessionShutdown {
+    fn new(sessions: CommandSessionManager) -> Self {
+        Self {
+            sessions: Some(sessions),
+        }
+    }
+
+    async fn finish(mut self) {
+        if let Some(sessions) = self.sessions.as_ref() {
+            sessions.stop_all().await;
+        }
+        self.sessions = None;
+    }
+}
+
+impl Drop for CommandSessionShutdown {
+    fn drop(&mut self) {
+        if let Some(sessions) = self.sessions.take() {
+            // Drop cannot await the async drain in stop_all; terminate is enough
+            // to stop leaked persistent command sessions after lease loss.
+            sessions.terminate_all();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -24,13 +24,13 @@ const RUN_CLAIM_EXPIRY_SAFETY_MARGIN: Duration = Duration::from_secs(5);
 const RUN_CLAIM_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(8);
 const FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 const START_FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2_500);
+const START_FAILURE_RECONCILE_TIMEOUT: Duration = Duration::from_secs(10);
 const FAILURE_CLEANUP_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 pub struct AgentRun {
     request: RunAgentRequest,
     runtime: RuntimeClient,
     run_id: String,
-    user_id: String,
     claim_id: String,
     workspace_root: std::path::PathBuf,
 }
@@ -38,10 +38,6 @@ pub struct AgentRun {
 impl AgentRun {
     pub fn run_id(&self) -> &str {
         &self.run_id
-    }
-
-    pub fn user_id(&self) -> &str {
-        &self.user_id
     }
 }
 
@@ -458,6 +454,10 @@ pub async fn start_agent_run(request: RunAgentRequest) -> anyhow::Result<AgentRu
     let workspace_root = resolve_workspace_root(&request.workspace_path)?;
 
     let created_run = runtime.create_run(&request).await?;
+    // The browser token is only needed to create and bind the run. Every later
+    // operation uses the run-scoped capability, so browser lifetime and token
+    // refresh can no longer interrupt an active local executor.
+    runtime.completion_client().clear_auth().await;
     if created_run.created {
         eprintln!("sprocket-agent: created run {}", created_run.run_id);
     } else {
@@ -467,13 +467,10 @@ pub async fn start_agent_run(request: RunAgentRequest) -> anyhow::Result<AgentRu
         );
     }
     let run_id = created_run.run_id;
-    let user_id = created_run.user_id;
-
     Ok(AgentRun {
         request,
         runtime,
         run_id,
-        user_id,
         claim_id,
         workspace_root,
     })
@@ -484,17 +481,44 @@ pub async fn finalize_failed_start(
     startup_error: String,
 ) -> anyhow::Result<()> {
     let runtime = RuntimeClient::from_request(&request).await?;
+    runtime.completion_client().clear_auth().await;
     let text = format!("Run failed before the model started: {startup_error}");
-    cleanup_twice(
-        &format!(
-            "startup failure cleanup for submission {}",
-            request.submission_id
-        ),
-        START_FAILURE_CLEANUP_ATTEMPT_TIMEOUT,
-        || runtime.finalize_failed_start(&request, &text, &startup_error),
-    )
-    .await
-    .map(|_| ())
+    let deadline = Instant::now() + START_FAILURE_RECONCILE_TIMEOUT;
+    loop {
+        let result = timeout(
+            START_FAILURE_CLEANUP_ATTEMPT_TIMEOUT,
+            runtime.finalize_failed_start(&request, &text, &startup_error),
+        )
+        .await;
+        match result {
+            Ok(Ok(true)) => return Ok(()),
+            Ok(Ok(false)) => {
+                eprintln!(
+                    "sprocket-agent: startup failure cleanup has not observed submission {}; retrying",
+                    request.submission_id
+                );
+            }
+            Ok(Err(error)) => {
+                eprintln!(
+                    "sprocket-agent: startup failure cleanup for submission {} failed; retrying: {error}",
+                    request.submission_id
+                );
+            }
+            Err(_) => {
+                eprintln!(
+                    "sprocket-agent: startup failure cleanup for submission {} timed out; retrying",
+                    request.submission_id
+                );
+            }
+        }
+        if Instant::now() + FAILURE_CLEANUP_RETRY_DELAY >= deadline {
+            return Err(anyhow!(
+                "startup failure cleanup did not reconcile submission {} before its deadline",
+                request.submission_id
+            ));
+        }
+        sleep(FAILURE_CLEANUP_RETRY_DELAY).await;
+    }
 }
 
 pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
@@ -502,7 +526,6 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         request,
         runtime,
         run_id,
-        user_id: _,
         claim_id,
         workspace_root,
     } = run;

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -427,6 +427,8 @@ impl rig::tool::Tool for WebSearchTool {
             payload,
             |cancellation| {
                 let mut action_args = BTreeMap::new();
+                action_args.insert("runId".to_string(), self.0.run_id.clone().into());
+                action_args.insert("claimId".to_string(), self.0.claim_id.clone().into());
                 action_args.insert("query".to_string(), args.query.clone().into());
                 // Omitted at the default so the Convex action owns the default value.
                 if !is_default_web_search_results(&args.num_results) {
@@ -473,6 +475,8 @@ impl rig::tool::Tool for ScrapeUrlTool {
             payload,
             |cancellation| {
                 let mut action_args = BTreeMap::new();
+                action_args.insert("runId".to_string(), self.0.run_id.clone().into());
+                action_args.insert("claimId".to_string(), self.0.claim_id.clone().into());
                 action_args.insert("url".to_string(), args.url.clone().into());
                 run_convex_tool_action(
                     &self.0.runtime,
@@ -589,6 +593,7 @@ where
             eprintln!("sprocket-agent: completed tool {} for run {}", kind, run_id);
             let mut complete_args = BTreeMap::new();
             complete_args.insert("jobId".to_string(), job_id.into());
+            complete_args.insert("runId".to_string(), run_id.to_string().into());
             complete_args.insert(
                 "result".to_string(),
                 Value::try_from(output.clone()).map_err(tool_error)?,
@@ -610,6 +615,7 @@ where
             );
             let mut fail_args = BTreeMap::new();
             fail_args.insert("jobId".to_string(), job_id.into());
+            fail_args.insert("runId".to_string(), run_id.to_string().into());
             fail_args.insert("error".to_string(), error.to_string().into());
             let accepted: bool = runtime
                 .mutation_json("executor:fail", fail_args)

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -594,6 +594,7 @@ where
             let mut complete_args = BTreeMap::new();
             complete_args.insert("jobId".to_string(), job_id.into());
             complete_args.insert("runId".to_string(), run_id.to_string().into());
+            complete_args.insert("claimId".to_string(), claim_id.to_string().into());
             complete_args.insert(
                 "result".to_string(),
                 Value::try_from(output.clone()).map_err(tool_error)?,
@@ -616,6 +617,7 @@ where
             let mut fail_args = BTreeMap::new();
             fail_args.insert("jobId".to_string(), job_id.into());
             fail_args.insert("runId".to_string(), run_id.to_string().into());
+            fail_args.insert("claimId".to_string(), claim_id.to_string().into());
             fail_args.insert("error".to_string(), error.to_string().into());
             let accepted: bool = runtime
                 .mutation_json("executor:fail", fail_args)

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -12,6 +12,7 @@ use sprocket_convex_provider::AuthTokenFetcher;
 pub struct RunAgentRequest {
     pub deployment_url: String,
     pub auth_token_fetcher: AuthTokenFetcher,
+    pub execution_secret: String,
     pub submission_id: String,
     pub thread_id: String,
     pub prompt: String,
@@ -28,7 +29,6 @@ pub struct CreateRunResponse {
     pub created: bool,
     pub run_id: String,
     pub prompt_message_id: String,
-    pub user_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -18,7 +18,7 @@ use rig::message::{ReasoningContent, ToolCall as RigToolCall, ToolChoice, ToolFu
 use rig::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
 use rustls::crypto::ring::default_provider;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Mutex;
 use tokio::time::{sleep, timeout};
 
 use crate::messages::{build_model_messages, instructions_text, normalize_convex_json_numbers};
@@ -26,7 +26,6 @@ use crate::messages::{build_model_messages, instructions_text, normalize_convex_
 const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 const COMPLETION_TRANSPORT_ATTEMPTS: u32 = 3;
 const COMPLETION_TRANSPORT_RETRY_DELAY: Duration = Duration::from_millis(400);
-const AUTH_REFRESH_CORRELATION_GRACE: Duration = Duration::from_millis(500);
 
 pub const COMPLETION_STREAM_SUPERSEDED: &str = "SPROCKET_COMPLETION_STREAM_SUPERSEDED";
 
@@ -41,14 +40,13 @@ pub fn is_completion_stream_superseded(error: &(impl std::fmt::Display + ?Sized)
 pub struct Client {
     pub(crate) inner: Arc<Mutex<ConvexClient>>,
     completion_inner: Arc<Mutex<ConvexClient>>,
-    auth_refresh_generation: Arc<AtomicU32>,
-    auth_refresh_notify: Arc<Notify>,
     completion_action_lock: Arc<Mutex<()>>,
     completion_action: Arc<str>,
     default_reasoning_effort: Option<Arc<str>>,
     default_service_tier: Option<Arc<str>>,
     stream_run_id: Option<Arc<str>>,
     claim_id: Option<Arc<str>>,
+    execution_secret: Option<Arc<str>>,
     attempt_counter: Arc<AtomicU32>,
 }
 
@@ -67,14 +65,13 @@ impl Client {
         Ok(Self {
             inner: Arc::new(Mutex::new(client)),
             completion_inner: Arc::new(Mutex::new(completion_client)),
-            auth_refresh_generation: Arc::new(AtomicU32::new(0)),
-            auth_refresh_notify: Arc::new(Notify::new()),
             completion_action_lock: Arc::new(Mutex::new(())),
             completion_action: completion_action.into().into(),
             default_reasoning_effort: None,
             default_service_tier: None,
             stream_run_id: None,
             claim_id: None,
+            execution_secret: None,
             attempt_counter: Arc::new(AtomicU32::new(0)),
         })
     }
@@ -83,18 +80,21 @@ impl Client {
         self.inner
             .lock()
             .await
-            .set_auth_callback(Some(convex_auth_fetcher(fetcher.clone(), None)))
+            .set_auth_callback(Some(convex_auth_fetcher(fetcher.clone())))
             .await;
         self.completion_inner
             .lock()
             .await
-            .set_auth_callback(Some(convex_auth_fetcher(
-                fetcher,
-                Some((
-                    self.auth_refresh_generation.clone(),
-                    self.auth_refresh_notify.clone(),
-                )),
-            )))
+            .set_auth_callback(Some(convex_auth_fetcher(fetcher)))
+            .await;
+    }
+
+    pub async fn clear_auth(&self) {
+        self.inner.lock().await.set_auth_callback(None).await;
+        self.completion_inner
+            .lock()
+            .await
+            .set_auth_callback(None)
             .await;
     }
 
@@ -154,6 +154,15 @@ impl Client {
     pub fn with_service_tier(mut self, service_tier: impl Into<String>) -> Self {
         self.default_service_tier = Some(service_tier.into().into());
         self
+    }
+
+    pub fn with_execution_secret(mut self, execution_secret: impl Into<String>) -> Self {
+        self.execution_secret = Some(execution_secret.into().into());
+        self
+    }
+
+    pub fn execution_secret(&self) -> Option<&str> {
+        self.execution_secret.as_deref()
     }
 
     pub fn with_completion_scope(mut self, stream_run_id: String, claim_id: String) -> Self {
@@ -290,6 +299,7 @@ struct ConvexActionArgs {
     messages_json: String,
     stream_run_id: Option<String>,
     claim_id: Option<String>,
+    execution_secret: Option<String>,
     tools: Vec<ToolDefinition>,
     tool_choice: Option<ConvexToolChoice>,
 }
@@ -347,6 +357,7 @@ impl RigCompletionModel for CompletionModel {
             messages_json: messages.to_string(),
             stream_run_id: self.client.stream_run_id.as_deref().map(str::to_owned),
             claim_id: self.client.claim_id.as_deref().map(str::to_owned),
+            execution_secret: self.client.execution_secret.as_deref().map(str::to_owned),
             tools: request.tools.clone(),
             tool_choice: request.tool_choice.as_ref().map(convert_tool_choice),
         };
@@ -492,16 +503,9 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
-fn convex_auth_fetcher(
-    fetcher: AuthTokenFetcher,
-    refresh_tracking: Option<(Arc<AtomicU32>, Arc<Notify>)>,
-) -> convex::AuthTokenFetcher {
+fn convex_auth_fetcher(fetcher: AuthTokenFetcher) -> convex::AuthTokenFetcher {
     Box::new(move |force_refresh| {
         let fetcher = fetcher.clone();
-        if force_refresh && let Some((generation, notify)) = &refresh_tracking {
-            generation.fetch_add(1, Ordering::Release);
-            notify.notify_waiters();
-        }
         Box::pin(async move { fetcher(force_refresh).await.map(AuthenticationToken::User) })
     })
 }
@@ -518,9 +522,12 @@ async fn call_completion_action(
     let claim_id = args.claim_id.as_ref().ok_or_else(|| {
         CompletionError::ProviderError("claimId is required for completion:complete".to_string())
     })?;
-    // A forced auth refresh belongs to a Convex connection, not an individual
-    // action. Completion actions use a dedicated connection and run serially on
-    // it, so refresh correlation cannot cross action or runtime RPC boundaries.
+    let execution_secret = args.execution_secret.as_ref().ok_or_else(|| {
+        CompletionError::ProviderError(
+            "executionSecret is required for completion:complete".to_string(),
+        )
+    })?;
+    // Completion actions use a dedicated connection and run serially on it.
     let _completion_action_guard = client.completion_action_lock.lock().await;
 
     let mut retry_delay = COMPLETION_TRANSPORT_RETRY_DELAY;
@@ -533,10 +540,6 @@ async fn call_completion_action(
         let attempt_seq = client.attempt_counter.fetch_add(1, Ordering::Relaxed) + 1;
         let stream_id = uuid::Uuid::new_v4().to_string();
         let mut convex = clone_locked(&client.completion_inner).await;
-        // Register before taking the generation snapshot so a refresh starting
-        // while this action is in flight cannot be missed by the grace wait.
-        let auth_refresh_started = client.auth_refresh_notify.notified();
-        let auth_refresh_generation = client.auth_refresh_generation.load(Ordering::Acquire);
         eprintln!(
             "sprocket-convex-provider: action start {} attempt {attempt_seq}",
             client.completion_action
@@ -549,6 +552,7 @@ async fn call_completion_action(
                     args,
                     stream_run_id,
                     claim_id,
+                    execution_secret,
                     attempt_seq,
                     &stream_id,
                     &superseded_stream_ids,
@@ -577,7 +581,7 @@ async fn call_completion_action(
             }
         };
 
-        let (provider_error, is_error_message) = match result {
+        let provider_error = match result {
             Ok(FunctionResult::Value(value)) => {
                 eprintln!(
                     "sprocket-convex-provider: action done {}",
@@ -585,8 +589,8 @@ async fn call_completion_action(
                 );
                 return Ok(value);
             }
-            Ok(FunctionResult::ErrorMessage(message)) => (message, true),
-            Ok(FunctionResult::ConvexError(error)) => (error.message, false),
+            Ok(FunctionResult::ErrorMessage(message)) => message,
+            Ok(FunctionResult::ConvexError(error)) => error.message,
             Err(error) => {
                 if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
                     return Err(to_completion_error(error));
@@ -610,87 +614,12 @@ async fn call_completion_action(
             backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
             continue;
         }
-        let auth_refresh_started = if attempt < COMPLETION_TRANSPORT_ATTEMPTS
-            && is_error_message
-            && is_redacted_convex_server_error(&provider_error)
-        {
-            auth_refresh_observed(
-                &client.auth_refresh_generation,
-                auth_refresh_generation,
-                auth_refresh_started,
-                AUTH_REFRESH_CORRELATION_GRACE,
-            )
-            .await
-        } else {
-            false
-        };
-        if should_retry_transient_server_error(
-            &provider_error,
-            is_error_message,
-            auth_refresh_started,
-            attempt,
-        ) {
-            // An expired identity interrupts in-flight actions with Convex's
-            // redacted server error. If a forced refresh began during the
-            // attempt, replay through the same stream-fencing path as transport
-            // failures. Requiring that correlation avoids retrying developer
-            // errors, which Convex redacts to the same text in production.
-            eprintln!(
-                "sprocket-convex-provider: action {} attempt {attempt} was interrupted by auth refresh; retrying with a fresh stream: {provider_error}",
-                client.completion_action,
-            );
-            backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
-            continue;
-        }
         return Err(CompletionError::ProviderError(provider_error));
     }
 }
 
 fn should_retry_superseded_completion(message: &str, attempt: u32) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS && is_completion_stream_superseded(message)
-}
-
-fn should_retry_transient_server_error(
-    message: &str,
-    is_error_message: bool,
-    auth_refresh_started: bool,
-    attempt: u32,
-) -> bool {
-    attempt < COMPLETION_TRANSPORT_ATTEMPTS
-        && is_error_message
-        && auth_refresh_started
-        && is_redacted_convex_server_error(message)
-}
-
-async fn auth_refresh_observed(
-    generation: &AtomicU32,
-    generation_at_start: u32,
-    refresh_started: impl Future<Output = ()>,
-    grace: Duration,
-) -> bool {
-    if generation.load(Ordering::Acquire) != generation_at_start {
-        return true;
-    }
-
-    // Convex can deliver the action error immediately before its background
-    // worker starts the reconnect auth callback. Give that callback one short
-    // reconnect window, then preserve redacted developer errors as fatal.
-    let _ = timeout(grace, refresh_started).await;
-    generation.load(Ordering::Acquire) != generation_at_start
-}
-
-/// Convex production failures are redacted to this exact shape. This alone
-/// does not distinguish infrastructure failures from developer errors; callers
-/// must also correlate the response with a forced authentication refresh.
-fn is_redacted_convex_server_error(message: &str) -> bool {
-    let Some((request_id, suffix)) = message
-        .trim()
-        .strip_prefix("[Request ID: ")
-        .and_then(|rest| rest.split_once(']'))
-    else {
-        return false;
-    };
-    !request_id.is_empty() && suffix == " Server Error"
 }
 
 async fn backoff_completion_retry(
@@ -707,6 +636,7 @@ fn action_args(
     args: &ConvexActionArgs,
     stream_run_id: &str,
     claim_id: &str,
+    execution_secret: &str,
     attempt_seq: u32,
     stream_id: &str,
     superseded_stream_ids: &[String],
@@ -739,6 +669,10 @@ fn action_args(
         args.messages_json.clone().into(),
     );
     payload.insert("streamRunId".to_string(), stream_run_id.to_string().into());
+    payload.insert(
+        "executionSecret".to_string(),
+        execution_secret.to_string().into(),
+    );
     if let Some(instructions) = &args.instructions {
         payload.insert("instructions".to_string(), instructions.clone().into());
     }
@@ -867,17 +801,14 @@ where
 mod tests {
     use super::{
         COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
-        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, auth_refresh_observed,
-        clone_locked, completion_choice, convex_auth_fetcher, is_completion_stream_superseded,
-        is_redacted_convex_server_error, reasoning_stream_choices,
-        should_retry_superseded_completion, should_retry_transient_server_error,
-        text_stream_choices,
+        CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, clone_locked, completion_choice,
+        is_completion_stream_superseded, reasoning_stream_choices,
+        should_retry_superseded_completion, text_stream_choices,
     };
     use rig::completion::{CompletionError, GetTokenUsage};
     use rig::message::AssistantContent;
     use rig::streaming::RawStreamingChoice;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
     use tokio::sync::Mutex;
     use tokio::time::timeout;
@@ -909,37 +840,6 @@ mod tests {
         }
 
         assert_eq!(*inner.lock().await, 1);
-    }
-
-    #[tokio::test]
-    async fn observes_auth_refresh_when_notification_is_lost() {
-        let generation = AtomicU32::new(0);
-        let refresh_started = std::future::poll_fn(|_| {
-            // Simulate a refresh starting after the first generation check but
-            // before the notification future registers its waiter.
-            generation.fetch_add(1, Ordering::Release);
-            std::task::Poll::<()>::Pending
-        });
-
-        assert!(
-            auth_refresh_observed(&generation, 0, refresh_started, Duration::from_millis(1),).await
-        );
-    }
-
-    #[tokio::test]
-    async fn runtime_auth_refresh_does_not_correlate_to_completion() {
-        let fetcher: super::AuthTokenFetcher =
-            Arc::new(|_| Box::pin(async { Ok("token".to_string()) }));
-        let generation = Arc::new(AtomicU32::new(0));
-        let notify = Arc::new(tokio::sync::Notify::new());
-
-        let runtime_fetcher = convex_auth_fetcher(fetcher.clone(), None);
-        runtime_fetcher(true).await.expect("runtime token");
-        assert_eq!(generation.load(Ordering::Acquire), 0);
-
-        let completion_fetcher = convex_auth_fetcher(fetcher, Some((generation.clone(), notify)));
-        completion_fetcher(true).await.expect("completion token");
-        assert_eq!(generation.load(Ordering::Acquire), 1);
     }
 
     #[test]
@@ -1091,61 +991,5 @@ mod tests {
             COMPLETION_TRANSPORT_ATTEMPTS,
         ));
         assert!(!should_retry_superseded_completion("provider failed", 1));
-    }
-
-    #[test]
-    fn recognizes_redacted_convex_server_errors() {
-        assert!(is_redacted_convex_server_error(
-            "[Request ID: b79af67f8bcd57b2] Server Error"
-        ));
-        assert!(is_redacted_convex_server_error(
-            " [Request ID: abc] Server Error "
-        ));
-
-        // Other error formats must stay fatal. Even the matching redacted
-        // shape is retried only when correlated with a forced auth refresh.
-        assert!(!is_redacted_convex_server_error("Server Error"));
-        assert!(!is_redacted_convex_server_error(
-            "[Request ID: ] Server Error"
-        ));
-        assert!(!is_redacted_convex_server_error(
-            "[Request ID: abc] Uncaught Error: insufficient credits"
-        ));
-        assert!(!is_redacted_convex_server_error(
-            "Server Error: something specific"
-        ));
-        assert!(!is_redacted_convex_server_error("rate limited"));
-    }
-
-    #[test]
-    fn retries_redacted_server_errors_until_the_transport_attempt_limit() {
-        let message = "[Request ID: b79af67f8bcd57b2] Server Error";
-
-        assert!(should_retry_transient_server_error(
-            message,
-            true,
-            true,
-            COMPLETION_TRANSPORT_ATTEMPTS - 1,
-        ));
-        assert!(!should_retry_transient_server_error(
-            message,
-            true,
-            true,
-            COMPLETION_TRANSPORT_ATTEMPTS,
-        ));
-        // ConvexError results are application data, never retried as transient.
-        assert!(!should_retry_transient_server_error(
-            message, false, true, 1
-        ));
-        // The same redacted text can represent a developer error in prod.
-        assert!(!should_retry_transient_server_error(
-            message, true, false, 1
-        ));
-        assert!(!should_retry_transient_server_error(
-            "insufficient credits",
-            true,
-            true,
-            1,
-        ));
     }
 }

--- a/crates/sprocket-server/README.md
+++ b/crates/sprocket-server/README.md
@@ -13,8 +13,9 @@ full process topology.
 
 - Establish local browser or desktop authorization.
 - Resolve, attach, and revalidate local workspaces.
-- Start agent runs with the authenticated cloud user token.
-- Coordinate token refresh while a run is active.
+- Start agent runs with a fresh authenticated cloud user token.
+- Detach accepted launches from browser requests and hand active work a
+  run-scoped execution capability.
 - Serve the local API and optional static web build.
 - Persist only machine-local state.
 
@@ -27,8 +28,9 @@ path.
 
 Local authorization and cloud authentication are separate. A local session
 permits access to machine-facing operations; a WorkOS token identifies the user
-to Convex. Refreshed run tokens are checked against the user that started the
-run.
+to Convex while the run is created. After creation, the agent uses a random
+capability whose hash is bound to that run, so closing the browser does not
+interrupt active work.
 
 The server binds locally by default. Static serving and API-only operation are
 two configurations of the same router rather than separate applications.

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -63,7 +63,6 @@ impl StartupInfo {
 #[derive(Clone)]
 pub struct AppState {
     pub auth: Arc<auth::AuthState>,
-    pub(crate) agent_tokens: routes::agent::AgentTokenStore,
     pub desktop_login: Arc<auth::DesktopLoginStore>,
     pub workspace_sessions: Arc<workspace_sessions::WorkspaceSessionStore>,
     pub http_base_url: String,
@@ -110,7 +109,6 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
 
     let state = AppState {
         auth,
-        agent_tokens: routes::agent::AgentTokenStore::default(),
         desktop_login: auth::DesktopLoginStore::new(),
         workspace_sessions,
         http_base_url: http_base_url.clone(),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -1,36 +1,31 @@
-use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::post;
 use axum_extra::extract::CookieJar;
 use serde::Deserialize;
 use sprocket_agent::{
-    AuthTokenFetcher, RunAgentRequest, authenticated_user_id, finalize_failed_start, run_agent,
-    start_agent_run,
+    AuthTokenFetcher, RunAgentRequest, finalize_failed_start, run_agent, start_agent_run,
 };
-use tokio::sync::{Mutex, watch};
+use tokio::sync::oneshot;
 use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::AppState;
 use crate::auth::require_session;
 
-const AGENT_TOKEN_REFRESH_TIMEOUT: Duration = Duration::from_secs(60);
 const AGENT_START_TIMEOUT: Duration = Duration::from_secs(20);
-const AGENT_START_CLEANUP_TIMEOUT: Duration = Duration::from_secs(6);
-const AGENT_TOKEN_VERIFY_TIMEOUT: Duration = Duration::from_secs(6);
+const AGENT_START_CLEANUP_TIMEOUT: Duration = Duration::from_secs(12);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RunAgentApiRequest {
-    auth_session_id: String,
     auth_token: String,
     submission_id: String,
     thread_id: String,
@@ -48,209 +43,20 @@ struct RunAgentStartResponse {
     run_id: String,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RefreshAgentTokenRequest {
-    auth_token: String,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-enum AgentTokenStatus {
-    RefreshRequired,
-    Complete,
-    NotFound,
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct AgentTokenStore {
-    entries: Arc<Mutex<HashMap<String, Arc<AgentTokenEntry>>>>,
-}
-
-struct AgentTokenEntry {
-    state: watch::Sender<AgentTokenState>,
-}
-
-#[derive(Clone)]
-struct AgentTokenState {
-    token: String,
-    user_id: Option<String>,
-    version: u64,
-    refresh_requested: bool,
-    closed: bool,
-}
-
-impl AgentTokenStore {
-    async fn create(&self, id: &str, token: String) -> anyhow::Result<Arc<AgentTokenEntry>> {
-        if token.trim().is_empty() {
-            return Err(anyhow!("agent auth token is empty"));
-        }
-
-        let mut entries = self.entries.lock().await;
-        if entries.contains_key(id) {
-            return Err(anyhow!("agent auth session already exists"));
-        }
-
-        let (state, _) = watch::channel(AgentTokenState {
-            token,
-            user_id: None,
-            version: 0,
-            refresh_requested: false,
-            closed: false,
-        });
-        let entry = Arc::new(AgentTokenEntry { state });
-        entries.insert(id.to_string(), entry.clone());
-        Ok(entry)
-    }
-
-    async fn get(&self, id: &str) -> Option<Arc<AgentTokenEntry>> {
-        self.entries.lock().await.get(id).cloned()
-    }
-
-    async fn close(&self, id: &str, entry: &Arc<AgentTokenEntry>) {
-        entry.state.send_modify(|state| {
-            state.closed = true;
-        });
-
-        let mut entries = self.entries.lock().await;
-        if entries
-            .get(id)
-            .is_some_and(|stored| Arc::ptr_eq(stored, entry))
-        {
-            entries.remove(id);
-        }
-    }
-}
-
-impl AgentTokenEntry {
-    fn fetcher(self: &Arc<Self>) -> AuthTokenFetcher {
-        let entry = self.clone();
-        Arc::new(move |force_refresh| {
-            let entry = entry.clone();
-            Box::pin(async move { entry.fetch(force_refresh).await })
+fn static_auth_token_fetcher(token: String) -> AuthTokenFetcher {
+    Arc::new(move |_force_refresh| {
+        let token = token.clone();
+        Box::pin(async move {
+            if token.trim().is_empty() {
+                return Err(anyhow!("agent auth token is empty"));
+            }
+            Ok(token)
         })
-    }
-
-    fn nonrefreshing_fetcher(self: &Arc<Self>) -> AuthTokenFetcher {
-        let entry = self.clone();
-        Arc::new(move |_| {
-            let entry = entry.clone();
-            Box::pin(async move { entry.current_token() })
-        })
-    }
-
-    fn current_token(&self) -> anyhow::Result<String> {
-        let state = self.state.borrow();
-        if state.closed {
-            return Err(anyhow!("agent auth session is closed"));
-        }
-        Ok(state.token.clone())
-    }
-
-    fn bind_user(&self, user_id: &str) -> anyhow::Result<()> {
-        let user_id = user_id.trim();
-        if user_id.is_empty() {
-            return Err(anyhow!("agent auth user ID is empty"));
-        }
-        let mut result = Ok(());
-        self.state
-            .send_modify(|state| match state.user_id.as_deref() {
-                Some(existing_user_id) if existing_user_id != user_id => {
-                    result = Err(anyhow!("agent auth session belongs to a different user"));
-                }
-                Some(_) => {}
-                None => state.user_id = Some(user_id.to_string()),
-            });
-        result
-    }
-
-    fn require_user(&self, user_id: &str) -> anyhow::Result<()> {
-        if self.state.borrow().user_id.as_deref() == Some(user_id) {
-            Ok(())
-        } else {
-            Err(anyhow!("agent auth session belongs to a different user"))
-        }
-    }
-
-    async fn fetch(&self, force_refresh: bool) -> anyhow::Result<String> {
-        let mut state_updates = self.state.subscribe();
-        let version = {
-            let state = state_updates.borrow();
-            if state.closed {
-                return Err(anyhow!("agent auth session is closed"));
-            }
-            if !force_refresh {
-                return Ok(state.token.clone());
-            }
-            state.version
-        };
-        self.state.send_modify(|state| {
-            state.refresh_requested = true;
-        });
-
-        timeout(AGENT_TOKEN_REFRESH_TIMEOUT, async {
-            loop {
-                state_updates
-                    .changed()
-                    .await
-                    .context("agent auth session is closed")?;
-                {
-                    let state = state_updates.borrow();
-                    if state.closed {
-                        return Err(anyhow!("agent auth session is closed"));
-                    }
-                    if state.version > version {
-                        return Ok(state.token.clone());
-                    }
-                }
-            }
-        })
-        .await
-        .context("timed out waiting for the browser to refresh agent authentication")?
-    }
-
-    async fn wait_for_refresh(&self) -> AgentTokenStatus {
-        let mut state_updates = self.state.subscribe();
-        loop {
-            {
-                let state = state_updates.borrow();
-                if state.closed {
-                    return AgentTokenStatus::Complete;
-                }
-                if state.refresh_requested {
-                    return AgentTokenStatus::RefreshRequired;
-                }
-            }
-            if state_updates.changed().await.is_err() {
-                return AgentTokenStatus::Complete;
-            }
-        }
-    }
-
-    fn update(&self, token: String) -> anyhow::Result<()> {
-        if token.trim().is_empty() {
-            return Err(anyhow!("agent auth token is empty"));
-        }
-
-        if self.state.borrow().closed {
-            return Err(anyhow!("agent auth session is closed"));
-        }
-        self.state.send_modify(|state| {
-            state.token = token;
-            state.version += 1;
-            state.refresh_requested = false;
-        });
-        Ok(())
-    }
+    })
 }
 
 pub fn routes() -> axum::Router<AppState> {
-    axum::Router::new()
-        .route("/agent/run", post(run_agent_handler))
-        .route(
-            "/agent/auth/{auth_session_id}",
-            get(wait_for_agent_token_handler).put(refresh_agent_token_handler),
-        )
+    axum::Router::new().route("/agent/run", post(run_agent_handler))
 }
 
 async fn run_agent_handler(
@@ -269,18 +75,11 @@ async fn run_agent_handler(
         .await
         .map_err(ApiError::bad_request)?;
 
-    let auth_session_id = Uuid::parse_str(payload.auth_session_id.trim())
-        .map_err(|_| ApiError::bad_request(anyhow!("invalid agent auth session ID")))?
-        .to_string();
-    let token_entry = state
-        .agent_tokens
-        .create(&auth_session_id, payload.auth_token)
-        .await
-        .map_err(ApiError::bad_request)?;
-
+    let auth_token_fetcher = static_auth_token_fetcher(payload.auth_token);
     let request = RunAgentRequest {
         deployment_url: state.convex_deployment_url.clone(),
-        auth_token_fetcher: token_entry.fetcher(),
+        auth_token_fetcher: auth_token_fetcher.clone(),
+        execution_secret: format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple()),
         submission_id: payload.submission_id,
         thread_id: payload.thread_id,
         prompt: payload.prompt,
@@ -292,44 +91,45 @@ async fn run_agent_handler(
     };
 
     let cleanup_request = request.clone();
-    let cleanup_token_entry = token_entry.clone();
-    let run = match await_agent_start(
-        start_agent_run(request),
-        AGENT_START_TIMEOUT,
-        AGENT_START_CLEANUP_TIMEOUT,
-        move |startup_error| {
-            let mut cleanup_request = cleanup_request;
-            cleanup_request.auth_token_fetcher = cleanup_token_entry.nonrefreshing_fetcher();
-            finalize_failed_start(cleanup_request, startup_error)
-        },
-        &state.agent_tokens,
-        &auth_session_id,
-        &token_entry,
-    )
-    .await
-    {
-        Ok(run) => {
-            if let Err(error) = token_entry.bind_user(run.user_id()) {
-                state
-                    .agent_tokens
-                    .close(&auth_session_id, &token_entry)
-                    .await;
-                return Err(ApiError::internal(error));
-            }
-            run
-        }
-        Err(error) => return Err(ApiError::internal(error)),
-    };
-    let run_id = run.run_id().to_string();
-    let token_store = state.agent_tokens.clone();
+    let (start_result_sender, start_result_receiver) = oneshot::channel();
 
+    // Detach the complete launch before waiting for its acknowledgement. Hyper
+    // may drop this handler when the browser closes the tab; the executor must
+    // still either run or durably reconcile the submitted run.
     tokio::spawn(async move {
-        if let Err(error) = run_agent(run).await {
-            eprintln!("sprocket-server: agent run failed: {error:#}");
+        let run = await_agent_start(
+            start_agent_run(request),
+            AGENT_START_TIMEOUT,
+            AGENT_START_CLEANUP_TIMEOUT,
+            move |startup_error| {
+                let mut cleanup_request = cleanup_request;
+                cleanup_request.auth_token_fetcher = auth_token_fetcher;
+                finalize_failed_start(cleanup_request, startup_error)
+            },
+        )
+        .await;
+
+        match run {
+            Ok(run) => {
+                let run_id = run.run_id().to_string();
+                let _ = start_result_sender.send(Ok(run_id));
+                if let Err(error) = run_agent(run).await {
+                    eprintln!("sprocket-server: agent run failed: {error:#}");
+                }
+            }
+            Err(error) => {
+                let error = format!("{error:#}");
+                if start_result_sender.send(Err(error.clone())).is_err() {
+                    eprintln!("sprocket-server: detached agent launch failed: {error}");
+                }
+            }
         }
-        token_store.close(&auth_session_id, &token_entry).await;
     });
 
+    let run_id = start_result_receiver
+        .await
+        .map_err(|_| ApiError::internal(anyhow!("agent launch task stopped unexpectedly")))?
+        .map_err(|error| ApiError::internal(anyhow!(error)))?;
     Ok((StatusCode::ACCEPTED, Json(RunAgentStartResponse { run_id })))
 }
 
@@ -338,9 +138,6 @@ async fn await_agent_start<F, T, C, CF>(
     startup_timeout: Duration,
     cleanup_timeout: Duration,
     cleanup: C,
-    token_store: &AgentTokenStore,
-    auth_session_id: &str,
-    token_entry: &Arc<AgentTokenEntry>,
 ) -> anyhow::Result<T>
 where
     F: Future<Output = anyhow::Result<T>>,
@@ -357,7 +154,6 @@ where
         Err(error) => {
             let startup_error = format!("{error:#}");
             let cleanup_result = timeout(cleanup_timeout, cleanup(startup_error.clone())).await;
-            token_store.close(auth_session_id, token_entry).await;
             match cleanup_result {
                 Ok(Ok(())) => Err(error),
                 Ok(Err(cleanup_error)) => Err(anyhow!(
@@ -369,55 +165,6 @@ where
             }
         }
     }
-}
-
-async fn wait_for_agent_token_handler(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    Path(auth_session_id): Path<String>,
-) -> Result<Json<AgentTokenStatus>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-
-    Ok(Json(match state.agent_tokens.get(&auth_session_id).await {
-        Some(entry) => entry.wait_for_refresh().await,
-        None => AgentTokenStatus::NotFound,
-    }))
-}
-
-async fn refresh_agent_token_handler(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    Path(auth_session_id): Path<String>,
-    Json(payload): Json<RefreshAgentTokenRequest>,
-) -> Result<StatusCode, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-
-    let Some(entry) = state.agent_tokens.get(&auth_session_id).await else {
-        return Err(ApiError::not_found(anyhow!(
-            "agent auth session was not found"
-        )));
-    };
-    let verified_user_id = timeout(
-        AGENT_TOKEN_VERIFY_TIMEOUT,
-        authenticated_user_id(&state.convex_deployment_url, payload.auth_token.clone()),
-    )
-    .await
-    .context("timed out verifying refreshed agent authentication")
-    .and_then(|result| result)
-    .map_err(ApiError::unauthorized)?;
-    entry
-        .require_user(&verified_user_id)
-        .map_err(ApiError::forbidden)?;
-    entry
-        .update(payload.auth_token)
-        .map_err(ApiError::bad_request)?;
-    Ok(StatusCode::NO_CONTENT)
 }
 
 #[derive(Debug)]
@@ -440,14 +187,6 @@ impl ApiError {
 
     fn bad_request(error: anyhow::Error) -> Self {
         Self::with_status(StatusCode::BAD_REQUEST, error)
-    }
-
-    fn forbidden(error: anyhow::Error) -> Self {
-        Self::with_status(StatusCode::FORBIDDEN, error)
-    }
-
-    fn not_found(error: anyhow::Error) -> Self {
-        Self::with_status(StatusCode::NOT_FOUND, error)
     }
 
     fn internal(error: anyhow::Error) -> Self {
@@ -483,95 +222,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forced_fetch_waits_for_a_browser_refresh() {
-        let store = AgentTokenStore::default();
-        let entry = store
-            .create("auth-session", "token-1".to_string())
-            .await
-            .expect("create token session");
-        let fetcher = entry.fetcher();
-
+    async fn static_fetcher_returns_the_launch_token_without_waiting() {
+        let fetcher = static_auth_token_fetcher("token-1".to_string());
         assert_eq!(fetcher(false).await.expect("initial token"), "token-1");
-
-        let refresh = tokio::spawn(async move { fetcher(true).await });
-        assert!(matches!(
-            entry.wait_for_refresh().await,
-            AgentTokenStatus::RefreshRequired
-        ));
-        entry.update("token-2".to_string()).expect("update token");
-
         assert_eq!(
-            refresh
+            timeout(Duration::from_millis(20), fetcher(true))
                 .await
-                .expect("refresh task")
-                .expect("refreshed token"),
-            "token-2"
+                .expect("forced refresh must be noninteractive")
+                .expect("same launch token"),
+            "token-1"
         );
     }
 
     #[tokio::test]
-    async fn refreshed_tokens_must_match_the_verified_run_user() {
-        let store = AgentTokenStore::default();
-        let entry = store
-            .create("auth-session", "token-1".to_string())
-            .await
-            .expect("create token session");
-
-        entry.bind_user("user-a").expect("bind verified user");
-
-        entry.require_user("user-a").expect("matching user");
-        assert!(entry.require_user("user-b").is_err());
-        assert_eq!(entry.current_token().expect("current token"), "token-1");
-    }
-
-    #[tokio::test]
-    async fn cleanup_fetcher_never_waits_for_an_interactive_refresh() {
-        let store = AgentTokenStore::default();
-        let entry = store
-            .create("auth-session", "token-1".to_string())
-            .await
-            .expect("create token session");
-        let interactive_fetcher = entry.fetcher();
-        let refresh = tokio::spawn(async move { interactive_fetcher(true).await });
-        assert!(matches!(
-            entry.wait_for_refresh().await,
-            AgentTokenStatus::RefreshRequired
-        ));
-
-        let cleanup_fetcher = entry.nonrefreshing_fetcher();
-        let cleanup_token = timeout(Duration::from_millis(20), cleanup_fetcher(true))
-            .await
-            .expect("cleanup token fetch must be noninteractive")
-            .expect("cleanup token");
-
-        assert_eq!(cleanup_token, "token-1");
-        refresh.abort();
-    }
-
-    #[tokio::test]
-    async fn closed_sessions_are_removed_and_wake_waiters() {
-        let store = AgentTokenStore::default();
-        let entry = store
-            .create("auth-session", "token-1".to_string())
-            .await
-            .expect("create token session");
-
-        store.close("auth-session", &entry).await;
-
-        assert!(store.get("auth-session").await.is_none());
-        assert!(matches!(
-            entry.wait_for_refresh().await,
-            AgentTokenStatus::Complete
-        ));
-    }
-
-    #[tokio::test]
-    async fn timed_out_startup_reconciles_before_closing_its_token_session() {
-        let store = AgentTokenStore::default();
-        let entry = store
-            .create("auth-session", "token-1".to_string())
-            .await
-            .expect("create token session");
+    async fn timed_out_startup_reconciles_before_returning() {
         let dropped = Arc::new(AtomicBool::new(false));
         let drop_signal = DropSignal(dropped.clone());
         let startup = async move {
@@ -580,20 +244,15 @@ mod tests {
         };
         let reconciled = Arc::new(AtomicBool::new(false));
         let cleanup_reconciled = reconciled.clone();
-        let cleanup_entry = entry.clone();
 
         let error = await_agent_start(
             startup,
             Duration::from_millis(1),
             Duration::from_secs(1),
             move |_| async move {
-                assert!(!cleanup_entry.state.borrow().closed);
                 cleanup_reconciled.store(true, Ordering::SeqCst);
                 Ok(())
             },
-            &store,
-            "auth-session",
-            &entry,
         )
         .await
         .expect_err("startup should time out");
@@ -601,9 +260,5 @@ mod tests {
         assert!(error.to_string().contains("timed out starting agent run"));
         assert!(dropped.load(Ordering::SeqCst));
         assert!(reconciled.load(Ordering::SeqCst));
-        assert!(matches!(
-            entry.wait_for_refresh().await,
-            AgentTokenStatus::Complete
-        ));
     }
 }

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -394,7 +394,6 @@ mod tests {
 
         let state = AppState {
             auth,
-            agent_tokens: crate::routes::agent::AgentTokenStore::default(),
             desktop_login: DesktopLoginStore::new(),
             workspace_sessions: WorkspaceSessionStore::new(temp_dir),
             http_base_url: "http://127.0.0.1:7731".to_string(),

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -206,6 +206,18 @@ impl CommandSessionManager {
         self.sessions.lock().await.clear();
     }
 
+    /// Best-effort synchronous terminate used when async cleanup cannot run
+    /// (for example during `Drop` outside a Tokio runtime).
+    pub fn terminate_all(&self) {
+        let Ok(mut sessions) = self.sessions.try_lock() else {
+            return;
+        };
+        for session in sessions.values() {
+            let _ = session.terminate();
+        }
+        sessions.clear();
+    }
+
     async fn observe_session(
         &self,
         session: Arc<CommandSession>,
@@ -913,6 +925,31 @@ mod tests {
         assert!(!finished.success);
         tokio::time::sleep(Duration::from_millis(300)).await;
         assert!(!root.join("leaked.txt").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn terminate_all_clears_active_sessions() {
+        let root = temp_workspace();
+        let sessions = CommandSessionManager::new(root.clone());
+        let started = sessions
+            .exec_command(
+                WorkspaceCancellation::new(),
+                "sleep 5",
+                ".",
+                &default_command_shell(),
+                5_000,
+                10,
+                20_000,
+            )
+            .await
+            .expect("command should start");
+        let session_id = started.session_id.expect("session id");
+        assert!(sessions.sessions.lock().await.contains_key(&session_id));
+
+        sessions.terminate_all();
+        assert!(sessions.sessions.lock().await.is_empty());
+        tokio::time::sleep(Duration::from_millis(300)).await;
         fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## Summary
- detach agent startup from the browser request lifecycle
- replace browser-mediated access-token refresh with strict, hashed run-scoped executor capabilities
- recover lost executor capabilities safely and fence stale claims from completions, tools, and finalization
- remove the obsolete browser/server auth-refresh protocol and update architecture docs

## Validation
- `bun run build`
- `bun run test`
- `cargo test`
- `prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps local agent runs active after the browser disconnects. The main changes are:

- Run-scoped executor capabilities stored as hashes.
- Capability-based access to runtime, completion, and tool operations.
- Claim fencing for renewals, streams, tool results, and finalization.
- Detached local startup and removal of browser-mediated token refresh.
- Updated tests and architecture documentation.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Expired same-claim restarts and contended session cleanup can leave stale execution state or child processes active.

- Tool results are now fenced by the capability, claim ID, and lease.
- An expired matching claim can still restart without takeover reconciliation.
- Drop-time session cleanup can silently do nothing when the session map is locked.

apps/web/src/convex/lib/runLease.ts, apps/web/src/convex/agentRuntime.ts, crates/sprocket-agent/src/provider.rs, and crates/sprocket-workspace/src/tools.rs
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a timeout-300s bun run across the specified test files to exercise the Convex runtime tests.
- Reproduced an expired same-claim restart in a focused Vitest lifecycle test; observed that the start mutation extended the lease and returned claimed: true, but the reconciliation failed because completion attempt, active job, response, and pending job were not reset or cancelled as expected.
- Reproduced a contended lock cleanup scenario using a Rust harness; observed the Drop callback returning while the session-map mutex was held, a survival marker was created, and the child lingered until stop\_all terminated it, after which no reproduction child remained according to a post-run check.

<a href="https://app.greptile.com/trex/runs/15430734/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Adds capability authorization and lease fencing, but same-claim restarts can bypass expired-claim reconciliation. |
| apps/web/src/convex/lib/runLease.ts | Adds active-claim ownership checks while retaining unconditional restart access for matching claim IDs. |
| apps/web/src/convex/executor.ts | Fences tool completion and failure by run capability, claim identity, and active lease. |
| crates/sprocket-agent/src/provider.rs | Adds drop-time session termination, but lock contention can cause cleanup to be skipped. |
| crates/sprocket-workspace/src/tools.rs | Provides the session termination fallback used when an in-flight provider operation is cancelled. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant UI as Browser
participant S as Local Server
participant A as Agent Executor
participant C as Convex
UI->>S: Start run with user token
S->>A: Launch detached executor
A->>C: Create run and bind capability
A->>C: Claim run
loop Model and tool turns
    A->>C: Renew claim
    A->>C: Stream completion and tool results
end
A->>C: Finalize run
Note over A,C: Execution continues after the browser closes
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/convex/lib/runLease.ts`, line 26 ([link](https://github.com/spikonado/sprocket/blob/ae2061f4b3d7f9c3a96c05ad4827d72c9cc6bc20/apps/web/src/convex/lib/runLease.ts#L26)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Expired Same-Claim Restart Skips Cleanup**

   When an executor calls `start` with the same claim ID after its lease expires, this branch accepts it as a renewal. `start` then extends the lease without clearing partial output, cancelling in-flight jobs, resetting the completion attempt, or clearing `activeJobId`, so stale execution state can become active again.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused Convex lifecycle test harness for the expired same-claim restart](https://app.greptile.com/trex/artifacts/e713905e-16d0-4a6c-8a26-319601a119ea)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: focused Vitest configuration used to execute the Convex harness](https://app.greptile.com/trex/artifacts/acc6fa4e-6f63-4177-b206-0316cc6b07c8)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: verbose failing Vitest output showing accepted restart and failed cleanup expectations](https://app.greptile.com/trex/artifacts/3c71748f-ea8a-4f9b-bd4f-975e72f5313b)**

   - Keeps the command output available without making the summary code-heavy.

   **[Repro: structured before-and-after runtime state showing the lease extension and retained stale fields](https://app.greptile.com/trex/artifacts/3908b67e-009f-4546-83ca-b67d89255adb)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/15430734/artifacts?artifact=e713905e-16d0-4a6c-8a26-319601a119ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/convex/lib/runLease.ts
   Line: 26

   Comment:
   **Expired Same-Claim Restart Skips Cleanup**

   When an executor calls `start` with the same claim ID after its lease expires, this branch accepts it as a renewal. `start` then extends the lease without clearing partial output, cancelling in-flight jobs, resetting the completion attempt, or clearing `activeJobId`, so stale execution state can become active again.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/web/src/convex/lib/runLease.ts:26
**Expired Same-Claim Restart Skips Cleanup**

When an executor calls `start` with the same claim ID after its lease expires, this branch accepts it as a renewal. `start` then extends the lease without clearing partial output, cancelling in-flight jobs, resetting the completion attempt, or clearing `activeJobId`, so stale execution state can become active again.

### Issue 2 of 2
crates/sprocket-agent/src/provider.rs:234-241
**Contended Lock Skips Session Cleanup**

When lease loss drops the provider operation while a tool or observer holds the session-map lock, `terminate_all()` uses `try_lock()` and silently skips termination. No later cleanup runs after cancellation, so command sessions and child processes can remain alive.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(agent): Drop redundant claim and ca..."](https://github.com/spikonado/sprocket/commit/ae2061f4b3d7f9c3a96c05ad4827d72c9cc6bc20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46294300)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->