### PR TITLE
feat(ui): Improve UI and add light mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Project Overview
 
-- Sprocket is an agentic platform that streamlines robotics development.
-- It's goal is to give its users and AI agents the best possible experience when developing robots and robot apps. They should be able to ship across the entire robotics stack much faster than ever before.
+- Sprocket is an agentic platform that streamlines hardware and software development.
+- It's goal is to give its users and AI agents the best possible experience when creating apps, robots, devices, and the systems that glue them together.
 - Sprocket should work seamlessly across different hardware platforms, operating systems, and Sprocket's own cloud for robotics development.
 
 ## Available Testing Commands

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Goal**: To make the world's best platform for developing hardware and software.
 
-Sprocket is currently a lightweight coding agent that works across multiple projects and machines, retrieves best-in-class web context, and writes high-quality code.
+Sprocket is currently a lightweight coding agent that writes high-quality code, and retrieves best-in-class context from the web and open-source projects.
 
 ![Sprocket](./assets/sprocket.png)
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
 		"@exalabs/convex-exa": "^0.1.0",
 		"@fontsource-variable/ibm-plex-sans": "^5.2.8",
 		"@fontsource/dm-sans": "^5.2.8",
+		"@fontsource/ibm-plex-mono": "^5.3.0",
 		"@lucide/svelte": "^1.18.0",
 		"@workos-inc/authkit-js": "^0.20.0",
 		"ai": "^7.0.37",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -53,8 +53,8 @@
 	--background: oklch(0.955 0.014 130);
 	--foreground: oklch(0.18 0.02 260);
 	--surface: oklch(0.99 0.004 130);
-	--muted: oklch(0.93 0.01 130);
-	--muted-foreground: oklch(0.48 0.02 260);
+	--muted: oklch(0.93 0.018 220);
+	--muted-foreground: oklch(0.45 0.03 250);
 	--popover: oklch(0.99 0.004 130);
 	--popover-foreground: oklch(0.18 0.02 260);
 	--card: oklch(0.99 0.004 130);
@@ -79,25 +79,32 @@
 	--hover-fill: oklch(0.18 0.02 260 / 0.05);
 	--hover-fill-strong: oklch(0.18 0.02 260 / 0.08);
 	--hairline: oklch(0.18 0.02 260 / 0.08);
+	/* Composer: bright paper with a soft sky shade around it */
 	--composer-shell: linear-gradient(
 		180deg,
-		oklch(0.18 0.02 260 / 0.06),
-		oklch(0.18 0.02 260 / 0.02)
+		oklch(0.78 0.08 230 / 0.55),
+		oklch(0.82 0.06 230 / 0.28)
 	);
-	--composer-inner: linear-gradient(180deg, oklch(0.995 0.003 130), oklch(0.97 0.008 130));
-	--composer-shadow: 0 24px 64px oklch(0.2 0.02 260 / 0.12);
-	--user-bubble: linear-gradient(180deg, oklch(0.97 0.008 130), oklch(0.94 0.012 130));
+	--composer-inner: linear-gradient(180deg, oklch(1 0.002 100), oklch(0.985 0.012 145));
+	--composer-shadow: 0 0 0 1px oklch(0.72 0.1 230 / 0.18), 0 18px 48px oklch(0.55 0.08 230 / 0.16);
+	/* Transcript: soft sky paper bubbles against parchment */
+	--user-bubble: linear-gradient(180deg, oklch(0.98 0.02 230), oklch(0.95 0.028 210));
+	--user-bubble-border: oklch(0.55 0.07 230 / 0.2);
+	--user-bubble-shadow: 0 10px 28px -16px oklch(0.4 0.05 250 / 0.2);
 	--transcript-fade: linear-gradient(
 		180deg,
 		oklch(0.955 0.014 130 / 0),
 		oklch(0.955 0.014 130 / 0.68) 48%,
 		oklch(0.955 0.014 130 / 0.92)
 	);
+	/* Site-like parchment wash with restrained sky glow */
 	--workspace-bg:
-		radial-gradient(ellipse 70% 55% at 85% 0%, oklch(0.72 0.1 230 / 0.1), transparent 55%),
-		linear-gradient(180deg, oklch(0.97 0.01 130) 0%, var(--background) 42%, var(--background) 100%);
-	--sidebar-bg: linear-gradient(180deg, oklch(0.985 0.006 130), oklch(0.96 0.012 130));
-	--sidebar-border: oklch(0.18 0.02 260 / 0.08);
+		radial-gradient(ellipse 70% 50% at 90% 0%, oklch(0.72 0.1 230 / 0.16), transparent 58%),
+		radial-gradient(ellipse 45% 40% at 0% 100%, oklch(0.72 0.08 230 / 0.08), transparent 55%),
+		linear-gradient(180deg, oklch(0.97 0.015 130) 0%, var(--background) 48%, var(--background) 100%);
+	/* Cool slate-sage rail — a step darker than the page so it separates */
+	--sidebar-bg: linear-gradient(180deg, oklch(0.935 0.018 200), oklch(0.905 0.02 185));
+	--sidebar-border: oklch(0.32 0.04 250 / 0.14);
 	--tooltip-bg: oklch(0.22 0.02 260);
 	--tooltip-fg: oklch(0.96 0.01 130);
 	--radius: 0.9rem;
@@ -105,54 +112,57 @@
 	color-scheme: light;
 }
 
