### PR TITLE
fix(web): Keep composer sendable if subscription query fails

### DIFF
--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -70,12 +70,14 @@
 	const subscriptionQuery = useQuery(api.billing.getMySubscription, () =>
 		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
 	);
-	const knownSubscriptionTier = $derived(subscriptionQuery.data?.tier);
+	// Fall back to free on query failure so send is not stuck disabled forever.
+	const subscriptionTier = $derived(
+		subscriptionQuery.data?.tier ?? (subscriptionQuery.error ? 'free' : undefined)
+	);
 	// Until the tier is known, render the free allowlist so locked models are never selectable.
-	const tierModelOptions = $derived(modelOptionsForTier(knownSubscriptionTier ?? 'free'));
+	const tierModelOptions = $derived(modelOptionsForTier(subscriptionTier ?? 'free'));
 	const canSubmitWithModel = $derived(
-		knownSubscriptionTier !== undefined &&
-			isModelAllowedForTier(knownSubscriptionTier, selectedModel)
+		subscriptionTier !== undefined && isModelAllowedForTier(subscriptionTier, selectedModel)
 	);
 
 	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
@@ -187,9 +189,10 @@
 	}
 
 	$effect(() => {
-		// Only coerce after the tier is known so paid users are not snapped to free defaults.
-		if (!knownSubscriptionTier) return;
-		const allowedModel = resolveModelForTier(knownSubscriptionTier, selectedModel);
+		// Only coerce after the tier is known (or failed closed to free) so paid users are
+		// not snapped to free defaults during a successful load.
+		if (!subscriptionTier) return;
+		const allowedModel = resolveModelForTier(subscriptionTier, selectedModel);
 		if (allowedModel === selectedModel) return;
 		selectedModel = allowedModel;
 		selectedReasoningEffort = getModelDefinition(allowedModel).defaultReasoningEffort;

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -70,14 +70,16 @@
 	const subscriptionQuery = useQuery(api.billing.getMySubscription, () =>
 		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
 	);
-	// Fall back to free on query failure so send is not stuck disabled forever.
-	const subscriptionTier = $derived(
-		subscriptionQuery.data?.tier ?? (subscriptionQuery.error ? 'free' : undefined)
-	);
+	const subscriptionTier = $derived(subscriptionQuery.data?.tier);
+	const subscriptionFailed = $derived(Boolean(subscriptionQuery.error));
 	// Until the tier is known, render the free allowlist so locked models are never selectable.
 	const tierModelOptions = $derived(modelOptionsForTier(subscriptionTier ?? 'free'));
+	// On query failure, keep send enabled and let the backend enforce entitlements so a
+	// transient error cannot permanently disable the composer or clobber a paid selection.
 	const canSubmitWithModel = $derived(
-		subscriptionTier !== undefined && isModelAllowedForTier(subscriptionTier, selectedModel)
+		subscriptionFailed
+			? true
+			: subscriptionTier !== undefined && isModelAllowedForTier(subscriptionTier, selectedModel)
 	);
 
 	let composerTextarea = $state<HTMLTextAreaElement | null>(null);
@@ -189,8 +191,8 @@
 	}
 
 	$effect(() => {
-		// Only coerce after the tier is known (or failed closed to free) so paid users are
-		// not snapped to free defaults during a successful load.
+		// Only coerce after a successful tier load so paid users are not snapped to free
+		// defaults during loading or transient query failures.
 		if (!subscriptionTier) return;
 		const allowedModel = resolveModelForTier(subscriptionTier, selectedModel);
 		if (allowedModel === selectedModel) return;


### PR DESCRIPTION
## Summary
- Fall back to the free tier for model gating when `getMySubscription` errors, so send/Enter are not stuck disabled indefinitely
- Keep the existing load-time gate that blocks submit until a tier is known, preserving the stale locked-model protection

## Test plan
- [ ] With a working subscription query, free users still cannot submit locked models while loading/after coerce
- [ ] Simulate/force a failed `getMySubscription` query and confirm send remains available for Claude Fable 5
- [ ] Pro/admin users still unlock all models when the subscription query succeeds

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Keeps the composer sendable when subscription lookup fails.
- Separates subscription-query failure state from tier loading.
- Defers entitlement enforcement to the backend on query failure.
- Avoids coercing the selected model until a tier loads successfully.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.

No files require additional attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial video captured the prior failed-query fallback behavior and interaction.
- The subsequent video shows Claude Fable 5 with the Send control enabled and the visible callback trace after Enter.
- Browser logs were inspected and show the measured disabled state, the selected model, the callback trace, the command, the working directory, and exit code 0.
- The harness source was included to document the real-component mount and forced query states.

<a href="https://app.greptile.com/trex/runs/15712819/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/prompt-composer.svelte | Updates model gating and coercion behavior for failed subscription queries without leaving a blocking failure related to the previous thread. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): Preserve model selection when ..."](https://github.com/spikonado/sprocket/commit/d5d4906f3cac93ff30db3a8f1a39ba4dadc145e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46931143)</sub>

<!-- /greptile_comment -->