### PR TITLE
feat(models): Add Amazon Bedrock provider fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ bun dev
 
 After creating a convex deployment and configuring authkit following the instructions, configure the Convex deployment with the API key for each enabled model provider (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `XAI_API_KEY`).
 
+Optional Amazon Bedrock fallback for OpenAI and Anthropic: set `AWS_BEARER_TOKEN_BEDROCK`, or `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`. `AWS_REGION` defaults to `us-east-1` (use a US Bedrock region; Anthropic fallback uses `us.` inference profiles).
+
 This runs Vite at `http://localhost:5173` and the Rust API at `http://127.0.0.1:7731`, with development state kept in `.sprocket-dev` inside the repository.
 To develop against Electron instead, run:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
 		"lint": "eslint . && convex typecheck"
 	},
 	"dependencies": {
+		"@ai-sdk/amazon-bedrock": "^5.0.28",
 		"@ai-sdk/anthropic": "^4.0.15",
 		"@ai-sdk/openai": "^4.0.11",
 		"@ai-sdk/xai": "^4.0.14",
@@ -25,6 +26,7 @@
 		"@lucide/svelte": "^1.18.0",
 		"@workos-inc/authkit-js": "^0.20.0",
 		"ai": "^7.0.19",
+		"ai-fallback": "^3.0.0",
 		"clsx": "^2.1.1",
 		"convex": "^1.37.0",
 		"convex-svelte": "^0.14.0",

--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -96,6 +96,14 @@ describe('Amazon Bedrock fallback routing', () => {
 			FallbackModel
 		);
 
+		const shouldRetry = (openaiFallback as FallbackModel).settings.shouldRetryThisError!;
+		expect(shouldRetry(Object.assign(new Error('auth'), { statusCode: 401 }))).toBe(false);
+		expect(
+			shouldRetry(Object.assign(new Error('auth'), { cause: { response: { status: 403 } } }))
+		).toBe(false);
+		expect(shouldRetry(new Error('Incorrect API key provided'))).toBe(false);
+		expect(shouldRetry(Object.assign(new Error('rate limited'), { statusCode: 429 }))).toBe(true);
+
 		vi.unstubAllEnvs();
 	});
 });

--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { createProviderFetch, resolveProviderOptions } from '@convex/lib/modelRegistry';
+import { describe, expect, it, vi } from 'vitest';
+import { FallbackModel } from 'ai-fallback';
+import {
+	createProviderFetch,
+	hasBedrockCredentials,
+	resolveLanguageModel,
+	resolveProviderOptions
+} from '@convex/lib/modelRegistry';
 
 describe('model provider request configuration', () => {
 	it('enables provider-native prompt caching controls', () => {
@@ -39,5 +45,57 @@ describe('model provider request configuration', () => {
 			},
 			{ model: 'claude-fable-5' }
 		]);
+	});
+});
+
+describe('Amazon Bedrock fallback routing', () => {
+	it('detects Bedrock credentials from bearer token or SigV4 keys', () => {
+		expect(hasBedrockCredentials({})).toBe(false);
+		expect(hasBedrockCredentials({ AWS_BEARER_TOKEN_BEDROCK: 'token' })).toBe(true);
+		expect(
+			hasBedrockCredentials({
+				AWS_ACCESS_KEY_ID: 'AKIA...',
+				AWS_SECRET_ACCESS_KEY: 'secret'
+			})
+		).toBe(true);
+		expect(hasBedrockCredentials({ AWS_ACCESS_KEY_ID: 'AKIA...' })).toBe(false);
+	});
+
+	it('wraps OpenAI and Anthropic models only when Bedrock credentials are set', () => {
+		vi.stubEnv('AWS_BEARER_TOKEN_BEDROCK', '');
+		vi.stubEnv('AWS_ACCESS_KEY_ID', '');
+		vi.stubEnv('AWS_SECRET_ACCESS_KEY', '');
+
+		expect(resolveLanguageModel('gpt-5.6-sol', 'standard', 'thread:abc')).not.toBeInstanceOf(
+			FallbackModel
+		);
+		expect(resolveLanguageModel('claude-fable-5', 'standard', 'thread:abc')).not.toBeInstanceOf(
+			FallbackModel
+		);
+		expect(resolveLanguageModel('grok-4.5', 'standard', 'thread:abc')).not.toBeInstanceOf(
+			FallbackModel
+		);
+
+		vi.stubEnv('AWS_BEARER_TOKEN_BEDROCK', 'test-bedrock-token');
+		const openaiFallback = resolveLanguageModel('gpt-5.6-sol', 'standard', 'thread:abc');
+		const anthropicFallback = resolveLanguageModel('claude-fable-5', 'standard', 'thread:abc');
+		expect(openaiFallback).toBeInstanceOf(FallbackModel);
+		expect(anthropicFallback).toBeInstanceOf(FallbackModel);
+		expect(openaiFallback).toMatchObject({
+			retryAfterOutput: false,
+			settings: {
+				models: [{ modelId: 'gpt-5.6-sol' }, { modelId: 'openai.gpt-5.6-sol' }]
+			}
+		});
+		expect(anthropicFallback).toMatchObject({
+			settings: {
+				models: [{ modelId: 'claude-fable-5' }, { modelId: 'us.anthropic.claude-fable-5' }]
+			}
+		});
+		expect(resolveLanguageModel('grok-4.5', 'standard', 'thread:abc')).not.toBeInstanceOf(
+			FallbackModel
+		);
+
+		vi.unstubAllEnvs();
 	});
 });

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -82,10 +82,33 @@ export function hasBedrockCredentials(env: NodeJS.ProcessEnv = process.env): boo
 	return Boolean(env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim());
 }
 
