### PR TITLE
build(release): Bump version to v0.2.0

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             source_sha="$TESTED_SHA"
-            version="0.0.0-dev.$source_sha"
+            version="0.2.0-dev.$source_sha"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             source_sha="$GITHUB_SHA"
             version="${GITHUB_REF_NAME#v}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-agent"
-version = "0.0.0-canary.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "convex",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-cli"
-version = "0.0.0-canary.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-convex-provider"
-version = "0.0.0-canary.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "convex",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-server"
-version = "0.0.0-canary.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-workspace"
-version = "0.0.0-canary.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cap-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.0.0-canary.1"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spikonado/sprocket",
-	"version": "0.0.0-canary.1",
+	"version": "0.2.0",
 	"description": "Sprocket: Agentic platform for streamlining robotics development",
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prepares the v0.2.0 release.
- Updates the shared Rust workspace and lockfile package versions to 0.2.0.
- Updates the root npm package version to 0.2.0.
- Changes workflow-generated npm development versions to use a 0.2.0 base.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the npm development-release workflow recognizes the new version prefix.

Workflow-run releases generate `0.2.0-dev.<sha>`, but the unchanged validation rejects that format before publication, the channel check would misclassify it as `latest`, and the release documentation still describes the obsolete prefix.

**Files Needing Attention:** .github/workflows/npm-release.yml
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced development releases validation failure under the workflow's Resolve logic using EVENT\_NAME=workflow\_run and a 40-character TESTED\_SHA to generate 0.2.0-dev.\<sha\>, exiting with status 1 and Invalid release version; observed the preserved tag-selection branch emitted npm-tag=latest instead of npm-tag=dev.
- Validated the post-change build path by setting SPROCKET\_VERSION=0.2.0, performing cargo build --locked --release -p sprocket-cli, and verifying the binary reports sprocket 0.2.0; npm tests pass (4/4); packaging includes three source-package files and exits with code 0.

<a href="https://app.greptile.com/trex/runs/15902974/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Changes the generated development version but leaves validation, dist-tag checks, and release documentation on the old prefix. |
| Cargo.toml | Updates the shared Rust workspace package version from the canary release to 0.2.0. |
| Cargo.lock | Consistently updates all workspace crate lockfile entries to 0.2.0. |
| npm/sprocket/package.json | Updates the root npm package manifest to version 0.2.0. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/npm-release.yml:43
**Development releases fail validation**

When a successful main-branch test triggers this workflow, it generates `0.2.0-dev.<sha>`, but the unchanged validation accepts only `0.0.0-dev.<sha>` and exits with `Invalid release version` before publishing. The release-channel check also retains the old prefix, so it must be updated alongside the validation to keep development releases on the `dev` dist-tag.

### Issue 2 of 2
.github/workflows/npm-release.yml:43
**Release documentation retains old prefix**

The workflow now generates `0.2.0-dev.<sha>`, while `npm/RELEASING.md` still documents development releases as `0.0.0-dev.<sha>`. Updating the documented format prevents maintainers from relying on obsolete release instructions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["build(release): Bump version to v0.2.0"](https://github.com/spikonado/sprocket/commit/61ca6d5cad71d27ffea9f0625a18c3f3120f36dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47324834)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->