### PR TITLE
fix(npm): Restore execute bits on published CLI binaries

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -183,6 +183,11 @@ jobs:
               npm pack --dry-run
             )
           done
+          binaries="$(find npm-dist -type f \( -name sprocket -o -name sprocket.js \))"
+          test -n "$binaries"
+          while IFS= read -r binary; do
+            test -x "$binary"
+          done <<< "$binaries"
       - uses: actions/upload-artifact@v6
         with:
           name: npm-packages-${{ needs.prepare.outputs.version }}
@@ -209,6 +214,10 @@ jobs:
         with:
           name: npm-packages-${{ needs.prepare.outputs.version }}
           path: npm-dist
+      - name: Restore executable bits after artifact download
+        run: >
+          find npm-dist -type f \( -name sprocket -o -name sprocket.js \)
+          -exec chmod 755 {} +
       - id: freshness
         name: Skip stale main-branch builds
         if: needs.prepare.outputs.npm-tag == 'dev'

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-auto-install-peers=true

--- a/apps/web/.npmrc
+++ b/apps/web/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/npm/sprocket/lib/launcher.js
+++ b/npm/sprocket/lib/launcher.js
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { accessSync, chmodSync, constants } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +45,21 @@ export function resolveNativeBinary(platform = process.platform, arch = process.
 	return path.join(path.dirname(packageJson), 'bin', executable);
 }
 
