### PR TITLE
ci(npm-release): Fix version pattern for dev releases

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
           echo "source-sha=$source_sha" >> "$GITHUB_OUTPUT"
-          if [[ "$version" == 0.0.0-dev.* ]]; then
+          if [[ "$version" == 0.2.0-dev.* ]]; then
             echo "npm-tag=dev" >> "$GITHUB_OUTPUT"
           elif [[ "$version" == *-canary.* ]]; then
             echo "npm-tag=canary" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
           echo "source-sha=$source_sha" >> "$GITHUB_OUTPUT"
-          if [[ "$version" == 0.2.0-dev.* ]]; then
+          if [[ "$version" =~ $dev_pattern ]]; then
             echo "npm-tag=dev" >> "$GITHUB_OUTPUT"
           elif [[ "$version" == *-canary.* ]]; then
             echo "npm-tag=canary" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -50,7 +50,7 @@ jobs:
           fi
           stable_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
           canary_pattern='^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$'
-          dev_pattern='^0\.0\.0-dev\.[0-9a-f]{40}$'
+          dev_pattern='^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9a-f]{40}$'
           if [[ ! "$version" =~ $stable_pattern && ! "$version" =~ $canary_pattern && ! "$version" =~ $dev_pattern ]]; then
             echo "::error::Invalid release version: $version"
             exit 1


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The workflow now accepts development versions based on any numeric semantic-version prefix and consistently assigns matching releases the npm `dev` dist-tag.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the version routing logic now directs valid numeric-dev versions to dev, stable versions to latest, canaries to canary, and malformed inputs exit with error.
- Compared the pre-change behavior to the post-change behavior and confirmed the before rule allowed valid dev inputs outside 0.2.0-dev.\* to be accepted and routed to latest, while the after rule routes them to dev.
- Captured and associated the validation script and the run logs as artifacts to support inspection of the routing behavior.
- Reviewed the log artifacts to verify that the routing results matched the expected mapping across runs.

<a href="https://app.greptile.com/trex/runs/15925489/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Broadens development-version validation and reuses the same pattern for npm dist-tag classification, completing the fixes discussed in the previous threads. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci(npm-release): Classify all dev versio..."](https://github.com/spikonado/sprocket/commit/67b95b715300813851f752a4f88a17da3e4154b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47336925)</sub>

<!-- /greptile_comment -->