### PR TITLE
feat(agent): Add context compaction

### DIFF
--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as lib_agentHistory from "../lib/agentHistory.js";
 import type * as lib_assistantParts from "../lib/assistantParts.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_completionStream from "../lib/completionStream.js";
+import type * as lib_contextCompaction from "../lib/contextCompaction.js";
 import type * as lib_imageUploads from "../lib/imageUploads.js";
 import type * as lib_json from "../lib/json.js";
 import type * as lib_modelRegistry from "../lib/modelRegistry.js";
@@ -65,6 +66,7 @@ declare const fullApi: ApiFromModules<{
   "lib/assistantParts": typeof lib_assistantParts;
   "lib/auth": typeof lib_auth;
   "lib/completionStream": typeof lib_completionStream;
+  "lib/contextCompaction": typeof lib_contextCompaction;
   "lib/imageUploads": typeof lib_imageUploads;
   "lib/json": typeof lib_json;
   "lib/modelRegistry": typeof lib_modelRegistry;

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { executionSecretHash } from '@convex/lib/auth';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+async function createQueuedRun(
+	asUser: ReturnType<ReturnType<typeof initConvexTest>['withIdentity']>,
+	threadId: Id<'threadRecords'>,
+	submissionId: string,
+	executionSecret: string,
+	prompt: string
+) {
+	return await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId,
+		threadId,
+		prompt,
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard',
+		executionSecret
+	});
+}
+
+describe('agentRuntime context accounting', () => {
+	it('fences compaction and usage writes to the active claim', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'context-run-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'context-run',
+			executionSecret,
+			'Continue the long task'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.saveContextCompaction, {
+				runId,
+				claimId: 'claim-a',
+				executionSecret,
+				summary: 'The setup is complete; implementation remains.',
+				processedTokens: 250_000,
+				persistForFutureRuns: false
+			})
+		).resolves.toBe(true);
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				executionSecret,
+				contextTokens: 8_000,
+				processedTokens: 9_000
+			})
+		).resolves.toBe(true);
+
+		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
+		expect(thread).toMatchObject({
+			contextTokens: 8_000,
+			totalTokensProcessed: 259_000
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(runId, { claimExpiresAt: Date.now() - 1 });
+		});
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-b',
+			executionSecret
+		});
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				executionSecret,
+				contextTokens: 99_000,
+				processedTokens: 99_000
+			})
+		).resolves.toBe(false);
+		await expect(
+			asUser.mutation(api.agentRuntime.saveContextCompaction, {
+				runId,
+				claimId: 'claim-a',
+				executionSecret,
+				summary: 'Stale summary',
+				processedTokens: 1,
+				persistForFutureRuns: true
+			})
+		).resolves.toBe(false);
+		expect(await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextTokens)).toBe(8_000);
+		expect(await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextSummary)).toBeFalsy();
+	});
+
+	it('rejects invalid token accounting values', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'invalid-context-usage-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'invalid-context-usage',
+			executionSecret,
+			'Continue'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.recordContextUsage, {
+				runId,
+				claimId: 'claim-a',
+				executionSecret,
+				contextTokens: -1,
+				processedTokens: 10
+			})
+		).rejects.toThrow('Invalid token count.');
+		expect(await t.run(async (ctx) => ctx.db.get(threadId))).not.toHaveProperty('contextTokens');
+	});
+
+	it('carries a compacted prefix into later runs without replaying covered history', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, workspaceSessionId } = await seedOwnedThread(t);
+		const firstSecret = 'context-first-secret';
+		const first = await createQueuedRun(
+			asUser,
+			threadId,
+			'context-first',
+			firstSecret,
+			'Old prompt that should be covered'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId: first.runId,
+			claimId: 'claim-1',
+			executionSecret: firstSecret
+		});
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId: first.runId,
+			expectedStatus: 'running',
+			expectedClaimId: 'claim-1',
+			text: 'Old work completed',
+			status: 'completed'
+		});
+
+		const secondSecret = 'context-second-secret';
+		const second = await createQueuedRun(
+			asUser,
+			threadId,
+			'context-second',
+			secondSecret,
+			'New prompt'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId: second.runId,
+			claimId: 'claim-2',
+			executionSecret: secondSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.insert('runs', {
+				threadId,
+				userId: 'user_alice',
+				submissionId: 'context-concurrent-later',
+				workspaceSessionId,
+				status: 'completed',
+				executionSecretHash: await executionSecretHash('context-concurrent-later-secret'),
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				startedAt: Date.now() + 1_000,
+				completedAt: Date.now() + 1_001
+			});
+		});
+		await asUser.mutation(api.agentRuntime.saveContextCompaction, {
+			runId: second.runId,
+			claimId: 'claim-2',
+			executionSecret: secondSecret,
+			summary: 'The old work is complete.',
+			processedTokens: 100,
+			persistForFutureRuns: true
+		});
+		expect(
+			await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextSummaryThroughRunId)
+		).toBe(first.runId);
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId: second.runId,
+			expectedStatus: 'running',
+			expectedClaimId: 'claim-2',
+			text: 'Second work completed',
+			status: 'completed'
+		});
+
+		const thirdSecret = 'context-third-secret';
+		const third = await createQueuedRun(
+			asUser,
+			threadId,
+			'context-third',
+			thirdSecret,
+			'Third prompt'
+		);
+		const context = await asUser.query(api.agentRuntime.getContext, {
+			runId: third.runId,
+			executionSecret: thirdSecret
+		});
+		const serialized = JSON.stringify(context.agentHistory);
+		expect(serialized).toContain('The old work is complete.');
+		expect(serialized).not.toContain('Old prompt that should be covered');
+		expect(serialized).toContain('New prompt');
+		expect(context.contextBudget).toEqual({
+			contextWindowTokens: 258_400,
+			autoCompactTokenLimit: 244_800
+		});
+	});
+});

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -5,10 +5,12 @@ import { getOwnedRun, getOwnedThreadRecord, getOwnedWorkspaceSession } from '@co
 import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
 import {
 	assertSupportedModelConfiguration,
+	getModelDefinition,
 	type SupportedModelId,
 	type SupportedServiceTier
 } from '@convex/lib/models';
 import { buildCanonicalAgentHistory } from '@convex/lib/agentHistory';