+export function ensureExecutable(binary) {
+	if (process.platform === 'win32') {
+		return;
+	}
+	try {
+		accessSync(binary, constants.X_OK);
+	} catch {
+		try {
+			chmodSync(binary, 0o755);
+		} catch {
+			// Best-effort; spawn reports EACCES if still unusable.
+		}
+	}
+}
+
 export function run(binary, args, options = {}) {
 	const result = (options.spawn ?? spawnSync)(binary, args, {
 		stdio: 'inherit',
@@ -64,7 +80,9 @@ export function launch(args) {
 	try {
 		const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 		const staticDir = path.resolve(packageRoot, '../web');
-		process.exitCode = run(resolveNativeBinary(), args, {
+		const binary = resolveNativeBinary();
+		ensureExecutable(binary);
+		process.exitCode = run(binary, args, {
 			env: {
 				...process.env,
 				SPROCKET_STATIC_DIR: process.env.SPROCKET_STATIC_DIR || staticDir

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -13,7 +13,7 @@
 		"web/"
 	],
 	"engines": {
-		"node": ">=24"
+		"node": ">=20"
 	},
 	"repository": {
 		"type": "git",

--- a/npm/sprocket/test/launcher.test.js
+++ b/npm/sprocket/test/launcher.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
-import { nativePackage, run } from '../lib/launcher.js';
+import { ensureExecutable, nativePackage, run } from '../lib/launcher.js';
 
 test('selects the native package for supported platforms', () => {
 	assert.deepEqual(nativePackage('linux', 'x64'), [
@@ -13,6 +16,23 @@ test('selects the native package for supported platforms', () => {
 		'sprocket.exe'
 	]);
 	assert.equal(nativePackage('freebsd', 'x64'), undefined);
+});
+
+test('restores execute bits on unix binaries', { skip: process.platform === 'win32' }, () => {
+	const directory = mkdtempSync(path.join(tmpdir(), 'sprocket-chmod-'));
+	const binary = path.join(directory, 'sprocket');
+	try {
+		writeFileSync(binary, '#!/bin/sh\n');
+		chmodSync(binary, 0o644);
+		ensureExecutable(binary);
+		assert.equal(statSync(binary).mode & 0o111, 0o111);
+
+		chmodSync(binary, 0o555);
+		ensureExecutable(binary);
+		assert.equal(statSync(binary).mode & 0o111, 0o111);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
 });
 
 test('runs the native executable with unchanged arguments and environment', () => {

--- a/npm/sprocket/test/npm-packages.test.js
+++ b/npm/sprocket/test/npm-packages.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { constants } from 'node:fs';
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -73,6 +74,13 @@ test('assembles version-matched root and native packages', async () => {
 			publishConfig: { access: 'public' },
 			libc: ['glibc']
 		});
+
+		const sourceManifest = JSON.parse(
+			await readFile(path.join(ROOT, 'npm/sprocket/package.json'), 'utf8')
+		);
+		assert.equal(rootManifest.engines.node, sourceManifest.engines.node);
+		await access(path.join(output, 'sprocket/bin/sprocket.js'), constants.X_OK);
+		await access(path.join(output, 'linux-x64-gnu/bin/sprocket'), constants.X_OK);
 	} finally {
 		await rm(temporary, { recursive: true, force: true });
 	}

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -66,6 +66,7 @@ async function copyRootPackage(output, web, version) {
 	for (const entry of ['bin', 'lib', 'README.md']) {
 		await cp(path.join(SOURCE_PACKAGE, entry), path.join(destination, entry), { recursive: true });
 	}
+	await chmod(path.join(destination, 'bin', 'sprocket.js'), 0o755);
 	await cp(path.join(ROOT, 'LICENSE'), path.join(destination, 'LICENSE'));
 	await cp(web, path.join(destination, 'web'), { recursive: true });
 


### PR DESCRIPTION
## Summary
- Restore `+x` on native CLI binaries after the npm release artifact download so published tarballs are executable again (fixes `spawnSync ... EACCES` from `npx @spikonado/sprocket`)
- Best-effort `chmod` in the JS launcher for already-broken installs, and drop unused monorepo `.npmrc` files that triggered npm warnings
- Lower published `@spikonado/sprocket` `engines.node` from `>=24` to `>=20` (launcher is a thin Node shim)

## Test plan
- [x] `nix develop -c node --test npm/sprocket/test/*.test.js`
- [ ] After merge/publish of a new `@dev` build: `npx @spikonado/sprocket@dev --web` no longer fails with EACCES
- [ ] Confirm no `Unknown project config "auto-install-peers"` warning when running npm/npx from the repo root

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores executable permissions throughout the npm packaging and publishing flow.
- Marks the JavaScript launcher and native Unix binaries executable during package assembly.
- Reapplies executable bits after GitHub artifact download and validates them before publication.
- Adds best-effort permission repair for existing installations.
- Expands launcher support to Node.js 20 and removes unused npm configuration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge with no actionable defects identified.

The package assembly, artifact handoff, publication, and runtime-launch paths consistently restore or verify executable permissions, while the shipped launcher uses APIs supported by the newly declared Node.js minimum.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused contract validation suite completed with exit code 0 and 4 passed, 0 failed, 0 skipped.
- Before: ensureExecutable was absent and the mode remained 644, which caused a spawn error EACCES.
- With ensureExecutable present, the mode is 755, the native launcher printed 'launcher-ran', and the process exited with status 0.
- The package assembly test verified both the assembled root launcher and the Linux native binary are executable.

<a href="https://app.greptile.com/trex/runs/15591736/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Validates executable package files and restores their modes after artifact download before every publish path. |
| scripts/build-npm-packages.mjs | Explicitly marks the assembled JavaScript CLI entry point executable. |
| npm/sprocket/lib/launcher.js | Adds a Unix-only best-effort permission repair before spawning the resolved native binary. |
| npm/sprocket/package.json | Lowers the published launcher’s Node.js requirement to a version compatible with its shipped APIs. |
| npm/sprocket/test/launcher.test.js | Covers restoration and preservation of Unix execute permissions. |
| npm/sprocket/test/npm-packages.test.js | Verifies assembled package engine metadata and executable modes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
B[Build npm packages] --> C[Set executable bits]
C --> V[Validate package contents and modes]
V --> U[Upload release artifact]
U --> D[Download artifact]
D --> R[Restore executable bits]
R --> P[Publish native packages]
P --> N[Publish root npm package]
N --> L[Launcher resolves native binary]
L --> E[Best-effort executable check and repair]
E --> X[Spawn native CLI]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(npm): Restore execute bits on publis..."](https://github.com/spikonado/sprocket/commit/cb4791ad150e2f801365ecfeed2844327a099c13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46697842)</sub>

<!-- /greptile_comment -->