### PR TITLE
fix(agent): Improve system prompt for web searching

### DIFF
--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -99,6 +99,7 @@ fn build_workspace_preamble(
 
         "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations. `git` is an exception to this rule.",
         "Prefer using the `scrape_url` tool over `web_search` when you have an idea on what URL could lead you to the information you need. `web_search` is more expensive and should be used as a fallback.",
+        "You are suggested to use `scrape_url` on the URLs returned by `web_search` to further ground the information you received from it.",
 
         "## Writing Tests",
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Improves the agent’s web-research guidance.
- Suggests using `scrape_url` on URLs returned by `web_search` when additional grounding is useful.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change only adds advisory prompt text and preserves the existing tool schemas, execution flow, and runtime contracts.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general-contract-validation-proof by comparing the before-state prompt-construction log, which showed exit code 101 and missing observed\_instruction.
- Validated the after-state prompt-construction log, which shows exit code 0 and the exact constructed prompt instruction.
- Verified the package tests rebuilt and all 14 library tests passed according to the sprocket-agent-lib-tests log.
- Confirmed the reusable prompt-construction harness is preserved in the prompt-construction-harness.sh file and that the tracked source remained unmodified.

<a href="https://app.greptile.com/trex/runs/15703045/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/run.rs | Adds non-binding system-prompt guidance encouraging deeper inspection of web-search results; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Improve system prompt for we..."](https://github.com/spikonado/sprocket/commit/7bbeadb1eaef3dcf8c3a8fcb7556c3cfd25d5bd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46915630)</sub>

<!-- /greptile_comment -->