+import { contextSummaryText } from '@convex/lib/contextCompaction';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import {
 	areImageUploadIdsEqual,
@@ -394,6 +396,10 @@ export const getContext = query({
 		prompt: string;
 		promptAttachments: RuntimePromptAttachment[];
 		agentHistory: AgentHistoryMessage[];
+		contextBudget: {
+			contextWindowTokens: number;
+			autoCompactTokenLimit: number;
+		};
 	}> => {
 		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const userId = run.userId;
@@ -412,10 +418,37 @@ export const getContext = query({
 			.query('executorJobs')
 			.withIndex('by_threadId_sequence', (query) => query.eq('threadId', run.threadId))
 			.collect();
-		const agentHistory: AgentHistoryMessage[] = buildCanonicalAgentHistory({
-			messages: messages.filter((message) => message.runId !== run._id),
-			jobs: jobs.filter((job) => job.runId !== run._id)
-		});
+		let historyRunIds: Set<Id<'runs'>> | undefined;
+		if (threadRecord.contextSummaryThroughRunId) {
+			const runs = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', run.threadId))
+				.collect();
+			const ordered = runs.sort(compareRunStartedAt);
+			const cutoffIndex = ordered.findIndex(
+				(candidate) => candidate._id === threadRecord.contextSummaryThroughRunId
+			);
+			if (cutoffIndex >= 0) {
+				historyRunIds = new Set(ordered.slice(cutoffIndex + 1).map((candidate) => candidate._id));
+			}
+		}
+		const includeInHistory = (candidateRunId: Id<'runs'>) =>
+			candidateRunId !== run._id && (!historyRunIds || historyRunIds.has(candidateRunId));
+		const summaryHistory: AgentHistoryMessage[] = threadRecord.contextSummary
+			? [
+					{
+						role: 'user',
+						contents: [{ type: 'text', text: contextSummaryText(threadRecord.contextSummary) }]
+					}
+				]
+			: [];
+		const agentHistory: AgentHistoryMessage[] = [
+			...summaryHistory,
+			...buildCanonicalAgentHistory({
+				messages: messages.filter((message) => includeInHistory(message.runId)),
+				jobs: jobs.filter((job) => includeInHistory(job.runId))
+			})
+		];
 		const promptMessage = messages.find(
 			(message) => message.runId === run._id && message.type === 'prompt'
 		);
@@ -429,6 +462,7 @@ export const getContext = query({
 		const promptAttachments: RuntimePromptAttachment[] = promptMessage.attachments.map(
 			({ mediaType, url }) => ({ mediaType, url })
 		);
+		const model = getModelDefinition(run.selectedModel);
 
 		return {
 			run,
@@ -436,7 +470,11 @@ export const getContext = query({
 			prompt,
 			promptAttachments,
 			agentHistory,
-			workspaceSession
+			workspaceSession,
+			contextBudget: {
+				contextWindowTokens: model.contextWindowTokens,
+				autoCompactTokenLimit: model.autoCompactTokenLimit
+			}
 		};
 	}
 });
@@ -485,6 +523,96 @@ export const completionActor = query({
 		};
 	}
 });
+
+export const saveContextCompaction = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		executionSecret: v.string(),
+		summary: v.string(),
+		processedTokens: v.number(),
+		persistForFutureRuns: v.boolean()
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) return false;
+		if (!args.summary.trim()) {
+			throw new Error('Invalid context compaction.');
+		}
+		assertValidTokenCount(args.processedTokens);
+		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
+		let durableSummary:
+			{ contextSummary: string; contextSummaryThroughRunId: Id<'runs'> } | undefined;
+		if (args.persistForFutureRuns) {
+			const runs = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', run.threadId))
+				.collect();
+			const previousRun = runs
+				.filter(
+					(candidate) =>
+						isRunFinalStatus(candidate.status) && compareRunStartedAt(candidate, run) < 0
+				)
+				.sort((left, right) => compareRunStartedAt(right, left))[0];
+			// Require a real cutoff run so getContext never serves a summary
+			// without filtering the covered history.
+			if (previousRun) {
+				durableSummary = {
+					contextSummary: args.summary,
+					contextSummaryThroughRunId: previousRun._id
+				};
+			}
+		}
+		await ctx.db.patch(thread._id, {
+			...(durableSummary ?? {}),
+			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed ?? 0, args.processedTokens)
+		});
+		return true;
+	}
+});
+
+export const recordContextUsage = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		executionSecret: v.string(),
+		contextTokens: v.number(),
+		processedTokens: v.number()
+	},
+	handler: async (ctx, args): Promise<boolean> => {
+		const run: Doc<'runs'> = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) return false;
+		assertValidTokenCount(args.contextTokens);
+		assertValidTokenCount(args.processedTokens);
+		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
+		await ctx.db.patch(thread._id, {
+			contextTokens: args.contextTokens,
+			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed ?? 0, args.processedTokens)
+		});
+		return true;
+	}
+});
+
+function compareRunStartedAt(
+	left: { startedAt: number; _creationTime: number },
+	right: { startedAt: number; _creationTime: number }
+): number {
+	return left.startedAt - right.startedAt || left._creationTime - right._creationTime;
+}
+
+function assertValidTokenCount(value: number): void {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error('Invalid token count.');
+	}
+}
+
+function addTokenCounts(left: number, right: number): number {
+	assertValidTokenCount(left);
+	assertValidTokenCount(right);
+	const total = left + right;
+	assertValidTokenCount(total);
+	return total;
+}
 
 export const registerCompletionAttempt = mutation({
 	args: {

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -8,7 +8,11 @@ import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
 import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
-import { isCurrentCompletionAttempt, isRunClaimLeaseActive } from '@convex/lib/runLease';
+import {
+	isCurrentCompletionAttempt,
+	isRunClaimLeaseActive,
+	ownsActiveRunClaim
+} from '@convex/lib/runLease';
 import { chargeModelUsage, checkModelUsageLimit } from '@convex/lib/rateLimits';
 import { vModelId, vReasoningEffort, vServiceTier } from '@convex/lib/validators';
 import {
@@ -19,6 +23,10 @@ import {
 	type SupportedReasoningEffort,
 	type SupportedServiceTier
 } from '@convex/lib/models';
+import {
+	COMPACTION_MAX_OUTPUT_TOKENS,
+	CONTEXT_COMPACTION_INSTRUCTIONS
+} from '@convex/lib/contextCompaction';
 import {
 	appendCompletionStreamEvent,
 	COMPLETION_STREAM_SUPERSEDED,
@@ -188,6 +196,85 @@ export const complete = action({
 			})),
 			stream_events: result.streamEvents
 		};
+	}
+});
+
+type SummarizeClaim = {
+	runId: Id<'runs'>;
+	claimId: string;
+	executionSecret: string;
+};
+
+export const summarize = action({
+	args: {
+		modelId: vModelId,
+		reasoningEffort: v.optional(vReasoningEffort),
+		serviceTier: v.optional(vServiceTier),
+		messagesJson: v.string(),
+		runId: v.id('runs'),
+		claimId: v.string(),
+		executionSecret: v.string()
+	},
+	handler: async (
+		ctx,
+		args
+	): Promise<{
+		summary: string;
+		usage: GenerateTextResult['usage'];
+	}> => {
+		const modelId = args.modelId;
+		const serviceTier = args.serviceTier ?? defaultServiceTier;
+		if (args.reasoningEffort !== undefined || args.serviceTier !== undefined) {
+			assertSupportedModelConfiguration({
+				modelId,
+				reasoningEffort: args.reasoningEffort,
+				serviceTier
+			});
+		}
+		const claim: SummarizeClaim = {
+			runId: args.runId,
+			claimId: args.claimId,
+			executionSecret: args.executionSecret
+		};
+		const completionContext = await prepareCompletionContext(ctx, args.runId, args.executionSecret);
+		await assertSummarizeStillAccepted(ctx, claim);
+		const messages = reviveImageUrls(
+			parseJson<SerializedModelMessage[]>(args.messagesJson, 'messagesJson')
+		);
+		const sharedArgs = buildSharedCompletionRequest(
+			{
+				modelId,
+				reasoningEffort: args.reasoningEffort,
+				serviceTier,
+				instructions: CONTEXT_COMPACTION_INSTRUCTIONS
+			},
+			{},
+			undefined,
+			completionContext.promptCacheKey
+		);
+		const abortController = new AbortController();
+		const result = await waitForCompletionWithAcceptance(
+			ctx,
+			generateText({
+				...sharedArgs,
+				messages,
+				maxOutputTokens: COMPACTION_MAX_OUTPUT_TOKENS,
+				abortSignal: abortController.signal
+			}),
+			claim,
+			abortController
+		);
+		const summary = result.text.trim();
+		if (!summary) throw new Error('The model returned an empty context summary.');
+		await assertSummarizeStillAccepted(ctx, claim);
+		await chargeModelUsage(ctx, {
+			userId: completionContext.userId,
+			modelId,
+			serviceTier,
+			tokens: normalizeCompletionUsage(result.usage)
+		});
+		await checkModelUsageLimit(ctx, completionContext.userId);
+		return { summary, usage: result.usage };
 	}
 });
 
