### PR TITLE
feat(web): Gate free-tier models and differentiate usage limits

### DIFF
--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -8,6 +8,7 @@ import {
 	type SupportedModelId,
 	type SupportedServiceTier
 } from '@convex/lib/models';
+import { assertModelAllowedForTier, getSubscriptionTier } from '@convex/lib/tiers';
 import { buildCanonicalAgentHistory } from '@convex/lib/agentHistory';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import {
@@ -187,6 +188,7 @@ export const createRun = mutation({
 			serviceTier: args.serviceTier
 		});
 		const userId: string = await getUserId(ctx);
+		assertModelAllowedForTier(await getSubscriptionTier(ctx, userId), args.selectedModel);
 		const secretHash = await executionSecretHash(args.executionSecret);
 		const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecord(
 			ctx.db,

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -49,7 +49,7 @@ export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModel
 	admin: modelIds
 };
 
-export const modelLockUpgradeMessage = 'Upgrade to a higher tier to unlock these models' as const;
+export const modelLockUpgradeMessage = 'Upgrade to a higher tier to unlock this model' as const;
 
 export function isModelAllowedForTier(tier: SubscriptionTier, modelId: SupportedModelId): boolean {
 	return tierAllowedModels[tier].includes(modelId);

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -1,5 +1,6 @@
 import type { GenericMutationCtx, GenericQueryCtx } from 'convex/server';
 import type { DataModel, Doc } from '@convex/_generated/dataModel';
+import { getModelDefinition, modelIds, type SupportedModelId } from '@convex/lib/models';
 
 export const subscriptionTierIds = ['free', 'pro', 'admin'] as const;
 export type SubscriptionTier = (typeof subscriptionTierIds)[number];
@@ -15,21 +16,59 @@ export type TierLimits = {
 	webTools: { weekly: number; monthly: number };
 };
 
-const sharedLimits: TierLimits = {
-	modelUsage: { weekly: 2_500, monthly: 7_500 },
+const freeLimits: TierLimits = {
+	modelUsage: { weekly: 5_000, monthly: 15_000 },
 	webTools: { weekly: 500, monthly: 1_500 }
+};
+
+const proLimits: TierLimits = {
+	modelUsage: {
+		weekly: freeLimits.modelUsage.weekly * 5,
+		monthly: freeLimits.modelUsage.monthly * 5
+	},
+	webTools: {
+		weekly: freeLimits.webTools.weekly * 5,
+		monthly: freeLimits.webTools.monthly * 5
+	}
 };
 
 const adminQuota = 1_000_000_000;
 
 export const tierLimits: Record<SubscriptionTier, TierLimits> = {
-	free: sharedLimits,
-	pro: sharedLimits,
+	free: freeLimits,
+	pro: proLimits,
 	admin: {
 		modelUsage: { weekly: adminQuota, monthly: adminQuota },
 		webTools: { weekly: adminQuota, monthly: adminQuota }
 	}
 };
+
+export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModelId[]> = {
+	free: ['claude-fable-5'],
+	pro: modelIds,
+	admin: modelIds
+};
+
+export const modelLockUpgradeMessage = 'Upgrade to a higher tier to unlock these models' as const;
+
+export function isModelAllowedForTier(tier: SubscriptionTier, modelId: SupportedModelId): boolean {
+	return tierAllowedModels[tier].includes(modelId);
+}
+
+export function assertModelAllowedForTier(tier: SubscriptionTier, modelId: SupportedModelId): void {
+	if (isModelAllowedForTier(tier, modelId)) return;
+	throw new Error(
+		`${getModelDefinition(modelId).label} is not available on the ${tierLabels[tier]} plan. Upgrade to a higher tier to unlock this model.`
+	);
+}
+
+export function resolveModelForTier(
+	tier: SubscriptionTier,
+	modelId: SupportedModelId
+): SupportedModelId {
+	if (isModelAllowedForTier(tier, modelId)) return modelId;
+	return tierAllowedModels[tier][0];
+}
 
 /** Dodo product id per paid tier; 'free' and 'admin' never have one. */
 export const tierProductIds: Partial<Record<SubscriptionTier, string>> = {};

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -46,6 +46,15 @@ export async function seedOwnedThread(
 	threadId: Id<'threadRecords'>;
 }> {
 	const asUser = t.withIdentity({ subject });
+	// Integration fixtures exercise every model; grant admin so free-tier allowlists do not block them.
+	await t.run(async (ctx) => {
+		await ctx.db.insert('subscriptions', {
+			userId: subject,
+			tier: 'admin',
+			status: 'active',
+			eventAt: 1
+		});
+	});
 	const workspaceSession = await asUser.mutation(api.workspaceSessions.upsertSelected, {
 		workspaceName: 'alpha',
 		connectedClientId: 'client-1'

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -4,6 +4,7 @@ import { v } from 'convex/values';
 import { getOwnedThreadRecord, getOwnedWorkspaceSession } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
 import { assertSupportedModelConfiguration } from '@convex/lib/models';
+import { assertModelAllowedForTier, getSubscriptionTier } from '@convex/lib/tiers';
 import { isRunFinalStatus, vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
 
 async function patchOwnedThread(
@@ -37,6 +38,7 @@ export const create = mutation({
 			serviceTier: args.serviceTier
 		});
 		const userId: string = await getUserId(ctx);
+		assertModelAllowedForTier(await getSubscriptionTier(ctx, userId), args.selectedModel);
 		await getOwnedWorkspaceSession(ctx.db, userId, args.workspaceSessionId);
 		const existingRecord = await ctx.db
 			.query('threadRecords')

--- a/apps/web/src/lib/chat/model-options.test.ts
+++ b/apps/web/src/lib/chat/model-options.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { modelIds } from '$convex/lib/models';
+import { modelOptionsForTier } from '$lib/chat/model-options';
+
+describe('modelOptionsForTier', () => {
+	it('does not lock models for pro', () => {
+		const options = modelOptionsForTier('pro');
+		expect(options.every((option) => !option.locked)).toBe(true);
+		expect(options.map((option) => option.id)).toEqual([...modelIds]);
+	});
+});

--- a/apps/web/src/lib/chat/model-options.ts
+++ b/apps/web/src/lib/chat/model-options.ts
@@ -5,16 +5,40 @@ import {
 	type SupportedReasoningEffort,
 	type SupportedServiceTier
 } from '$convex/lib/models';
+import {
+	isModelAllowedForTier,
+	modelLockUpgradeMessage,
+	type SubscriptionTier
+} from '$convex/lib/tiers';
 
 export type ModelSelectorOption = {
 	id: SupportedModelId;
 	label: string;
 	provider: ModelProvider;
+	locked?: boolean;
+	lockTooltip?: string;
 };
 
 export const modelOptions: ModelSelectorOption[] = modelDefinitions.map(
 	({ id, label, provider }) => ({ id, label, provider })
 );
+
+export function modelOptionsForTier(tier: SubscriptionTier): ModelSelectorOption[] {
+	const unlocked: ModelSelectorOption[] = [];
+	const locked: ModelSelectorOption[] = [];
+	for (const option of modelOptions) {
+		if (isModelAllowedForTier(tier, option.id)) {
+			unlocked.push(option);
+		} else {
+			locked.push({
+				...option,
+				locked: true,
+				lockTooltip: modelLockUpgradeMessage
+			});
+		}
+	}
+	return [...unlocked, ...locked];
+}
 
 export const reasoningEffortLabels: Record<SupportedReasoningEffort, string> = {
 	none: 'None',

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { ArrowUp, ImagePlus, Square, X } from '@lucide/svelte';
+	import { useAuth, useQuery } from 'convex-svelte';
+	import { api } from '$convex/_generated/api';
 	import OptionSelector from '$lib/components/option-selector.svelte';
 	import ProviderLogo from '$lib/components/provider-logo.svelte';
 	import ReasoningServiceSelector from '$lib/components/reasoning-service-selector.svelte';
@@ -15,7 +17,8 @@
 		SupportedReasoningEffort,
 		SupportedServiceTier
 	} from '$convex/lib/models';
-	import { modelOptions } from '$lib/chat/model-options';
+	import { resolveModelForTier } from '$convex/lib/tiers';
+	import { modelOptionsForTier } from '$lib/chat/model-options';
 	import {
 		MAX_IMAGE_ATTACHMENTS,
 		SUPPORTED_IMAGE_MEDIA_TYPES,
@@ -55,6 +58,14 @@
 		onSubmit,
 		onCancel
 	}: Props = $props();
+
+	const convexAuth = useAuth();
+	const subscriptionQuery = useQuery(api.billing.getMySubscription, () =>
+		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
+	);
+	const knownSubscriptionTier = $derived(subscriptionQuery.data?.tier);
+	// Until the tier is known, render the free allowlist so locked models are never selectable.
+	const tierModelOptions = $derived(modelOptionsForTier(knownSubscriptionTier ?? 'free'));
 
 	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
 	let attachmentInput = $state<HTMLInputElement | null>(null);
@@ -140,6 +151,15 @@
 	function handleModelChange(modelId: SupportedModelId) {
 		selectedReasoningEffort = getModelDefinition(modelId).defaultReasoningEffort;
 	}
+
+	$effect(() => {
+		// Only coerce after the tier is known so paid users are not snapped to free defaults.
+		if (!knownSubscriptionTier) return;
+		const allowedModel = resolveModelForTier(knownSubscriptionTier, selectedModel);
+		if (allowedModel === selectedModel) return;
+		selectedModel = allowedModel;
+		selectedReasoningEffort = getModelDefinition(allowedModel).defaultReasoningEffort;
+	});
 
 	$effect(() => {
 		void prompt;
@@ -273,7 +293,7 @@
 
 							<OptionSelector
 								bind:value={selectedModel}
-								options={modelOptions}
+								options={tierModelOptions}
 								ariaLabel="Select model"
 								menuTitle="Model"
 								disabled={isRunning}

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -17,7 +17,7 @@
 		SupportedReasoningEffort,
 		SupportedServiceTier
 	} from '$convex/lib/models';
-	import { resolveModelForTier } from '$convex/lib/tiers';
+	import { isModelAllowedForTier, resolveModelForTier } from '$convex/lib/tiers';
 	import { modelOptionsForTier } from '$lib/chat/model-options';
 	import {
 		MAX_IMAGE_ATTACHMENTS,
@@ -66,6 +66,10 @@
 	const knownSubscriptionTier = $derived(subscriptionQuery.data?.tier);
 	// Until the tier is known, render the free allowlist so locked models are never selectable.
 	const tierModelOptions = $derived(modelOptionsForTier(knownSubscriptionTier ?? 'free'));
+	const canSubmitWithModel = $derived(
+		knownSubscriptionTier !== undefined &&
+			isModelAllowedForTier(knownSubscriptionTier, selectedModel)
+	);
 
 	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
 	let attachmentInput = $state<HTMLInputElement | null>(null);
@@ -136,7 +140,14 @@
 	}
 
 	function handleComposerKeydown(event: KeyboardEvent) {
-		if (!canSend || isSubmitting || isRunning || !hasMessageContent || attachmentsPending) {
+		if (
+			!canSend ||
+			!canSubmitWithModel ||
+			isSubmitting ||
+			isRunning ||
+			!hasMessageContent ||
+			attachmentsPending
+		) {
 			return;
 		}
 
@@ -334,7 +345,11 @@
 									type="button"
 									class="bg-primary/90 text-primary-foreground hover:bg-primary flex h-10 w-10 items-center justify-center rounded-full transition-all duration-150 hover:scale-105 enabled:cursor-pointer disabled:pointer-events-none disabled:opacity-30 disabled:hover:scale-100"
 									onclick={onSubmit}
-									disabled={!canSend || isSubmitting || !hasMessageContent || attachmentsPending}
+									disabled={!canSend ||
+										!canSubmitWithModel ||
+										isSubmitting ||
+										!hasMessageContent ||
+										attachmentsPending}
 									aria-label="Send message"
 								>
 									<ArrowUp class="size-4" />

--- a/apps/web/src/lib/components/option-selector.svelte
+++ b/apps/web/src/lib/components/option-selector.svelte
@@ -1,5 +1,8 @@
-<script lang="ts" generics="TOption extends { id: string; label: string; triggerLabel?: string }">
-	import { Check, ChevronDown, Search } from '@lucide/svelte';
+<script
+	lang="ts"
+	generics="TOption extends { id: string; label: string; triggerLabel?: string; locked?: boolean; lockTooltip?: string }"
+>
+	import { Check, ChevronDown, Lock, Search } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
 	type Props = {
@@ -33,9 +36,14 @@
 	let rootElement = $state<HTMLDivElement | null>(null);
 	let triggerElement = $state<HTMLButtonElement | null>(null);
 	let searchElement = $state<HTMLInputElement | null>(null);
-	let selectedOption = $derived(
-		options.find((option) => option.id === value) ?? options[0] ?? null
-	);
+	let lockTooltip = $state<{ top: number; left: number; label: string } | null>(null);
+	let stickyLockTooltip = $state(false);
+	let stickyLockTooltipTimer: ReturnType<typeof setTimeout> | null = null;
+	let selectedOption = $derived.by(() => {
+		const matched = options.find((option) => option.id === value);
+		if (matched && !matched.locked) return matched;
+		return options.find((option) => !option.locked) ?? matched ?? options[0] ?? null;
+	});
 	let filteredOptions = $derived(
 		searchable && searchQuery.trim()
 			? options.filter((option) =>
@@ -43,6 +51,7 @@
 				)
 			: options
 	);
+	let selectableFilteredOptions = $derived(filteredOptions.filter((option) => !option.locked));
 
 	function toggleMenu() {
 		if (disabled) {
@@ -54,25 +63,66 @@
 		else searchQuery = '';
 	}
 
-	function selectOption(optionId: TOption['id']) {
+	function selectOption(optionId: TOption['id'], event?: MouseEvent) {
+		const option = options.find((entry) => entry.id === optionId);
+		if (!option) return;
+		if (option.locked) {
+			if (event && option.lockTooltip) showLockTooltip(event, option.lockTooltip, true);
+			return;
+		}
 		if (optionId !== value) {
 			value = optionId;
 			onValueChange?.(optionId);
 		}
 		isOpen = false;
 		searchQuery = '';
+		hideLockTooltip(true);
 		triggerElement?.focus();
 	}
 
 	function handleSearchKeydown(event: KeyboardEvent) {
-		if (event.key !== 'Enter' || filteredOptions.length === 0) return;
+		if (event.key !== 'Enter' || selectableFilteredOptions.length === 0) return;
 		event.preventDefault();
-		selectOption(filteredOptions[0].id);
+		selectOption(selectableFilteredOptions[0].id);
+	}
+
+	function clearStickyLockTooltipTimer() {
+		if (!stickyLockTooltipTimer) return;
+		clearTimeout(stickyLockTooltipTimer);
+		stickyLockTooltipTimer = null;
+	}
+
+	function showLockTooltip(event: MouseEvent | FocusEvent, label: string, sticky = false) {
+		const target = event.currentTarget;
+		if (!(target instanceof HTMLElement)) return;
+		const rect = target.getBoundingClientRect();
+		clearStickyLockTooltipTimer();
+		stickyLockTooltip = sticky;
+		lockTooltip = {
+			top: rect.top - 8,
+			left: rect.left + rect.width / 2,
+			label
+		};
+		if (sticky) {
+			stickyLockTooltipTimer = setTimeout(() => {
+				stickyLockTooltip = false;
+				stickyLockTooltipTimer = null;
+				lockTooltip = null;
+			}, 2500);
+		}
+	}
+
+	function hideLockTooltip(force = false) {
+		if (stickyLockTooltip && !force) return;
+		clearStickyLockTooltipTimer();
+		stickyLockTooltip = false;
+		lockTooltip = null;
 	}
 
 	$effect(() => {
 		if (!isOpen) {
 			searchQuery = '';
+			hideLockTooltip();
 			return;
 		}
 
@@ -160,31 +210,59 @@
 
 			<div class={cn('space-y-0.5', searchable && 'pt-1.5')}>
 				{#each filteredOptions as option (option.id)}
+					{@const locked = Boolean(option.locked)}
 					<button
 						type="button"
 						class={cn(
-							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left outline-none hover:bg-white/4 focus-visible:ring-2',
-							option.id === value && 'bg-white/[0.035]'
+							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left outline-none focus-visible:ring-2',
+							locked ? 'cursor-not-allowed opacity-45' : 'hover:bg-white/4',
+							!locked && option.id === value && 'bg-white/[0.035]'
 						)}
-						aria-pressed={option.id === value}
-						onclick={() => {
-							selectOption(option.id);
+						aria-pressed={!locked && option.id === value}
+						aria-disabled={locked}
+						aria-label={locked && option.lockTooltip
+							? `${option.label}. ${option.lockTooltip}`
+							: undefined}
+						onmouseenter={(event) => {
+							if (locked && option.lockTooltip) showLockTooltip(event, option.lockTooltip);
+						}}
+						onmouseleave={() => hideLockTooltip()}
+						onfocus={(event) => {
+							if (locked && option.lockTooltip) showLockTooltip(event, option.lockTooltip);
+						}}
+						onblur={() => hideLockTooltip()}
+						onclick={(event) => {
+							selectOption(option.id, event);
 						}}
 					>
 						{#if optionIcon}
-							<span class="flex size-7 shrink-0 items-center justify-center text-slate-300">
+							<span
+								class={cn(
+									'flex size-7 shrink-0 items-center justify-center',
+									locked ? 'text-slate-500' : 'text-slate-300'
+								)}
+							>
 								{@render optionIcon(option)}
 							</span>
 						{/if}
-						<span class="min-w-0 flex-1 truncate text-sm font-medium text-slate-100"
-							>{option.label}</span
-						>
-						<Check
+						<span
 							class={cn(
-								'size-4 shrink-0 text-blue-400 transition-opacity',
-								option.id === value ? 'opacity-100' : 'opacity-0'
-							)}
-						/>
+								'min-w-0 flex-1 truncate text-sm font-medium',
+								locked ? 'text-slate-400' : 'text-slate-100'
+							)}>{option.label}</span
+						>
+						{#if locked}
+							<span class="shrink-0 text-slate-500" aria-hidden="true">
+								<Lock class="size-3.5" />
+							</span>
+						{:else}
+							<Check
+								class={cn(
+									'size-4 shrink-0 text-blue-400 transition-opacity',
+									option.id === value ? 'opacity-100' : 'opacity-0'
+								)}
+							/>
+						{/if}
 					</button>
 				{/each}
 				{#if filteredOptions.length === 0}
@@ -194,3 +272,13 @@
 		</div>
 	{/if}
 </div>
+
+{#if lockTooltip}
+	<div
+		class="pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md bg-[#1a1d27] px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap text-slate-100 shadow-lg ring-1 ring-white/10"
+		style={`top: ${lockTooltip.top}px; left: ${lockTooltip.left}px;`}
+		role="tooltip"
+	>
+		{lockTooltip.label}
+	</div>
+{/if}


### PR DESCRIPTION
## Summary
- Double free-tier model usage limits and set pro quotas to 5× free (web tools stay at the original free baseline)
- Restrict free-tier users to Claude Fable 5, with backend enforcement on thread/run creation
- Show locked models below allowed ones in the picker, greyed out with a lock icon and upgrade tooltip

## Test plan
- [ ] As a free user, confirm only Claude Fable 5 is selectable and other models show lock + upgrade tooltip
- [ ] As a free user, confirm creating a run with a locked model is rejected by the backend
- [ ] As a pro/admin user, confirm all models remain selectable and free-default loading does not clobber the selection
- [ ] Confirm usage settings show free model limits at 5k/15k and web tools at 500/1.5k; pro at 5× those values

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces tier-specific quotas and model access controls.
- Enforces the model allowlist during backend thread and run creation.
- Derives tier-aware model-picker options and renders unavailable models as locked.
- Reconciles the selected composer model after subscription data loads and gates submission on model access.
- Updates test fixtures and adds coverage for pro-tier model options.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR needs a fix before merging because a failed subscription query can silently disable all prompt submission indefinitely.

The new submission gate depends exclusively on successful subscription-query data, while the query's error state is neither handled in the composer nor surfaced by the page.

apps/web/src/lib/components/home/prompt-composer.svelte
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex verified that a failing subscription blocks submission in the prompt composer, leaving the send button disabled and preventing Enter from triggering submission.
- T-Rex confirmed the UI did not surface a subscription-query error and that the execution log shows both guarded submission paths remain blocked.
- T-Rex catalogued and inspected the reproduction artifacts (video, images, logs, and harness code) to support review of the failure scenario.
- T-Rex reviewed baseline validation evidence showing the genuine app route returns a 500 error and runtime-config issues (502), indicating the environment blocks the flow.
- T-Rex inspected additional baseline evidence including runtime-blocked route screenshots and logs, and captured a zip artifact package for transfer.

<a href="https://app.greptile.com/trex/runs/15709632/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/prompt-composer.svelte | Adds tier loading, selection reconciliation, and submission gating, but an unhandled subscription-query failure can leave submission disabled indefinitely. |
| apps/web/src/convex/lib/tiers.ts | Defines differentiated quotas, model allowlists, and shared tier-resolution helpers. |
| apps/web/src/convex/agentRuntime.ts | Enforces the current user's model allowlist before creating a run. |
| apps/web/src/convex/threads.ts | Enforces the current user's model allowlist before creating a thread. |
| apps/web/src/lib/components/option-selector.svelte | Adds non-selectable locked options, lock indicators, and upgrade tooltips. |
| apps/web/src/lib/chat/model-options.ts | Produces tier-aware model options with allowed models ordered before locked models. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/lib/components/home/prompt-composer.svelte:69-72
**Subscription failure disables submission**

When the subscription query fails after the authenticated composer renders, its data remains undefined and `canSubmitWithModel` remains false, causing both Enter submission and the send button to stay disabled for every model without surfacing the query error.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): Singularize locked-model upgra..."](https://github.com/spikonado/sprocket/commit/f954b7b2da0b8e92594e7bf2c222bbc7450c0e61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46703108)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->