### PR TITLE
feat(workspace): Add Bashkit-sandboxed reference repository clones

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,8 +168,10 @@ The local server binds to loopback by default. Exposing it on another interface
 changes the trust model and should be treated as a security-sensitive
 deployment choice.
 
-Workspace patches are confined to the attached workspace. Shell commands are
-not sandboxed: they run with the permissions of the local Sprocket process.
+Workspace patches are confined to the attached workspace. Shell commands
+normally run with the permissions of the local Sprocket process. Commands whose
+working directory is in the reference-repository cache are automatically run
+through Bashkit with that cache mounted read-only and network access disabled.
 
 ## Reliability model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,15 @@ name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -252,6 +267,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bashkit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3189734e07ea68a23e008c486d9f3cdb1a7eea74a8a32122ec750ade99620014"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags",
+ "chrono",
+ "clap",
+ "fancy-regex",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hmac",
+ "md-5",
+ "num-traits",
+ "os_display",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tower",
+ "unit-prefix",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +424,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -511,6 +602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +782,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -842,8 +963,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -885,7 +1008,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1014,6 +1137,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1247,6 +1394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1448,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1484,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1353,10 +1526,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1402,6 +1594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_display"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1584,6 +1785,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1960,6 +2173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2252,7 @@ name = "sprocket-agent"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "bashkit",
  "convex",
  "futures",
  "rig-core",