@@ -539,6 +626,38 @@ async function assertCompletionStillAccepted(
 		})
 	) {
 		throw new Error(COMPLETION_STREAM_SUPERSEDED);
+	}
+}
+
+async function assertSummarizeStillAccepted(ctx: ActionCtx, claim: SummarizeClaim): Promise<void> {
+	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+		runId: claim.runId,
+		executionSecret: claim.executionSecret
+	});
+	assertRunAcceptsModelCompletion(actor.status);
+	if (!ownsActiveRunClaim(actor, claim.claimId, Date.now())) {
+		throw new Error(RUN_NO_LONGER_ACTIVE);
+	}
+}
+
+async function waitForCompletionWithAcceptance<T>(
+	ctx: ActionCtx,
+	completion: Promise<T>,
+	claim: SummarizeClaim,
+	abortController: AbortController
+): Promise<T> {
+	while (true) {
+		const outcome = await Promise.race([
+			completion.then((value) => ({ type: 'completed' as const, value })),
+			delay(COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS).then(() => ({ type: 'check' as const }))
+		]);
+		if (outcome.type === 'completed') return outcome.value;
+		try {
+			await assertSummarizeStillAccepted(ctx, claim);
+		} catch (error) {
+			abortController.abort(error);
+			throw error;
+		}
 	}
 }
 

--- a/apps/web/src/convex/lib/contextCompaction.ts
+++ b/apps/web/src/convex/lib/contextCompaction.ts
@@ -9,7 +9,7 @@ export function contextSummaryText(summary: string): string {
 
 export const COMPACTION_MAX_OUTPUT_TOKENS = 12_000;
 
-export const CONTEXT_COMPACTION_INSTRUCTIONS = `Summarize the supplied coding-agent conversation so another agent can continue without the original messages.
+export const CONTEXT_COMPACTION_INSTRUCTIONS = `Summarize the supplied engineering agent conversation so another agent can continue without the original messages.
 
 Preserve:
 - every user request and the current objective

--- a/apps/web/src/convex/lib/contextCompaction.ts
+++ b/apps/web/src/convex/lib/contextCompaction.ts
@@ -1,0 +1,21 @@
+// Keep the preamble and <conversation_summary> wrapper in sync with
+// `context_summary_text` in crates/sprocket-agent/src/compaction.rs.
+const COMPACTED_CONTEXT_PREAMBLE =
+	'The conversation context was automatically compacted. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.';
+
+export function contextSummaryText(summary: string): string {
+	return `${COMPACTED_CONTEXT_PREAMBLE}\n\n<conversation_summary>\n${summary}\n</conversation_summary>`;
+}
+
+export const COMPACTION_MAX_OUTPUT_TOKENS = 12_000;
+
+export const CONTEXT_COMPACTION_INSTRUCTIONS = `Summarize the supplied coding-agent conversation so another agent can continue without the original messages.
+
+Preserve:
+- every user request and the current objective
+- decisions, constraints, plans, and unresolved questions
+- files inspected or changed and the important technical details
+- tool results, errors, tests, and commands that still matter
+- completed work and the exact next steps
+
+Be dense and factual. Do not address the user, continue the task, call tools, or add commentary. Output only the summary.`;

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
 	assertSupportedModelConfiguration,
 	completionUsageUnits,
-	getModelDefinition,
 	modelIds
 } from '@convex/lib/models';
 
@@ -15,23 +14,6 @@ describe('model configuration', () => {
 			'claude-fable-5',
 			'grok-4.5'
 		]);