+function statusCodeFromError(error: unknown): number | undefined {
+	if (!error || typeof error !== 'object') return undefined;
+	const value = error as Record<string, unknown>;
+	if (typeof value.statusCode === 'number') return value.statusCode;
+	if (typeof value.status === 'number') return value.status;
+	const response = value.response;
+	if (response && typeof response === 'object') {
+		const status = (response as Record<string, unknown>).status;
+		if (typeof status === 'number') return status;
+	}
+	return statusCodeFromError(value.cause);
+}
+
 function shouldFailoverToBedrock(error: Error): boolean {
-	const statusCode = (error as { statusCode?: unknown }).statusCode;
+	const statusCode = statusCodeFromError(error);
 	// Auth/permission failures are configuration problems; do not silently bill Bedrock.
 	if (statusCode === 401 || statusCode === 403) return false;
+	const message = error.message.toLowerCase();
+	if (
+		message.includes('wrong-key') ||
+		message.includes('invalid api key') ||
+		message.includes('incorrect api key') ||
+		message.includes('unauthorized') ||
+		message.includes('authentication')
+	) {
+		return false;
+	}
 	return defaultShouldRetryThisError(error);
 }
 

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -1,5 +1,7 @@
 'use node';
 
+import { createBedrockAnthropic } from '@ai-sdk/amazon-bedrock/anthropic';
+import { createBedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
 import { createAnthropic, type AnthropicProvider } from '@ai-sdk/anthropic';
 import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
 import { createXai, type XaiProvider } from '@ai-sdk/xai';
@@ -10,6 +12,9 @@ import {
 	type SupportedServiceTier
 } from '@convex/lib/models';
 import type { JSONValue, LanguageModel } from 'ai';
+import { createFallback, defaultShouldRetryThisError } from 'ai-fallback';
+
+type FallbackModels = NonNullable<Parameters<typeof createFallback>[0]['models']>;
 
 type ProviderFetch = NonNullable<NonNullable<Parameters<typeof createAnthropic>[0]>['fetch']>;
 type ProviderFetchInput = Parameters<ProviderFetch>[0];
@@ -72,6 +77,49 @@ const anthropicFast: AnthropicProvider = createAnthropic({
 	fetch: createProviderFetch({ serviceTier: 'auto' })
 });
 
+export function hasBedrockCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.AWS_BEARER_TOKEN_BEDROCK?.trim()) return true;
+	return Boolean(env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim());
+}
+
+function shouldFailoverToBedrock(error: Error): boolean {
+	const statusCode = (error as { statusCode?: unknown }).statusCode;
+	// Auth/permission failures are configuration problems; do not silently bill Bedrock.
+	if (statusCode === 401 || statusCode === 403) return false;
+	return defaultShouldRetryThisError(error);
+}
+
+function withBedrockFallback(
+	primary: LanguageModel,
+	createFallbackModel: () => LanguageModel
+): LanguageModel {
+	if (!hasBedrockCredentials()) return primary;
+	return createFallback({
+		models: [primary, createFallbackModel()] as FallbackModels,
+		// Never splice a restarted Bedrock generation into an already-persisted stream.
+		retryAfterOutput: false,
+		shouldRetryThisError: shouldFailoverToBedrock,
+		onError: (error, failedModelId) => {
+			console.warn(`Model provider ${failedModelId} failed during completion.`, error);
+		}
+	});
+}
+
+function resolveBedrockFallbackModel(
+	provider: 'openai' | 'anthropic',
+	modelId: SupportedModelId
+): LanguageModel {
+	const region = process.env.AWS_REGION?.trim() || 'us-east-1';
+	if (provider === 'anthropic') {
+		return createBedrockAnthropic({ region })(`us.anthropic.${modelId}`);
+	}
+	// Mantle Responses expects the OpenAI-compatible path (/openai/v1), not the SDK default /v1.
+	return createBedrockMantle({
+		region,
+		baseURL: `https://bedrock-mantle.${region}.api.aws/openai/v1`
+	}).responses(`openai.${modelId}`);
+}
+
 export function resolveLanguageModel(
 	modelId: SupportedModelId,
 	serviceTier: SupportedServiceTier,
@@ -79,7 +127,8 @@ export function resolveLanguageModel(
 ): LanguageModel {
 	const provider = getModelDefinition(modelId).provider;
 	if (provider === 'anthropic') {
-		return serviceTier === 'fast' ? anthropicFast(modelId) : anthropic(modelId);
+		const primary = serviceTier === 'fast' ? anthropicFast(modelId) : anthropic(modelId);
+		return withBedrockFallback(primary, () => resolveBedrockFallbackModel('anthropic', modelId));
 	}
 	if (provider === 'xai') {
 		const xai: XaiProvider = createXai({
@@ -91,7 +140,7 @@ export function resolveLanguageModel(
 		});
 		return xai(modelId);
 	}
-	return openai(modelId);
+	return withBedrockFallback(openai(modelId), () => resolveBedrockFallbackModel('openai', modelId));
 }
 
 export function resolveProviderOptions(

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "name": "@sprocket/web",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/amazon-bedrock": "^5.0.28",
         "@ai-sdk/anthropic": "^4.0.15",
         "@ai-sdk/openai": "^4.0.11",
         "@ai-sdk/xai": "^4.0.14",
@@ -36,6 +37,7 @@
         "@lucide/svelte": "^1.18.0",
         "@workos-inc/authkit-js": "^0.20.0",
         "ai": "^7.0.19",
+        "ai-fallback": "^3.0.0",
         "clsx": "^2.1.1",
         "convex": "^1.37.0",
         "convex-svelte": "^0.14.0",
@@ -91,6 +93,8 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
+    "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@5.0.28", "", { "dependencies": { "@ai-sdk/anthropic": "4.0.18", "@ai-sdk/openai": "4.0.18", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12", "@smithy/eventstream-codec": "^4.3.3", "@smithy/util-utf8": "^4.3.3", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZXCitTEoAGVR4FpcQlGgsjU00KxldUKnIcxDW473T4D6pN7q9tjllvhyRscQJkk0qSL/SMIt3kZcAkVBJztsYQ=="],
+
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6iVlzqZjqqoHTmgO1WU9id/33pYykIRasWJFAMf1+d+nhju6d7566VRFsOGZ2W2GzgNtzKs8DGsYN7X5/wOGuw=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg=="],
@@ -101,7 +105,7 @@
 
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA=="],
 
     "@ai-sdk/xai": ["@ai-sdk/xai@4.0.14", "", { "dependencies": { "@ai-sdk/openai-compatible": "3.0.11", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BRalRQZPS0LSvH0ICZPGPivTi05YK4CvuVEAVeyUwg9FvfdrpENkd+Sv+gz5U1h99KvLJWa/3HB5DyHtqU71cw=="],
 
@@ -407,6 +411,14 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
+    "@smithy/core": ["@smithy/core@3.29.7", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.4.12", "", { "dependencies": { "@smithy/core": "^3.29.7", "tslib": "^2.6.2" } }, "sha512-J1hJGf2yN6dbO960oGEDhAe6saEn2yzR2IC9vFKEYIYsiq8y8jdwQWGhY4UrvAdxozcnJ92KFHE0HdB75a9qHg=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.4.12", "", { "dependencies": { "@smithy/core": "^3.29.7", "tslib": "^2.6.2" } }, "sha512-yQiehL+My27xXCnbRGzrRsWzuL5JZY5rvyK+g+mWWkEHonUOXyjmvp+fuYMaFG7XluzZX5AWzzL9JfE6JzFYNg=="],
+
     "@sprocket/desktop": ["@sprocket/desktop@workspace:apps/desktop"],
 
     "@sprocket/eslint-config": ["@sprocket/eslint-config@workspace:packages/eslint-config"],
@@ -575,6 +587,8 @@
 
     "ai": ["ai@7.0.22", "", { "dependencies": { "@ai-sdk/gateway": "4.0.16", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg=="],
 
+    "ai-fallback": ["ai-fallback@3.0.0", "", { "peerDependencies": { "@ai-sdk/provider": ">=4.0.0", "@ai-sdk/provider-utils": ">=5.0.0" } }, "sha512-gWDUeKWT6ySREk7rpBkQUioxYI8pTbaCf//c9vpcBmSqtDsjKceOaccDO7jrSKtXgB9LEE0fd2H1K80zuLBNmQ=="],
+
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -602,6 +616,8 @@
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "aws4": ["aws4@1.13.2", "", {}, "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -1403,9 +1419,19 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@ai-sdk/amazon-bedrock/@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.18", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CpSBDI7DWk3DHM+qwbjhH7JxqqEqr5sK/SDrC9eit8Q03Uf1xBBrgMAVf9FajbpaH3oHxynLn474lf6ikjjO8A=="],
+
+    "@ai-sdk/amazon-bedrock/@ai-sdk/openai": ["@ai-sdk/openai@4.0.18", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+qz0wGrn6gSNoxMetnQIhUPV/xhzfhYMiLBZnLperfIQE6d0V/NNA0rI01k27zaiQdg/2FCPeYg6GOf21cp45g=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
+
     "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
 
     "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
+
+    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
 
     "@electron/fuses/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 


### PR DESCRIPTION
## Summary
- Fail over OpenAI and Anthropic completions to Amazon Bedrock when primary providers error (rate limits/outages), via `ai-fallback`
- Map GPT-5.6 models to Bedrock Mantle Responses (`openai.{id}` on `/openai/v1`) and Claude Fable 5 to Bedrock Anthropic (`us.anthropic.{id}`)
- Enable only when `AWS_BEARER_TOKEN_BEDROCK` or SigV4 AWS credentials are configured; xAI stays primary-only

## Test plan
- [ ] Unit tests in `modelRegistry.test.ts` pass (credential gating + fallback model ids)
- [ ] Without Bedrock env vars, completions behave as before
- [ ] With `AWS_BEARER_TOKEN_BEDROCK` set, force an OpenAI/Anthropic failure and confirm Bedrock serves the completion
- [ ] Confirm mid-stream failures do not splice a second generation into the transcript (`retryAfterOutput: false`)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Amazon Bedrock fallback for OpenAI and Anthropic completions. The main changes are:

- Enables fallback only when Bedrock credentials are configured.
- Routes supported OpenAI and Anthropic models to Bedrock equivalents.
- Prevents fallback after streamed output begins.
- Excludes authentication failures from cross-provider retries.
- Adds dependencies, tests, and setup documentation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

The updated error classifier handles top-level and wrapped authentication status codes. Tests cover nested response status values and common authentication errors. No blocking issues remain in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before baseline the focused command passed 2 pre-existing tests on origin/main.
- After the baseline change (commit 93f6a4a), the focused command passed all 4 tests, including both Amazon Bedrock fallback-routing tests.
- Both test captures include UTC timestamp, revision, exact command, working directory, output, and exit code.

<a href="https://app.greptile.com/trex/runs/15546592/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/modelRegistry.ts | Adds credential-gated Bedrock routing and blocks fallback for wrapped authentication errors. |
| apps/web/src/convex/lib/modelRegistry.test.ts | Covers credential gating, fallback model IDs, stream retry settings, and wrapped authentication failures. |
| apps/web/package.json | Adds the Bedrock provider and fallback orchestration dependencies. |
| README.md | Documents Bedrock credentials and region configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(models): Harden Bedrock auth-error f..."](https://github.com/spikonado/sprocket/commit/93f6a4ae54962f9616c624f92ef7a3f2c1d13660) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46551866)</sub>

<!-- /greptile_comment -->