@@ -2105,6 +2336,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2506,7 +2738,7 @@ dependencies = [
  "rand",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.7",
  "thiserror",
  "url",
  "utf-8",
@@ -2537,10 +2769,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -2715,6 +2959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,10 +2988,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -35,6 +35,11 @@ export const vApplyPatchPayload = v.object({
 	patch: v.string()
 });
 
+export const vCloneRefRepoPayload = v.object({
+	url: v.string(),
+	reference: v.optional(v.string())
+});
+
 export const vExecCommandPayload = v.object({
 	cmd: v.string(),
 	workdir: v.optional(v.string()),
@@ -67,6 +72,7 @@ export const vReadSkillPayload = v.object({
 export const vExecutorJobPayload = v.union(
 	v.object({}),
 	vApplyPatchPayload,
+	vCloneRefRepoPayload,
 	vExecCommandPayload,
 	vReadSkillPayload,
 	vScrapeUrlPayload,
@@ -87,6 +93,12 @@ export const vApplyPatchResult = v.object({
 			)
 		})
 	)
+});
+
+export const vCloneRefRepoResult = v.object({
+	path: v.string(),
+	commit: v.string(),
+	reused: v.boolean()
 });
 
 export const vCommandExecResult = v.object({
@@ -134,6 +146,7 @@ export const vExecutorJobResult = v.union(
 	v.string(),
 	v.array(vWorkspaceInstruction),
 	vApplyPatchResult,
+	vCloneRefRepoResult,
 	vCommandExecResult,
 	vReadSkillResult,
 	vScrapeUrlResult,
@@ -163,6 +176,7 @@ export function isRunFinalStatus(
 
 export const vExecutorJobKind = v.union(
 	v.literal('apply_patch'),
+	v.literal('clone_ref_repo'),
 	v.literal('exec_command'),
 	v.literal('get_workspace_instructions'),
 	v.literal('read_skill'),

--- a/apps/web/src/lib/chat/tool-icons.ts
+++ b/apps/web/src/lib/chat/tool-icons.ts
@@ -1,6 +1,7 @@
 import {
 	BookOpen,
 	FileDiff,
+	GitFork,
 	Globe,
 	NotebookPen,
 	ScrollText,
@@ -14,6 +15,7 @@ import {
 const TOOL_KIND_ICONS: Record<string, LucideIcon> = {
 	apply_patch: FileDiff,
 	check_docs: BookOpen,
+	clone_ref_repo: GitFork,
 	exec_command: Terminal,
 	get_workspace_instructions: ScrollText,
 	read_skill: NotebookPen,

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -76,6 +76,8 @@
 				return 'Changed Files';
 			case 'check_docs':
 				return 'Checked Docs';
+			case 'clone_ref_repo':
+				return 'Cloned Repositories';
 			case 'exec_command':
 				return 'Ran Commands';
 			case 'get_workspace_instructions':
@@ -123,6 +125,10 @@
 					: typeof fields?.path === 'string'
 						? fields.path
 						: 'Docs';
+			case 'clone_ref_repo':
+				return typeof fields?.url === 'string'
+					? `${fields.url}${typeof fields.reference === 'string' ? ` @ ${fields.reference}` : ''}`
+					: 'Git repository';
 			case 'exec_command':
 				return typeof fields?.cmd === 'string'
 					? `${fields.cmd}${describeExecCommandOptions(input)}`
@@ -226,7 +232,10 @@
 		return new Set(tools.flatMap((tool) => patchSummary(tool)?.split('\n') ?? [])).size;
 	}
 
-	function summarizeWebToolResult(kind: string, result: JsonValue | undefined) {
+	function summarizeToolResult(kind: string, result: JsonValue | undefined) {
+		if (kind === 'clone_ref_repo' && isJsonObject(result) && result.reused === true) {
+			return ' (cached)';
+		}
 		if (kind === 'web_search' && isJsonObject(result) && Array.isArray(result.results)) {
 			const count = result.results.length;
 			return ` (${count} result${count === 1 ? '' : 's'})`;
@@ -255,7 +264,7 @@
 			}
 			return (
 				summarizeTool(toolLog.job.kind, toolLog.job.payload) +
-				summarizeWebToolResult(toolLog.job.kind, toolLog.job.result)
+				summarizeToolResult(toolLog.job.kind, toolLog.job.result)
 			);
 		}
 		return summarizeTool(toolLog.name, toolLog.input);

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
+bashkit = { version = "0.14.3", features = ["realfs"] }
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 futures = "0.3.32"
 rig = { package = "rig-core", version = "0.40.0", default-features = false }
@@ -15,5 +16,5 @@ serde_json = "1.0.149"
 sprocket-convex-provider = { path = "../sprocket-convex-provider" }
 sprocket-workspace = { path = "../sprocket-workspace" }
 thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "sync", "time"] }
+tokio = { version = "1.52.1", features = ["fs", "macros", "sync", "time"] }
 uuid = { version = "1.21.0", features = ["v4"] }

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -34,15 +34,19 @@ the on-disk layout.
 ## Tools
 
 The agent currently offers command execution, command-session input, workspace
-patching, skill loading (`read_skill`), web search, and web-page scraping. Every
-tool call is wrapped in a durable executor-job record and observes run
-cancellation while work is active.
+patching, Git repository cloning, skill loading (`read_skill`), web search, and
+web-page scraping. Every tool call is wrapped in a durable executor-job record
+and observes run cancellation while work is active.
 
-Command execution has full local process permissions. Patch operations are
-confined to the workspace by `sprocket-workspace`. Web search and scraping run
-as Convex actions (`webTools`) built on the Exa and Context.dev Convex
-components, keyed by deployment-side environment variables (`EXA_API_KEY`,
-`CONTEXT_DEV_API_KEY`); only the results flow back through the executor job.
+Command execution normally has full local process permissions. When its working
+directory resolves inside `<SPROCKET_DATA_DIR>/ref-repos`, it is automatically
+executed by Bashkit instead, with the cache mounted read-only and without host
+process or network access. Repository clones are shallow, matching snapshots
+are reused, and patch operations remain confined to the workspace by
+`sprocket-workspace`. Web search and scraping run as Convex actions (`webTools`)
+built on the Exa and Context.dev Convex components, keyed by deployment-side
+environment variables (`EXA_API_KEY`, `CONTEXT_DEV_API_KEY`); only the results
+flow back through the executor job.
 
 ## Main areas
 

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -6,6 +6,7 @@ use rig::completion::CompletionModel;
 
 pub(crate) const AGENT_TOOL_NAMES: &[&str] = &[
     "apply_patch",
+    "clone_ref_repo",
     "exec_command",
     "read_skill",
     "scrape_url",

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -67,6 +67,7 @@ pub(crate) struct AgentProviderRequest {
     pub(crate) preamble: String,
     pub(crate) prior_history: Vec<Message>,
     pub(crate) workspace_root: PathBuf,
+    pub(crate) ref_repos_root: PathBuf,
     pub(crate) skills: Arc<[WorkspaceSkill]>,
     pub(crate) model: String,
     pub(crate) reasoning_effort: String,
@@ -130,6 +131,7 @@ where
         request.run_id.clone(),
         request.claim_id.clone(),
         request.workspace_root.clone(),
+        request.ref_repos_root.clone(),
         tool_call_tracker.clone(),
         request.skills.clone(),
     );
@@ -138,6 +140,7 @@ where
         .agent(model)
         .preamble(&request.preamble)
         .tool(tools.apply_patch)
+        .tool(tools.clone_ref_repo)
         .tool(tools.exec_command)
         .tool(tools.read_skill)
         .tool(tools.scrape_url)

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -35,6 +35,7 @@ pub struct AgentRun {
     run_id: String,
     claim_id: String,
     workspace_root: std::path::PathBuf,
+    ref_repos_root: std::path::PathBuf,
 }
 
 impl AgentRun {
@@ -128,6 +129,7 @@ fn build_workspace_preamble(
         "## Tool Usage",
         "",
         "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations. `git` is an exception to this rule.",
+        "Use clone_ref_repo for reference repositories, then inspect the returned path with exec_command. Commands run from that cache are automatically sandboxed and cannot modify the cached repositories.",
         "Prefer using the `scrape_url` tool over `web_search` when you have an idea on what URL could lead you to the information you need. `web_search` is more expensive and should be used as a fallback.",
         "You are suggested to use `scrape_url` on the URLs returned by `web_search` to further ground the information you received from it.",
         "",
@@ -503,6 +505,7 @@ pub async fn start_agent_run(request: RunAgentRequest) -> anyhow::Result<AgentRu
     }
     let run_id = created_run.run_id;
     Ok(AgentRun {
+        ref_repos_root: request.ref_repos_root.clone(),
         request,
         runtime,
         run_id,
@@ -563,6 +566,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         run_id,
         claim_id,
         workspace_root,
+        ref_repos_root,
     } = run;
 
     let context: RunContextResponse = match runtime.run_context(&run_id).await {
@@ -656,6 +660,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
                     preamble,
                     prior_history,
                     workspace_root,
+                    ref_repos_root,
                     skills,
                     model,
                     reasoning_effort,

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use bashkit::{BashTool as SandboxBashTool, Tool as BashkitToolContract, ToolRequest};
 use convex::Value;
 use futures::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sprocket_workspace::{
-    CommandSessionManager, WorkspaceCancellation, WorkspaceSkill, apply_workspace_patch,
-    default_command_shell, read_skill_content,
+    CommandExecOutput, CommandSessionManager, WorkspaceCancellation, WorkspaceSkill,
+    apply_workspace_patch, clone_ref_repo, default_command_shell, read_skill_content,
 };
 
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 60_000;
@@ -35,6 +36,7 @@ struct AgentToolContext {
     run_id: String,
     claim_id: String,
     workspace_root: PathBuf,
+    ref_repos_root: PathBuf,
     tool_call_tracker: ToolCallTracker,
     command_sessions: CommandSessionManager,
 }
@@ -45,6 +47,7 @@ impl AgentToolContext {
         run_id: String,
         claim_id: String,
         workspace_root: PathBuf,
+        ref_repos_root: PathBuf,
         tool_call_tracker: ToolCallTracker,
         command_sessions: CommandSessionManager,
     ) -> Self {
@@ -53,6 +56,7 @@ impl AgentToolContext {
             run_id,
             claim_id,
             workspace_root,
+            ref_repos_root,
             tool_call_tracker,
             command_sessions,
         }
@@ -64,6 +68,9 @@ pub(crate) struct ApplyPatchTool(AgentToolContext);
 
 #[derive(Clone)]
 pub(crate) struct ExecCommandTool(AgentToolContext);
+
+#[derive(Clone)]
+pub(crate) struct CloneRefRepoTool(AgentToolContext);
 
 #[derive(Clone)]
 pub(crate) struct ScrapeUrlTool(AgentToolContext);
@@ -82,6 +89,7 @@ pub(crate) struct ReadSkillTool {
 
 pub(crate) struct AgentToolSet {
     pub(crate) apply_patch: ApplyPatchTool,
+    pub(crate) clone_ref_repo: CloneRefRepoTool,
     pub(crate) command_sessions: CommandSessionManager,
     pub(crate) exec_command: ExecCommandTool,
     pub(crate) read_skill: ReadSkillTool,
@@ -95,6 +103,7 @@ pub(crate) fn agent_tools(
     run_id: String,
     claim_id: String,
     workspace_root: PathBuf,
+    ref_repos_root: PathBuf,
     tool_call_tracker: ToolCallTracker,
     skills: Arc<[WorkspaceSkill]>,
 ) -> AgentToolSet {
@@ -104,11 +113,13 @@ pub(crate) fn agent_tools(
         run_id,
         claim_id,
         workspace_root,
+        ref_repos_root,
         tool_call_tracker,
         command_sessions.clone(),
     );
     AgentToolSet {
         apply_patch: ApplyPatchTool(context.clone()),
+        clone_ref_repo: CloneRefRepoTool(context.clone()),
         command_sessions,
         exec_command: ExecCommandTool(context.clone()),
         read_skill: ReadSkillTool {
@@ -212,7 +223,8 @@ pub(crate) struct ExecCommandArgs {
     )]
     #[schemars(default = "default_workdir")]
     workdir: String,
-    /// Shell binary to launch. Defaults to the user's shell.
+    /// Shell binary to launch. Defaults to the user's shell. Reference-repository commands use
+    /// the sandbox shell and reject custom values.
     #[serde(
         default = "default_command_shell",
         skip_serializing_if = "is_default_shell"
@@ -227,7 +239,8 @@ pub(crate) struct ExecCommandArgs {
     )]
     #[schemars(default = "default_timeout_ms")]
     timeout_ms: u64,
-    /// Wait before yielding a running session, in milliseconds. Defaults to 10000.
+    /// Wait before yielding a running session, in milliseconds. Defaults to 10000. Reference-
+    /// repository commands run to completion in the sandbox and never yield a session.
     #[serde(
         rename = "yieldTimeMs",
         default = "default_command_yield_ms",
@@ -273,6 +286,15 @@ pub(crate) struct ApplyPatchArgs {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct CloneRefRepoArgs {
+    /// Git remote URL. HTTPS and SSH remotes from GitHub, GitLab, and other Git hosts are supported.
+    url: String,
+    /// Optional branch or tag to check out. The remote's default branch is used when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reference: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct WebSearchArgs {
     /// Web search query.
     query: String,
@@ -305,7 +327,7 @@ impl rig::tool::Tool for ExecCommandTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Run a shell command with full machine access. Long-running commands yield a sessionId for write_stdin polling and input."
+        "Run a shell command. Relative workdirs resolve from the project root. Commands inside the reference-repository cache run through an isolated, read-only sandbox; other commands have full machine access. Long-running host commands yield a sessionId for write_stdin polling and input."
             .to_string()
     }
 
@@ -322,20 +344,95 @@ impl rig::tool::Tool for ExecCommandTool {
             &self.0.tool_call_tracker,
             serde_json::to_value(&args).map_err(tool_error)?,
             |cancellation| async {
-                let output = self
+                let requested_cwd = self.0.command_sessions.requested_workdir(&args.workdir);
+                let cwd = self
                     .0
                     .command_sessions
-                    .exec_command(
-                        cancellation,
-                        &args.cmd,
-                        &args.workdir,
-                        &args.shell,
-                        args.timeout_ms,
-                        args.yield_time_ms,
-                        args.max_output_chars,
-                    )
-                    .await
+                    .resolve_workdir(&args.workdir)
                     .map_err(tool_error)?;
+                let ref_repos_root = match tokio::fs::canonicalize(&self.0.ref_repos_root).await {
+                    Ok(root) => Some(root),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(error) => return Err(tool_error(error)),
+                };
+                let sandboxed = ref_repos_root
+                    .as_deref()
+                    .map(|root| ref_repo_workdir(root, &requested_cwd, &cwd))
+                    .transpose()?
+                    .unwrap_or(false);
+                let output = if sandboxed {
+                    let ref_repos_root =
+                        ref_repos_root.expect("sandboxed workdir has a cache root");
+                    exec_ref_repo_command(&ref_repos_root, &cwd, cancellation, &args).await?
+                } else {
+                    self.0
+                        .command_sessions
+                        .exec_command(
+                            cancellation,
+                            &args.cmd,
+                            &args.workdir,
+                            &args.shell,
+                            args.timeout_ms,
+                            args.yield_time_ms,
+                            args.max_output_chars,
+                        )
+                        .await
+                        .map_err(tool_error)?
+                };
+                serde_json::to_value(output).map_err(tool_error)
+            },
+        )
+        .await
+    }
+}
+
+fn ref_repo_workdir(
+    ref_repos_root: &Path,
+    requested_cwd: &Path,
+    resolved_cwd: &Path,
+) -> Result<bool, AgentToolError> {
+    let requested_inside = requested_cwd.starts_with(ref_repos_root);
+    let resolved_inside = resolved_cwd.starts_with(ref_repos_root);
+    if requested_inside && !resolved_inside {
+        return Err(tool_error(
+            "reference-repository workdir resolves outside its cache root",
+        ));
+    }
+    Ok(resolved_inside)
+}
+
+impl rig::tool::Tool for CloneRefRepoTool {
+    const NAME: &'static str = "clone_ref_repo";
+    type Error = AgentToolError;
+    type Args = CloneRefRepoArgs;
+    type Output = serde_json::Value;
+
+    fn description(&self) -> String {
+        "Clone a shallow Git repository snapshot into Sprocket's dedicated reference-repository cache. Returns an absolute path that can be explored with exec_command; commands in that path are automatically sandboxed and read-only. Existing matching snapshots are reused."
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schemars::schema_for!(CloneRefRepoArgs))
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        execute_tool_job(
+            &self.0.runtime,
+            &self.0.run_id,
+            &self.0.claim_id,
+            Self::NAME,
+            &self.0.tool_call_tracker,
+            serde_json::to_value(&args).map_err(tool_error)?,
+            |cancellation| async {
+                let output = clone_ref_repo(
+                    self.0.ref_repos_root.clone(),
+                    cancellation,
+                    &args.url,
+                    args.reference.as_deref(),
+                )
+                .await
+                .map_err(tool_error)?;
                 serde_json::to_value(output).map_err(tool_error)
             },
         )
@@ -576,6 +673,95 @@ pub(crate) fn resolve_read_skill(
         value["truncated"] = json!(true);
     }
     Ok(value)
+}
+
+fn build_ref_repo_bashkit(ref_repos_root: PathBuf, cwd: PathBuf) -> SandboxBashTool {
+    let allowed_root = ref_repos_root.clone();
+    let mounted_root = ref_repos_root.clone();
+    let ref_repos_env = ref_repos_root.to_string_lossy().into_owned();
+    SandboxBashTool::builder()
+        .username("agent")
+        .hostname("sprocket-sandbox")
+        .cwd(cwd)
+        .env("REF_REPOS", ref_repos_env)
+        .configure(move |builder| {
+            builder
+                .allowed_mount_paths([allowed_root.clone()])
+                .mount_real_readonly_at(ref_repos_root.clone(), mounted_root.clone())
+        })
+        .build()
+}
+
+async fn exec_ref_repo_command(
+    ref_repos_root: &Path,
+    cwd: &Path,
+    cancellation: WorkspaceCancellation,
+    args: &ExecCommandArgs,
+) -> Result<CommandExecOutput, AgentToolError> {
+    if args.cmd.trim().is_empty() {
+        return Err(tool_error("command cannot be empty"));
+    }
+    if !is_default_shell(&args.shell) {
+        return Err(tool_error(
+            "shell cannot be customized for reference-repository commands",
+        ));
+    }
+    if !is_default_command_yield_ms(&args.yield_time_ms) {
+        return Err(tool_error(
+            "yieldTimeMs cannot be customized for reference-repository commands, which run to completion in the sandbox",
+        ));
+    }
+    let relative_cwd = cwd
+        .strip_prefix(ref_repos_root)
+        .map_err(|_| tool_error("reference-repository workdir escaped its cache root"))?;
+    let virtual_cwd = ref_repos_root.join(relative_cwd);
+    let tool = build_ref_repo_bashkit(ref_repos_root.to_path_buf(), virtual_cwd);
+    let request = ToolRequest {
+        commands: args.cmd.clone(),
+        timeout_ms: Some(args.timeout_ms.max(1)),
+    };
+    let response = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(AgentToolError::Cancelled),
+        response = tool.execute(request) => response,
+    };
+
+    let combined = combine_output(&response.stdout, &response.stderr);
+    let (output, limit_truncated) =
+        limit_output_chars(&combined, args.max_output_chars.clamp(1, 80_000));
+    let timed_out = response.error.as_deref() == Some("timeout");
+    let success = response.exit_code == 0 && response.error.is_none();
+    Ok(CommandExecOutput {
+        command: args.cmd.clone(),
+        cwd: cwd.to_string_lossy().into_owned(),
+        session_id: None,
+        exit_code: Some(response.exit_code),
+        success,
+        running: false,
+        timed_out,
+        stdout: response.stdout,
+        stderr: response.stderr,
+        output,
+        truncated: response.stdout_truncated || response.stderr_truncated || limit_truncated,
+        error: response.error,
+    })
+}
+
+fn combine_output(stdout: &str, stderr: &str) -> String {
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, _) => stderr.to_string(),
+        (_, true) => stdout.to_string(),
+        (false, false) => format!("{stdout}\n{stderr}"),
+    }
+}
+
+fn limit_output_chars(contents: &str, max_chars: usize) -> (String, bool) {
+    let mut output: String = contents.chars().take(max_chars).collect();
+    let truncated = contents.chars().nth(max_chars).is_some();
+    if truncated {
+        output.push_str("\n\n...[truncated]");
+    }
+    (output, truncated)
 }
 
 /// Runs a tool's work as a Convex action, aborting the wait when the run is
@@ -823,5 +1009,49 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("Unknown skill 'missing'"));
         assert!(message.contains("alpha, bravo"));
+    }
+
+    #[test]
+    fn ref_repo_workdir_rejects_symlink_escape() {
+        let root = Path::new("/data/ref-repos");
+        let error = ref_repo_workdir(
+            root,
+            Path::new("/data/ref-repos/example/escape"),
+            Path::new("/outside"),
+        )
+        .expect_err("a lexical cache path must not resolve outside the cache");
+
+        assert!(error.to_string().contains("outside its cache root"));
+    }
+
+    #[tokio::test]
+    async fn exec_command_uses_read_only_bashkit_for_reference_repositories() {
+        let root =
+            std::env::temp_dir().join(format!("sprocket-bashkit-test-{}", uuid::Uuid::new_v4()));
+        let repository = root.join("example");
+        std::fs::create_dir_all(&repository).expect("reference repository directory");
+        std::fs::write(repository.join("README.md"), "original\n")
+            .expect("reference repository fixture");
+
+        let args: ExecCommandArgs = serde_json::from_value(serde_json::json!({
+            "cmd": "pwd; cat README.md; printf changed > README.md"
+        }))
+        .expect("valid exec_command request");
+        let output = exec_ref_repo_command(&root, &repository, WorkspaceCancellation::new(), &args)
+            .await
+            .expect("sandboxed exec_command execution");
+
+        assert_eq!(
+            output.stdout,
+            format!("{}\noriginal\n", repository.display())
+        );
+        assert_ne!(output.exit_code, Some(0));
+        assert!(!output.success);
+        assert_eq!(output.cwd, repository.to_string_lossy());
+        assert_eq!(
+            std::fs::read_to_string(repository.join("README.md")).unwrap(),
+            "original\n"
+        );
+        std::fs::remove_dir_all(root).expect("temporary directory should be removed");
     }
 }

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -7,6 +7,7 @@ use rig::message::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use sprocket_convex_provider::AuthTokenFetcher;
+use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct RunAgentRequest {
@@ -21,6 +22,8 @@ pub struct RunAgentRequest {
     pub reasoning_effort: String,
     pub service_tier: String,
     pub workspace_path: String,
+    /// Local cache root supplied by the Sprocket server; it is never sent to Convex.
+    pub ref_repos_root: PathBuf,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -65,6 +65,7 @@ pub struct AppState {
     pub auth: Arc<auth::AuthState>,
     pub desktop_login: Arc<auth::DesktopLoginStore>,
     pub workspace_sessions: Arc<workspace_sessions::WorkspaceSessionStore>,
+    pub ref_repos_root: PathBuf,
     pub http_base_url: String,
     pub desktop_login_callback_url: String,
     pub loopback_desktop_login_supported: bool,
@@ -95,6 +96,8 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     let auth = auth::AuthState::load(&data_dir)?;
     let pairing_credential = auth.pairing_credential().to_string();
     let workspace_sessions = workspace_sessions::WorkspaceSessionStore::new(data_dir.clone());
+    let ref_repos_root = data_dir.join("ref-repos");
+    tokio::fs::create_dir_all(&ref_repos_root).await?;
     let http_base_url = config.listen_url();
     let web_ui_enabled = config
         .resolve_static_dir()
@@ -111,6 +114,7 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         auth,
         desktop_login: auth::DesktopLoginStore::new(),
         workspace_sessions,
+        ref_repos_root,
         http_base_url: http_base_url.clone(),
         desktop_login_callback_url: auth::desktop_login_callback_url(config.port),
         loopback_desktop_login_supported: auth::host_supports_loopback_desktop_login(&config.host),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -88,6 +88,7 @@ async fn run_agent_handler(
         reasoning_effort: payload.reasoning_effort,
         service_tier: payload.service_tier,
         workspace_path,
+        ref_repos_root: state.ref_repos_root.clone(),
     };
 
     let cleanup_request = request.clone();

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -396,6 +396,7 @@ mod tests {
             auth,
             desktop_login: DesktopLoginStore::new(),
             workspace_sessions: WorkspaceSessionStore::new(temp_dir),
+            ref_repos_root: std::env::temp_dir().join("sprocket-auth-test-ref-repos"),
             http_base_url: "http://127.0.0.1:7731".to_string(),
             desktop_login_callback_url: auth::desktop_login_callback_url(7731),
             loopback_desktop_login_supported: loopback_supported,

--- a/crates/sprocket-workspace/Cargo.toml
+++ b/crates/sprocket-workspace/Cargo.toml
@@ -11,6 +11,7 @@ diffy = { version = "0.5.0", features = ["std"] }
 libc = "0.2.186"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+sha2 = "0.11.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full"] }
 tokio-util = "0.7.18"

--- a/crates/sprocket-workspace/README.md
+++ b/crates/sprocket-workspace/README.md
@@ -12,6 +12,7 @@ See [ARCHITECTURE.md](../../ARCHITECTURE.md) for its role in the complete system
 - Load scoped workspace instructions and skills.
 - Run cancellable shell commands and manage long-running sessions.
 - Apply multi-file patches inside a workspace.
+- Clone and cache remote Git repositories atomically.
 
 ## Design
 
@@ -25,6 +26,10 @@ workspace by default, but they are not sandboxed and may access the wider
 machine with the permissions of the Sprocket process. Output is bounded, and
 cancellation or timeout stops the process tree.
 
+HTTPS and SSH repository clones are populated in temporary sibling directories
+before an atomic rename. Matching, untampered snapshots are reused, while URL
+hash collisions remain in separate directories.
+
 Workspace instruction loading follows the project hierarchy so deeper
 instructions can refine root-level guidance without coupling that behavior to
 the agent implementation.
@@ -36,6 +41,7 @@ the agent implementation.
 - `skills.rs` and `skills/`: skill discovery and built-in skill embedding.
 - `tools.rs`: command sessions and cancellation.
 - `patch.rs`: confined transactional patches.
+- `ref_repo.rs`: cancellable, reusable Git clones.
 
 ## Built-in skills
 

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -5,6 +5,7 @@ mod builtin_skills;
 mod patch;
 mod paths;
 mod project_root;
+mod ref_repo;
 mod skill_name;
 mod skills;
 #[cfg(test)]
@@ -20,6 +21,7 @@ pub use browse::{
 };
 pub use builtin_skills::BUILTIN_SKILLS;
 pub use patch::{ApplyPatchOutput, PatchChangeOutput, PatchOperation, apply_workspace_patch};
+pub use ref_repo::{CloneRefRepoOutput, clone_ref_repo};
 pub use skills::{
     SkillSource, WorkspaceSkill, WorkspaceSkills, default_user_skills_dirs, load_workspace_skills,
     read_skill_content,

--- a/crates/sprocket-workspace/src/ref_repo.rs
+++ b/crates/sprocket-workspace/src/ref_repo.rs
@@ -1,0 +1,687 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+use crate::tools::{WorkspaceCancellation, WorkspaceOperationCancelled};
+
+const CLONE_DEPTH: &str = "1";
+const CLONE_TIMEOUT: Duration = Duration::from_secs(300);
+const LOCAL_GIT_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_GIT_ERROR_BYTES: usize = 16_384;
+const CACHE_METADATA_FILE: &str = ".git/sprocket-ref-repo.json";
+static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloneRefRepoOutput {
+    pub path: String,
+    pub commit: String,
+    pub reused: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CacheMetadata {
+    url: String,
+    reference: Option<String>,
+    commit: String,
+}
+
+/// Clone a remote into Sprocket's repository cache, or reuse an identical clone.
+///
+/// A temporary sibling is populated first and atomically renamed, so interrupted
+/// clones never look complete. The destination includes the requested reference
+/// and a URL hash; the origin is still checked before any existing clone is reused.
+pub async fn clone_ref_repo(
+    ref_repos_root: PathBuf,
+    cancellation: WorkspaceCancellation,
+    url: &str,
+    reference: Option<&str>,
+) -> Result<CloneRefRepoOutput> {
+    cancellation.ensure_active()?;
+    let url = validate_value("repository URL", url)?;
+    reject_embedded_credentials(url)?;
+    validate_remote_url(url)?;
+    clone_ref_repo_validated(ref_repos_root, cancellation, url, reference, false).await
+}
+
+async fn clone_ref_repo_validated(
+    ref_repos_root: PathBuf,
+    cancellation: WorkspaceCancellation,
+    url: &str,
+    reference: Option<&str>,
+    allow_local_fixture: bool,
+) -> Result<CloneRefRepoOutput> {
+    let reference = reference
+        .map(|value| validate_value("reference", value))
+        .transpose()?;
+
+    tokio::fs::create_dir_all(&ref_repos_root)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to create repository cache {}",
+                ref_repos_root.display()
+            )
+        })?;
+    let ref_repos_root = tokio::fs::canonicalize(&ref_repos_root)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to resolve repository cache {}",
+                ref_repos_root.display()
+            )
+        })?;
+
+    let base_name = ref_repo_directory_name(url, reference);
+    if let Some(output) =
+        find_existing_clone(&ref_repos_root, &base_name, url, reference, &cancellation).await?
+    {
+        return Ok(output);
+    }
+
+    let started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temp_path = ref_repos_root.join(format!(
+        ".clone-{}-{started_at}-{}",
+        std::process::id(),
+        NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed)
+    ));
+    let clone_result = run_clone(
+        &temp_path,
+        &cancellation,
+        url,
+        reference,
+        allow_local_fixture,
+    )
+    .await;
+    if let Err(error) = clone_result {
+        let _ = tokio::fs::remove_dir_all(&temp_path).await;
+        return Err(error);
+    }
+    let commit = match validate_new_clone(&temp_path, url, &cancellation).await {
+        Ok(commit) => commit,
+        Err(error) => {
+            let _ = tokio::fs::remove_dir_all(&temp_path).await;
+            return Err(error);
+        }
+    };
+    let metadata = CacheMetadata {
+        url: url.to_owned(),
+        reference: reference.map(str::to_owned),
+        commit: commit.clone(),
+    };
+    if let Err(error) = write_cache_metadata(&temp_path, &metadata).await {
+        let _ = tokio::fs::remove_dir_all(&temp_path).await;
+        return Err(error);
+    }
+
+    // Another process may have completed the same clone while ours was running.
+    // Try progressively suffixed names as well, which also makes hash collisions safe.
+    for suffix in 1_u32.. {
+        if let Err(error) = cancellation.ensure_active() {
+            let _ = tokio::fs::remove_dir_all(&temp_path).await;
+            return Err(error);
+        }
+        let destination = candidate_path(&ref_repos_root, &base_name, suffix);
+        let destination_exists = match path_entry_exists(&destination).await {
+            Ok(exists) => exists,
+            Err(error) => {
+                let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                return Err(error);
+            }
+        };
+        if destination_exists {
+            match validate_cached_clone(&destination, url, reference, &cancellation).await {
+                Ok(Some(output)) => {
+                    let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                    return Ok(output);
+                }
+                Ok(None) => continue,
+                Err(error) => {
+                    let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                    return Err(error);
+                }
+            }
+        }
+
+        match tokio::fs::rename(&temp_path, &destination).await {
+            Ok(()) => {
+                return Ok(CloneRefRepoOutput {
+                    path: destination.to_string_lossy().into_owned(),
+                    commit,
+                    reused: false,
+                });
+            }
+            Err(rename_error) => {
+                let destination_exists = match path_entry_exists(&destination).await {
+                    Ok(exists) => exists,
+                    Err(error) => {
+                        let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                        return Err(error);
+                    }
+                };
+                if destination_exists {
+                    match validate_cached_clone(&destination, url, reference, &cancellation).await {
+                        Ok(Some(output)) => {
+                            let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                            return Ok(output);
+                        }
+                        Ok(None) => continue,
+                        Err(error) => {
+                            let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                            return Err(error);
+                        }
+                    }
+                }
+                let _ = tokio::fs::remove_dir_all(&temp_path).await;
+                return Err(rename_error).with_context(|| {
+                    format!(
+                        "failed to install cloned repository at {}",
+                        destination.display()
+                    )
+                });
+            }
+        }
+    }
+
+    unreachable!("repository suffix space is not exhaustible")
+}
+
+fn validate_remote_url(url: &str) -> Result<()> {
+    let valid = if let Some(remainder) = url.strip_prefix("https://") {
+        remainder
+            .split('/')
+            .next()
+            .and_then(|authority| authority.split(':').next())
+            .is_some_and(valid_git_host)
+    } else if let Some(remainder) = url.strip_prefix("ssh://") {
+        let authority = remainder.split('/').next().unwrap_or_default();
+        authority
+            .strip_prefix("git@")
+            .unwrap_or(authority)
+            .split(':')
+            .next()
+            .is_some_and(valid_git_host)
+    } else if let Some(remainder) = url.strip_prefix("git@") {
+        remainder
+            .split_once(':')
+            .is_some_and(|(host, path)| valid_git_host(host) && !path.is_empty())
+    } else {
+        false
+    };
+    if !valid {
+        bail!("repository URL must be an HTTPS or SSH Git remote");
+    }
+    Ok(())
+}
+
+fn valid_git_host(host: &str) -> bool {
+    !host.is_empty()
+        && !host.starts_with('-')
+        && host
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '-'))
+}
+
+fn validate_value<'a>(name: &str, value: &'a str) -> Result<&'a str> {
+    let value = value.trim();
+    if value.is_empty() {
+        bail!("{name} cannot be empty");
+    }
+    if value.chars().any(char::is_control) {
+        bail!("{name} cannot contain control characters");
+    }
+    Ok(value)
+}
+
+fn reject_embedded_credentials(url: &str) -> Result<()> {
+    if url.contains(['?', '#']) {
+        bail!("repository URLs cannot contain query parameters or fragments");
+    }
+    if let Some((scheme, remainder)) = url.split_once("://") {
+        let authority = remainder.split('/').next().unwrap_or(remainder);
+        let allowed_ssh_user = scheme.eq_ignore_ascii_case("ssh")
+            && authority
+                .split_once('@')
+                .is_some_and(|(user, _)| user == "git");
+        if authority.contains('@') && !allowed_ssh_user {
+            bail!(
+                "repository URLs cannot contain credentials; use Git's credential helper or SSH authentication"
+            );
+        }
+    } else if url.contains('@') && !url.starts_with("git@") {
+        bail!(
+            "repository URLs cannot contain credentials; use Git's credential helper or SSH authentication"
+        );
+    }
+    Ok(())
+}
+
+fn ref_repo_directory_name(url: &str, reference: Option<&str>) -> String {
+    let without_query = url.split(['?', '#']).next().unwrap_or(url);
+    let name = without_query
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', ':'])
+        .next()
+        .unwrap_or("repository");
+    let name = name.strip_suffix(".git").unwrap_or(name);
+    let slug: String = name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .take(64)
+        .collect();
+    let slug = slug.trim_matches(['-', '.']);
+    let slug = if slug.is_empty() { "repository" } else { slug };
+
+    let mut hasher = Sha256::new();
+    hasher.update(url.as_bytes());
+    hasher.update([0]);
+    if let Some(reference) = reference {
+        hasher.update(reference.as_bytes());
+    }
+    let digest = hasher.finalize();
+    format!("{slug}-{}", hex_prefix(&digest[..8]))
+}
+
+fn hex_prefix(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn candidate_path(root: &Path, base_name: &str, suffix: u32) -> PathBuf {
+    if suffix == 1 {
+        root.join(base_name)
+    } else {
+        root.join(format!("{base_name}-{suffix}"))
+    }
+}
+
+async fn find_existing_clone(
+    root: &Path,
+    base_name: &str,
+    url: &str,
+    reference: Option<&str>,
+    cancellation: &WorkspaceCancellation,
+) -> Result<Option<CloneRefRepoOutput>> {
+    for suffix in 1_u32.. {
+        cancellation.ensure_active()?;
+        let candidate = candidate_path(root, base_name, suffix);
+        if !path_entry_exists(&candidate).await? {
+            return Ok(None);
+        }
+        if let Some(output) =
+            validate_cached_clone(&candidate, url, reference, cancellation).await?
+        {
+            return Ok(Some(output));
+        }
+    }
+    unreachable!("repository suffix space is not exhaustible")
+}
+
+async fn path_entry_exists(path: &Path) -> Result<bool> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
+    }
+}
+
+async fn validate_new_clone(
+    path: &Path,
+    url: &str,
+    cancellation: &WorkspaceCancellation,
+) -> Result<String> {
+    if !ref_repo_origin_matches(path, url, cancellation).await? {
+        bail!("cloned repository origin does not match the requested URL");
+    }
+    read_head(path, cancellation).await
+}
+
+async fn write_cache_metadata(path: &Path, metadata: &CacheMetadata) -> Result<()> {
+    let contents =
+        serde_json::to_vec(metadata).context("failed to serialize repository cache metadata")?;
+    tokio::fs::write(path.join(CACHE_METADATA_FILE), contents)
+        .await
+        .context("failed to write repository cache metadata")
+}
+
+async fn validate_cached_clone(
+    path: &Path,
+    url: &str,
+    reference: Option<&str>,
+    cancellation: &WorkspaceCancellation,
+) -> Result<Option<CloneRefRepoOutput>> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("failed to inspect repository cache entry"),
+    };
+    if !metadata.file_type().is_dir() {
+        return Ok(None);
+    }
+    let contents = match tokio::fs::read(path.join(CACHE_METADATA_FILE)).await {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("failed to read repository cache metadata"),
+    };
+    let metadata: CacheMetadata = match serde_json::from_slice(&contents) {
+        Ok(metadata) => metadata,
+        Err(_) => return Ok(None),
+    };
+    if metadata.url != url || metadata.reference.as_deref() != reference {
+        return Ok(None);
+    }
+    if !ref_repo_origin_matches(path, url, cancellation).await? {
+        return Ok(None);
+    }
+    let head = match read_head(path, cancellation).await {
+        Ok(head) => head,
+        Err(_) => {
+            cancellation.ensure_active()?;
+            return Ok(None);
+        }
+    };
+    if head != metadata.commit {
+        return Ok(None);
+    }
+    if !ref_repo_worktree_clean(path, cancellation).await? {
+        return Ok(None);
+    }
+    Ok(Some(CloneRefRepoOutput {
+        path: path.to_string_lossy().into_owned(),
+        commit: metadata.commit,
+        reused: true,
+    }))
+}
+
+async fn ref_repo_worktree_clean(
+    path: &Path,
+    cancellation: &WorkspaceCancellation,
+) -> Result<bool> {
+    let mut command = Command::new("git");
+    command
+        .args(["-C"])
+        .arg(path)
+        .args(["status", "--porcelain=v1", "--untracked-files=all"]);
+    let output = run_local_git(command, cancellation).await?;
+    Ok(output.status.success() && output.stdout.is_empty())
+}
+
+async fn ref_repo_origin_matches(
+    path: &Path,
+    url: &str,
+    cancellation: &WorkspaceCancellation,
+) -> Result<bool> {
+    if !path.is_dir() {
+        return Ok(false);
+    }
+    let mut command = Command::new("git");
+    command
+        .args(["-C"])
+        .arg(path)
+        .args(["remote", "get-url", "origin"]);
+    let output = run_local_git(command, cancellation).await?;
+    Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == url)
+}
+
+async fn run_clone(
+    destination: &Path,
+    cancellation: &WorkspaceCancellation,
+    url: &str,
+    reference: Option<&str>,
+    allow_local_fixture: bool,
+) -> Result<()> {
+    let mut command = Command::new("git");
+    command.args(["clone", "--depth", CLONE_DEPTH]);
+    if let Some(reference) = reference {
+        command.args(["--branch", reference, "--single-branch"]);
+    }
+    command
+        .arg("--")
+        .arg(url)
+        .arg(destination)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .env(
+            "GIT_ALLOW_PROTOCOL",
+            if allow_local_fixture {
+                "file:https:ssh"
+            } else {
+                "https:ssh"
+            },
+        )
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+
+    let mut child = command
+        .spawn()
+        .context("failed to run git; install Git to clone repositories")?;
+    let process_id = child.id();
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("failed to capture git clone error output"))?;
+    let stderr_task = tokio::spawn(async move {
+        let mut captured = Vec::new();
+        let mut buffer = [0_u8; 8_192];
+        loop {
+            let count = stderr.read(&mut buffer).await?;
+            if count == 0 {
+                return Ok::<_, std::io::Error>(captured);
+            }
+            let remaining = MAX_GIT_ERROR_BYTES.saturating_sub(captured.len());
+            captured.extend_from_slice(&buffer[..count.min(remaining)]);
+        }
+    });
+
+    let status = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => {
+            terminate_clone(&mut child, process_id).await;
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            return Err(WorkspaceOperationCancelled.into());
+        }
+        _ = tokio::time::sleep(CLONE_TIMEOUT) => {
+            terminate_clone(&mut child, process_id).await;
+            let _ = child.wait().await;
+            let _ = stderr_task.await;
+            bail!("git clone timed out after {} seconds", CLONE_TIMEOUT.as_secs());
+        }
+        status = child.wait() => status.context("failed while waiting for git clone")?,
+    };
+    let stderr = stderr_task
+        .await
+        .context("git clone error reader stopped unexpectedly")??;
+    if status.success() {
+        return Ok(());
+    }
+    let detail = String::from_utf8_lossy(&stderr)
+        .replace(url, "<repository URL>")
+        .trim()
+        .to_string();
+    if detail.is_empty() {
+        bail!("git clone failed with {status}");
+    }
+    bail!("git clone failed: {detail}")
+}
+
+async fn terminate_clone(child: &mut tokio::process::Child, process_id: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(process_id) = process_id {
+        // SAFETY: the child was placed in a new process group whose ID is its PID.
+        unsafe {
+            libc::kill(-(process_id as i32), libc::SIGKILL);
+        }
+        return;
+    }
+    let _ = child.kill().await;
+}
+
+async fn run_local_git(
+    mut command: Command,
+    cancellation: &WorkspaceCancellation,
+) -> Result<std::process::Output> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(WorkspaceOperationCancelled.into()),
+        result = tokio::time::timeout(LOCAL_GIT_TIMEOUT, command.output()) => {
+            result.context("local git command timed out")?
+                .context("failed to run git; install Git to clone repositories")
+        }
+    }
+}
+
+async fn read_head(path: &Path, cancellation: &WorkspaceCancellation) -> Result<String> {
+    let mut command = Command::new("git");
+    command.args(["-C"]).arg(&path).args(["rev-parse", "HEAD"]);
+    let output = run_local_git(command, cancellation).await?;
+    if !output.status.success() {
+        bail!(
+            "cached repository at {} is not a valid checkout",
+            path.display()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command as StdCommand;
+
+    use super::{clone_ref_repo, clone_ref_repo_validated, ref_repo_directory_name};
+    use crate::WorkspaceCancellation;
+    use crate::test_support::temp_workspace;
+
+    fn run_git(directory: &Path, args: &[&str]) {
+        let status = StdCommand::new("git")
+            .args(["-C"])
+            .arg(directory)
+            .args(args)
+            .status()
+            .expect("git should start");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn create_repository(root: &Path) -> PathBuf {
+        let source = root.join("source.git");
+        fs::create_dir(&source).expect("source directory");
+        run_git(&source, &["init", "--initial-branch=main"]);
+        run_git(&source, &["config", "user.name", "Sprocket Test"]);
+        run_git(&source, &["config", "user.email", "test@sprocket.local"]);
+        fs::write(source.join("README.md"), "hello\n").expect("fixture file");
+        run_git(&source, &["add", "README.md"]);
+        run_git(&source, &["commit", "-m", "initial"]);
+        source
+    }
+
+    #[tokio::test]
+    async fn reuses_matching_clone_without_overwriting_a_collision() {
+        let root = temp_workspace();
+        let source = create_repository(&root);
+        let cache = root.join("cache");
+        fs::create_dir(&cache).expect("cache directory");
+        let url = source.to_string_lossy().into_owned();
+        let collision = cache.join(ref_repo_directory_name(&url, None));
+        fs::create_dir(&collision).expect("collision fixture");
+
+        let first = clone_ref_repo_validated(
+            cache.clone(),
+            WorkspaceCancellation::new(),
+            &url,
+            None,
+            true,
+        )
+        .await
+        .expect("repository should clone");
+        let second = clone_ref_repo_validated(
+            cache.clone(),
+            WorkspaceCancellation::new(),
+            &url,
+            None,
+            true,
+        )
+        .await
+        .expect("repository should be reused");
+
+        assert!(!first.reused);
+        assert!(second.reused);
+        assert_eq!(first.path, second.path);
+        assert_eq!(first.commit, second.commit);
+        assert!(collision.is_dir());
+        assert!(fs::read_dir(collision).unwrap().next().is_none());
+
+        fs::write(Path::new(&first.path).join("README.md"), "tampered\n")
+            .expect("tampered fixture");
+
+        let replacement =
+            clone_ref_repo_validated(cache, WorkspaceCancellation::new(), &url, None, true)
+                .await
+                .expect("tampered repository should be replaced");
+        assert!(!replacement.reused);
+        assert_ne!(replacement.path, first.path);
+        assert_eq!(replacement.commit, first.commit);
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[tokio::test]
+    async fn rejects_local_path_before_creating_the_cache() {
+        let root = temp_workspace();
+        let source = create_repository(&root);
+        let cache = root.join("cache");
+        let error = clone_ref_repo(
+            cache.clone(),
+            WorkspaceCancellation::new(),
+            &source.to_string_lossy(),
+            None,
+        )
+        .await
+        .expect_err("local repository paths should be rejected");
+
+        assert!(error.to_string().contains("HTTPS or SSH"));
+        assert!(!cache.exists());
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+
+    #[tokio::test]
+    async fn rejects_credentials_before_creating_the_cache() {
+        let root = temp_workspace();
+        let cache = root.join("cache");
+        let error = clone_ref_repo(
+            cache.clone(),
+            WorkspaceCancellation::new(),
+            "https://token@example.com/org/repo.git",
+            None,
+        )
+        .await
+        .expect_err("embedded credentials should be rejected");
+
+        assert!(error.to_string().contains("cannot contain credentials"));
+        assert!(!cache.exists());
+        fs::remove_dir_all(root).expect("temp directory should be removed");
+    }
+}

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -68,6 +68,15 @@ impl CommandSessionManager {
         }
     }
 
+    pub fn resolve_workdir(&self, workdir: &str) -> Result<PathBuf> {
+        let candidate = self.requested_workdir(workdir);
+        resolve_command_workdir(candidate)
+    }
+
+    pub fn requested_workdir(&self, workdir: &str) -> PathBuf {
+        command_workdir_candidate(&self.workspace_root, workdir)
+    }
+
     pub async fn exec_command(
         &self,
         cancellation: WorkspaceCancellation,
@@ -83,7 +92,7 @@ impl CommandSessionManager {
             bail!("command cannot be empty");
         }
 
-        let cwd = resolve_command_workdir(&self.workspace_root, workdir)?;
+        let cwd = self.resolve_workdir(workdir)?;
         let mut process = build_shell_command(command, shell);
         process
             .current_dir(&cwd)
@@ -537,13 +546,16 @@ async fn join_capture_task(mut task: tokio::task::JoinHandle<Result<()>>) -> Res
     }
 }
 
-fn resolve_command_workdir(workspace_root: &Path, workdir: &str) -> Result<PathBuf> {
+fn command_workdir_candidate(workspace_root: &Path, workdir: &str) -> PathBuf {
     let expanded = PathBuf::from(expand_home(workdir.trim()));
-    let candidate = if expanded.is_absolute() {
+    if expanded.is_absolute() {
         expanded
     } else {
         workspace_root.join(expanded)
-    };
+    }
+}
+
+fn resolve_command_workdir(candidate: PathBuf) -> Result<PathBuf> {
     let resolved = candidate
         .canonicalize()
         .with_context(|| format!("failed to resolve command workdir {}", candidate.display()))?;


### PR DESCRIPTION
## Summary
- Add `clone_ref_repo` for shallow, reusable Git clones in a dedicated cache.
- Automatically run commands inside that cache through Bashkit with a read-only mount and no network.
- Surface the new tool in the agent/UI and document the sandbox boundary.

## Test plan
- [ ] Clone a reference repo via the agent and inspect the returned path with `exec_command`
- [ ] Confirm writes inside the cache fail / do not mutate the cached snapshot
- [ ] Confirm normal workspace `exec_command` still has full host access