-	});
-
-	it('uses the coding-agent context and compaction budgets', () => {
-		expect(getModelDefinition('gpt-5.6-sol')).toMatchObject({
-			contextWindowTokens: 258_400,
-			autoCompactTokenLimit: 244_800
-		});
-		expect(getModelDefinition('gpt-5.6-terra').contextWindowTokens).toBe(258_400);
-		expect(getModelDefinition('gpt-5.6-luna').contextWindowTokens).toBe(258_400);
-		expect(getModelDefinition('claude-fable-5')).toMatchObject({
-			contextWindowTokens: 980_000,
-			autoCompactTokenLimit: 967_000
-		});
-		expect(getModelDefinition('grok-4.5')).toMatchObject({
-			contextWindowTokens: 500_000,
-			autoCompactTokenLimit: 400_000
-		});
 	});
 
 	it('rejects reasoning efforts unsupported by a model', () => {

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	assertSupportedModelConfiguration,
 	completionUsageUnits,
+	getModelDefinition,
 	modelIds
 } from '@convex/lib/models';
 
@@ -14,6 +15,23 @@ describe('model configuration', () => {
 			'claude-fable-5',
 			'grok-4.5'
 		]);
+	});
+
+	it('uses the coding-agent context and compaction budgets', () => {
+		expect(getModelDefinition('gpt-5.6-sol')).toMatchObject({
+			contextWindowTokens: 258_400,
+			autoCompactTokenLimit: 244_800
+		});
+		expect(getModelDefinition('gpt-5.6-terra').contextWindowTokens).toBe(258_400);
+		expect(getModelDefinition('gpt-5.6-luna').contextWindowTokens).toBe(258_400);
+		expect(getModelDefinition('claude-fable-5')).toMatchObject({
+			contextWindowTokens: 980_000,
+			autoCompactTokenLimit: 967_000
+		});
+		expect(getModelDefinition('grok-4.5')).toMatchObject({
+			contextWindowTokens: 500_000,
+			autoCompactTokenLimit: 400_000
+		});
 	});
 
 	it('rejects reasoning efforts unsupported by a model', () => {

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -40,8 +40,6 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-sol',
 		label: 'GPT-5.6 Sol',
 		provider: 'openai',
-		// https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json
-		// Codex reserves 5% of its 272k catalog window and compacts at 90%.
 		contextWindowTokens: 258_400,
 		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
@@ -104,8 +102,6 @@ export const modelDefinitions = [
 		id: 'claude-fable-5',
 		label: 'Claude Fable 5',
 		provider: 'anthropic',
-		// https://code.claude.com/docs/en/model-config#work-with-fable-5
-		// Claude Code reserves 20k output tokens, then a further 13k for compaction.
 		contextWindowTokens: 980_000,
 		autoCompactTokenLimit: 967_000,
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
@@ -120,8 +116,6 @@ export const modelDefinitions = [
 		id: 'grok-4.5',
 		label: 'Grok 4.5',
 		provider: 'xai',
-		// https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-models/default_models.json
-		// Grok Build's model catalog sets an 80% threshold on the 500k window.
 		contextWindowTokens: 500_000,
 		autoCompactTokenLimit: 400_000,
 		reasoningEfforts: ['low', 'medium', 'high'],

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -19,6 +19,10 @@ type ModelDefinition = {
 	id: SupportedModelId;
 	label: string;
 	provider: ModelProvider;
+	/** Context budget exposed by the provider's coding-agent harness. */
+	contextWindowTokens: number;
+	/** Input-token count at which the harness automatically compacts. */
+	autoCompactTokenLimit: number;
 	reasoningEfforts: readonly SupportedReasoningEffort[];
 	defaultReasoningEffort: SupportedReasoningEffort;
 	serviceTiers: readonly SupportedServiceTier[];
@@ -36,6 +40,10 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-sol',
 		label: 'GPT-5.6 Sol',
 		provider: 'openai',
+		// https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json
+		// Codex reserves 5% of its 272k catalog window and compacts at 90%.
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -53,6 +61,8 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-terra',
 		label: 'GPT-5.6 Terra',
 		provider: 'openai',
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -75,6 +85,8 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-luna',
 		label: 'GPT-5.6 Luna',
 		provider: 'openai',
+		contextWindowTokens: 258_400,
+		autoCompactTokenLimit: 244_800,
 		reasoningEfforts: reasoningEffortIds,
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
@@ -92,6 +104,10 @@ export const modelDefinitions = [
 		id: 'claude-fable-5',
 		label: 'Claude Fable 5',
 		provider: 'anthropic',
+		// https://code.claude.com/docs/en/model-config#work-with-fable-5
+		// Claude Code reserves 20k output tokens, then a further 13k for compaction.
+		contextWindowTokens: 980_000,
+		autoCompactTokenLimit: 967_000,
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,
@@ -104,6 +120,10 @@ export const modelDefinitions = [
 		id: 'grok-4.5',
 		label: 'Grok 4.5',
 		provider: 'xai',
+		// https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-models/default_models.json
+		// Grok Build's model catalog sets an 80% threshold on the 500k window.
+		contextWindowTokens: 500_000,
+		autoCompactTokenLimit: 400_000,
 		reasoningEfforts: ['low', 'medium', 'high'],
 		defaultReasoningEffort: 'high',
 		serviceTiers: serviceTierIds,

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -53,6 +53,10 @@ export default defineSchema({
 		selectedModel: vModelId,
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
+		contextTokens: v.optional(v.number()),
+		totalTokensProcessed: v.optional(v.number()),
+		contextSummary: v.optional(v.string()),
+		contextSummaryThroughRunId: v.optional(v.id('runs')),
 		lastMessageAt: v.number(),
 		archivedAt: v.optional(v.number())
 	})

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -35,6 +35,12 @@
 		isStarting: boolean;
 		isRunning: boolean;
 		elapsedLabel: string | null;
+		contextUsage: {
+			inputTokens: number;
+			totalTokensProcessed: number;
+			contextWindowTokens: number;
+			autoCompactTokenLimit: number;
+		};
 		onSubmit: () => void;
 		onCancel: () => void;
 	};
@@ -52,6 +58,7 @@
 		isStarting,
 		isRunning,
 		elapsedLabel,
+		contextUsage,
 		onSubmit,
 		onCancel
 	}: Props = $props();
@@ -69,6 +76,12 @@
 	);
 	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
 	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
+	const contextPercent = $derived(
+		Math.min(100, Math.round((contextUsage.inputTokens / contextUsage.contextWindowTokens) * 100))
+	);
+	const contextCompactPercent = $derived(
+		Math.round((contextUsage.autoCompactTokenLimit / contextUsage.contextWindowTokens) * 100)
+	);
 
 	const COMPOSER_MIN_HEIGHT_PX = 68;
 	const COMPOSER_MAX_HEIGHT_PX = 160;
@@ -139,6 +152,16 @@
 
 	function handleModelChange(modelId: SupportedModelId) {
 		selectedReasoningEffort = getModelDefinition(modelId).defaultReasoningEffort;
+	}
+
+	function formatTokens(value: number): string {
+		if (value >= 1_000_000) {
+			return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1).replace(/\.0$/, '')}m`;
+		}
+		if (value >= 1_000) {
+			return `${Math.round(value / 1_000)}k`;
+		}
+		return String(value);
 	}
 
 	$effect(() => {
@@ -299,6 +322,48 @@
 						</div>
 
 						<div class="flex shrink-0 flex-nowrap items-center justify-end gap-2.5">
+							<div class="group/context relative">
+								<button
+									type="button"
+									class="relative flex size-8 cursor-help items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
+									aria-label={`Context window ${contextPercent}% full`}
+									aria-describedby="context-window-details"
+									style={`background: conic-gradient(rgb(59 130 246) ${contextPercent * 3.6}deg, rgb(255 255 255 / 0.08) 0deg);`}
+									onkeydown={(event) => {
+										if (event.key === 'Escape') event.currentTarget.blur();
+									}}
+								>
+									<span class="size-5.5 rounded-full bg-[#202023]"></span>
+								</button>
+								<div
+									id="context-window-details"
+									class="invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border border-white/9 bg-[#19191b] p-4 opacity-0 shadow-[0_18px_55px_rgba(0,0,0,0.45)] transition duration-150 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100"
+									role="tooltip"
+								>
+									<div class="flex items-center justify-between gap-4 text-[13px]">
+										<span class="font-medium text-slate-200">Context window</span>
+										<span class="text-slate-400"
+											>{contextPercent}% · {formatTokens(contextUsage.inputTokens)}/{formatTokens(
+												contextUsage.contextWindowTokens
+											)}</span
+										>
+									</div>
+									<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-white/5">
+										<div
+											class="h-full rounded-full bg-blue-500 transition-[width] duration-300"
+											style={`width: ${contextPercent}%`}
+										></div>
+									</div>
+									<div class="mt-3 flex items-center justify-between text-[12px] text-slate-500">
+										<span>Total processed</span>
+										<span>{formatTokens(contextUsage.totalTokensProcessed)}</span>
+									</div>
+									<p class="mt-4 text-[12px] leading-5 text-slate-500">
+										Sprocket automatically compacts context at about {contextCompactPercent}% so
+										long-running work can continue.
+									</p>
+								</div>
+							</div>
 							{#if isRunning}
 								<button
 									type="button"

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -48,6 +48,7 @@
 		defaultModelId,
 		defaultReasoningEffort,
 		defaultServiceTier,
+		getModelDefinition,
 		type SupportedModelId,
 		type SupportedReasoningEffort,
 		type SupportedServiceTier
@@ -438,6 +439,15 @@
 		});
 	});
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
+	const contextUsage = $derived.by(() => {
+		const model = getModelDefinition(selectedModel);
+		return {
+			inputTokens: currentActiveThread?.contextTokens ?? 0,
+			totalTokensProcessed: currentActiveThread?.totalTokensProcessed ?? 0,
+			contextWindowTokens: model.contextWindowTokens,
+			autoCompactTokenLimit: model.autoCompactTokenLimit
+		};
+	});
 	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
 	const currentHistoryMessagesData = $derived(
 		dataForThread(historyMessagesQuery.data, currentThreadId)
@@ -1803,6 +1813,7 @@
 						isStarting={hasPendingAgentLaunch}
 						{isRunning}
 						elapsedLabel={isRunning ? formatElapsedDuration(elapsedSeconds) : null}
+						{contextUsage}
 						onSubmit={() => {
 							void submitPrompt();
 						}}

--- a/crates/sprocket-agent/src/compaction.rs
+++ b/crates/sprocket-agent/src/compaction.rs
@@ -1,0 +1,587 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rig::agent::{AgentHook, Flow, RequestPatch, StepEvent, StepEventKind};
+use rig::completion::{CompletionModel, Message, Usage};
+use rig::message::UserContent;
+use sprocket_convex_provider::completion_messages_json;
+use tokio::time::timeout;
+
+use crate::convex::RuntimeClient;
+use crate::types::ContextBudget;
+
+const CONTEXT_USAGE_TIMEOUT: Duration = Duration::from_secs(5);
+const SUMMARIZE_RETRY_DELAY: Duration = Duration::from_millis(250);
+/// Keep a small recent tail so the model retains immediate working context.
+const RECENT_TAIL_MESSAGES: usize = 6;
+/// Must match `COMPACTION_MAX_OUTPUT_TOKENS` in
+/// `apps/web/src/convex/lib/contextCompaction.ts`.
+const COMPACTION_MAX_OUTPUT_TOKENS: u64 = 12_000;
+
+// Keep the preamble and <conversation_summary> wrapper in sync with
+// `contextSummaryText` in apps/web/src/convex/lib/contextCompaction.ts.
+const COMPACTED_CONTEXT_PREAMBLE: &str = "The conversation context was automatically compacted. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.";
+
+#[derive(Clone, Debug)]
+struct CompactedContext {
+    summary: String,
+    replaced_prefix_len: usize,
+}
+
+#[derive(Debug, Default)]
+struct CompactionState {
+    last_input_tokens: u64,
+    active_summary: Option<CompactedContext>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ContextCompactionHook {
+    runtime: RuntimeClient,
+    run_id: String,
+    claim_id: String,
+    model: String,
+    reasoning_effort: String,
+    service_tier: String,
+    context_budget: ContextBudget,
+    prior_history_len: usize,
+    state: Arc<Mutex<CompactionState>>,
+}
+
+impl ContextCompactionHook {
+    pub(crate) fn new(
+        runtime: RuntimeClient,
+        run_id: String,
+        claim_id: String,
+        model: String,
+        reasoning_effort: String,
+        service_tier: String,
+        context_budget: ContextBudget,
+        prior_history_len: usize,
+    ) -> Self {
+        Self {
+            runtime,
+            run_id,
+            claim_id,
+            model,
+            reasoning_effort,
+            service_tier,
+            context_budget,
+            prior_history_len,
+            state: Arc::new(Mutex::new(CompactionState::default())),
+        }
+    }
+}
+
+impl<M> AgentHook<M> for ContextCompactionHook
+where
+    M: CompletionModel,
+{
+    async fn on_event(&self, _context: &rig::agent::HookContext, event: StepEvent<'_, M>) -> Flow {
+        match event {
+            StepEvent::ModelTurnFinished { usage, .. } => {
+                self.on_model_turn_finished(usage).await;
+                Flow::cont()
+            }
+            StepEvent::CompletionCall { history, .. } => self.on_completion_call(history).await,
+            _ => Flow::cont(),
+        }
+    }
+
+    fn observes(&self, kind: StepEventKind) -> bool {
+        matches!(
+            kind,
+            StepEventKind::CompletionCall | StepEventKind::ModelTurnFinished
+        )
+    }
+}
+
+impl ContextCompactionHook {
+    async fn on_model_turn_finished(&self, usage: Usage) {
+        let context_tokens = context_input_tokens(&usage);
+        let processed_tokens = context_tokens.saturating_add(usage.output_tokens);
+        if let Ok(mut state) = self.state.lock() {
+            state.last_input_tokens = context_tokens;
+        }
+
+        match timeout(
+            CONTEXT_USAGE_TIMEOUT,
+            self.runtime.record_context_usage(
+                &self.run_id,
+                &self.claim_id,
+                context_tokens,
+                processed_tokens,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
+                eprintln!(
+                    "sprocket-agent: recordContextUsage skipped for {} (claim no longer active)",
+                    self.run_id
+                );
+            }
+            Ok(Err(error)) => {
+                eprintln!(
+                    "sprocket-agent: recordContextUsage failed for {}: {error:#}",
+                    self.run_id
+                );
+            }
+            Err(_) => {
+                eprintln!(
+                    "sprocket-agent: recordContextUsage timed out for {}",
+                    self.run_id
+                );
+            }
+        }
+    }
+
+    async fn on_completion_call(&self, history: &[Message]) -> Flow {
+        let (last_input_tokens, active_summary) = {
+            let state = match self.state.lock() {
+                Ok(state) => state,
+                Err(_) => return Flow::cont(),
+            };
+            (state.last_input_tokens, state.active_summary.clone())
+        };
+
+        let effective_history = rebuild_effective_history(history, active_summary.as_ref());
+        if !should_compact(
+            last_input_tokens,
+            self.context_budget.auto_compact_token_limit,
+            &effective_history,
+        ) {
+            return continue_with_history(active_summary.is_some(), effective_history);
+        }
+
+        let prior_boundary = prior_boundary_in_effective(
+            active_summary.as_ref(),
+            self.prior_history_len,
+            history.len(),
+        );
+        let split = choose_split_index(
+            &effective_history,
+            prior_boundary,
+            self.context_budget.auto_compact_token_limit,
+        );
+        if split == 0 {
+            return continue_with_history(active_summary.is_some(), effective_history);
+        }
+
+        let prefix = &effective_history[..split];
+        let tail = effective_history[split..].to_vec();
+        let messages_json = match completion_messages_json(prefix.iter()) {
+            Ok(value) => value.to_string(),
+            Err(error) => {
+                eprintln!(
+                    "sprocket-agent: failed to serialize compaction messages for {}: {error}",
+                    self.run_id
+                );
+                return self.compaction_failure_flow(active_summary.is_some(), &effective_history);
+            }
+        };
+
+        let summary = match self.summarize_with_retry(&messages_json).await {
+            Ok(summary) => summary,
+            Err(error) => {
+                eprintln!(
+                    "sprocket-agent: context summarization failed for {}: {error:#}",
+                    self.run_id
+                );
+                return self.compaction_failure_flow(active_summary.is_some(), &effective_history);
+            }
+        };
+
+        let processed_tokens = summary.processed_tokens();
+        let summary_text = summary.summary;
+        let replaced_prefix_len =
+            next_replaced_prefix_len(active_summary.as_ref(), history.len(), split);
+        let persist_for_future_runs =
+            should_persist_for_future_runs(self.prior_history_len, replaced_prefix_len);
+
+        match self
+            .runtime
+            .save_context_compaction(
+                &self.run_id,
+                &self.claim_id,
+                &summary_text,
+                processed_tokens,
+                persist_for_future_runs,
+            )
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                eprintln!(
+                    "sprocket-agent: saveContextCompaction skipped for {} (claim no longer active)",
+                    self.run_id
+                );
+            }
+            Err(error) => {
+                eprintln!(
+                    "sprocket-agent: saveContextCompaction failed for {}: {error:#}",
+                    self.run_id
+                );
+            }
+        }
+
+        if let Ok(mut state) = self.state.lock() {
+            state.active_summary = Some(CompactedContext {
+                summary: summary_text.clone(),
+                replaced_prefix_len,
+            });
+        }
+
+        let mut compacted = vec![Message::user(context_summary_text(&summary_text))];
+        compacted.extend(tail);
+        Flow::patch_request(RequestPatch::new().history(compacted))
+    }
+
+    async fn summarize_with_retry(
+        &self,
+        messages_json: &str,
+    ) -> anyhow::Result<crate::convex::SummarizeResponse> {
+        match self
+            .runtime
+            .summarize(
+                &self.run_id,
+                &self.claim_id,
+                &self.model,
+                &self.reasoning_effort,
+                &self.service_tier,
+                messages_json,
+            )
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(first_error) => {
+                tokio::time::sleep(SUMMARIZE_RETRY_DELAY).await;
+                self.runtime
+                    .summarize(
+                        &self.run_id,
+                        &self.claim_id,
+                        &self.model,
+                        &self.reasoning_effort,
+                        &self.service_tier,
+                        messages_json,
+                    )
+                    .await
+                    .map_err(|retry_error| {
+                        anyhow::anyhow!(
+                            "{retry_error:#}; initial summarization failed: {first_error:#}"
+                        )
+                    })
+            }
+        }
+    }
+
+    fn compaction_failure_flow(
+        &self,
+        has_active_summary: bool,
+        effective_history: &[Message],
+    ) -> Flow {
+        let estimated = estimate_context_tokens(effective_history);
+        if estimated >= self.context_budget.context_window_tokens {
+            return Flow::terminate(format!(
+                "Context compaction failed and the conversation (~{estimated} tokens) exceeds the model context window ({} tokens).",
+                self.context_budget.context_window_tokens
+            ));
+        }
+        continue_with_history(has_active_summary, effective_history.to_vec())
+    }
+}
+
+fn context_input_tokens(usage: &Usage) -> u64 {
+    usage
+        .input_tokens
+        .saturating_add(usage.cached_input_tokens)
+        .saturating_add(usage.cache_creation_input_tokens)
+}
+
+fn context_summary_text(summary: &str) -> String {
+    format!(
+        "{COMPACTED_CONTEXT_PREAMBLE}\n\n<conversation_summary>\n{summary}\n</conversation_summary>"
+    )
+}
+
+fn continue_with_history(has_active_summary: bool, history: Vec<Message>) -> Flow {
+    if has_active_summary {
+        Flow::patch_request(RequestPatch::new().history(history))
+    } else {
+        Flow::cont()
+    }
+}
+
+fn rebuild_effective_history(
+    history: &[Message],
+    active_summary: Option<&CompactedContext>,
+) -> Vec<Message> {
+    let Some(active) = active_summary else {
+        return history.to_vec();
+    };
+    let mut effective = vec![Message::user(context_summary_text(&active.summary))];
+    let suffix_start = active.replaced_prefix_len.min(history.len());
+    effective.extend(history[suffix_start..].iter().cloned());
+    effective
+}
+
+fn next_replaced_prefix_len(
+    active_summary: Option<&CompactedContext>,
+    raw_history_len: usize,
+    effective_split: usize,
+) -> usize {
+    match active_summary {
+        None => effective_split.min(raw_history_len),
+        Some(active) => {
+            // effective = [summary] + raw[replaced_prefix_len..]
+            // compacting effective[..split] advances the raw cutoff by (split - 1).
+            let advanced = effective_split.saturating_sub(1);
+            active
+                .replaced_prefix_len
+                .saturating_add(advanced)
+                .min(raw_history_len)
+        }
+    }
+}
+
+fn should_compact(
+    last_input_tokens: u64,
+    auto_compact_token_limit: u64,
+    messages: &[Message],
+) -> bool {
+    if last_input_tokens >= auto_compact_token_limit {
+        return true;
+    }
+    estimate_context_tokens(messages) >= auto_compact_token_limit
+}
+
+fn estimate_context_tokens(messages: &[Message]) -> u64 {
+    let serialized = serde_json::to_string(messages).unwrap_or_default();
+    serialized.len().div_ceil(3) as u64
+}
+
+fn prior_boundary_in_effective(
+    active_summary: Option<&CompactedContext>,
+    prior_history_len: usize,
+    raw_history_len: usize,
+) -> Option<usize> {
+    let boundary = prior_history_len.min(raw_history_len);
+    match active_summary {
+        None => (boundary > 0).then_some(boundary),
+        Some(active) => {
+            // effective = [summary] + raw[replaced_prefix_len..]
+            if boundary <= active.replaced_prefix_len {
+                return None;
+            }
+            Some(1 + (boundary - active.replaced_prefix_len))
+        }
+    }
+}
+
+fn choose_split_index(
+    history: &[Message],
+    prior_boundary_in_effective: Option<usize>,
+    auto_compact_token_limit: u64,
+) -> usize {
+    if history.len() <= 1 {
+        return 0;
+    }
+
+    // Prefer compacting exactly the prior-history prefix when the remaining
+    // tail (plus room for the summary) still fits under the compact limit.
+    if let Some(boundary) = prior_boundary_in_effective {
+        let boundary = adjust_split_for_tool_results(history, boundary);
+        if boundary > 0
+            && estimate_context_tokens(&history[boundary..]) + COMPACTION_MAX_OUTPUT_TOKENS
+                < auto_compact_token_limit
+        {
+            if !(boundary == 1 && is_summary_user_message(&history[0])) {
+                return boundary;
+            }
+        }
+    }
+
+    let mut split = history.len().saturating_sub(RECENT_TAIL_MESSAGES);
+    if split == 0 {
+        split = history.len().saturating_sub(1);
+    }
+    split = adjust_split_for_tool_results(history, split);
+
+    // Compacting only the summary message is pointless.
+    if split == 1 && is_summary_user_message(&history[0]) {
+        return 0;
+    }
+
+    split
+}
+
+fn adjust_split_for_tool_results(history: &[Message], mut split: usize) -> usize {
+    split = split.min(history.len());
+    while split > 0 && split < history.len() && is_tool_result_user(&history[split]) {
+        split -= 1;
+    }
+    split
+}
+
+/// Durable thread summaries require a prior-run cutoff. Persist only when prior
+/// history exists and the compacted prefix covers all of it.
+fn should_persist_for_future_runs(prior_history_len: usize, replaced_prefix_len: usize) -> bool {
+    prior_history_len > 0 && replaced_prefix_len >= prior_history_len
+}
+
+fn is_tool_result_user(message: &Message) -> bool {
+    match message {
+        Message::User { content } => content
+            .iter()
+            .any(|part| matches!(part, UserContent::ToolResult(_))),
+        _ => false,
+    }
+}
+
+fn is_summary_user_message(message: &Message) -> bool {
+    match message {
+        Message::User { content } => content.iter().any(|part| match part {
+            UserContent::Text(text) => {
+                text.text.contains("<conversation_summary>")
+                    && text.text.contains(COMPACTED_CONTEXT_PREAMBLE)
+            }
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::OneOrMany;
+    use rig::message::{
+        AssistantContent, Text, ToolCall, ToolFunction, ToolResult, ToolResultContent,
+    };
+
+    fn user_text(text: &str) -> Message {
+        Message::user(text)
+    }
+
+    fn assistant_tool_call(id: &str) -> Message {
+        Message::Assistant {
+            id: None,
+            content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+                id: id.to_string(),
+                call_id: Some(id.to_string()),
+                function: ToolFunction {
+                    name: "exec_command".to_string(),
+                    arguments: serde_json::json!({ "cmd": "pwd" }),
+                },
+                signature: None,
+                additional_params: None,
+            })),
+        }
+    }
+
+    fn user_tool_result(id: &str) -> Message {
+        Message::User {
+            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+                id: id.to_string(),
+                call_id: Some(id.to_string()),
+                content: OneOrMany::one(ToolResultContent::Text(Text::new("ok"))),
+            })),
+        }
+    }
+
+    #[test]
+    fn split_point_does_not_orphan_leading_tool_result() {
+        let history = vec![
+            user_text("old work"),
+            assistant_tool_call("call_1"),
+            user_tool_result("call_1"),
+            user_text("continue"),
+            assistant_tool_call("call_2"),
+            user_tool_result("call_2"),
+            user_text("latest"),
+        ];
+
+        // Force a recent-tail landing that would otherwise start on a tool result.
+        let chosen = choose_split_index(&history, None, u64::MAX);
+        assert!(chosen > 0);
+        assert!(!is_tool_result_user(&history[chosen]));
+        assert_eq!(
+            adjust_split_for_tool_results(&history, 2),
+            1,
+            "tool-result at index 2 must pull the split back onto its tool call"
+        );
+    }
+
+    #[test]
+    fn prefers_prior_history_boundary_when_tail_fits() {
+        let history = vec![
+            user_text("prior a"),
+            user_text("prior b"),
+            user_text("current"),
+        ];
+        let chosen = choose_split_index(&history, Some(2), 100_000);
+        assert_eq!(chosen, 2);
+    }
+
+    #[test]
+    fn rebuilds_effective_history_with_active_summary() {
+        let history = vec![
+            user_text("covered"),
+            user_text("kept a"),
+            user_text("kept b"),
+        ];
+        let active = CompactedContext {
+            summary: "Prior work is done.".to_string(),
+            replaced_prefix_len: 1,
+        };
+
+        let effective = rebuild_effective_history(&history, Some(&active));
+        assert_eq!(effective.len(), 3);
+        match &effective[0] {
+            Message::User { content } => {
+                let text = match content.iter().next() {
+                    Some(UserContent::Text(text)) => &text.text,
+                    other => panic!("expected summary text, got {other:?}"),
+                };
+                assert!(text.contains("Prior work is done."));
+                assert!(text.contains("<conversation_summary>"));
+            }
+            other => panic!("expected summary user message, got {other:?}"),
+        }
+        assert_eq!(effective[1], user_text("kept a"));
+        assert_eq!(effective[2], user_text("kept b"));
+    }
+
+    #[test]
+    fn should_compact_uses_usage_and_preflight_estimate() {
+        let small = vec![user_text("hi")];
+        assert!(!should_compact(10, 100, &small));
+        assert!(should_compact(100, 100, &small));
+
+        let large_text = "x".repeat(400);
+        let large = vec![user_text(&large_text)];
+        // ceil(len/3) for a serialized message is well above 50.
+        assert!(should_compact(0, 50, &large));
+        assert!(estimate_context_tokens(&large) >= 50);
+    }
+
+    #[test]
+    fn advances_replaced_prefix_len_in_raw_coordinates() {
+        assert_eq!(next_replaced_prefix_len(None, 10, 4), 4);
+        let active = CompactedContext {
+            summary: "s".to_string(),
+            replaced_prefix_len: 3,
+        };
+        // effective split 3 => summary + 2 raw messages compacted => raw cutoff 5
+        assert_eq!(next_replaced_prefix_len(Some(&active), 10, 3), 5);
+    }
+
+    #[test]
+    fn persist_gate_requires_covered_prior_history() {
+        assert!(!should_persist_for_future_runs(0, 0));
+        assert!(!should_persist_for_future_runs(0, 4));
+        assert!(!should_persist_for_future_runs(6, 4));
+        assert!(should_persist_for_future_runs(6, 6));
+        assert!(should_persist_for_future_runs(6, 8));
+    }
+}

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, anyhow};
 use convex::{FunctionResult, QuerySubscription, Value};
 use serde::Deserialize;
-use sprocket_convex_provider::Client as ConvexProviderClient;
+use sprocket_convex_provider::{Client as ConvexProviderClient, Usage as CompletionUsage};
 use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -233,6 +233,68 @@ impl RuntimeClient {
         .await
     }
 
+    pub(crate) async fn record_context_usage(
+        &self,
+        run_id: &str,
+        claim_id: &str,
+        context_tokens: u64,
+        processed_tokens: u64,
+    ) -> anyhow::Result<bool> {
+        let mut args = self.run_args_with_claim(run_id, claim_id);
+        args.insert(
+            "contextTokens".to_string(),
+            Value::Float64(context_tokens as f64),
+        );
+        args.insert(
+            "processedTokens".to_string(),
+            Value::Float64(processed_tokens as f64),
+        );
+        self.mutation_json("agentRuntime:recordContextUsage", args)
+            .await
+    }
+
+    pub(crate) async fn save_context_compaction(
+        &self,
+        run_id: &str,
+        claim_id: &str,
+        summary: &str,
+        processed_tokens: u64,
+        persist_for_future_runs: bool,
+    ) -> anyhow::Result<bool> {
+        let mut args = self.run_args_with_claim(run_id, claim_id);
+        args.insert("summary".to_string(), summary.to_string().into());
+        args.insert(
+            "processedTokens".to_string(),
+            Value::Float64(processed_tokens as f64),
+        );
+        args.insert(
+            "persistForFutureRuns".to_string(),
+            Value::Boolean(persist_for_future_runs),
+        );
+        self.mutation_json("agentRuntime:saveContextCompaction", args)
+            .await
+    }
+
+    pub(crate) async fn summarize(
+        &self,
+        run_id: &str,
+        claim_id: &str,
+        model_id: &str,
+        reasoning_effort: &str,
+        service_tier: &str,
+        messages_json: &str,
+    ) -> anyhow::Result<SummarizeResponse> {
+        let mut args = self.run_args_with_claim(run_id, claim_id);
+        args.insert("modelId".to_string(), model_id.to_string().into());
+        args.insert(
+            "reasoningEffort".to_string(),
+            reasoning_effort.to_string().into(),
+        );
+        args.insert("serviceTier".to_string(), service_tier.to_string().into());
+        args.insert("messagesJson".to_string(), messages_json.to_string().into());
+        self.action_json("completion:summarize", args).await
+    }
+
     pub(crate) async fn begin_assistant_message(&self, run_id: &str) -> anyhow::Result<()> {
         self.mutation_unit("agentRuntime:beginAssistantMessage", self.run_args(run_id))
             .await
@@ -331,6 +393,30 @@ impl RuntimeClient {
         let mut args = self.run_args(run_id);
         args.insert("claimId".to_string(), claim_id.to_string().into());
         args
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SummarizeResponse {
+    pub(crate) summary: String,
+    pub(crate) usage: CompletionUsage,
+}
+
+impl SummarizeResponse {
+    pub(crate) fn processed_tokens(&self) -> u64 {
+        // Prefer `input_tokens` when it already includes cache details; otherwise add them.
+        let cache_tokens = self
+            .usage
+            .input_token_details
+            .cache_read_tokens
+            .saturating_add(self.usage.input_token_details.cache_write_tokens);
+        let input = if self.usage.input_tokens >= cache_tokens {
+            self.usage.input_tokens
+        } else {
+            self.usage.input_tokens.saturating_add(cache_tokens)
+        };
+        input.saturating_add(self.usage.output_tokens)
     }
 }
 

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -1,3 +1,4 @@
+mod compaction;
 mod convex;
 mod hooks;
 mod provider;

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -8,10 +8,11 @@ use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
 use sprocket_convex_provider::{Client as ConvexProviderClient, is_completion_stream_superseded};
 use sprocket_workspace::CommandSessionManager;
 
+use crate::compaction::ContextCompactionHook;
 use crate::convex::RuntimeClient;
 use crate::hooks::{AgentPromptHook, ToolCallTracker};
 use crate::tools::agent_tools;
-use crate::types::RunContextResponse;
+use crate::types::{ContextBudget, RunContextResponse};
 
 const AGENT_MAX_TURNS: usize = 1_000;
 const MAX_INVALID_TOOL_CALL_RETRIES: usize = 3;
@@ -65,6 +66,10 @@ pub(crate) struct AgentProviderRequest {
     pub(crate) preamble: String,
     pub(crate) prior_history: Vec<Message>,
     pub(crate) workspace_root: PathBuf,
+    pub(crate) model: String,
+    pub(crate) reasoning_effort: String,
+    pub(crate) service_tier: String,
+    pub(crate) context_budget: ContextBudget,
 }
 
 pub(crate) enum AgentProviderResult {
@@ -139,13 +144,25 @@ where
     eprintln!("sprocket-agent: built agent {}", request.run_id);
     eprintln!("sprocket-agent: prompting model {}", request.run_id);
 
-    let hook = AgentPromptHook::new(tool_call_tracker);
+    let prompt_hook = AgentPromptHook::new(tool_call_tracker);
+    let prior_history_len = request.prior_history.len();
+    let compaction_hook = ContextCompactionHook::new(
+        runtime,
+        request.run_id.clone(),
+        request.claim_id.clone(),
+        request.model,
+        request.reasoning_effort,
+        request.service_tier,
+        request.context_budget,
+        prior_history_len,
+    );
 
     let mut stream = agent
         .stream_prompt(request.prompt)
         .history(request.prior_history)
         .max_turns(AGENT_MAX_TURNS)
-        .add_hook(hook)
+        .add_hook(prompt_hook)
+        .add_hook(compaction_hook)
         .max_invalid_tool_call_retries(MAX_INVALID_TOOL_CALL_RETRIES)
         .await;
     let mut final_text = String::new();

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -536,6 +536,11 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
     };
     eprintln!("sprocket-agent: loaded run context {}", run_id);
 
+    let model = context.run.selected_model.clone();
+    let reasoning_effort = context.run.reasoning_effort.clone();
+    let service_tier = context.run.service_tier.clone();
+    let context_budget = context.context_budget.clone();
+
     let prepared = (|| {
         let workspace_instructions = load_workspace_instructions(&workspace_root)?;
         let prompt_text = context.prompt.trim();
@@ -615,6 +620,10 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
                     preamble,
                     prior_history,
                     workspace_root,
+                    model,
+                    reasoning_effort,
+                    service_tier,
+                    context_budget,
                 },
             )
             .await;

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -5,7 +5,7 @@ use rig::message::{
     AssistantContent, ReasoningContent, Text, ToolCall, ToolFunction, ToolResult,
     ToolResultContent, UserContent,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use sprocket_convex_provider::AuthTokenFetcher;
 
 #[derive(Clone)]
@@ -52,6 +52,29 @@ pub struct RunContextResponse {
     pub prompt_attachments: Vec<ResolvedImageAttachment>,
     pub agent_history: Vec<AgentHistoryMessage>,
     pub workspace_session: WorkspaceSessionSnapshot,
+    pub context_budget: ContextBudget,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextBudget {
+    #[serde(deserialize_with = "deserialize_convex_u64")]
+    pub context_window_tokens: u64,
+    #[serde(deserialize_with = "deserialize_convex_u64")]
+    pub auto_compact_token_limit: u64,
+}
+
+fn deserialize_convex_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = f64::deserialize(deserializer)?;
+    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+        return Err(serde::de::Error::custom(format!(
+            "expected a non-negative integer-compatible Convex number, got {value}"
+        )));
+    }
+    Ok(value as u64)
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-convex-provider/src/lib.rs
+++ b/crates/sprocket-convex-provider/src/lib.rs
@@ -5,3 +5,4 @@ pub use client::{
     AuthTokenFetcher, COMPLETION_STREAM_SUPERSEDED, Client, CompletionModel, CompletionOutput,
     InputTokenDetails, OutputTokenDetails, ToolCall, Usage, is_completion_stream_superseded,
 };
+pub use messages::completion_messages_json;

--- a/crates/sprocket-convex-provider/src/messages.rs
+++ b/crates/sprocket-convex-provider/src/messages.rs
@@ -6,10 +6,18 @@ use rig::message::{AssistantContent, ReasoningContent, ToolResultContent, UserCo
 pub(crate) fn build_model_messages(
     request: &CompletionRequest,
 ) -> Result<serde_json::Value, CompletionError> {
-    let mut messages: Vec<serde_json::Value> = Vec::new();
-    let mut tool_names_by_call_id: BTreeMap<String, String> = BTreeMap::<String, String>::new();
+    completion_messages_json(request.chat_history.iter())
+}
 
-    for message in request.chat_history.iter() {
+/// Serializes Rig messages into the AI SDK model-message JSON accepted by the
+/// Convex completion actions.
+pub fn completion_messages_json<'a>(
+    history: impl IntoIterator<Item = &'a Message>,
+) -> Result<serde_json::Value, CompletionError> {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    let mut tool_names_by_call_id: BTreeMap<String, String> = BTreeMap::new();
+
+    for message in history {
         match message {
             Message::System { .. } => {}
             Message::User { content } => {


### PR DESCRIPTION
## Summary
- Add a rig `ContextCompactionHook` that compacts long histories before model calls, with summarization via a non-streaming `completion:summarize` action so summary text never enters the visible transcript
- Persist thread context budgets/usage and durable cross-run summaries through claim-fenced Convex mutations (`recordContextUsage`, `saveContextCompaction`) and serve them from `getContext`
- Surface a filling-circle context meter in the prompt composer using per-model `contextWindowTokens` / `autoCompactTokenLimit`

## Test plan
- [ ] `nix develop -c cargo test`
- [ ] `nix develop -c bun run test` (includes `agentRuntime.context.test.ts`)
- [ ] `nix develop -c bun run --cwd apps/web build`
- [ ] `nix develop -c bun run --cwd apps/web check`
- [ ] `nix develop -c prek run -a`
- [ ] Manually: run a long thread past a model's auto-compact limit and confirm the meter updates, compaction does not pollute the assistant message, and a later run receives the persisted summary instead of covered history

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds automatic context compaction and context-usage reporting across the agent runtime.
- Introduces a Rust Rig hook that summarizes long histories before subsequent model calls.
- Persists claim-fenced context usage and durable summaries in Convex.
- Filters covered history when restoring compacted context for later runs.
- Adds per-model context budgets and a context meter to the prompt composer.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains in this follow-up review.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the rust-context-compaction-tests suite and captured the full command output, working directory, build results, named test results, totals, and exit status in the rust-context-compaction-tests log.
- Validated that the relevant passing compaction tests cover summary reconstruction, split boundaries, prior-history handling, persistence gating, raw-coordinate prefix advancement, and compaction triggering.
- Confirmed the test run exited with status 0, indicating successful execution.

<a href="https://app.greptile.com/trex/runs/15701884/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/compaction.rs | Adds threshold detection, history splitting, summarization, request patching, and context-usage persistence. |
| apps/web/src/convex/agentRuntime.ts | Adds durable summary cutoffs, filtered context reconstruction, and claim-fenced context accounting mutations. |
| apps/web/src/convex/completion.ts | Adds the non-streaming, claim-aware model action used to summarize compacted history. |
| crates/sprocket-agent/src/provider.rs | Installs the context-compaction hook into the Rig agent loop. |
| crates/sprocket-convex-provider/src/messages.rs | Exposes reusable Rig-to-model message serialization for summary requests. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Adds an accessible context-window meter and token-usage tooltip. |
| apps/web/src/routes/+page.svelte | Derives context usage from thread state and the selected model and passes it to the composer. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant UI as Web UI
participant C as Convex
participant A as Rust Agent
participant M as Model
UI->>C: Create run
A->>C: getContext
C-->>A: History, durable summary, context budget
A->>M: Completion request
M-->>A: Response and token usage
A->>C: recordContextUsage
alt Context exceeds compaction threshold
    A->>C: completion:summarize
    C->>M: Non-streaming summary request
    M-->>C: Summary
    C-->>A: Summary and usage
    A->>C: saveContextCompaction
    A->>M: Continue with summary and recent tail
end
C-->>UI: Updated context usage
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(web): Trim context compaction comm..."](https://github.com/spikonado/sprocket/commit/b17b02d5e8c28146ed0f4467b081165c237c0e0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46870903)</sub>

<!-- /greptile_comment -->