-/* Dark workspace — Spikonado ink */
+/* Dark workspace — cool ink, clearer chat/sidebar separation */
 [data-theme='dark'] {
-	--background: oklch(0.16 0.015 40);
-	--foreground: oklch(0.93 0.01 80);
-	--surface: oklch(0.2 0.012 40);
-	--muted: oklch(0.22 0.012 40);
-	--muted-foreground: oklch(0.68 0.015 80);
-	--popover: oklch(0.18 0.014 40);
-	--popover-foreground: oklch(0.93 0.01 80);
-	--card: oklch(0.2 0.012 40);
-	--card-foreground: oklch(0.93 0.01 80);
-	--border: oklch(0.28 0.012 40);
-	--input: oklch(0.26 0.012 40);
+	--background: oklch(0.155 0.018 250);
+	--foreground: oklch(0.94 0.012 230);
+	--surface: oklch(0.2 0.02 250);
+	--muted: oklch(0.24 0.022 250);
+	--muted-foreground: oklch(0.74 0.02 230);
+	--popover: oklch(0.19 0.022 250);
+	--popover-foreground: oklch(0.94 0.012 230);
+	--card: oklch(0.21 0.022 250);
+	--card-foreground: oklch(0.94 0.012 230);
+	--border: oklch(0.32 0.03 250);
+	--input: oklch(0.27 0.025 250);
 	--primary: oklch(0.72 0.1 230);
-	--primary-foreground: oklch(0.16 0.015 40);
-	--secondary: oklch(0.24 0.012 40);
+	--primary-foreground: oklch(0.16 0.02 250);
+	--secondary: oklch(0.25 0.02 250);
 	--secondary-foreground: oklch(0.93 0.01 80);
 	--accent: oklch(0.72 0.1 230);
-	--accent-foreground: oklch(0.93 0.01 80);
-	--accent-strong: oklch(0.78 0.12 230);
-	--accent-soft: oklch(0.28 0.04 230);
+	--accent-foreground: oklch(0.94 0.012 230);
+	--accent-strong: oklch(0.8 0.11 230);
+	--accent-soft: oklch(0.28 0.045 230);
 	--mark: oklch(0.45 0.08 95);
 	--destructive: oklch(0.62 0.2 25);
 	--destructive-foreground: oklch(0.99 0.004 130);
 	--ring: oklch(0.72 0.1 230);
-	--overlay: oklch(0.1 0.01 40 / 0.55);
-	--panel: oklch(0.2 0.012 40);
-	--panel-elevated: oklch(0.24 0.012 40);
-	--hover-fill: oklch(1 0 0 / 0.05);
-	--hover-fill-strong: oklch(1 0 0 / 0.08);
-	--hairline: oklch(1 0 0 / 0.08);
-	--composer-shell: linear-gradient(180deg, oklch(1 0 0 / 0.06), oklch(1 0 0 / 0.02));
-	--composer-inner: linear-gradient(180deg, oklch(0.24 0.01 40 / 0.98), oklch(0.2 0.012 40 / 0.98));
-	--composer-shadow: 0 24px 64px oklch(0 0 0 / 0.28);
-	--user-bubble: linear-gradient(180deg, oklch(0.26 0.012 40 / 0.96), oklch(0.2 0.012 40 / 0.96));
+	--overlay: oklch(0.1 0.02 250 / 0.55);
+	--panel: oklch(0.2 0.02 250);
+	--panel-elevated: oklch(0.26 0.028 250);
+	--hover-fill: oklch(0.75 0.06 230 / 0.1);
+	--hover-fill-strong: oklch(0.75 0.06 230 / 0.16);
+	--hairline: oklch(0.78 0.05 230 / 0.16);
+	--composer-shell: linear-gradient(180deg, oklch(0.72 0.08 230 / 0.18), oklch(1 0 0 / 0.04));
+	--composer-inner: linear-gradient(180deg, oklch(0.24 0.024 250), oklch(0.2 0.02 250));
+	--composer-shadow: 0 24px 64px oklch(0.08 0.03 250 / 0.45);
+	/* Transcript: lifted cool slate bubbles vs flat charcoal */
+	--user-bubble: linear-gradient(180deg, oklch(0.3 0.035 245), oklch(0.24 0.03 250));
+	--user-bubble-border: oklch(0.72 0.08 230 / 0.28);
+	--user-bubble-shadow: 0 12px 32px -16px oklch(0.08 0.04 250 / 0.7);
 	--transcript-fade: linear-gradient(
 		180deg,
-		oklch(0.16 0.015 40 / 0),
-		oklch(0.16 0.015 40 / 0.68) 48%,
-		oklch(0.16 0.015 40 / 0.92)
+		oklch(0.155 0.018 250 / 0),
+		oklch(0.155 0.018 250 / 0.7) 48%,
+		oklch(0.155 0.018 250 / 0.94)
 	);
 	--workspace-bg:
-		radial-gradient(circle at 50% 0%, oklch(1 0 0 / 0.05), transparent 26%),
-		linear-gradient(180deg, oklch(0.19 0.012 40) 0%, oklch(0.15 0.014 40) 100%);
+		radial-gradient(ellipse 80% 45% at 70% 0%, oklch(0.55 0.08 230 / 0.12), transparent 55%),
+		linear-gradient(180deg, oklch(0.175 0.022 250) 0%, oklch(0.145 0.018 250) 100%);
 	--sidebar-bg: linear-gradient(180deg, oklch(0.2 0.016 250 / 0.96), oklch(0.17 0.014 250 / 0.98));
 	--sidebar-border: oklch(1 0 0 / 0.06);
-	--tooltip-bg: oklch(0.2 0.014 250);
-	--tooltip-fg: oklch(0.93 0.01 80);
+	--tooltip-bg: oklch(0.22 0.03 250);
+	--tooltip-fg: oklch(0.94 0.015 230);
 	--radius: 0.9rem;
 	--selection: oklch(0.72 0.1 230 / 0.28);
 	color-scheme: dark;
@@ -222,16 +232,22 @@ body::after {
 }
 
 .composer-shell {
-	background-image: var(--composer-shell);
+	background: var(--composer-shell);
 }
 
 .composer-inner {
-	background-image: var(--composer-inner);
+	background: var(--composer-inner);
 	box-shadow: var(--composer-shadow);
+}
+
+[data-theme='light'] .composer-inner {
+	border-color: transparent;
 }
 
 .user-bubble {
 	background-image: var(--user-bubble);
+	border-color: var(--user-bubble-border);
+	box-shadow: var(--user-bubble-shadow);
 }
 
 .transcript-fade {
@@ -364,9 +380,9 @@ body::after {
 }
 
 .chat-markdown :not(pre) > code {
-	border: 1px solid var(--border);
+	border: 1px solid var(--hairline);
 	border-radius: 0.5rem;
-	background: color-mix(in oklab, var(--muted) 82%, var(--background));
+	background: var(--muted);
 	padding: 0.14rem 0.42rem;
 	font-family: var(--font-mono);
 	font-size: 0.8em;
@@ -374,14 +390,14 @@ body::after {
 
 .chat-markdown pre {
 	overflow-x: auto;
-	border: 1px solid var(--border);
+	border: 1px solid var(--hairline);
 	border-radius: 1rem;
-	background: color-mix(in oklab, var(--background) 82%, var(--foreground));
+	background: var(--panel-elevated);
 	padding: 0.95rem 1rem;
 }
 
 [data-theme='light'] .chat-markdown pre {
-	background: color-mix(in oklab, var(--muted) 70%, var(--background));
+	background: color-mix(in oklab, var(--muted) 55%, var(--surface));
 }
 
 .chat-markdown pre code {

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,65 +1,169 @@
 @import '@fontsource/dm-sans';
 @import '@fontsource-variable/ibm-plex-sans/wght.css';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
 @import 'tailwindcss';
+
+@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
 
 @theme inline {
 	--font-sans: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
 	--font-brand: 'IBM Plex Sans Variable', ui-sans-serif, system-ui, sans-serif;
-	--color-background: hsl(var(--background));
-	--color-foreground: hsl(var(--foreground));
-	--color-card: hsl(var(--card));
-	--color-card-foreground: hsl(var(--card-foreground));
-	--color-popover: hsl(var(--popover));
-	--color-popover-foreground: hsl(var(--popover-foreground));
-	--color-primary: hsl(var(--primary));
-	--color-primary-foreground: hsl(var(--primary-foreground));
-	--color-secondary: hsl(var(--secondary));
-	--color-secondary-foreground: hsl(var(--secondary-foreground));
-	--color-muted: hsl(var(--muted));
-	--color-muted-foreground: hsl(var(--muted-foreground));
-	--color-accent: hsl(var(--accent));
-	--color-accent-foreground: hsl(var(--accent-foreground));
-	--color-destructive: hsl(var(--destructive));
-	--color-destructive-foreground: hsl(var(--destructive-foreground));
-	--color-border: hsl(var(--border));
-	--color-input: hsl(var(--input));
-	--color-ring: hsl(var(--ring));
+	--font-mono: 'IBM Plex Mono', ui-monospace, 'Cascadia Code', 'Segoe UI Mono', monospace;
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-surface: var(--surface);
+	--color-card: var(--card);
+	--color-card-foreground: var(--card-foreground);
+	--color-popover: var(--popover);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-accent-strong: var(--accent-strong);
+	--color-accent-soft: var(--accent-soft);
+	--color-mark: var(--mark);
+	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
+	--color-border: var(--border);
+	--color-input: var(--input);
+	--color-ring: var(--ring);
+	--color-overlay: var(--overlay);
+	--color-panel: var(--panel);
+	--color-panel-elevated: var(--panel-elevated);
+	--color-tooltip: var(--tooltip-bg);
+	--color-tooltip-foreground: var(--tooltip-fg);
+	--color-hover-fill: var(--hover-fill);
+	--color-hover-fill-strong: var(--hover-fill-strong);
+	--color-hairline: var(--hairline);
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 6px);
 }
 
-:root {
-	--background: 30 8% 8%;
-	--foreground: 30 9% 93%;
-	--muted: 24 6% 14%;
-	--muted-foreground: 24 5% 57%;
-	--popover: 30 8% 10%;
-	--popover-foreground: 30 9% 93%;
-	--card: 24 6% 12%;
-	--card-foreground: 30 9% 93%;
-	--border: 24 6% 18%;
-	--input: 24 6% 20%;
-	--primary: 223 73% 58%;
-	--primary-foreground: 0 0% 100%;
-	--secondary: 24 6% 16%;
-	--secondary-foreground: 30 9% 93%;
-	--accent: 24 6% 16%;
-	--accent-foreground: 30 9% 93%;
-	--destructive: 0 72% 58%;
-	--destructive-foreground: 0 0% 100%;
-	--ring: 223 73% 58%;
+/* Light brand system — Spikonado parchment */
+:root,
+[data-theme='light'] {
+	--background: oklch(0.955 0.014 130);
+	--foreground: oklch(0.18 0.02 260);
+	--surface: oklch(0.99 0.004 130);
+	--muted: oklch(0.93 0.01 130);
+	--muted-foreground: oklch(0.48 0.02 260);
+	--popover: oklch(0.99 0.004 130);
+	--popover-foreground: oklch(0.18 0.02 260);
+	--card: oklch(0.99 0.004 130);
+	--card-foreground: oklch(0.18 0.02 260);
+	--border: oklch(0.88 0.012 130);
+	--input: oklch(0.9 0.01 130);
+	--primary: oklch(0.18 0.02 260);
+	--primary-foreground: oklch(0.99 0.004 130);
+	--secondary: oklch(0.93 0.01 130);
+	--secondary-foreground: oklch(0.18 0.02 260);
+	--accent: oklch(0.72 0.1 230);
+	--accent-foreground: oklch(0.18 0.02 260);
+	--accent-strong: oklch(0.52 0.16 250);
+	--accent-soft: oklch(0.92 0.04 230);
+	--mark: oklch(0.93 0.08 95);
+	--destructive: oklch(0.58 0.2 25);
+	--destructive-foreground: oklch(0.99 0.004 130);
+	--ring: oklch(0.72 0.08 230);
+	--overlay: oklch(0.18 0.02 260 / 0.45);
+	--panel: oklch(0.99 0.004 130);
+	--panel-elevated: oklch(0.97 0.008 130);
+	--hover-fill: oklch(0.18 0.02 260 / 0.05);
+	--hover-fill-strong: oklch(0.18 0.02 260 / 0.08);
+	--hairline: oklch(0.18 0.02 260 / 0.08);
+	--composer-shell: linear-gradient(
+		180deg,
+		oklch(0.18 0.02 260 / 0.06),
+		oklch(0.18 0.02 260 / 0.02)
+	);
+	--composer-inner: linear-gradient(180deg, oklch(0.995 0.003 130), oklch(0.97 0.008 130));
+	--composer-shadow: 0 24px 64px oklch(0.2 0.02 260 / 0.12);
+	--user-bubble: linear-gradient(180deg, oklch(0.97 0.008 130), oklch(0.94 0.012 130));
+	--transcript-fade: linear-gradient(
+		180deg,
+		oklch(0.955 0.014 130 / 0),
+		oklch(0.955 0.014 130 / 0.68) 48%,
+		oklch(0.955 0.014 130 / 0.92)
+	);
+	--workspace-bg:
+		radial-gradient(ellipse 70% 55% at 85% 0%, oklch(0.72 0.1 230 / 0.1), transparent 55%),
+		linear-gradient(180deg, oklch(0.97 0.01 130) 0%, var(--background) 42%, var(--background) 100%);
+	--sidebar-bg: linear-gradient(180deg, oklch(0.985 0.006 130), oklch(0.96 0.012 130));
+	--sidebar-border: oklch(0.18 0.02 260 / 0.08);
+	--tooltip-bg: oklch(0.22 0.02 260);
+	--tooltip-fg: oklch(0.96 0.01 130);
 	--radius: 0.9rem;
+	--selection: oklch(0.92 0.04 230);
+	color-scheme: light;
+}
+
+/* Dark workspace — Spikonado ink */
+[data-theme='dark'] {
+	--background: oklch(0.16 0.015 40);
+	--foreground: oklch(0.93 0.01 80);
+	--surface: oklch(0.2 0.012 40);
+	--muted: oklch(0.22 0.012 40);
+	--muted-foreground: oklch(0.68 0.015 80);
+	--popover: oklch(0.18 0.014 40);
+	--popover-foreground: oklch(0.93 0.01 80);
+	--card: oklch(0.2 0.012 40);
+	--card-foreground: oklch(0.93 0.01 80);
+	--border: oklch(0.28 0.012 40);
+	--input: oklch(0.26 0.012 40);
+	--primary: oklch(0.72 0.1 230);
+	--primary-foreground: oklch(0.16 0.015 40);
+	--secondary: oklch(0.24 0.012 40);
+	--secondary-foreground: oklch(0.93 0.01 80);
+	--accent: oklch(0.72 0.1 230);
+	--accent-foreground: oklch(0.93 0.01 80);
+	--accent-strong: oklch(0.78 0.12 230);
+	--accent-soft: oklch(0.28 0.04 230);
+	--mark: oklch(0.45 0.08 95);
+	--destructive: oklch(0.62 0.2 25);
+	--destructive-foreground: oklch(0.99 0.004 130);
+	--ring: oklch(0.72 0.1 230);
+	--overlay: oklch(0.1 0.01 40 / 0.55);
+	--panel: oklch(0.2 0.012 40);
+	--panel-elevated: oklch(0.24 0.012 40);
+	--hover-fill: oklch(1 0 0 / 0.05);
+	--hover-fill-strong: oklch(1 0 0 / 0.08);
+	--hairline: oklch(1 0 0 / 0.08);
+	--composer-shell: linear-gradient(180deg, oklch(1 0 0 / 0.06), oklch(1 0 0 / 0.02));
+	--composer-inner: linear-gradient(180deg, oklch(0.24 0.01 40 / 0.98), oklch(0.2 0.012 40 / 0.98));
+	--composer-shadow: 0 24px 64px oklch(0 0 0 / 0.28);
+	--user-bubble: linear-gradient(180deg, oklch(0.26 0.012 40 / 0.96), oklch(0.2 0.012 40 / 0.96));
+	--transcript-fade: linear-gradient(
+		180deg,
+		oklch(0.16 0.015 40 / 0),
+		oklch(0.16 0.015 40 / 0.68) 48%,
+		oklch(0.16 0.015 40 / 0.92)
+	);
+	--workspace-bg:
+		radial-gradient(circle at 50% 0%, oklch(1 0 0 / 0.05), transparent 26%),
+		linear-gradient(180deg, oklch(0.19 0.012 40) 0%, oklch(0.15 0.014 40) 100%);
+	--sidebar-bg: linear-gradient(180deg, oklch(0.2 0.016 250 / 0.96), oklch(0.17 0.014 250 / 0.98));
+	--sidebar-border: oklch(1 0 0 / 0.06);
+	--tooltip-bg: oklch(0.2 0.014 250);
+	--tooltip-fg: oklch(0.93 0.01 80);
+	--radius: 0.9rem;
+	--selection: oklch(0.72 0.1 230 / 0.28);
+	color-scheme: dark;
 }
 
 @layer base {
 	* {
-		border-color: hsl(var(--border));
+		border-color: var(--border);
 	}
 
 	html {
-		color-scheme: dark;
 		height: 100%;
 		overflow: hidden;
 	}
@@ -67,10 +171,8 @@
 	body {
 		height: 100%;
 		min-height: 100vh;
-		background:
-			radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.045), transparent 24%),
-			linear-gradient(180deg, rgba(24, 24, 26, 1) 0%, rgba(15, 15, 17, 1) 100%);
-		color: hsl(var(--foreground));
+		background: var(--workspace-bg);
+		color: var(--foreground);
 		font-family: var(--font-sans);
 		font-feature-settings: 'ss01' 1;
 		margin: 0;
@@ -84,7 +186,8 @@
 	}
 
 	::selection {
-		background: rgba(108, 128, 214, 0.28);
+		background: var(--selection);
+		color: var(--foreground);
 	}
 }
 
@@ -110,8 +213,69 @@ body::after {
 .app-sidebar-panel {
 	min-height: 0;
 	overflow: hidden;
-	border-right: 1px solid rgba(255, 255, 255, 0.06);
-	background: linear-gradient(180deg, rgba(24, 28, 38, 0.96), rgba(18, 21, 29, 0.98));
+	border-right: 1px solid var(--sidebar-border);
+	background: var(--sidebar-bg);
+}
+
+.app-workspace-shell {
+	background: var(--workspace-bg);
+}
+
+.composer-shell {
+	background-image: var(--composer-shell);
+}
+
+.composer-inner {
+	background-image: var(--composer-inner);
+	box-shadow: var(--composer-shadow);
+}
+
+.user-bubble {
+	background-image: var(--user-bubble);
+}
+
+.transcript-fade {
+	background-image: var(--transcript-fade);
+}
+
+.app-entry-shell {
+	background-color: var(--background);
+	background-image:
+		radial-gradient(ellipse 70% 55% at 85% 15%, oklch(0.72 0.1 230 / 0.14), transparent 58%),
+		radial-gradient(ellipse 50% 45% at 10% 85%, oklch(0.72 0.1 230 / 0.08), transparent 55%),
+		linear-gradient(180deg, oklch(0.97 0.01 130) 0%, var(--background) 42%, var(--background) 100%);
+}
+
+.app-entry-shell::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background-image:
+		linear-gradient(to right, oklch(0.18 0.02 260 / 0.045) 1px, transparent 1px),
+		linear-gradient(to bottom, oklch(0.18 0.02 260 / 0.045) 1px, transparent 1px);
+	background-size: 56px 56px;
+	mask-image: radial-gradient(ellipse 75% 70% at 50% 45%, black 20%, transparent 72%);
+}
+
+.mark-accent {
+	color: var(--accent-strong);
+	padding-inline: 0.2em;
+	border-radius: 0.25rem;
+	background-image: linear-gradient(var(--accent-soft), var(--accent-soft));
+	background-repeat: no-repeat;
+	background-size: 100% 0.72em;
+	background-position: 0 0.78em;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
+.mark-verb {
+	background-color: var(--mark);
+	border-radius: 0.15rem;
+	padding-inline: 0.15em;
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
 }
 
 .chat-markdown {
@@ -150,7 +314,7 @@ body::after {
 	line-height: 1.35;
 	font-weight: 600;
 	letter-spacing: -0.02em;
-	color: hsl(var(--foreground));
+	color: var(--foreground);
 }
 
 .chat-markdown h1 {
@@ -183,9 +347,9 @@ body::after {
 }
 
 .chat-markdown a {
-	color: hsl(var(--primary));
+	color: var(--accent-strong);
 	text-decoration: underline;
-	text-decoration-color: color-mix(in srgb, hsl(var(--primary)) 45%, transparent);
+	text-decoration-color: color-mix(in oklab, var(--accent-strong) 45%, transparent);
 	text-underline-offset: 0.16rem;
 }
 
@@ -194,39 +358,43 @@ body::after {
 }
 
 .chat-markdown blockquote {
-	border-left: 2px solid hsl(var(--border));
+	border-left: 2px solid var(--border);
 	padding-left: 0.9rem;
-	color: hsl(var(--muted-foreground));
+	color: var(--muted-foreground);
 }
 
 .chat-markdown :not(pre) > code {
-	border: 1px solid hsl(var(--border));
+	border: 1px solid var(--border);
 	border-radius: 0.5rem;
-	background: color-mix(in srgb, hsl(var(--muted)) 82%, hsl(var(--background)));
+	background: color-mix(in oklab, var(--muted) 82%, var(--background));
 	padding: 0.14rem 0.42rem;
-	font-family: 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-family: var(--font-mono);
 	font-size: 0.8em;
 }
 
 .chat-markdown pre {
 	overflow-x: auto;
-	border: 1px solid hsl(var(--border));
+	border: 1px solid var(--border);
 	border-radius: 1rem;
-	background: color-mix(in srgb, hsl(var(--background)) 82%, black);
+	background: color-mix(in oklab, var(--background) 82%, var(--foreground));
 	padding: 0.95rem 1rem;
+}
+
+[data-theme='light'] .chat-markdown pre {
+	background: color-mix(in oklab, var(--muted) 70%, var(--background));
 }
 
 .chat-markdown pre code {
 	background: transparent;
 	padding: 0;
-	font-family: 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-family: var(--font-mono);
 	font-size: 0.82rem;
 	line-height: 1.7;
 }
 
 .chat-markdown hr {
 	border: 0;
-	border-top: 1px solid hsl(var(--border));
+	border-top: 1px solid var(--border);
 	margin: 1rem 0;
 }
 
@@ -238,12 +406,12 @@ body::after {
 
 .chat-markdown th,
 .chat-markdown td {
-	border: 1px solid hsl(var(--border));
+	border: 1px solid var(--border);
 	padding: 0.5rem 0.65rem;
 	text-align: left;
 }
 
 .chat-markdown th {
-	background: color-mix(in srgb, hsl(var(--muted)) 88%, hsl(var(--background)));
+	background: color-mix(in oklab, var(--muted) 88%, var(--background));
 	font-weight: 600;
 }

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,10 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 	<head>
 		<title>web</title>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			// Boot light so entry shells (auth/pair/connecting) never flash dark.
+			// Workspace theme is applied after auth from localStorage / Convex.
+			(function () {
+				document.documentElement.dataset.theme = 'light';
+				document.documentElement.style.colorScheme = 'light';
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -7,7 +7,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<script>
 			// Boot light so entry shells (auth/pair/connecting) never flash dark.
-			// Workspace theme is applied after auth from localStorage / Convex.
+			// Workspace theme is applied after auth from Convex.
 			(function () {
 				document.documentElement.dataset.theme = 'light';
 				document.documentElement.style.colorScheme = 'light';

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -32,7 +32,8 @@ export default defineSchema({
 	}).index('by_userId', ['userId']),
 	uiPreferences: defineTable({
 		userId: v.string(),
-		lastThreadId: v.optional(v.id('threadRecords'))
+		lastThreadId: v.optional(v.id('threadRecords')),
+		theme: v.optional(v.union(v.literal('light'), v.literal('dark')))
 	}).index('by_userId', ['userId']),
 	workspaceSessions: defineTable({
 		userId: v.string(),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -33,7 +33,7 @@ export default defineSchema({
 	uiPreferences: defineTable({
 		userId: v.string(),
 		lastThreadId: v.optional(v.id('threadRecords')),
-		theme: v.optional(v.union(v.literal('light'), v.literal('dark')))
+		theme: v.union(v.literal('light'), v.literal('dark'))
 	}).index('by_userId', ['userId']),
 	workspaceSessions: defineTable({
 		userId: v.string(),

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -2,6 +2,8 @@ import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 
+const vTheme = v.union(v.literal('light'), v.literal('dark'));
+
 export const getMine = query({
 	args: {},
 	handler: async (ctx) => {
@@ -34,6 +36,32 @@ export const setLastThread = mutation({
 		const id = await ctx.db.insert('uiPreferences', {
 			userId,
 			lastThreadId: args.threadId
+		});
+		return await ctx.db.get(id);
+	}
+});
+
+export const setTheme = mutation({
+	args: {
+		theme: vTheme
+	},
+	handler: async (ctx, args) => {
+		const userId: string = await getUserId(ctx);
+		const existing = await ctx.db
+			.query('uiPreferences')
+			.withIndex('by_userId', (query) => query.eq('userId', userId))
+			.unique();
+
+		if (existing) {
+			await ctx.db.patch(existing._id, {
+				theme: args.theme
+			});
+			return await ctx.db.get(existing._id);
+		}
+
+		const id = await ctx.db.insert('uiPreferences', {
+			userId,
+			theme: args.theme
 		});
 		return await ctx.db.get(id);
 	}

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
+const DEFAULT_THEME = 'dark' as const;
 
 export const getMine = query({
 	args: {},
@@ -35,7 +36,8 @@ export const setLastThread = mutation({
 
 		const id = await ctx.db.insert('uiPreferences', {
 			userId,
-			lastThreadId: args.threadId
+			lastThreadId: args.threadId,
+			theme: DEFAULT_THEME
 		});
 		return await ctx.db.get(id);
 	}

--- a/apps/web/src/lib/components/brand-mark.svelte
+++ b/apps/web/src/lib/components/brand-mark.svelte
@@ -14,7 +14,7 @@
 
 <div class={cn('flex min-w-0 items-center gap-2', className)}>
 	<img src="/logo.png" alt="" class={cn('shrink-0', sizeClass)} />
-	<span class={cn('font-brand truncate font-normal tracking-tight text-white', textClass)}>
+	<span class={cn('font-brand text-foreground truncate font-semibold tracking-tight', textClass)}>
 		Sprocket
 	</span>
 </div>

--- a/apps/web/src/lib/components/home/auth-gate.svelte
+++ b/apps/web/src/lib/components/home/auth-gate.svelte
@@ -58,12 +58,12 @@
 <div inert={overlayOpen} aria-hidden={overlayOpen ? true : undefined}>
 	<CalmCentered title={headline} {description}>
 		{#if showError}
-			<p class="text-center text-sm text-rose-300" role="alert">{authState.error}</p>
+			<p class="text-destructive text-center text-sm" role="alert">{authState.error}</p>
 		{/if}
 
 		{#if authState.isLoading}
 			<div
-				class="flex items-center justify-center gap-2 text-sm text-slate-400"
+				class="text-muted-foreground flex items-center justify-center gap-2 text-sm"
 				aria-live="polite"
 				aria-busy="true"
 			>

--- a/apps/web/src/lib/components/home/browser-signin-overlay.svelte
+++ b/apps/web/src/lib/components/home/browser-signin-overlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Check, Copy, ExternalLink, LoaderCircle } from '@lucide/svelte';
 	import { tick } from 'svelte';
+	import Button from '$lib/components/ui/button/button.svelte';
 
 	type Props = {
 		open: boolean;
@@ -150,7 +151,7 @@
 
 {#if open}
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-[#0f1218]/92 px-6"
+		class="app-entry-shell fixed inset-0 z-50 flex items-center justify-center px-6"
 		role="presentation"
 		onclick={(event) => {
 			if (event.target === event.currentTarget) {
@@ -160,7 +161,7 @@
 	>
 		<div
 			bind:this={dialogEl}
-			class="w-full max-w-md text-center outline-none"
+			class="border-border/70 bg-surface relative z-10 w-full max-w-md rounded-2xl border p-8 text-center shadow-[0_18px_50px_-28px_oklch(0.2_0.02_260/0.45)] outline-none"
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="browser-signin-title"
@@ -168,24 +169,24 @@
 			tabindex="-1"
 		>
 			{#if !signInUrl}
-				<div class="mb-4 flex justify-center text-slate-400" aria-hidden="true">
+				<div class="text-muted-foreground mb-4 flex justify-center" aria-hidden="true">
 					<LoaderCircle class="size-5 animate-spin" />
 				</div>
 			{/if}
 
 			<h2
 				id="browser-signin-title"
-				class="text-[1.35rem] font-medium tracking-tight text-slate-200"
+				class="font-brand text-foreground text-[1.35rem] font-semibold tracking-tight"
 			>
 				{overlayCopy.title}
 			</h2>
-			<p id="browser-signin-desc" class="mt-3 text-sm leading-[1.55] text-slate-400">
+			<p id="browser-signin-desc" class="text-muted-foreground mt-3 text-sm leading-[1.55]">
 				{overlayCopy.description}
 			</p>
 
 			{#if signInUrl}
 				<p
-					class="mt-6 max-h-24 overflow-y-auto font-mono text-[11px] leading-5 break-all text-slate-500 select-all"
+					class="text-muted-foreground mt-6 max-h-24 overflow-y-auto font-mono text-[11px] leading-5 break-all select-all"
 					title={signInUrl}
 				>
 					{signInUrl}
@@ -193,27 +194,19 @@
 			{/if}
 
 			{#if error}
-				<p class="mt-4 text-sm text-rose-300" role="alert">{error}</p>
+				<p class="text-destructive mt-4 text-sm" role="alert">{error}</p>
 			{/if}
 			{#if copyError}
-				<p class="mt-4 text-sm text-amber-200" role="alert">{copyError}</p>
+				<p class="mt-4 text-sm text-amber-700" role="alert">{copyError}</p>
 			{/if}
 
 			<div class="mt-6 flex flex-wrap items-center justify-center gap-3">
 				{#if signInUrl}
-					<button
-						type="button"
-						class="inline-flex h-10 items-center justify-center gap-2 rounded-xl bg-white px-4 text-sm font-medium text-black transition hover:bg-slate-100"
-						onclick={openSignInUrl}
-					>
+					<Button onclick={openSignInUrl}>
 						<ExternalLink class="size-4" aria-hidden="true" />
 						Open browser
-					</button>
-					<button
-						type="button"
-						class="inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-white/12 px-4 text-sm text-slate-200 transition hover:bg-white/5"
-						onclick={() => void copySignInUrl()}
-					>
+					</Button>
+					<Button variant="outline" onclick={() => void copySignInUrl()}>
 						{#if copied}
 							<Check class="size-4" aria-hidden="true" />
 							Copied
@@ -221,10 +214,10 @@
 							<Copy class="size-4" aria-hidden="true" />
 							Copy link
 						{/if}
-					</button>
+					</Button>
 				{:else}
 					<span
-						class="inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-white/8 px-4 text-sm text-slate-500"
+						class="text-muted-foreground border-border inline-flex h-10 items-center justify-center gap-2 rounded-full border px-4 text-sm"
 					>
 						Preparing link…
 					</span>
@@ -234,7 +227,7 @@
 			<div class="mt-6">
 				<button
 					type="button"
-					class="text-[13px] text-slate-500 transition hover:text-slate-300"
+					class="text-muted-foreground hover:text-foreground decoration-foreground/30 hover:decoration-foreground text-[13px] underline underline-offset-4 transition-colors"
 					onclick={onCancel}
 				>
 					Cancel

--- a/apps/web/src/lib/components/home/calm-centered.svelte
+++ b/apps/web/src/lib/components/home/calm-centered.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import BrandMark from '$lib/components/brand-mark.svelte';
+	import { forceEntryTheme } from '$lib/theme';
 	import { cn } from '$lib/utils';
 
 	type Props = {
@@ -19,16 +21,18 @@
 		children,
 		actions
 	}: Props = $props();
+
+	onMount(() => forceEntryTheme());
 </script>
 
 <div
 	class={cn(
-		'flex min-h-screen items-center justify-center bg-[#0f1218] px-8 py-10 text-center',
+		'app-entry-shell relative flex min-h-screen items-center justify-center px-8 py-10 text-center',
 		className
 	)}
 >
 	<div
-		class="w-full max-w-md"
+		class="relative z-10 w-full max-w-md"
 		aria-busy={busy ? true : undefined}
 		aria-live={busy ? 'polite' : undefined}
 	>
@@ -36,13 +40,13 @@
 			<BrandMark />
 		</div>
 
-		<h1 class="text-[1.35rem] font-medium tracking-tight text-slate-200">{title}</h1>
+		<h1 class="font-brand text-foreground text-[1.5rem] font-semibold tracking-tight">{title}</h1>
 		{#if description}
-			<p class="mt-3 text-sm leading-[1.55] text-slate-400">{description}</p>
+			<p class="text-muted-foreground mt-3 text-sm leading-[1.55]">{description}</p>
 		{/if}
 
 		{#if children}
-			<div class="mt-5 space-y-4 [&:not(:has(*))]:mt-0 [&:not(:has(*))]:hidden">
+			<div class="mt-5 space-y-4 text-left [&:not(:has(*))]:mt-0 [&:not(:has(*))]:hidden">
 				{@render children()}
 			</div>
 		{/if}

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -378,31 +378,31 @@
 	});
 
 	const composerShellClass =
-		'mx-auto w-full max-w-[48rem] rounded-[28px] bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02))] p-px transition-colors duration-200';
+		'composer-shell mx-auto w-full max-w-[48rem] rounded-[28px] p-px transition-colors duration-200';
 	const composerInnerClass =
-		'rounded-[27px] border border-white/6 bg-[linear-gradient(180deg,rgba(35,35,38,0.98),rgba(28,28,30,0.98))] shadow-[0_24px_64px_rgba(0,0,0,0.28)] transition-colors duration-200';
+		'composer-inner rounded-[27px] border border-[var(--hairline)] transition-colors duration-200';
 </script>
 
 <footer class="shrink-0 px-6 py-4">
 	<div class="mx-auto max-w-336">
 		{#if elapsedLabel}
-			<div class="mb-3 flex items-center gap-2 px-4 text-[11px] text-slate-400">
+			<div class="text-muted-foreground mb-3 flex items-center gap-2 px-4 text-[11px]">
 				<span class="inline-flex items-center gap-0.75">
-					<span class="size-1 animate-pulse rounded-full bg-white/28"></span>
-					<span class="size-1 animate-pulse rounded-full bg-white/28 [animation-delay:200ms]"
+					<span class="bg-foreground/28 size-1 animate-pulse rounded-full"></span>
+					<span class="bg-foreground/28 size-1 animate-pulse rounded-full [animation-delay:200ms]"
 					></span>
-					<span class="size-1 animate-pulse rounded-full bg-white/28 [animation-delay:400ms]"
+					<span class="bg-foreground/28 size-1 animate-pulse rounded-full [animation-delay:400ms]"
 					></span>
 				</span>
 				<span>Working for {elapsedLabel}</span>
 			</div>
 		{:else if isSubmitting}
 			<div
-				class="mb-3 flex items-center gap-2 px-4 text-[11px] text-slate-400"
+				class="text-muted-foreground mb-3 flex items-center gap-2 px-4 text-[11px]"
 				role="status"
 				aria-live="polite"
 			>
-				<span class="size-1.5 animate-pulse rounded-full bg-white/28"></span>
+				<span class="bg-foreground/28 size-1.5 animate-pulse rounded-full"></span>
 				<span>{isStarting ? 'Starting agent…' : 'Sending request…'}</span>
 			</div>
 		{/if}
@@ -417,7 +417,7 @@
 									class="group relative size-14 overflow-hidden rounded-xl border {attachment.status ===
 									'error'
 										? 'border-rose-500/60'
-										: 'border-white/10'}"
+										: 'border-border'}"
 									title={attachment.error ?? attachment.name}
 								>
 									<img
@@ -434,12 +434,12 @@
 											aria-label="Uploading {attachment.name}"
 										>
 											<span
-												class="size-3.5 animate-spin rounded-full border-2 border-white/25 border-t-white/80"
+												class="border-border border-t-foreground/80 size-3.5 animate-spin rounded-full border-2"
 											></span>
 										</span>
 									{:else if attachment.status === 'error'}
 										<span
-											class="absolute inset-x-0 bottom-0 bg-rose-950/80 px-1 py-0.5 text-center text-[9px] leading-3 text-rose-200"
+											class="text-destructive absolute inset-x-0 bottom-0 bg-rose-950/80 px-1 py-0.5 text-center text-[9px] leading-3"
 											role="alert"
 										>
 											Failed
@@ -447,7 +447,7 @@
 									{/if}
 									<button
 										type="button"
-										class="absolute top-1 right-1 flex size-4.5 cursor-pointer items-center justify-center rounded-full bg-black/70 text-slate-200 transition hover:bg-black/90 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+										class="bg-foreground/70 text-background hover:bg-foreground/90 absolute top-1 right-1 flex size-4.5 cursor-pointer items-center justify-center rounded-full transition disabled:cursor-not-allowed disabled:opacity-40"
 										aria-label="Remove {attachment.name}"
 										disabled={isRunning || isSubmitting}
 										onclick={() => onRemoveAttachment(attachment.localId)}
@@ -461,7 +461,7 @@
 					<div class="relative min-h-0 flex-1">
 						{#if skillsPopupOpen}
 							<div
-								class="absolute inset-x-0 bottom-full z-30 mb-2 max-h-56 overflow-y-auto rounded-xl border border-white/10 bg-[#1c1c1f] py-1 shadow-2xl"
+								class="border-border bg-popover absolute inset-x-0 bottom-full z-30 mb-2 max-h-56 overflow-y-auto rounded-xl border py-1 shadow-2xl"
 								id="composer-skills-listbox"
 								aria-label="Available skills"
 								role={skillsLoadState === 'ready' && filteredSkills.length > 0
@@ -469,13 +469,13 @@
 									: 'status'}
 							>
 								{#if skillsLoadState === 'loading'}
-									<p class="px-3 py-2 text-sm text-slate-500">Loading skills…</p>
+									<p class="text-muted-foreground px-3 py-2 text-sm">Loading skills…</p>
 								{:else if skillsLoadState === 'error'}
 									<div class="flex items-center justify-between gap-3 px-3 py-2">
-										<p class="text-sm text-slate-500">Couldn’t load skills</p>
+										<p class="text-muted-foreground text-sm">Couldn’t load skills</p>
 										<button
 											type="button"
-											class="text-sm text-slate-300 underline-offset-2 hover:text-white hover:underline"
+											class="text-muted-foreground hover:text-foreground text-sm underline-offset-2 hover:underline"
 											onclick={() => {
 												void ensureSkillsLoaded(true);
 											}}
@@ -484,7 +484,7 @@
 										</button>
 									</div>
 								{:else if filteredSkills.length === 0}
-									<p class="px-3 py-2 text-sm text-slate-500">No matching skills</p>
+									<p class="text-muted-foreground px-3 py-2 text-sm">No matching skills</p>
 								{:else}
 									{#each filteredSkills as skill, index (skill.name)}
 										<button
@@ -493,8 +493,8 @@
 											id="composer-skill-option-{index}"
 											class={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition ${
 												highlightedIndex === index
-													? 'bg-white/8 text-white'
-													: 'text-slate-300 hover:bg-white/4 hover:text-white'
+													? 'text-foreground bg-[var(--hover-fill-strong)]'
+													: 'text-muted-foreground hover:text-foreground hover:bg-[var(--hover-fill)]'
 											}`}
 											role="option"
 											aria-selected={highlightedIndex === index}
@@ -506,7 +506,7 @@
 											}}
 										>
 											<span class="text-sm font-medium">${skill.name}</span>
-											<span class="line-clamp-2 text-[12px] text-slate-500"
+											<span class="text-muted-foreground line-clamp-2 text-[12px]"
 												>{skill.description}</span
 											>
 										</button>
@@ -518,7 +518,7 @@
 							bind:this={composerTextarea}
 							bind:value={prompt}
 							rows="1"
-							class="field-sizing-content max-h-40 min-h-17 w-full resize-none overflow-y-auto border-0 bg-transparent px-0 py-0 text-[14px] leading-6 text-slate-100 outline-none placeholder:text-slate-500"
+							class="text-foreground placeholder:text-muted-foreground field-sizing-content max-h-40 min-h-17 w-full resize-none overflow-y-auto border-0 bg-transparent px-0 py-0 text-[14px] leading-6 outline-none"
 							placeholder="Ask anything, @tag files/directories, or use $ to show available skills"
 							disabled={isRunning || isSubmitting}
 							role="combobox"
@@ -554,7 +554,7 @@
 							/>
 							<button
 								type="button"
-								class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-slate-400 transition enabled:cursor-pointer enabled:hover:text-slate-200 disabled:opacity-40"
+								class="text-muted-foreground enabled:hover:text-foreground flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition enabled:cursor-pointer disabled:opacity-40"
 								aria-label={attachTooltipLabel}
 								disabled={!canAttachMore}
 								onmouseenter={showAttachTooltip}
@@ -569,7 +569,9 @@
 								<ImagePlus class="size-4" aria-hidden="true" />
 							</button>
 
-							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>
+							<div
+								class="mx-1 hidden h-4 w-px shrink-0 bg-[var(--hover-fill-strong)] sm:block"
+							></div>
 
 							<OptionSelector
 								bind:value={selectedModel}
@@ -580,14 +582,16 @@
 								searchable
 								onValueChange={handleModelChange}
 								className="z-20 shrink-0"
-								triggerClassName="h-9 border-0 bg-transparent px-2 text-[15px] text-slate-200 shadow-none hover:bg-transparent focus-visible:ring-0"
+								triggerClassName="h-9 border-0 bg-transparent px-2 text-[15px] text-foreground shadow-none hover:bg-transparent focus-visible:ring-0"
 							>
 								{#snippet optionIcon(option)}
 									<ProviderLogo provider={option.provider} className="size-4 shrink-0" />
 								{/snippet}
 							</OptionSelector>
 
-							<div class="mx-1 hidden h-4 w-px shrink-0 bg-white/8 sm:block"></div>
+							<div
+								class="mx-1 hidden h-4 w-px shrink-0 bg-[var(--hover-fill-strong)] sm:block"
+							></div>
 
 							{#if selectedCatalogModel}
 								<ReasoningServiceSelector
@@ -604,40 +608,42 @@
 							<div class="group/context relative">
 								<button
 									type="button"
-									class="relative flex size-8 cursor-help items-center justify-center rounded-full focus-visible:ring-2 focus-visible:ring-blue-400/60 focus-visible:outline-none"
+									class="focus-visible:ring-ring/60 relative flex size-8 cursor-help items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
 									aria-label={`Context window ${contextPercent}% full`}
 									aria-describedby="context-window-details"
-									style={`background: conic-gradient(rgb(59 130 246) ${contextPercent * 3.6}deg, rgb(255 255 255 / 0.08) 0deg);`}
+									style={`background: conic-gradient(var(--accent) ${contextPercent * 3.6}deg, var(--hover-fill-strong) 0deg);`}
 									onkeydown={(event) => {
 										if (event.key === 'Escape') event.currentTarget.blur();
 									}}
 								>
-									<span class="size-5.5 rounded-full bg-[#202023]"></span>
+									<span class="bg-muted size-5.5 rounded-full"></span>
 								</button>
 								<div
 									id="context-window-details"
-									class="invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border border-white/9 bg-[#19191b] p-4 opacity-0 shadow-[0_18px_55px_rgba(0,0,0,0.45)] transition duration-150 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100"
+									class="border-border bg-popover invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border p-4 opacity-0 shadow-[var(--composer-shadow)] transition duration-150 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100"
 									role="tooltip"
 								>
 									<div class="flex items-center justify-between gap-4 text-[13px]">
-										<span class="font-medium text-slate-200">Context window</span>
-										<span class="text-slate-400"
+										<span class="text-foreground font-medium">Context window</span>
+										<span class="text-muted-foreground"
 											>{contextPercent}% · {formatTokens(contextUsage.inputTokens)}/{formatTokens(
 												contextUsage.contextWindowTokens
 											)}</span
 										>
 									</div>
-									<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-white/5">
+									<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--hover-fill)]">
 										<div
-											class="h-full rounded-full bg-blue-500 transition-[width] duration-300"
+											class="bg-accent h-full rounded-full transition-[width] duration-300"
 											style={`width: ${contextPercent}%`}
 										></div>
 									</div>
-									<div class="mt-3 flex items-center justify-between text-[12px] text-slate-500">
+									<div
+										class="text-muted-foreground mt-3 flex items-center justify-between text-[12px]"
+									>
 										<span>Total processed</span>
 										<span>{formatTokens(contextUsage.totalTokensProcessed)}</span>
 									</div>
-									<p class="mt-4 text-[12px] leading-5 text-slate-500">
+									<p class="text-muted-foreground mt-4 text-[12px] leading-5">
 										Sprocket automatically compacts context at about {contextCompactPercent}% so
 										long-running work can continue.
 									</p>
@@ -678,7 +684,7 @@
 
 {#if attachTooltip}
 	<div
-		class="pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md bg-[#1a1d27] px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap text-slate-100 shadow-lg ring-1 ring-white/10"
+		class="bg-tooltip text-tooltip-foreground ring-border pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap shadow-lg ring-1"
 		style={`top: ${attachTooltip.top}px; left: ${attachTooltip.left}px;`}
 		role="tooltip"
 	>

--- a/apps/web/src/lib/components/home/reasoning-disclosure.svelte
+++ b/apps/web/src/lib/components/home/reasoning-disclosure.svelte
@@ -31,10 +31,10 @@
 	}
 </script>
 
-<div class="text-sm text-slate-500">
+<div class="text-muted-foreground text-sm">
 	<button
 		type="button"
-		class="inline-flex items-center gap-1.5 text-slate-500 transition hover:text-slate-300"
+		class="text-muted-foreground hover:text-muted-foreground inline-flex items-center gap-1.5 transition"
 		onclick={toggle}
 		aria-expanded={expanded}
 	>
@@ -46,7 +46,7 @@
 		/>
 	</button>
 	{#if expanded}
-		<div class="mt-1.5 text-[13px] leading-6 whitespace-pre-wrap text-slate-400">
+		<div class="text-muted-foreground mt-1.5 text-[13px] leading-6 whitespace-pre-wrap">
 			{text}
 		</div>
 	{/if}

--- a/apps/web/src/lib/components/home/settings-account.svelte
+++ b/apps/web/src/lib/components/home/settings-account.svelte
@@ -5,13 +5,17 @@
 	import { api } from '$convex/_generated/api';
 	import { tierLabels } from '$convex/lib/tiers';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import type { SprocketTheme } from '$lib/theme';
+	import { cn } from '$lib/utils';
 
 	type Props = {
 		user: User | null;
+		theme: SprocketTheme;
+		onThemeChange: (theme: SprocketTheme) => void;
 		onSignOut: () => void;
 	};
 
-	let { user, onSignOut }: Props = $props();
+	let { user, theme, onThemeChange, onSignOut }: Props = $props();
 	let emailRevealed = $state(false);
 
 	const convexAuth = useAuth();
@@ -22,26 +26,33 @@
 	const displayName = $derived(
 		[user?.firstName, user?.lastName].filter(Boolean).join(' ').trim() || null
 	);
+
+	const themeOptions: ReadonlyArray<{ id: SprocketTheme; label: string }> = [
+		{ id: 'light', label: 'Light' },
+		{ id: 'dark', label: 'Dark' }
+	];
 </script>
 
 <section class="flex h-full min-h-0 flex-col overflow-hidden">
 	<header class="flex h-12 shrink-0 items-center px-6">
-		<h1 class="text-[1rem] font-medium tracking-[-0.03em] text-white">Account</h1>
+		<h1 class="text-foreground text-[1rem] font-medium tracking-[-0.03em]">Account</h1>
 	</header>
 
 	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
 		<div class="max-w-xl space-y-10">
 			<div>
-				<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Profile</p>
+				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
+					Profile
+				</p>
 				{#if displayName || user?.email}
 					<div class="mt-3 space-y-1">
 						{#if displayName}
-							<p class="text-[15px] text-white">{displayName}</p>
+							<p class="text-foreground text-[15px]">{displayName}</p>
 						{/if}
 						{#if user?.email}
 							<button
 								type="button"
-								class="block text-left text-sm text-slate-400 transition hover:text-slate-300"
+								class="text-muted-foreground hover:text-foreground block text-left text-sm transition"
 								aria-pressed={emailRevealed}
 								aria-label={emailRevealed ? 'Hide email address' : 'Show email address'}
 								onclick={() => {
@@ -55,26 +66,63 @@
 						{/if}
 					</div>
 				{:else}
-					<p class="mt-3 text-sm text-slate-400">You’re signed in to Sprocket.</p>
+					<p class="text-muted-foreground mt-3 text-sm">You’re signed in to Sprocket.</p>
 				{/if}
 			</div>
 
 			<div>
-				<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">
+				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
+					Appearance
+				</p>
+				<p class="text-muted-foreground mt-2 text-sm leading-6">
+					Choose the workspace theme. Sign-in and pairing screens always stay light.
+				</p>
+				<div
+					class="border-border bg-muted/60 mt-4 inline-flex rounded-full border p-1"
+					role="group"
+					aria-label="Workspace theme"
+				>
+					{#each themeOptions as option (option.id)}
+						<button
+							type="button"
+							class={cn(
+								'rounded-full px-4 py-1.5 text-sm font-medium transition',
+								theme === option.id
+									? 'bg-primary text-primary-foreground shadow-sm'
+									: 'text-muted-foreground hover:text-foreground'
+							)}
+							aria-pressed={theme === option.id}
+							onclick={() => onThemeChange(option.id)}
+						>
+							{option.label}
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<div>
+				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
 					Spikonado Subscription Tier
 				</p>
 				{#if subscriptionQuery.data}
-					<p class="mt-3 text-[15px] text-white">{tierLabels[subscriptionQuery.data.tier]}</p>
+					<p class="text-foreground mt-3 text-[15px]">{tierLabels[subscriptionQuery.data.tier]}</p>
 				{:else if subscriptionQuery.error}
-					<p class="mt-3 text-sm text-slate-500">Couldn’t load your subscription right now.</p>
+					<p class="text-muted-foreground mt-3 text-sm">
+						Couldn’t load your subscription right now.
+					</p>
 				{:else}
-					<div class="mt-3.5 h-4 w-16 animate-pulse rounded bg-white/5" aria-hidden="true"></div>
+					<div
+						class="mt-3.5 h-4 w-16 animate-pulse rounded bg-[var(--hover-fill)]"
+						aria-hidden="true"
+					></div>
 				{/if}
 			</div>
 
 			<div>
-				<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Session</p>
-				<p class="mt-2 text-sm leading-6 text-slate-400">
+				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
+					Session
+				</p>
+				<p class="text-muted-foreground mt-2 text-sm leading-6">
 					Sign out of this device. You’ll need to authenticate again to open your workspace.
 				</p>
 				<div class="mt-4">

--- a/apps/web/src/lib/components/home/settings-account.svelte
+++ b/apps/web/src/lib/components/home/settings-account.svelte
@@ -5,17 +5,13 @@
 	import { api } from '$convex/_generated/api';
 	import { tierLabels } from '$convex/lib/tiers';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import type { SprocketTheme } from '$lib/theme';
-	import { cn } from '$lib/utils';
 
 	type Props = {
 		user: User | null;
-		theme: SprocketTheme;
-		onThemeChange: (theme: SprocketTheme) => void;
 		onSignOut: () => void;
 	};
 
-	let { user, theme, onThemeChange, onSignOut }: Props = $props();
+	let { user, onSignOut }: Props = $props();
 	let emailRevealed = $state(false);
 
 	const convexAuth = useAuth();
@@ -26,11 +22,6 @@
 	const displayName = $derived(
 		[user?.firstName, user?.lastName].filter(Boolean).join(' ').trim() || null
 	);
-
-	const themeOptions: ReadonlyArray<{ id: SprocketTheme; label: string }> = [
-		{ id: 'light', label: 'Light' },
-		{ id: 'dark', label: 'Dark' }
-	];
 </script>
 
 <section class="flex h-full min-h-0 flex-col overflow-hidden">
@@ -68,36 +59,6 @@
 				{:else}
 					<p class="text-muted-foreground mt-3 text-sm">You’re signed in to Sprocket.</p>
 				{/if}
-			</div>
-
-			<div>
-				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
-					Appearance
-				</p>
-				<p class="text-muted-foreground mt-2 text-sm leading-6">
-					Choose the workspace theme. Sign-in and pairing screens always stay light.
-				</p>
-				<div
-					class="border-border bg-muted/60 mt-4 inline-flex rounded-full border p-1"
-					role="group"
-					aria-label="Workspace theme"
-				>
-					{#each themeOptions as option (option.id)}
-						<button
-							type="button"
-							class={cn(
-								'rounded-full px-4 py-1.5 text-sm font-medium transition',
-								theme === option.id
-									? 'bg-primary text-primary-foreground shadow-sm'
-									: 'text-muted-foreground hover:text-foreground'
-							)}
-							aria-pressed={theme === option.id}
-							onclick={() => onThemeChange(option.id)}
-						>
-							{option.label}
-						</button>
-					{/each}
-				</div>
 			</div>
 
 			<div>

--- a/apps/web/src/lib/components/home/settings-archived.svelte
+++ b/apps/web/src/lib/components/home/settings-archived.svelte
@@ -19,26 +19,26 @@
 
 <section class="flex h-full min-h-0 flex-col overflow-hidden">
 	<header class="flex h-12 shrink-0 items-center px-6">
-		<h1 class="text-[1rem] font-medium tracking-[-0.03em] text-white">Archived Threads</h1>
+		<h1 class="text-foreground text-[1rem] font-medium tracking-[-0.03em]">Archived Threads</h1>
 	</header>
 
 	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
-		<p class="mb-6 max-w-xl text-sm leading-6 text-slate-500">
+		<p class="text-muted-foreground mb-6 max-w-xl text-sm leading-6">
 			We may permanently delete archived threads from our database at any time.
 		</p>
 		{#if archivedThreads.length === 0}
-			<p class="max-w-xl text-sm leading-6 text-slate-500">No archived threads.</p>
+			<p class="text-muted-foreground max-w-xl text-sm leading-6">No archived threads.</p>
 		{:else}
 			<ul class="max-w-xl space-y-1">
 				{#each archivedThreads as thread (thread.threadId)}
 					<li class="group flex items-center gap-3 py-2">
 						<div class="min-w-0 flex-1">
-							<p class="truncate text-[14px] text-slate-200">{thread.title}</p>
-							<p class="truncate text-[12px] text-slate-500">{thread.workspaceName}</p>
+							<p class="text-foreground truncate text-[14px]">{thread.title}</p>
+							<p class="text-muted-foreground truncate text-[12px]">{thread.workspaceName}</p>
 						</div>
 						<button
 							type="button"
-							class="shrink-0 px-1 text-[12px] text-slate-500 opacity-0 transition group-hover:opacity-100 hover:text-slate-300 focus-visible:opacity-100"
+							class="text-muted-foreground hover:text-muted-foreground shrink-0 px-1 text-[12px] opacity-0 transition group-hover:opacity-100 focus-visible:opacity-100"
 							onclick={() => {
 								onRestore(thread.threadId);
 							}}

--- a/apps/web/src/lib/components/home/settings-sidebar.svelte
+++ b/apps/web/src/lib/components/home/settings-sidebar.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
 	import { Archive, ArrowLeft, ChartNoAxesColumn, UserRound } from '@lucide/svelte';
+	import SidebarTopActions from '$lib/components/home/sidebar-top-actions.svelte';
+	import type { SprocketTheme } from '$lib/theme';
 
 	export type SettingsPage = 'account' | 'usage' | 'archived';
 
 	type Props = {
 		activePage: SettingsPage;
+		theme: SprocketTheme;
+		onThemeChange: (theme: SprocketTheme) => void;
 		onBack: () => void;
 		onNavigate: (page: SettingsPage) => void;
 	};
 
-	let { activePage, onBack, onNavigate }: Props = $props();
+	let { activePage, theme, onThemeChange, onBack, onNavigate }: Props = $props();
 
 	const navItems: ReadonlyArray<{ id: SettingsPage; label: string; icon: typeof UserRound }> = [
 		{ id: 'account', label: 'Account', icon: UserRound },
@@ -26,7 +30,7 @@
 
 <aside class="app-sidebar-panel">
 	<div class="flex h-full min-h-0 flex-col overflow-hidden">
-		<div class="px-3.5 pt-3 pb-3">
+		<div class="flex items-center justify-between gap-2 px-3.5 pt-3 pb-3">
 			<button
 				type="button"
 				class="text-muted-foreground hover:text-foreground inline-flex h-8 items-center gap-2 rounded-lg px-2 text-[13px] transition hover:bg-[var(--hover-fill)]"
@@ -35,6 +39,7 @@
 				<ArrowLeft class="size-3.5" aria-hidden="true" />
 				Back
 			</button>
+			<SidebarTopActions {theme} {onThemeChange} />
 		</div>
 
 		<nav

--- a/apps/web/src/lib/components/home/settings-sidebar.svelte
+++ b/apps/web/src/lib/components/home/settings-sidebar.svelte
@@ -19,8 +19,9 @@
 
 	const navItemClass =
 		'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-[13px] transition';
-	const navItemActiveClass = 'bg-white/8 text-white';
-	const navItemIdleClass = 'text-slate-300 hover:bg-white/5 hover:text-white';
+	const navItemActiveClass = 'bg-[var(--hover-fill-strong)] text-foreground';
+	const navItemIdleClass =
+		'text-muted-foreground hover:bg-[var(--hover-fill)] hover:text-foreground';
 </script>
 
 <aside class="app-sidebar-panel">
@@ -28,7 +29,7 @@
 		<div class="px-3.5 pt-3 pb-3">
 			<button
 				type="button"
-				class="inline-flex h-8 items-center gap-2 rounded-lg px-2 text-[13px] text-slate-300 transition hover:bg-white/5 hover:text-white"
+				class="text-muted-foreground hover:text-foreground inline-flex h-8 items-center gap-2 rounded-lg px-2 text-[13px] transition hover:bg-[var(--hover-fill)]"
 				onclick={onBack}
 			>
 				<ArrowLeft class="size-3.5" aria-hidden="true" />
@@ -49,7 +50,7 @@
 						onNavigate(item.id);
 					}}
 				>
-					<item.icon class="size-4 shrink-0 text-slate-400" aria-hidden="true" />
+					<item.icon class="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
 					<span class="truncate">{item.label}</span>
 				</button>
 			{/each}

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -48,31 +48,31 @@
 		if (nearLimit) {
 			return 'bg-amber-400/90';
 		}
-		return 'bg-slate-200/90';
+		return 'bg-foreground/25';
 	}
 </script>
 
 <section class="flex h-full min-h-0 flex-col overflow-hidden">
 	<header class="flex h-12 shrink-0 items-center px-6">
-		<h1 class="text-[1rem] font-medium tracking-[-0.03em] text-white">Usage</h1>
+		<h1 class="text-foreground text-[1rem] font-medium tracking-[-0.03em]">Usage</h1>
 	</header>
 
 	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
 		<div class="max-w-xl space-y-10">
 			{#if usageQuery.error}
-				<p class="text-sm leading-6 text-slate-500">
+				<p class="text-muted-foreground text-sm leading-6">
 					Couldn’t load your usage right now. Try again in a moment.
 				</p>
 			{:else if usageQuery.isLoading || usageQuery.data === undefined}
 				<div class="animate-pulse space-y-10" aria-hidden="true">
-					<div class="h-4 w-24 rounded bg-white/5"></div>
+					<div class="h-4 w-24 rounded bg-[var(--hover-fill)]"></div>
 					{#each usageMeters as meter (meter.id)}
 						<div class="space-y-5">
-							<div class="h-3 w-28 rounded bg-white/5"></div>
+							<div class="h-3 w-28 rounded bg-[var(--hover-fill)]"></div>
 							{#each usagePeriods as period (period)}
 								<div class="space-y-2">
-									<div class="h-3.5 w-full rounded bg-white/5"></div>
-									<div class="h-1.5 w-full rounded-full bg-white/5"></div>
+									<div class="h-3.5 w-full rounded bg-[var(--hover-fill)]"></div>
+									<div class="h-1.5 w-full rounded-full bg-[var(--hover-fill)]"></div>
 								</div>
 							{/each}
 						</div>
@@ -80,17 +80,21 @@
 				</div>
 			{:else}
 				<div>
-					<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">Subscription Tier</p>
-					<p class="mt-3 text-[15px] text-white">
+					<p class="text-muted-foreground text-[11px] tracking-[0.18em] uppercase">
+						Subscription Tier
+					</p>
+					<p class="text-foreground mt-3 text-[15px]">
 						{tierLabels[usageQuery.data.tier]}
 					</p>
 				</div>
 
 				{#each usageQuery.data.meters as meter (meter.id)}
 					<div>
-						<p class="text-[11px] tracking-[0.18em] text-slate-500 uppercase">{meter.label}</p>
+						<p class="text-muted-foreground text-[11px] tracking-[0.18em] uppercase">
+							{meter.label}
+						</p>
 						{#if meter.description}
-							<p class="mt-1 text-[12px] text-slate-500">{meter.description}</p>
+							<p class="text-muted-foreground mt-1 text-[12px]">{meter.description}</p>
 						{/if}
 						<div class="mt-4 space-y-6">
 							{#each meter.windows as meterWindow (meterWindow.period)}
@@ -102,22 +106,24 @@
 								{@const nearLimit = hasLimit && meterWindow.used >= meterWindow.limit * 0.9}
 								<div>
 									<div class="flex items-baseline justify-between gap-3">
-										<p class="text-[13px] text-slate-300">{periodLabels[meterWindow.period]}</p>
+										<p class="text-muted-foreground text-[13px]">
+											{periodLabels[meterWindow.period]}
+										</p>
 										{#if hasLimit}
 											<p
-												class={`text-[12px] ${atLimit ? 'text-rose-300' : nearLimit ? 'text-amber-300' : 'text-slate-500'}`}
+												class={`text-[12px] ${atLimit ? 'text-destructive' : nearLimit ? 'text-amber-800 dark:text-amber-300' : 'text-muted-foreground'}`}
 											>
 												{percent}% used
 											</p>
 										{/if}
 									</div>
-									<p class="mt-0.5 text-[12px] text-slate-500">
+									<p class="text-muted-foreground mt-0.5 text-[12px]">
 										{compactAmount.format(hasLimit ? meterWindow.used : 0)} / {compactAmount.format(
 											hasLimit ? meterWindow.limit : 0
 										)}
 									</p>
 									<div
-										class="mt-2 h-1.5 overflow-hidden rounded-full bg-white/5"
+										class="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--hover-fill)]"
 										role="progressbar"
 										aria-label={`${meter.label} — ${periodLabels[meterWindow.period]}`}
 										aria-valuemin={0}
@@ -131,7 +137,7 @@
 										></div>
 									</div>
 									{#if meterWindow.resetsAt !== null}
-										<p class="mt-1.5 text-[12px] text-slate-500">
+										<p class="text-muted-foreground mt-1.5 text-[12px]">
 											Resets in {formatResetsIn(meterWindow.resetsAt)}
 										</p>
 									{/if}

--- a/apps/web/src/lib/components/home/sidebar-top-actions.svelte
+++ b/apps/web/src/lib/components/home/sidebar-top-actions.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { Moon, Sun } from '@lucide/svelte';
+	import type { SprocketTheme } from '$lib/theme';
+
+	type Props = {
+		theme: SprocketTheme;
+		onThemeChange: (theme: SprocketTheme) => void;
+	};
+
+	let { theme, onThemeChange }: Props = $props();
+</script>
+
+<button
+	type="button"
+	class="text-muted-foreground hover:text-foreground inline-flex size-7 shrink-0 items-center justify-center rounded-md transition hover:bg-[var(--hover-fill)]"
+	aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+	title={theme === 'dark' ? 'Light mode' : 'Dark mode'}
+	onclick={() => onThemeChange(theme === 'dark' ? 'light' : 'dark')}
+>
+	{#if theme === 'dark'}
+		<Sun class="size-3.5" aria-hidden="true" />
+	{:else}
+		<Moon class="size-3.5" aria-hidden="true" />
+	{/if}
+</button>

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -275,7 +275,7 @@
 	}
 
 	const userMessageClass =
-		'w-fit max-w-[33rem] rounded-xl border border-white/7 bg-[linear-gradient(180deg,rgba(39,39,42,0.96),rgba(28,28,30,0.96))] px-5 py-3.5 text-[15.5px] leading-7 text-slate-100';
+		'user-bubble w-fit max-w-[33rem] rounded-xl border border-[var(--hairline)] px-5 py-3.5 text-[15.5px] leading-7 text-foreground';
 
 	let viewerImage = $state<ViewerImage | null>(null);
 
@@ -352,7 +352,7 @@
 			{#if currentError}
 				<div
 					role="alert"
-					class="mb-6 rounded-2xl border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100"
+					class="text-destructive mb-6 rounded-2xl border border-rose-500/20 bg-rose-500/10 px-4 py-3 text-sm"
 				>
 					{currentError}
 				</div>
@@ -361,7 +361,7 @@
 			{#if runError}
 				<div
 					role="alert"
-					class="mb-6 rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-100"
+					class="mb-6 rounded-2xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
 				>
 					{runError}
 				</div>
@@ -370,9 +370,9 @@
 			{#if messages.length === 0}
 				<div class="flex flex-1 items-center justify-center">
 					<div class="max-w-2xl text-center">
-						<p class="text-sm leading-7 text-slate-500">{emptyStateMessage}</p>
+						<p class="text-muted-foreground text-sm leading-7">{emptyStateMessage}</p>
 						{#if emptyStateHint}
-							<p class="mt-3 text-xs tracking-[0.16em] text-slate-600 uppercase">
+							<p class="text-muted-foreground mt-3 text-xs tracking-[0.16em] uppercase">
 								{emptyStateHint}
 							</p>
 						{/if}
@@ -394,7 +394,7 @@
 													{@const url = attachment.url}
 													<button
 														type="button"
-														class="block size-14 cursor-zoom-in overflow-hidden rounded-xl border border-white/10 transition hover:border-white/25 focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:outline-none"
+														class="border-border hover:border-border focus-visible:ring-ring/40 block size-14 cursor-zoom-in overflow-hidden rounded-xl border transition focus-visible:ring-2 focus-visible:outline-none"
 														aria-label="View {attachment.name}"
 														title={attachment.name}
 														onclick={() => {
@@ -409,7 +409,7 @@
 													</button>
 												{:else}
 													<span
-														class="inline-flex items-center rounded-xl border border-white/7 bg-white/4 px-3 py-2 text-xs text-slate-400"
+														class="text-muted-foreground inline-flex items-center rounded-xl border border-[var(--hairline)] bg-[var(--hover-fill)] px-3 py-2 text-xs"
 													>
 														{attachment.name} (unavailable)
 													</span>
@@ -420,13 +420,13 @@
 								{/if}
 								{#if message.text || !message.attachments.length}
 									<div class={userMessageClass}>
-										<ChatMarkdown content={message.text || ' '} className="text-slate-100" />
+										<ChatMarkdown content={message.text || ' '} className="text-foreground" />
 									</div>
 								{/if}
 								{#if message.text}
 									<button
 										type="button"
-										class="inline-flex size-6 items-center justify-center rounded-md text-slate-600 transition hover:text-slate-400"
+										class="text-muted-foreground hover:text-muted-foreground inline-flex size-6 items-center justify-center rounded-md transition"
 										aria-label={copiedMessageId === message._id ? 'Copied' : 'Copy message'}
 										onclick={() => {
 											void copyUserMessage(message._id, message.text);
@@ -469,11 +469,11 @@
 							>
 								<div class="space-y-3">
 									{#if !hasPersistedAssistantContent && (message.text || (isStreaming && timeline.length === 0))}
-										<ChatMarkdown content={message.text || '...'} className="text-slate-200" />
+										<ChatMarkdown content={message.text || '...'} className="text-foreground" />
 									{/if}
 									{#each sections as section, sectionIndex (`${section.type}-${section.type === 'work' ? section.key : section.id}-${sectionIndex}`)}
 										{#if section.type === 'text'}
-											<ChatMarkdown content={section.text || ' '} className="text-slate-200" />
+											<ChatMarkdown content={section.text || ' '} className="text-foreground" />
 										{:else}
 											{@const { settledBlocks, runningTools } = partitionWorkSectionTools(
 												section.blocks,
@@ -532,8 +532,8 @@
 																				<span class={toolSummaryClass(tool)}>{toolSummary}</span>
 																				<span
 																					class={toolFailureKind === 'failed'
-																						? 'text-rose-200'
-																						: 'text-amber-200'}
+																						? 'text-destructive'
+																						: 'text-amber-800 dark:text-amber-200'}
 																				>
 																					({toolFailureKind})
 																				</span>
@@ -541,8 +541,8 @@
 																			<p
 																				class="mt-1.5 text-xs leading-5 wrap-break-word whitespace-pre-wrap {toolFailureKind ===
 																				'failed'
-																					? 'text-rose-200'
-																					: 'text-amber-200'}"
+																					? 'text-destructive'
+																					: 'text-amber-800 dark:text-amber-200'}"
 																				role="status"
 																			>
 																				{toolError}
@@ -578,7 +578,7 @@
 															title={`${toolSummary} (running)`}
 														>
 															<ToolIcon
-																class="mt-1.5 size-3 shrink-0 text-slate-500"
+																class="text-muted-foreground mt-1.5 size-3 shrink-0"
 																aria-hidden="true"
 															/>
 															<span class={toolSummaryClass(tool)}>{toolSummary}</span>
@@ -589,7 +589,7 @@
 										{/if}
 									{/each}
 									{#if !isStreaming && message.runCompletedAt !== undefined}
-										<p class="text-sm text-slate-500">
+										<p class="text-muted-foreground text-sm">
 											Worked for {formatElapsedDuration(
 												Math.max(
 													0,
@@ -607,9 +607,7 @@
 		</div>
 	</div>
 
-	<div
-		class="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-[linear-gradient(180deg,rgba(15,15,17,0),rgba(15,15,17,0.68)_48%,rgba(15,15,17,0.92))]"
-	></div>
+	<div class="transcript-fade pointer-events-none absolute inset-x-0 bottom-0 h-16"></div>
 </div>
 
 <ImageViewer

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -275,7 +275,7 @@
 	}
 
 	const userMessageClass =
-		'user-bubble w-fit max-w-[33rem] rounded-xl border border-[var(--hairline)] px-5 py-3.5 text-[15.5px] leading-7 text-foreground';
+		'user-bubble w-fit max-w-[33rem] rounded-xl border px-5 py-3.5 text-[15.5px] leading-7 text-foreground';
 
 	let viewerImage = $state<ViewerImage | null>(null);
 

--- a/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
+++ b/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
@@ -25,10 +25,10 @@
 	}
 </script>
 
-<div class="text-sm text-slate-500">
+<div class="text-muted-foreground text-sm">
 	<button
 		type="button"
-		class="inline-flex items-center gap-1.5 text-slate-500 transition hover:text-slate-300"
+		class="text-muted-foreground hover:text-muted-foreground inline-flex items-center gap-1.5 transition"
 		onclick={toggle}
 		aria-expanded={expanded}
 	>
@@ -40,7 +40,7 @@
 		/>
 	</button>
 	{#if expanded}
-		<div class="mt-1.5 space-y-1.5 text-[13px] leading-6 text-slate-400">
+		<div class="text-muted-foreground mt-1.5 space-y-1.5 text-[13px] leading-6">
 			{#each tools as tool (tool.callId)}
 				{@render toolRow(tool)}
 			{/each}

--- a/apps/web/src/lib/components/home/work-disclosure.svelte
+++ b/apps/web/src/lib/components/home/work-disclosure.svelte
@@ -60,10 +60,10 @@
 	}
 </script>
 
-<div class="text-sm text-slate-500">
+<div class="text-muted-foreground text-sm">
 	<button
 		type="button"
-		class="inline-flex items-center gap-1 text-slate-500 transition hover:text-slate-300"
+		class="text-muted-foreground hover:text-muted-foreground inline-flex items-center gap-1 transition"
 		onclick={toggle}
 		aria-expanded={expanded}
 	>

--- a/apps/web/src/lib/components/home/workspace-picker.svelte
+++ b/apps/web/src/lib/components/home/workspace-picker.svelte
@@ -241,7 +241,7 @@
 
 {#if open}
 	<div
-		class="fixed inset-0 z-50 flex items-start justify-center bg-black/50 px-4 pt-[10vh] backdrop-blur-[2px]"
+		class="bg-overlay fixed inset-0 z-50 flex items-start justify-center px-4 pt-[10vh] backdrop-blur-[2px]"
 		role="presentation"
 		onclick={(event) => {
 			if (event.target === event.currentTarget) {
@@ -250,21 +250,21 @@
 		}}
 	>
 		<div
-			class="flex max-h-[min(32rem,70vh)] w-full max-w-xl min-w-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#1c1c1f] text-white shadow-2xl"
+			class="border-border bg-popover text-foreground flex max-h-[min(32rem,70vh)] w-full max-w-xl min-w-0 flex-col overflow-hidden rounded-2xl border shadow-2xl"
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="workspace-picker-title"
 			tabindex="-1"
 			onkeydown={handleDialogKeydown}
 		>
-			<div class="border-b border-white/8 px-2.5 py-1.5">
+			<div class="border-b border-[var(--hairline)] px-2.5 py-1.5">
 				<div class="relative flex items-center">
-					<div class="pointer-events-none flex items-center ps-2 text-slate-500">
+					<div class="text-muted-foreground pointer-events-none flex items-center ps-2">
 						<FolderPlus class="size-4" />
 					</div>
 					<input
 						id="workspace-picker-title"
-						class="min-w-0 flex-1 bg-transparent py-2 ps-2 pe-28 text-sm text-white outline-none placeholder:text-slate-500"
+						class="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent py-2 ps-2 pe-28 text-sm outline-none"
 						bind:value={query}
 						placeholder="Enter project path (e.g. ~/projects/my-robot)"
 						autocomplete="off"
@@ -272,12 +272,12 @@
 					/>
 					{#if isLoadingBrowse}
 						<LoaderCircle
-							class="pointer-events-none absolute inset-e-24 top-1/2 size-4 -translate-y-1/2 animate-spin text-slate-500"
+							class="text-muted-foreground pointer-events-none absolute inset-e-24 top-1/2 size-4 -translate-y-1/2 animate-spin"
 						/>
 					{/if}
 					<button
 						type="button"
-						class="absolute inset-e-2 top-1/2 -translate-y-1/2 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[12px] text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+						class="border-border text-foreground absolute inset-e-2 top-1/2 -translate-y-1/2 rounded-md border bg-[var(--hover-fill)] px-2 py-1 text-[12px] transition hover:bg-[var(--hover-fill-strong)] disabled:cursor-not-allowed disabled:opacity-40"
 						disabled={!canSubmit || isSubmitting}
 						onclick={() => {
 							void confirmSelection();
@@ -287,18 +287,18 @@
 					</button>
 				</div>
 				{#if mode === 'reconnect' && expectedWorkspaceName}
-					<p class="px-2 pb-1 text-[11px] text-slate-500">
-						Reconnect <span class="text-slate-300">{expectedWorkspaceName}</span> to a local directory
+					<p class="text-muted-foreground px-2 pb-1 text-[11px]">
+						Reconnect <span class="text-muted-foreground">{expectedWorkspaceName}</span> to a local directory
 					</p>
 				{/if}
 			</div>
 
 			{#if recentWorkspaces.length > 0}
-				<div class="flex flex-wrap gap-1.5 border-b border-white/6 px-3 py-2">
+				<div class="flex flex-wrap gap-1.5 border-b border-[var(--hairline)] px-3 py-2">
 					{#each recentWorkspaces as recent (recent.workspacePath)}
 						<button
 							type="button"
-							class="rounded-md px-2 py-0.5 text-[11px] text-slate-400 transition hover:bg-white/6 hover:text-slate-200"
+							class="text-muted-foreground hover:text-foreground rounded-md px-2 py-0.5 text-[11px] transition hover:bg-[var(--hover-fill)]"
 							onclick={() => {
 								selectRecentWorkspace(recent);
 							}}
@@ -311,7 +311,7 @@
 
 			<div class="min-h-0 flex-1 overflow-y-auto py-1" role="listbox" aria-label="Directories">
 				{#if displayedEntries.length === 0}
-					<p class="px-3 py-8 text-center text-sm text-slate-500">
+					<p class="text-muted-foreground px-3 py-8 text-center text-sm">
 						{emptyListMessage}
 					</p>
 				{:else}
@@ -320,8 +320,8 @@
 							type="button"
 							class={`flex min-h-8 w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition ${
 								highlightedPath === entry.fullPath
-									? 'bg-white/8 text-white'
-									: 'text-slate-300 hover:bg-white/4 hover:text-white'
+									? 'text-foreground bg-[var(--hover-fill-strong)]'
+									: 'text-muted-foreground hover:text-foreground hover:bg-[var(--hover-fill)]'
 							}`}
 							role="option"
 							aria-selected={highlightedPath === entry.fullPath}
@@ -330,9 +330,9 @@
 							}}
 						>
 							{#if entry.name === '..'}
-								<CornerLeftUp class="size-4 shrink-0 text-slate-500" />
+								<CornerLeftUp class="text-muted-foreground size-4 shrink-0" />
 							{:else}
-								<Folder class="size-4 shrink-0 text-slate-500" />
+								<Folder class="text-muted-foreground size-4 shrink-0" />
 							{/if}
 							<span class="truncate">{entry.name}</span>
 						</button>
@@ -341,13 +341,13 @@
 			</div>
 
 			{#if errorMessage}
-				<p class="border-t border-rose-500/20 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+				<p class="text-destructive border-t border-rose-500/20 bg-rose-500/10 px-3 py-2 text-sm">
 					{errorMessage}
 				</p>
 			{/if}
 
 			<footer
-				class="flex items-center justify-between gap-3 border-t border-white/8 px-3 py-2 text-[11px] text-slate-500"
+				class="text-muted-foreground flex items-center justify-between gap-3 border-t border-[var(--hairline)] px-3 py-2 text-[11px]"
 			>
 				<div class="flex flex-wrap items-center gap-3">
 					<span>↑↓ Navigate</span>
@@ -356,7 +356,7 @@
 				</div>
 				<button
 					type="button"
-					class="text-slate-400 transition hover:text-slate-200"
+					class="text-muted-foreground hover:text-foreground transition"
 					onclick={onClose}
 					disabled={isSubmitting}
 				>

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { Archive, ChevronRight, Folder, FolderOpen, Settings, SquarePen } from '@lucide/svelte';
 	import BrandMark from '$lib/components/brand-mark.svelte';
+	import SidebarTopActions from '$lib/components/home/sidebar-top-actions.svelte';
 	import type { Id } from '$convex/_generated/dataModel';
+	import type { SprocketTheme } from '$lib/theme';
 	import type { ThreadSummary, WorkspaceThreadGroup } from '$lib/types/sprocket';
 	import { isAgentLaunchPending, type PendingAgentLaunches } from '$lib/workspace/threads';
 
@@ -10,6 +12,8 @@
 		currentThreadId: Id<'threadRecords'> | null;
 		groups: WorkspaceThreadGroup[];
 		pendingAgentLaunches?: PendingAgentLaunches;
+		theme: SprocketTheme;
+		onThemeChange: (theme: SprocketTheme) => void;
 		onChooseWorkspace: () => void;
 		onReconnectWorkspace: (workspaceSessionId: Id<'workspaceSessions'>) => void;
 		onOpenSettings: () => void;
@@ -24,6 +28,8 @@
 		currentThreadId,
 		groups,
 		pendingAgentLaunches = {},
+		theme,
+		onThemeChange,
 		onChooseWorkspace,
 		onReconnectWorkspace,
 		onOpenSettings,
@@ -186,8 +192,9 @@
 
 <aside class="app-sidebar-panel">
 	<div class="flex h-full min-h-0 flex-col overflow-hidden">
-		<header class="flex items-center px-3.5 pt-3 pb-4">
+		<header class="flex items-center justify-between gap-2 px-3.5 pt-3 pb-4">
 			<BrandMark size="sm" class="min-w-0" />
+			<SidebarTopActions {theme} {onThemeChange} />
 		</header>
 
 		<div class="px-3.5 pb-1">

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -35,8 +35,8 @@
 
 	const DEFAULT_VISIBLE_THREAD_COUNT = 3;
 	const sidebarActionButtonClass =
-		'flex h-9 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium tracking-[-0.02em] text-slate-200 transition hover:bg-white/5 hover:text-white';
-	const sidebarActionIconClass = 'size-4 shrink-0 text-slate-400';
+		'flex h-9 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium tracking-[-0.02em] text-foreground transition hover:bg-[var(--hover-fill)] hover:text-foreground';
+	const sidebarActionIconClass = 'size-4 shrink-0 text-muted-foreground';
 	let expandedProjects = $state<Record<string, boolean>>({});
 	let collapsedProjects = $state<Record<string, boolean>>({});
 	let hoveredThreadTitle = $state<string | null>(null);
@@ -199,12 +199,12 @@
 
 		<div class="hide-scrollbar min-h-0 flex-1 overflow-y-auto px-2.5 py-3">
 			<div class="mb-3 px-2">
-				<p class="text-[10px] tracking-[0.24em] text-slate-500 uppercase">Projects</p>
+				<p class="text-muted-foreground text-[10px] tracking-[0.24em] uppercase">Projects</p>
 			</div>
 
 			{#if groups.length === 0}
 				<div
-					class="rounded-3xl border border-dashed border-white/8 bg-white/2 px-4 py-4 text-sm leading-6 text-slate-400"
+					class="text-muted-foreground rounded-3xl border border-dashed border-[var(--hairline)] bg-[var(--hover-fill)] px-4 py-4 text-sm leading-6"
 				>
 					Choose a project to start organizing threads.
 				</div>
@@ -218,8 +218,8 @@
 									type="button"
 									class={`flex min-w-0 flex-1 items-center gap-2 rounded-xl px-2 py-1 pr-8 text-left transition ${
 										group.workspaceName === currentWorkspaceName
-											? 'text-white'
-											: 'text-slate-300 hover:text-white'
+											? 'text-foreground'
+											: 'text-muted-foreground hover:text-foreground'
 									}`}
 									onclick={() => {
 										toggleProjectCollapsed(group.key);
@@ -229,11 +229,11 @@
 										: `Collapse ${group.workspaceName} threads`}
 								>
 									<ChevronRight
-										class={`size-3 shrink-0 text-slate-500 transition-transform ${
+										class={`text-muted-foreground size-3 shrink-0 transition-transform ${
 											isProjectCollapsed(group.key) ? '' : 'rotate-90'
 										}`}
 									/>
-									<Folder class="size-4 shrink-0 text-slate-500" />
+									<Folder class="text-muted-foreground size-4 shrink-0" />
 									<p class="truncate text-[0.88rem] font-medium tracking-[-0.02em]">
 										{group.workspaceName}
 									</p>
@@ -241,8 +241,8 @@
 										<span
 											class={`rounded-full px-1.5 py-0.5 text-[10px] ${
 												group.localWorkspaceAvailability === 'unavailable'
-													? 'border border-amber-500/20 bg-amber-500/10 text-amber-100'
-													: 'border border-sky-500/20 bg-sky-500/10 text-sky-100'
+													? 'border border-amber-500/25 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+													: 'border border-sky-500/25 bg-sky-500/10 text-sky-800 dark:text-sky-200'
 											}`}
 										>
 											{statusLabel}
@@ -250,7 +250,7 @@
 									{/if}
 									{#if group.activeThreadCount > 0}
 										<span
-											class="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-1.5 py-0.5 text-[10px] text-emerald-200"
+											class="rounded-full border border-emerald-500/25 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-800 dark:text-emerald-200"
 										>
 											{group.activeThreadCount}
 										</span>
@@ -259,7 +259,7 @@
 
 								<button
 									type="button"
-									class="absolute top-0.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md text-slate-500 opacity-0 transition group-hover:opacity-100 hover:bg-white/6 hover:text-white focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+									class="text-muted-foreground hover:text-foreground absolute top-0.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md opacity-0 transition group-hover:opacity-100 hover:bg-[var(--hover-fill)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
 									onclick={() => {
 										if (group.localWorkspaceAvailability === 'available') {
 											onStartThreadDraft(group.workspaceName);
@@ -283,9 +283,9 @@
 							</div>
 
 							{#if !isProjectCollapsed(group.key)}
-								<div class="ml-5 border-l border-white/6 pl-3">
+								<div class="ml-5 border-l border-[var(--hairline)] pl-3">
 									{#if group.localWorkspaceAvailability === 'unavailable' || group.localWorkspaceAvailability === 'unlinked'}
-										<p class="pb-2 text-[12px] leading-5 text-slate-500">
+										<p class="text-muted-foreground pb-2 text-[12px] leading-5">
 											{group.localWorkspaceError ??
 												(group.localWorkspaceAvailability === 'unlinked'
 													? 'This project needs a local directory attached before you can use it.'
@@ -293,7 +293,7 @@
 										</p>
 									{/if}
 									{#if group.threads.length === 0}
-										<p class="py-1.5 text-[12px] text-slate-500">No threads yet</p>
+										<p class="text-muted-foreground py-1.5 text-[12px]">No threads yet</p>
 									{:else}
 										{@const projectExpanded = isProjectExpanded(group.key)}
 										{@const visibleThreads = projectExpanded
@@ -319,7 +319,7 @@
 														<input
 															bind:this={renameInput}
 															bind:value={renameDraft}
-															class="h-9 w-full rounded-lg border border-white/10 bg-white/5 px-2 text-[13px] text-white outline-none focus:border-white/20"
+															class="border-border text-foreground focus:border-ring h-9 w-full rounded-lg border bg-[var(--hover-fill)] px-2 text-[13px] outline-none"
 															aria-label="Rename thread"
 															onkeydown={(event) => {
 																if (event.key === 'Escape') {
@@ -337,7 +337,9 @@
 														<button
 															type="button"
 															class={`${sidebarActionButtonClass} pr-8 ${
-																isSelected ? 'bg-white/5 text-white' : 'text-slate-400'
+																isSelected
+																	? 'text-foreground bg-[var(--hover-fill)]'
+																	: 'text-muted-foreground'
 															}`}
 															aria-current={isSelected ? 'page' : undefined}
 															onmouseenter={(event) => {
@@ -370,7 +372,7 @@
 														</button>
 														<button
 															type="button"
-															class={`absolute top-1.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md text-slate-500 transition hover:bg-white/6 hover:text-white focus-visible:opacity-100 ${
+															class={`text-muted-foreground hover:text-foreground absolute top-1.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md transition hover:bg-[var(--hover-fill)] focus-visible:opacity-100 ${
 																isSelected
 																	? 'opacity-100'
 																	: 'opacity-0 group-focus-within/thread:opacity-100 group-hover/thread:opacity-100'
@@ -391,7 +393,7 @@
 											{#if hasHiddenThreads}
 												<button
 													type="button"
-													class="px-2 py-1 text-[12px] text-slate-500 transition hover:text-slate-300"
+													class="text-muted-foreground hover:text-muted-foreground px-2 py-1 text-[12px] transition"
 													onclick={() => {
 														toggleProjectExpanded(group.key);
 													}}
@@ -420,7 +422,7 @@
 
 {#if hoveredThreadTitle && hoveredThreadTooltip && !contextMenu && !renamingThreadId}
 	<div
-		class="pointer-events-none fixed z-100 max-w-64 -translate-y-1/2 rounded-md bg-[#1a1d27] px-2.5 py-1.5 text-[12px] leading-4 text-slate-100 shadow-lg ring-1 ring-white/10"
+		class="bg-tooltip text-tooltip-foreground ring-border pointer-events-none fixed z-100 max-w-64 -translate-y-1/2 rounded-md px-2.5 py-1.5 text-[12px] leading-4 shadow-lg ring-1"
 		style={`top: ${hoveredThreadTooltip.top}px; left: ${hoveredThreadTooltip.left}px;`}
 		role="tooltip"
 	>
@@ -431,13 +433,13 @@
 {#if contextMenu}
 	<div
 		data-thread-context-menu
-		class="fixed z-110 min-w-36 rounded-lg border border-white/8 bg-[#1a1d27] py-1 shadow-xl"
+		class="bg-popover text-popover-foreground fixed z-110 min-w-36 rounded-lg border border-[var(--hairline)] py-1 shadow-xl"
 		style={`top: ${contextMenu.y}px; left: ${contextMenu.x}px;`}
 		role="menu"
 	>
 		<button
 			type="button"
-			class="flex w-full px-3 py-1.5 text-left text-[13px] text-slate-200 transition hover:bg-white/6 hover:text-white"
+			class="text-foreground hover:text-foreground flex w-full px-3 py-1.5 text-left text-[13px] transition hover:bg-[var(--hover-fill)]"
 			role="menuitem"
 			onclick={() => {
 				beginRename(contextMenu!.threadId, contextMenu!.title);

--- a/apps/web/src/lib/components/image-viewer.svelte
+++ b/apps/web/src/lib/components/image-viewer.svelte
@@ -236,13 +236,13 @@
 	}
 
 	const actionButtonClass =
-		'inline-flex size-9 items-center justify-center rounded-lg border border-white/15 bg-black/65 text-slate-100 shadow-lg backdrop-blur-sm transition hover:bg-black/80 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none aria-disabled:cursor-wait aria-disabled:opacity-60';
+		'inline-flex size-9 items-center justify-center rounded-lg border border-white/15 bg-black/65 text-white shadow-lg backdrop-blur-sm transition hover:bg-black/80 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none aria-disabled:cursor-wait aria-disabled:opacity-60';
 </script>
 
 {#if image}
 	{@const current = image}
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-[#0f1218]/92 px-3 py-4 sm:px-6 sm:py-12"
+		class="bg-background/92 fixed inset-0 z-50 flex items-center justify-center px-3 py-4 sm:px-6 sm:py-12"
 		role="presentation"
 		onclick={(event) => {
 			if (event.target === event.currentTarget) {
@@ -261,7 +261,7 @@
 			<img
 				src={current.url}
 				alt={current.name}
-				class="block max-h-[calc(100dvh-2rem)] max-w-full rounded-2xl border border-white/10 object-contain sm:max-h-[calc(100dvh-6rem)]"
+				class="border-border block max-h-[calc(100dvh-2rem)] max-w-full rounded-2xl border object-contain sm:max-h-[calc(100dvh-6rem)]"
 			/>
 
 			<div class="absolute right-3 bottom-3 flex items-center gap-2">
@@ -308,7 +308,7 @@
 
 			{#if copyError || downloadError}
 				<p
-					class="absolute right-3 bottom-14 max-w-[min(20rem,calc(100%-1.5rem))] rounded-lg border border-white/10 bg-black/80 px-3 py-2 text-xs text-amber-100 shadow-lg backdrop-blur-sm"
+					class="border-border absolute right-3 bottom-14 max-w-[min(20rem,calc(100%-1.5rem))] rounded-lg border bg-black/80 px-3 py-2 text-xs text-amber-100 shadow-lg backdrop-blur-sm"
 					role="alert"
 				>
 					{copyError ?? downloadError}

--- a/apps/web/src/lib/components/option-selector.svelte
+++ b/apps/web/src/lib/components/option-selector.svelte
@@ -167,7 +167,7 @@
 		bind:this={triggerElement}
 		type="button"
 		class={cn(
-			'focus-visible:ring-ring/60 inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-transparent bg-transparent px-2 text-sm font-medium text-slate-300 transition outline-none hover:bg-white/[0.03] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
+			'focus-visible:ring-ring/60 text-muted-foreground inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-transparent bg-transparent px-2 text-sm font-medium transition outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
 			!optionIcon && 'gap-1',
 			triggerClassName
 		)}
@@ -182,24 +182,29 @@
 		{/if}
 		<span class="truncate">{selectedOption?.triggerLabel ?? selectedOption?.label ?? value}</span>
 		<ChevronDown
-			class={cn('size-3 shrink-0 text-slate-500 transition-transform', isOpen && 'rotate-180')}
+			class={cn(
+				'text-muted-foreground size-3 shrink-0 transition-transform',
+				isOpen && 'rotate-180'
+			)}
 		/>
 	</button>
 
 	{#if isOpen}
 		<div
-			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[19rem] rounded-[18px] border border-white/8 p-2 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[19rem] rounded-[18px] border border-[var(--hairline)] p-2 shadow-[var(--composer-shadow)] backdrop-blur-xl"
 			role="dialog"
 			aria-label={menuTitle}
 		>
 			{#if searchable}
-				<label class="flex h-10 items-center gap-2 border-b border-white/6 px-2 text-slate-400">
+				<label
+					class="text-muted-foreground flex h-10 items-center gap-2 border-b border-[var(--hairline)] px-2"
+				>
 					<Search class="size-4 shrink-0" />
 					<span class="sr-only">Search {menuTitle.toLocaleLowerCase()}</span>
 					<input
 						bind:this={searchElement}
 						bind:value={searchQuery}
-						class="min-w-0 flex-1 bg-transparent text-sm text-slate-100 outline-none placeholder:text-slate-500"
+						class="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-sm outline-none"
 						placeholder={`Search ${menuTitle.toLocaleLowerCase()}…`}
 						onkeydown={handleSearchKeydown}
 					/>
@@ -215,8 +220,8 @@
 						type="button"
 						class={cn(
 							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left outline-none focus-visible:ring-2',
-							locked ? 'cursor-not-allowed opacity-45' : 'hover:bg-white/4',
-							!locked && option.id === value && 'bg-white/[0.035]'
+							locked ? 'cursor-not-allowed opacity-45' : 'hover:bg-[var(--hover-fill)]',
+							!locked && option.id === value && 'bg-[var(--hover-fill)]'
 						)}
 						aria-pressed={!locked && option.id === value}
 						aria-disabled={locked}
@@ -239,7 +244,7 @@
 							<span
 								class={cn(
 									'flex size-7 shrink-0 items-center justify-center',
-									locked ? 'text-slate-500' : 'text-slate-300'
+									locked ? 'text-muted-foreground' : 'text-muted-foreground'
 								)}
 							>
 								{@render optionIcon(option)}
@@ -248,17 +253,17 @@
 						<span
 							class={cn(
 								'min-w-0 flex-1 truncate text-sm font-medium',
-								locked ? 'text-slate-400' : 'text-slate-100'
+								locked ? 'text-muted-foreground' : 'text-foreground'
 							)}>{option.label}</span
 						>
 						{#if locked}
-							<span class="shrink-0 text-slate-500" aria-hidden="true">
+							<span class="text-muted-foreground shrink-0" aria-hidden="true">
 								<Lock class="size-3.5" />
 							</span>
 						{:else}
 							<Check
 								class={cn(
-									'size-4 shrink-0 text-blue-400 transition-opacity',
+									'text-accent-strong size-4 shrink-0 transition-opacity',
 									option.id === value ? 'opacity-100' : 'opacity-0'
 								)}
 							/>
@@ -266,7 +271,7 @@
 					</button>
 				{/each}
 				{#if filteredOptions.length === 0}
-					<p class="px-3 py-5 text-center text-sm text-slate-500">No matches found</p>
+					<p class="text-muted-foreground px-3 py-5 text-center text-sm">No matches found</p>
 				{/if}
 			</div>
 		</div>
@@ -275,7 +280,7 @@
 
 {#if lockTooltip}
 	<div
-		class="pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md bg-[#1a1d27] px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap text-slate-100 shadow-lg ring-1 ring-white/10"
+		class="text-tooltip-foreground bg-tooltip ring-border pointer-events-none fixed z-100 -translate-x-1/2 -translate-y-full rounded-md px-2.5 py-1.5 text-[12px] leading-4 whitespace-nowrap shadow-lg ring-1"
 		style={`top: ${lockTooltip.top}px; left: ${lockTooltip.left}px;`}
 		role="tooltip"
 	>

--- a/apps/web/src/lib/components/provider-logo.svelte
+++ b/apps/web/src/lib/components/provider-logo.svelte
@@ -12,7 +12,7 @@
 </script>
 
 {#if provider === 'openai'}
-	<OpenAiBlossom className={cn('size-4 text-white', className)} />
+	<OpenAiBlossom className={cn('size-4 text-foreground', className)} />
 {:else if provider === 'anthropic'}
 	<svg
 		viewBox="0 0 24 24"
@@ -28,7 +28,7 @@
 {:else if provider === 'xai'}
 	<svg
 		viewBox="0 0 24 24"
-		class={cn('size-4 text-white', className)}
+		class={cn('text-foreground size-4', className)}
 		role="img"
 		aria-label="xAI"
 		fill="currentColor"
@@ -40,7 +40,7 @@
 {:else}
 	<svg
 		viewBox="0 0 24 24"
-		class={cn('size-4 text-slate-400', className)}
+		class={cn('text-muted-foreground size-4', className)}
 		role="img"
 		aria-label={provider || 'Unknown provider'}
 		fill="none"

--- a/apps/web/src/lib/components/reasoning-service-selector.svelte
+++ b/apps/web/src/lib/components/reasoning-service-selector.svelte
@@ -82,7 +82,7 @@
 	<button
 		bind:this={triggerElement}
 		type="button"
-		class="focus-visible:ring-ring/60 inline-flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-[15px] text-slate-300 transition outline-none hover:bg-white/[0.03] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
+		class="focus-visible:ring-ring/60 text-muted-foreground inline-flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-[15px] transition outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
 		aria-haspopup="dialog"
 		aria-expanded={isOpen}
 		aria-label="Select reasoning effort and service tier"
@@ -93,22 +93,25 @@
 	>
 		<span>{reasoningEffortLabel(reasoningEffort)} · {serviceTierLabel(serviceTier)}</span>
 		<ChevronDown
-			class={cn('size-3 shrink-0 text-slate-500 transition-transform', isOpen && 'rotate-180')}
+			class={cn(
+				'text-muted-foreground size-3 shrink-0 transition-transform',
+				isOpen && 'rotate-180'
+			)}
 		/>
 	</button>
 
 	{#if isOpen}
 		<div
-			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[15rem] rounded-[18px] border border-white/8 p-2 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+			class="bg-popover/96 absolute bottom-[calc(100%+0.75rem)] left-0 z-50 min-w-[15rem] rounded-[18px] border border-[var(--hairline)] p-2 shadow-[var(--composer-shadow)] backdrop-blur-xl"
 			role="dialog"
 			aria-label="Reasoning and service tier"
 		>
-			<p class="px-3 pt-1 pb-1.5 text-[11px] font-medium text-slate-500">Reasoning</p>
+			<p class="text-muted-foreground px-3 pt-1 pb-1.5 text-[11px] font-medium">Reasoning</p>
 			<div class="space-y-0.5">
 				{#each model.reasoningEfforts as effort (effort)}
 					<button
 						type="button"
-						class="focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-slate-100 outline-none hover:bg-white/4 focus-visible:ring-2"
+						class="focus-visible:ring-ring/60 text-foreground flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2"
 						aria-pressed={effort === reasoningEffort}
 						onclick={() => selectReasoning(effort)}
 					>
@@ -120,19 +123,19 @@
 						/>
 						<span>{reasoningEffortLabel(effort)}</span>
 						{#if effort === model.defaultReasoningEffort}
-							<span class="ml-auto text-xs text-slate-500">Default</span>
+							<span class="text-muted-foreground ml-auto text-xs">Default</span>
 						{/if}
 					</button>
 				{/each}
 			</div>
 
-			<div class="mx-2 my-2 h-px bg-white/6"></div>
-			<p class="px-3 pb-1.5 text-[11px] font-medium text-slate-500">Service tier</p>
+			<div class="mx-2 my-2 h-px bg-[var(--hairline)]"></div>
+			<p class="text-muted-foreground px-3 pb-1.5 text-[11px] font-medium">Service tier</p>
 			<div class="space-y-0.5">
 				{#each model.serviceTiers as tier (tier)}
 					<button
 						type="button"
-						class="focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm text-slate-100 outline-none hover:bg-white/4 focus-visible:ring-2"
+						class="focus-visible:ring-ring/60 text-foreground flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2"
 						aria-pressed={tier === serviceTier}
 						onclick={() => selectServiceTier(tier)}
 					>
@@ -145,7 +148,7 @@
 						{#if tier === 'fast'}<Zap class="size-3.5 text-amber-400" />{/if}
 						<span>{serviceTierLabel(tier)}</span>
 						{#if tier === model.serviceTiers[0]}
-							<span class="ml-auto text-xs text-slate-500">Default</span>
+							<span class="text-muted-foreground ml-auto text-xs">Default</span>
 						{/if}
 					</button>
 				{/each}

--- a/apps/web/src/lib/components/ui/button/button.svelte
+++ b/apps/web/src/lib/components/ui/button/button.svelte
@@ -21,8 +21,8 @@
 
 	const variantClass = $derived(
 		variant === 'outline'
-			? 'border-border/90 bg-background/30 text-foreground hover:border-white/14 hover:bg-white/4'
-			: 'bg-primary text-primary-foreground hover:bg-primary/92'
+			? 'border-border bg-surface/80 text-foreground hover:bg-[var(--hover-fill)]'
+			: 'bg-primary text-primary-foreground hover:opacity-90'
 	);
 </script>
 
@@ -30,7 +30,7 @@
 	{type}
 	{disabled}
 	class={cn(
-		'focus-visible:ring-ring/70 inline-flex h-10 items-center justify-center rounded-xl border border-transparent px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+		'focus-visible:ring-ring/50 inline-flex h-10 items-center justify-center gap-2 rounded-full border border-transparent px-5 py-2 text-sm font-medium transition-opacity focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
 		variantClass,
 		className
 	)}

--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	DEFAULT_THEME,
+	applyTheme,
+	forceEntryTheme,
+	isSprocketTheme,
+	persistTheme,
+	resolveTheme,
+	THEME_STORAGE_KEY
+} from './theme';
+
+function stubDocument(theme: string | undefined = undefined) {
+	const dataset: Record<string, string> = {};
+	if (theme) dataset.theme = theme;
+	const style: { colorScheme: string } = { colorScheme: '' };
+	vi.stubGlobal('document', {
+		documentElement: { dataset, style }
+	});
+	return { dataset, style };
+}
+
+describe('theme helpers', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('accepts only light and dark themes', () => {
+		expect(isSprocketTheme('light')).toBe(true);
+		expect(isSprocketTheme('dark')).toBe(true);
+		expect(isSprocketTheme('system')).toBe(false);
+		expect(isSprocketTheme(null)).toBe(false);
+	});
+
+	it('resolves an explicit preference first', () => {
+		expect(resolveTheme('light')).toBe('light');
+		expect(resolveTheme('dark')).toBe('dark');
+	});
+
+	it('falls back to stored theme, then the default', () => {
+		vi.stubGlobal('localStorage', {
+			getItem: (key: string) => (key === THEME_STORAGE_KEY ? 'light' : null),
+			setItem: () => {},
+			removeItem: () => {},
+			clear: () => {},
+			key: () => null,
+			length: 0
+		} satisfies Storage);
+
+		expect(resolveTheme(null)).toBe('light');
+		expect(resolveTheme(undefined)).toBe('light');
+
+		vi.stubGlobal('localStorage', {
+			getItem: () => null,
+			setItem: () => {},
+			removeItem: () => {},
+			clear: () => {},
+			key: () => null,
+			length: 0
+		} satisfies Storage);
+
+		expect(resolveTheme(null)).toBe(DEFAULT_THEME);
+	});
+
+	it('parks applyTheme while entry theme is forced, then restores on last release', () => {
+		const { dataset, style } = stubDocument('dark');
+		const releaseA = forceEntryTheme();
+		const releaseB = forceEntryTheme();
+
+		try {
+			expect(dataset.theme).toBe('light');
+			expect(style.colorScheme).toBe('light');
+
+			applyTheme('dark');
+			expect(dataset.theme).toBe('light');
+
+			persistTheme('light');
+			expect(dataset.theme).toBe('light');
+
+			releaseA();
+			expect(dataset.theme).toBe('light');
+
+			releaseB();
+			expect(dataset.theme).toBe('light');
+			expect(style.colorScheme).toBe('light');
+		} finally {
+			releaseA();
+			releaseB();
+		}
+	});
+});

--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,13 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-	DEFAULT_THEME,
-	applyTheme,
-	forceEntryTheme,
-	isSprocketTheme,
-	persistTheme,
-	resolveTheme,
-	THEME_STORAGE_KEY
-} from './theme';
+import { DEFAULT_THEME, applyTheme, forceEntryTheme, isSprocketTheme, resolveTheme } from './theme';
 
 function stubDocument(theme: string | undefined = undefined) {
 	const dataset: Record<string, string> = {};
@@ -32,34 +24,11 @@ describe('theme helpers', () => {
 		expect(isSprocketTheme(null)).toBe(false);
 	});
 
-	it('resolves an explicit preference first', () => {
+	it('resolves an explicit preference first, otherwise the default', () => {
 		expect(resolveTheme('light')).toBe('light');
 		expect(resolveTheme('dark')).toBe('dark');
-	});
-
-	it('falls back to stored theme, then the default', () => {
-		vi.stubGlobal('localStorage', {
-			getItem: (key: string) => (key === THEME_STORAGE_KEY ? 'light' : null),
-			setItem: () => {},
-			removeItem: () => {},
-			clear: () => {},
-			key: () => null,
-			length: 0
-		} satisfies Storage);
-
-		expect(resolveTheme(null)).toBe('light');
-		expect(resolveTheme(undefined)).toBe('light');
-
-		vi.stubGlobal('localStorage', {
-			getItem: () => null,
-			setItem: () => {},
-			removeItem: () => {},
-			clear: () => {},
-			key: () => null,
-			length: 0
-		} satisfies Storage);
-
 		expect(resolveTheme(null)).toBe(DEFAULT_THEME);
+		expect(resolveTheme(undefined)).toBe(DEFAULT_THEME);
 	});
 
 	it('parks applyTheme while entry theme is forced, then restores on last release', () => {
@@ -74,7 +43,7 @@ describe('theme helpers', () => {
 			applyTheme('dark');
 			expect(dataset.theme).toBe('light');
 
-			persistTheme('light');
+			applyTheme('light');
 			expect(dataset.theme).toBe('light');
 
 			releaseA();

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,85 @@
+export type SprocketTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'sprocket-theme';
+export const DEFAULT_THEME: SprocketTheme = 'dark';
+
+export function isSprocketTheme(value: unknown): value is SprocketTheme {
+	return value === 'light' || value === 'dark';
+}
+
+export function readStoredTheme(): SprocketTheme | null {
+	if (typeof localStorage === 'undefined') {
+		return null;
+	}
+
+	try {
+		const stored = localStorage.getItem(THEME_STORAGE_KEY);
+		return isSprocketTheme(stored) ? stored : null;
+	} catch {
+		return null;
+	}
+}
+
+export function resolveTheme(preference: SprocketTheme | null | undefined): SprocketTheme {
+	return preference ?? readStoredTheme() ?? DEFAULT_THEME;
+}
+
+let entryThemeDepth = 0;
+let themeBeforeEntry: SprocketTheme | null = null;
+
+function writeTheme(theme: SprocketTheme): void {
+	document.documentElement.dataset.theme = theme;
+	document.documentElement.style.colorScheme = theme;
+}
+
+export function applyTheme(theme: SprocketTheme): void {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	if (entryThemeDepth > 0) {
+		// Keep entry shells light; remember the preferred theme for restore.
+		themeBeforeEntry = theme;
+		return;
+	}
+
+	writeTheme(theme);
+}
+
+export function persistTheme(theme: SprocketTheme): void {
+	applyTheme(theme);
+
+	if (typeof localStorage === 'undefined') {
+		return;
+	}
+
+	try {
+		localStorage.setItem(THEME_STORAGE_KEY, theme);
+	} catch {
+		// Ignore quota / private-mode failures; in-memory theme still applies.
+	}
+}
+
+/** Force light theme for entry shells; restores the previous theme when the last shell unmounts. */
+export function forceEntryTheme(): () => void {
+	if (typeof document === 'undefined') {
+		return () => {};
+	}
+
+	if (entryThemeDepth === 0) {
+		themeBeforeEntry = isSprocketTheme(document.documentElement.dataset.theme)
+			? document.documentElement.dataset.theme
+			: resolveTheme(null);
+		writeTheme('light');
+	}
+	entryThemeDepth += 1;
+
+	return () => {
+		entryThemeDepth = Math.max(0, entryThemeDepth - 1);
+		if (entryThemeDepth === 0) {
+			const restore = themeBeforeEntry ?? resolveTheme(null);
+			themeBeforeEntry = null;
+			writeTheme(restore);
+		}
+	};
+}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,27 +1,13 @@
 export type SprocketTheme = 'light' | 'dark';
 
-export const THEME_STORAGE_KEY = 'sprocket-theme';
 export const DEFAULT_THEME: SprocketTheme = 'dark';
 
 export function isSprocketTheme(value: unknown): value is SprocketTheme {
 	return value === 'light' || value === 'dark';
 }
 
-export function readStoredTheme(): SprocketTheme | null {
-	if (typeof localStorage === 'undefined') {
-		return null;
-	}
-
-	try {
-		const stored = localStorage.getItem(THEME_STORAGE_KEY);
-		return isSprocketTheme(stored) ? stored : null;
-	} catch {
-		return null;
-	}
-}
-
 export function resolveTheme(preference: SprocketTheme | null | undefined): SprocketTheme {
-	return preference ?? readStoredTheme() ?? DEFAULT_THEME;
+	return preference ?? DEFAULT_THEME;
 }
 
 let entryThemeDepth = 0;
@@ -44,20 +30,6 @@ export function applyTheme(theme: SprocketTheme): void {
 	}
 
 	writeTheme(theme);
-}
-
-export function persistTheme(theme: SprocketTheme): void {
-	applyTheme(theme);
-
-	if (typeof localStorage === 'undefined') {
-		return;
-	}
-
-	try {
-		localStorage.setItem(THEME_STORAGE_KEY, theme);
-	} catch {
-		// Ignore quota / private-mode failures; in-memory theme still applies.
-	}
 }
 
 /** Force light theme for entry shells; restores the previous theme when the last shell unmounts. */

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -81,7 +81,7 @@
 		resolveDesktopApi
 	} from '$lib/local/client';
 	import { resolve } from '$app/paths';
-	import { isSprocketTheme, persistTheme, resolveTheme, type SprocketTheme } from '$lib/theme';
+	import { applyTheme, resolveTheme, type SprocketTheme } from '$lib/theme';
 	import type {
 		DesktopApi,
 		ThreadMessage,
@@ -378,26 +378,25 @@
 	let hasHydratedTheme = false;
 	let lastServerTheme: SprocketTheme | null | undefined = undefined;
 	let pendingTheme: SprocketTheme | null = null;
+	let themeSaveGeneration = 0;
 
 	$effect(() => {
 		if (!authReady) {
 			hasHydratedTheme = false;
 			lastServerTheme = undefined;
 			pendingTheme = null;
+			themeSaveGeneration = 0;
 			return;
 		}
 
 		const preferences = uiPreferencesQuery.data;
 
-		// Apply local preference as soon as the workspace mounts (boot script stays light for entry).
+		// Wait for Convex before applying a workspace theme (boot script stays light for entry).
 		if (preferences === undefined) {
-			const localTheme = resolveTheme(null);
-			workspaceTheme = localTheme;
-			persistTheme(localTheme);
 			return;
 		}
 
-		// Ignore preference snapshots while a local theme save is in flight.
+		// Ignore preference snapshots while a theme save is in flight.
 		if (pendingTheme !== null) {
 			return;
 		}
@@ -409,25 +408,34 @@
 		hasHydratedTheme = true;
 		lastServerTheme = serverTheme;
 
-		const nextTheme = isSprocketTheme(serverTheme) ? serverTheme : resolveTheme(null);
+		const nextTheme = resolveTheme(serverTheme);
 		workspaceTheme = nextTheme;
-		persistTheme(nextTheme);
+		applyTheme(nextTheme);
 	});
 
 	async function handleThemeChange(theme: SprocketTheme) {
 		const previous = workspaceTheme;
+		const generation = ++themeSaveGeneration;
 		pendingTheme = theme;
 		workspaceTheme = theme;
-		persistTheme(theme);
+		applyTheme(theme);
 		try {
 			await setThemePreference({ theme });
+			if (generation !== themeSaveGeneration) {
+				return;
+			}
 			lastServerTheme = theme;
 		} catch (error) {
+			if (generation !== themeSaveGeneration) {
+				return;
+			}
 			workspaceTheme = previous;
-			persistTheme(previous);
+			applyTheme(previous);
 			currentError = error instanceof Error ? error.message : 'Failed to save theme preference.';
 		} finally {
-			pendingTheme = null;
+			if (generation === themeSaveGeneration) {
+				pendingTheme = null;
+			}
 		}
 	}
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1831,6 +1831,8 @@
 			{#if settingsOpen}
 				<SettingsSidebar
 					activePage={settingsPage}
+					theme={workspaceTheme}
+					onThemeChange={(theme) => void handleThemeChange(theme)}
 					onBack={() => {
 						settingsOpen = false;
 						settingsPage = 'account';
@@ -1845,6 +1847,8 @@
 					{currentThreadId}
 					groups={groupedWorkspaceThreads}
 					{pendingAgentLaunches}
+					theme={workspaceTheme}
+					onThemeChange={(theme) => void handleThemeChange(theme)}
 					onChooseWorkspace={() => {
 						openWorkspacePicker('add');
 					}}
@@ -1878,12 +1882,7 @@
 					{:else if settingsPage === 'usage'}
 						<SettingsUsage />
 					{:else}
-						<SettingsAccount
-							user={$authState.user}
-							theme={workspaceTheme}
-							onThemeChange={(theme) => void handleThemeChange(theme)}
-							onSignOut={() => void signOut()}
-						/>
+						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
 					{/if}
 				{:else}
 					<ThreadTranscript

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -81,6 +81,7 @@
 		resolveDesktopApi
 	} from '$lib/local/client';
 	import { resolve } from '$app/paths';
+	import { isSprocketTheme, persistTheme, resolveTheme, type SprocketTheme } from '$lib/theme';
 	import type {
 		DesktopApi,
 		ThreadMessage,
@@ -131,6 +132,7 @@
 	const restoreThreadMutation = useMutation(api.threads.restore);
 	const finalizeRun = useMutation(api.agentRuntime.finalizeRun);
 	const setLastThread = useMutation(api.uiPreferences.setLastThread);
+	const setThemePreference = useMutation(api.uiPreferences.setTheme);
 	const generateImageUploadUrl = useMutation(api.imageUploads.generateUploadUrl);
 	const registerImageUpload = useMutation(api.imageUploads.register);
 	const discardImageUpload = useMutation(api.imageUploads.discard);
@@ -372,6 +374,63 @@
 	);
 	const threadsQuery = useQuery(api.threads.listMine, getAuthenticatedQueryArgs);
 	const uiPreferencesQuery = useQuery(api.uiPreferences.getMine, getAuthenticatedQueryArgs);
+	let workspaceTheme = $state<SprocketTheme>(resolveTheme(null));
+	let hasHydratedTheme = false;
+	let lastServerTheme: SprocketTheme | null | undefined = undefined;
+	let pendingTheme: SprocketTheme | null = null;
+
+	$effect(() => {
+		if (!authReady) {
+			hasHydratedTheme = false;
+			lastServerTheme = undefined;
+			pendingTheme = null;
+			return;
+		}
+
+		const preferences = uiPreferencesQuery.data;
+
+		// Apply local preference as soon as the workspace mounts (boot script stays light for entry).
+		if (preferences === undefined) {
+			const localTheme = resolveTheme(null);
+			workspaceTheme = localTheme;
+			persistTheme(localTheme);
+			return;
+		}
+
+		// Ignore preference snapshots while a local theme save is in flight.
+		if (pendingTheme !== null) {
+			return;
+		}
+
+		const serverTheme = preferences?.theme;
+		if (hasHydratedTheme && serverTheme === lastServerTheme) {
+			return;
+		}
+		hasHydratedTheme = true;
+		lastServerTheme = serverTheme;
+
+		const nextTheme = isSprocketTheme(serverTheme) ? serverTheme : resolveTheme(null);
+		workspaceTheme = nextTheme;
+		persistTheme(nextTheme);
+	});
+
+	async function handleThemeChange(theme: SprocketTheme) {
+		const previous = workspaceTheme;
+		pendingTheme = theme;
+		workspaceTheme = theme;
+		persistTheme(theme);
+		try {
+			await setThemePreference({ theme });
+			lastServerTheme = theme;
+		} catch (error) {
+			workspaceTheme = previous;
+			persistTheme(previous);
+			currentError = error instanceof Error ? error.message : 'Failed to save theme preference.';
+		} finally {
+			pendingTheme = null;
+		}
+	}
+
 	const authenticatedThreadQueryArgs = () =>
 		currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
 			? { threadId: currentThreadId }
@@ -1731,7 +1790,7 @@
 	>
 		{#snippet actions()}
 			<a
-				class="inline-flex h-10 items-center justify-center rounded-xl bg-white px-4 text-sm font-medium text-black transition hover:bg-slate-100"
+				class="bg-primary text-primary-foreground inline-flex h-10 items-center justify-center rounded-full px-5 text-sm font-medium transition hover:opacity-90"
 				href={resolve('/pair')}
 			>
 				Open pairing
@@ -1739,7 +1798,7 @@
 		{/snippet}
 	</CalmCentered>
 {:else if !authReady}
-	<div class="h-screen overflow-hidden bg-[#0f1218]">
+	<div class="bg-background h-screen overflow-hidden">
 		<AuthGate
 			authState={{
 				isLoading:
@@ -1768,9 +1827,7 @@
 	</div>
 {:else}
 	<div class="h-screen overflow-hidden">
-		<div
-			class="grid h-screen grid-cols-[292px_minmax(0,1fr)] overflow-hidden bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.05),transparent_26%),linear-gradient(180deg,rgba(22,22,24,0.98),rgba(15,15,17,1))]"
-		>
+		<div class="app-workspace-shell grid h-screen grid-cols-[292px_minmax(0,1fr)] overflow-hidden">
 			{#if settingsOpen}
 				<SettingsSidebar
 					activePage={settingsPage}
@@ -1821,7 +1878,12 @@
 					{:else if settingsPage === 'usage'}
 						<SettingsUsage />
 					{:else}
-						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
+						<SettingsAccount
+							user={$authState.user}
+							theme={workspaceTheme}
+							onThemeChange={(theme) => void handleThemeChange(theme)}
+							onSignOut={() => void signOut()}
+						/>
 					{/if}
 				{:else}
 					<ThreadTranscript

--- a/apps/web/src/routes/pair/+page.svelte
+++ b/apps/web/src/routes/pair/+page.svelte
@@ -93,9 +93,9 @@
 		}}
 	>
 		<label class="block space-y-2">
-			<span class="text-sm text-slate-400">Pairing token</span>
+			<span class="text-muted-foreground text-sm">Pairing token</span>
 			<input
-				class="w-full rounded-xl border border-white/10 bg-white/3 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-500 focus:border-white/20"
+				class="border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring w-full rounded-xl border px-4 py-3 text-sm outline-none"
 				bind:value={pairingToken}
 				placeholder="Paste token"
 				autocomplete="off"
@@ -103,11 +103,11 @@
 		</label>
 
 		{#if error}
-			<p class="text-sm text-rose-300">{error}</p>
+			<p class="text-destructive text-sm">{error}</p>
 		{/if}
 
 		<button
-			class="w-full rounded-xl bg-white px-4 py-3 text-sm font-medium text-black transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+			class="bg-primary text-primary-foreground w-full rounded-full px-4 py-3 text-sm font-medium transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
 			disabled={isSubmitting}
 			type="submit"
 		>

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@exalabs/convex-exa": "^0.1.0",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@lucide/svelte": "^1.18.0",
         "@workos-inc/authkit-js": "^0.20.0",
         "ai": "^7.0.37",
@@ -252,6 +253,8 @@
     "@fontsource-variable/ibm-plex-sans": ["@fontsource-variable/ibm-plex-sans@5.3.0", "", {}, "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ=="],
 
     "@fontsource/dm-sans": ["@fontsource/dm-sans@5.3.0", "", {}, "sha512-lYJtMXXO28q1z+yz+z8XKd0s4hXaa9QdkETzkyD760sidCv5heI86weYA0sx0Nc4pAMAQTUuyf4gO44cYKKS9g=="],
+
+    "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.3.0", "", {}, "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 


### PR DESCRIPTION
## Summary
- Add Spikonado dual-theme tokens with always-light entry shells and workspace light/dark themes (default dark)
- Persist theme preference in Convex and expose a single sidebar Sun/Moon toggle
- Retokenize workspace UI and polish light/dark transcript, sidebar, and composer surfaces

## Test plan
- [ ] Open auth/pair/connecting entry flows and confirm they stay light regardless of workspace theme
- [ ] Toggle light/dark from the main and settings sidebars; confirm preference persists across reload
- [ ] Spot-check home workspace: sidebar, transcript bubbles, code blocks, and prompt composer in both themes
- [ ] Confirm Account settings no longer has a separate Appearance theme control
- [ ] Run `bun run test` / relevant web checks as needed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds persistent light/dark workspace themes while keeping entry flows light.
- Introduces shared theme tokens and retokenizes workspace components.
- Stores each user’s theme preference in Convex.
- Adds sidebar theme controls and guards preference hydration during saves.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain within the scope of the theme-save behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I recorded a before-change render to verify the pair entry shell and the root connect flow were present.
- I captured a post-change render to confirm the updated pair entry shell renders correctly after the change.
- I inspected browser logs for both phases and confirmed the UI loaded as real application content with no blank pages or error overlays.
- I reviewed the available assets and confirmed the client-side JavaScript bundle used for rendering was present and loadable.

<a href="https://app.greptile.com/trex/runs/15901856/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/routes/+page.svelte | Coordinates theme hydration, optimistic updates, persistence, and sidebar controls; the generation guard addresses the previously reported overlapping-save race. |
| apps/web/src/convex/uiPreferences.ts | Adds authenticated persistence for each user’s workspace theme. |
| apps/web/src/lib/theme.ts | Defines theme resolution, DOM application, and reference-counted light entry-shell behavior. |
| apps/web/src/app.css | Introduces light and dark design tokens and applies them across workspace surfaces. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): Persist workspace theme only i..."](https://github.com/spikonado/sprocket/commit/2e7df9ac63adb0326b01f0d66fd10b29b435596e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47320758)</sub>

<!-- /greptile_comment -->