### PR TITLE
feat(agent): Persist command sessions across agent runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "uuid",
  "walkdir",
 ]
 

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -37,6 +37,9 @@ export const vApplyPatchPayload = v.object({
 
 export const vExecCommandPayload = v.object({
 	cmd: v.string(),
+	// Reserved by the local agent before the process starts so a cancelled run
+	// can still expose and stop the surviving command session.
+	sessionId: v.optional(v.string()),
 	workdir: v.optional(v.string()),
 	shell: v.optional(v.string()),
 	timeoutMs: v.optional(v.number()),

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -370,11 +370,7 @@ describe('groupAssistantTimelineSections', () => {
 describe('partitionWorkSectionTools', () => {
 	function partition(blocks: AssistantTimelineWorkBlock[], isStreaming: boolean) {
 		const tools = blocks.flatMap((block) => (block.type === 'tool-group' ? block.tools : []));
-		return partitionWorkSectionTools(
-			blocks,
-			isStreaming,
-			buildOpenExecCommandSessions(tools, isStreaming)
-		);
+		return partitionWorkSectionTools(blocks, isStreaming, buildOpenExecCommandSessions(tools));
 	}
 
 	it('pulls running tools out and leaves settled reasoning/tools behind', () => {
@@ -492,7 +488,7 @@ describe('partitionWorkSectionTools', () => {
 		]);
 	});
 
-	it('closes sessions using message-wide open state across text section breaks', () => {
+	it('closes earlier-run sessions using thread-wide monitor state', () => {
 		const exec = tool('exec-1', 'exec_command', {
 			input: { cmd: 'npm run dev' },
 			output: { sessionId: '7', running: true },
@@ -507,7 +503,7 @@ describe('partitionWorkSectionTools', () => {
 				payload: { sessionId: '7' }
 			})
 		});
-		const openSessions = buildOpenExecCommandSessions([exec, monitor], true);
+		const openSessions = buildOpenExecCommandSessions([exec, monitor]);
 		const earlierSection: AssistantTimelineWorkBlock[] = [
 			{ type: 'tool-group', toolKey: 'exec_command', tools: [exec] }
 		];
@@ -528,7 +524,7 @@ describe('partitionWorkSectionTools', () => {
 		]);
 	});
 
-	it('settles in-flight tools and yielded commands after the run stops', () => {
+	it('keeps yielded commands running after the agent run stops', () => {
 		const claimedTool = tool('patch-1', 'apply_patch', {
 			job: executorJob('job-patch', 1, { status: 'claimed', kind: 'apply_patch' })
 		});
@@ -548,14 +544,35 @@ describe('partitionWorkSectionTools', () => {
 
 		const { settledBlocks, runningTools } = partition(blocks, false);
 
-		expect(runningTools).toEqual([]);
-		expect(settledBlocks).toEqual(blocks);
+		expect(runningTools).toEqual([yieldedCommand]);
+		expect(settledBlocks).toEqual([
+			{ type: 'tool-group', toolKey: 'apply_patch', tools: [claimedTool, claimedToolWithResult] }
+		]);
 		expect(assistantTimelineToolFailureKind(claimedTool, false)).toBe('interrupted');
 		expect(assistantTimelineToolError(claimedTool, false)).toBe(
 			'The agent stopped before this tool call finished.'
 		);
 		expect(assistantTimelineToolFailureKind(claimedToolWithResult, false)).toBeUndefined();
 		expect(assistantTimelineToolFailureKind(yieldedCommand, false)).toBeUndefined();
+	});
+
+	it('keeps a cancelled run command open from its reserved session payload', () => {
+		const command = tool('exec-1', 'exec_command', {
+			input: { cmd: 'npm run dev' },
+			job: executorJob('job-exec', 1, {
+				status: 'cancelled',
+				kind: 'exec_command',
+				payload: { cmd: 'npm run dev', sessionId: 'reserved-session' }
+			})
+		});
+		const blocks: AssistantTimelineWorkBlock[] = [
+			{ type: 'tool-group', toolKey: 'exec_command', tools: [command] }
+		];
+
+		const { settledBlocks, runningTools } = partition(blocks, false);
+
+		expect(settledBlocks).toEqual([]);
+		expect(runningTools).toEqual([command]);
 	});
 });
 

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -237,7 +237,7 @@ function jsonStringProp(value: JsonValue | undefined, key: string): string | und
 }
 
 /** Session id from command tool output, else input/payload (write_stdin completion omits it). */
-function commandSessionIdFromTool(tool: AssistantTimelineTool): string | undefined {
+export function commandSessionIdFromTool(tool: AssistantTimelineTool): string | undefined {
 	return (
 		jsonStringProp(tool.output, 'sessionId') ??
 		jsonStringProp(tool.input, 'sessionId') ??
@@ -284,18 +284,10 @@ export function resolveCommandSessionLabel(
 
 /**
  * Sessions still running that also have an exec_command row.
- * Returns empty when the run is not streaming so yielded commands settle after a crash/stop.
  * Later tool outputs win on the running flag (write_stdin completion clears the session).
- * Pass the full message tool list so monitors after text section breaks still close sessions.
+ * Pass the full thread tool list so later runs can close sessions started by earlier runs.
  */
-export function buildOpenExecCommandSessions(
-	tools: readonly AssistantTimelineTool[],
-	isStreaming: boolean
-): Set<string> {
-	if (!isStreaming) {
-		return new Set();
-	}
-
+export function buildOpenExecCommandSessions(tools: readonly AssistantTimelineTool[]): Set<string> {
 	const sessionRunning = new Map<string, boolean>();
 	const execSessions = new Set<string>();
 
@@ -306,6 +298,9 @@ export function buildOpenExecCommandSessions(
 		}
 		if (assistantTimelineToolKey(tool) === 'exec_command') {
 			execSessions.add(sessionId);
+			if (!sessionRunning.has(sessionId)) {
+				sessionRunning.set(sessionId, tool.job?.status !== 'failed');
+			}
 		}
 		if (isJsonObject(tool.output) && typeof tool.output.running === 'boolean') {
 			sessionRunning.set(sessionId, tool.output.running);

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { Check, Copy, LoaderCircle } from '@lucide/svelte';
+	import { Check, Copy, LoaderCircle, Trash2 } from '@lucide/svelte';
 	import { tick } from 'svelte';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { isJsonObject, type JsonValue } from '$convex/lib/json';
 	import {
 		assistantTimelineToolError,
@@ -8,6 +9,7 @@
 		buildAssistantTimeline,
 		buildCommandSessionCommandMap,
 		buildOpenExecCommandSessions,
+		commandSessionIdFromTool,
 		groupAssistantTimeline,
 		groupAssistantTimelineSections,
 		isAssistantTimelineToolRunning,
@@ -24,7 +26,12 @@
 	import ToolCallsDisclosure from '$lib/components/home/tool-calls-disclosure.svelte';
 	import WorkDisclosure from '$lib/components/home/work-disclosure.svelte';
 	import { formatElapsedDuration } from '$lib/format';
-	import type { ExecutorJob, ThreadMessage, WorkspaceSession } from '$lib/types/sprocket';
+	import type {
+		CommandSessionInfo,
+		ExecutorJob,
+		ThreadMessage,
+		WorkspaceSession
+	} from '$lib/types/sprocket';
 
 	type Props = {
 		currentError: string | null;
@@ -33,8 +40,10 @@
 		actions: ExecutorJob[];
 		activeRunId: ThreadMessage['runId'] | null;
 		workspaceSession: WorkspaceSession | null;
+		liveCommandSessions: CommandSessionInfo[] | null;
 		emptyStateMessage?: string;
 		emptyStateHint?: string | null;
+		onStopCommand: (threadId: ThreadMessage['threadId'], sessionId: string) => Promise<void>;
 	};
 
 	let {
@@ -44,6 +53,8 @@
 		actions,
 		activeRunId,
 		workspaceSession,
+		liveCommandSessions,
+		onStopCommand,
 		emptyStateMessage = workspaceSession
 			? 'Start a thread and ask Sprocket to inspect code, edit files, or run project commands.'
 			: 'Add a project to begin.',
@@ -51,6 +62,55 @@
 	}: Props = $props();
 	let scrollViewport = $state<HTMLDivElement | null>(null);
 	let stickToBottom = $state(true);
+	const stoppingCommandSessions = new SvelteSet<string>();
+	const stoppedCommandSessions = new SvelteSet<string>();
+	const commandStopErrors = new SvelteMap<string, string>();
+	let stopStateThreadId = $state<ThreadMessage['threadId'] | null>(null);
+
+	const transcriptThreadId = $derived(messages[0]?.threadId ?? null);
+	const allTimelineTools = $derived.by(() =>
+		messages.flatMap((message) => {
+			if (message.type !== 'response') return [];
+			return buildAssistantTimeline(
+				message.parts ?? [],
+				actions.filter((job) => job.runId === message.runId)
+			).filter((item): item is AssistantTimelineTool => item.type === 'tool');
+		})
+	);
+	const sessionCommands = $derived(buildCommandSessionCommandMap(allTimelineTools));
+	const transcriptOpenCommandSessions = $derived(buildOpenExecCommandSessions(allTimelineTools));
+	const liveOpenCommandSessions = $derived(
+		new SvelteSet(
+			(liveCommandSessions ?? [])
+				.filter((session) => session.running)
+				.map((session) => session.sessionId)
+		)
+	);
+	const openCommandSessions = $derived.by(() => {
+		return new SvelteSet(
+			[...transcriptOpenCommandSessions].filter(
+				(sessionId) =>
+					liveOpenCommandSessions.has(sessionId) && !stoppedCommandSessions.has(sessionId)
+			)
+		);
+	});
+
+	$effect(() => {
+		const threadId = transcriptThreadId;
+		if (threadId === null || threadId === stopStateThreadId) return;
+		stopStateThreadId = threadId;
+		stoppingCommandSessions.clear();
+		stoppedCommandSessions.clear();
+		commandStopErrors.clear();
+	});
+
+	$effect(() => {
+		for (const sessionId of [...stoppedCommandSessions]) {
+			if (!liveOpenCommandSessions.has(sessionId)) {
+				stoppedCommandSessions.delete(sessionId);
+			}
+		}
+	});
 
 	const SCROLL_EPSILON_PX = 28;
 
@@ -274,6 +334,23 @@
 		return error ? `${summary} (${error})` : summary;
 	}
 
+	async function stopCommand(threadId: ThreadMessage['threadId'], sessionId: string) {
+		if (stoppingCommandSessions.has(sessionId) || stoppedCommandSessions.has(sessionId)) return;
+		stoppingCommandSessions.add(sessionId);
+		commandStopErrors.delete(sessionId);
+		try {
+			await onStopCommand(threadId, sessionId);
+			stoppedCommandSessions.add(sessionId);
+		} catch (error) {
+			commandStopErrors.set(
+				sessionId,
+				error instanceof Error ? error.message : 'Failed to stop command.'
+			);
+		} finally {
+			stoppingCommandSessions.delete(sessionId);
+		}
+	}
+
 	const userMessageClass =
 		'user-bubble w-fit max-w-[33rem] rounded-xl border px-5 py-3.5 text-[15.5px] leading-7 text-foreground';
 
@@ -446,7 +523,6 @@
 							{@const timelineTools = timeline.filter(
 								(item): item is AssistantTimelineTool => item.type === 'tool'
 							)}
-							{@const sessionCommands = buildCommandSessionCommandMap(timelineTools)}
 							{@const blocks = groupAssistantTimeline(timeline)}
 							{@const sections = groupAssistantTimelineSections(blocks)}
 							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
@@ -456,7 +532,10 @@
 								message.runStatus !== 'completed' &&
 								message.runStatus !== 'failed' &&
 								message.runStatus !== 'cancelled'}
-							{@const openSessions = buildOpenExecCommandSessions(timelineTools, isStreaming)}
+							{@const hasOpenCommand = timelineTools.some((tool) => {
+								const sessionId = commandSessionIdFromTool(tool);
+								return sessionId !== undefined && openCommandSessions.has(sessionId);
+							})}
 							{@const hasPersistedAssistantContent = timeline.some(
 								(part) => part.type === 'text' || part.type === 'reasoning'
 							)}
@@ -478,11 +557,11 @@
 											{@const { settledBlocks, runningTools } = partitionWorkSectionTools(
 												section.blocks,
 												isStreaming,
-												openSessions
+												openCommandSessions
 											)}
 											{@const workInProgress =
-												isStreaming &&
-												(sectionIndex === sections.length - 1 || runningTools.length > 0)}
+												runningTools.length > 0 ||
+												(isStreaming && sectionIndex === sections.length - 1)}
 											{@const workSectionOrder = workIndexBySectionIndex[sectionIndex] ?? 0}
 											{@const timing = workSectionTimingAnchor(section, {
 												inProgress: workInProgress,
@@ -573,7 +652,8 @@
 													{#snippet toolRow(tool)}
 														{@const ToolIcon = toolLogIcon(tool)}
 														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
-														<p
+														{@const commandSessionId = commandSessionIdFromTool(tool)}
+														<div
 															class="flex min-w-0 items-start gap-1.5"
 															title={`${toolSummary} (running)`}
 														>
@@ -581,14 +661,34 @@
 																class="text-muted-foreground mt-1.5 size-3 shrink-0"
 																aria-hidden="true"
 															/>
-															<span class={toolSummaryClass(tool)}>{toolSummary}</span>
-														</p>
+															<span class={`min-w-0 flex-1 ${toolSummaryClass(tool)}`}
+																>{toolSummary}</span
+															>
+															{#if commandSessionId && openCommandSessions.has(commandSessionId)}
+																<button
+																	type="button"
+																	class="mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-slate-500 transition hover:bg-rose-500/10 hover:text-rose-300 focus-visible:ring-2 focus-visible:ring-rose-300/50 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50"
+																	disabled={stoppingCommandSessions.has(commandSessionId)}
+																	aria-label={`Stop command: ${toolSummary}`}
+																	title="Stop command"
+																	onclick={() =>
+																		void stopCommand(message.threadId, commandSessionId)}
+																>
+																	<Trash2 class="size-3.5" aria-hidden="true" />
+																</button>
+															{/if}
+														</div>
+														{#if commandSessionId && commandStopErrors.has(commandSessionId)}
+															<p class="pl-[18px] text-xs text-rose-300" role="alert">
+																{commandStopErrors.get(commandSessionId)}
+															</p>
+														{/if}
 													{/snippet}
 												</ToolCallsDisclosure>
 											{/if}
 										{/if}
 									{/each}
-									{#if !isStreaming && message.runCompletedAt !== undefined}
+									{#if !isStreaming && !hasOpenCommand && message.runCompletedAt !== undefined}
 										<p class="text-muted-foreground text-sm">
 											Worked for {formatElapsedDuration(
 												Math.max(

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { readWorkspaceLaunchFromHash, workspaceLaunchHash } from '$lib/local/client';
+import {
+	createLocalClient,
+	readWorkspaceLaunchFromHash,
+	workspaceLaunchHash
+} from '$lib/local/client';
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -13,5 +17,44 @@ describe('workspace launch fragments', () => {
 
 		expect(hash).toBe('#workspace=%2Frobots%2Farm+%26+gripper');
 		expect(readWorkspaceLaunchFromHash()).toBe(workspacePath);
+	});
+});
+
+describe('command session requests', () => {
+	it('lists and stops a thread command through the local API', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify([
+						{
+							sessionId: 'session/1',
+							command: 'sleep 5',
+							cwd: '/workspace',
+							running: true
+						}
+					]),
+					{ headers: { 'content-type': 'application/json' } }
+				)
+			)
+			.mockResolvedValueOnce(new Response(null, { status: 204 }));
+		vi.stubGlobal('fetch', fetchMock);
+		const client = createLocalClient('http://localhost:7731');
+
+		await expect(client.listCommandSessions('thread/1' as never)).resolves.toEqual([
+			expect.objectContaining({ sessionId: 'session/1', running: true })
+		]);
+		await expect(client.stopCommand('thread/1' as never, 'session/1')).resolves.toBeUndefined();
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			'http://localhost:7731/api/agent/commands/thread%2F1',
+			expect.objectContaining({ credentials: 'include' })
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			'http://localhost:7731/api/agent/commands/thread%2F1/session%2F1',
+			expect.objectContaining({ method: 'DELETE', credentials: 'include' })
+		);
 	});
 });

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -231,7 +231,15 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 			request<AgentRunStart>('/api/agent/run', {
 				method: 'POST',
 				body: JSON.stringify(requestBody)
-			})
+			}),
+		listCommandSessions: (threadId) =>
+			request(`/api/agent/commands/${encodeURIComponent(threadId)}`),
+		stopCommand: async (threadId, sessionId) => {
+			await request(
+				`/api/agent/commands/${encodeURIComponent(threadId)}/${encodeURIComponent(sessionId)}`,
+				{ method: 'DELETE' }
+			);
+		}
 	};
 }
 

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -143,6 +143,14 @@ export type AgentRunStart = {
 	runId: Id<'runs'>;
 };
 
+export type CommandSessionInfo = {
+	sessionId: string;
+	command: string;
+	cwd: string;
+	running: boolean;
+	error?: string;
+};
+
 export type FilesystemBrowseEntry = {
 	name: string;
 	fullPath: string;
@@ -178,6 +186,8 @@ export type DesktopApi = {
 		session: WorkspaceSessionAttachment
 	) => Promise<WorkspaceSessionLocation>;
 	runAgent: (request: AgentRunRequest) => Promise<AgentRunStart>;
+	listCommandSessions: (threadId: Id<'threadRecords'>) => Promise<CommandSessionInfo[]>;
+	stopCommand: (threadId: Id<'threadRecords'>, sessionId: string) => Promise<void>;
 };
 
 export type WorkspacePathResolution = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -83,6 +83,7 @@
 	import { resolve } from '$app/paths';
 	import { applyTheme, resolveTheme, type SprocketTheme } from '$lib/theme';
 	import type {
+		CommandSessionInfo,
 		DesktopApi,
 		ThreadMessage,
 		ThreadSummary,
@@ -177,6 +178,8 @@
 
 	let desktopApi = $state<DesktopApi | null>(null);
 	let desktopApiResolved = $state(false);
+	let liveCommandSessions = $state<CommandSessionInfo[] | null>(null);
+	let commandSessionsRequestSequence = 0;
 	let currentWorkspaceName = $state<string | null>(null);
 	let currentThreadId = $state<Id<'threadRecords'> | null>(null);
 	let draftWorkspaceName = $state<string | null>(null);
@@ -586,6 +589,48 @@
 
 	const runState = $derived(currentLatestRunData?.run ?? null);
 	const visibleActions = $derived((currentLatestRunData?.jobs ?? []).slice(-60));
+
+	async function refreshLiveCommandSessions(client: DesktopApi, threadId: Id<'threadRecords'>) {
+		const requestSequence = ++commandSessionsRequestSequence;
+		const sessions = await client.listCommandSessions(threadId);
+		if (
+			requestSequence === commandSessionsRequestSequence &&
+			desktopApi === client &&
+			currentThreadId === threadId
+		) {
+			liveCommandSessions = sessions;
+		}
+	}
+
+	$effect(() => {
+		const client = desktopApi;
+		const threadId = currentThreadId;
+		commandSessionsRequestSequence += 1;
+		liveCommandSessions = null;
+		if (!client || !threadId) return;
+
+		let disposed = false;
+		const refresh = async () => {
+			try {
+				await refreshLiveCommandSessions(client, threadId);
+			} catch {
+				// Keep the last confirmed state during a transient local API failure.
+			}
+		};
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
+		const poll = async () => {
+			await refresh();
+			if (!disposed) {
+				timeoutId = window.setTimeout(() => void poll(), 1_000);
+			}
+		};
+		void poll();
+		return () => {
+			disposed = true;
+			commandSessionsRequestSequence += 1;
+			if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+		};
+	});
 	const currentComposerScope = $derived(
 		getComposerScope(currentThreadId, currentWorkspaceSessionId)
 	);
@@ -1335,6 +1380,17 @@
 		}
 	}
 
+	async function stopCommand(threadId: Id<'threadRecords'>, sessionId: string) {
+		const client = desktopApi;
+		if (!client) {
+			throw new Error(localServerRequiredMessage);
+		}
+		await client.stopCommand(threadId, sessionId);
+		if (currentThreadId === threadId) {
+			await refreshLiveCommandSessions(client, threadId);
+		}
+	}
+
 	$effect(() => {
 		const data = currentLatestRunData;
 		if (!data) {
@@ -1900,6 +1956,8 @@
 						actions={visibleActions}
 						activeRunId={isRunning ? (runState?._id ?? null) : null}
 						workspaceSession={currentWorkspaceSession}
+						{liveCommandSessions}
+						onStopCommand={stopCommand}
 					/>
 
 					<PromptComposer

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -36,7 +36,9 @@ the on-disk layout.
 The agent currently offers command execution, command-session input, workspace
 patching, skill loading (`read_skill`), web search, and web-page scraping. Every
 tool call is wrapped in a durable executor-job record and observes run
-cancellation while work is active.
+cancellation while work is active. Long-running command sessions are scoped to a
+thread rather than one run, so a later prompt can monitor a command that
+survived cancellation of its originating run.
 
 Command execution has full local process permissions. Patch operations are
 confined to the workspace by `sprocket-workspace`. Web search and scraping run

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -55,6 +55,11 @@ fn tool_payload_compatible(raw: &serde_json::Value, normalized: &serde_json::Val
     match (raw, normalized) {
         (serde_json::Value::Object(raw), serde_json::Value::Object(normalized)) => {
             normalized.iter().all(|(key, value)| {
+                // exec_command reserves this internal field before persisting
+                // the job; it is not part of the model-facing tool arguments.
+                if key == "sessionId" && !raw.contains_key(key) {
+                    return true;
+                }
                 raw.get(key)
                     .is_some_and(|raw| tool_payload_compatible(raw, value))
             })
@@ -288,6 +293,23 @@ mod tests {
         assert_eq!(
             tracker.claim("exec_command", &serde_json::json!({ "cmd": "ls" })),
             Some("call-2".to_string())
+        );
+    }
+
+    #[test]
+    fn tracker_ignores_reserved_exec_session_id() {
+        let tracker = ToolCallTracker::default();
+        tracker.record(Some("call-1"), "exec_command", r#"{"cmd":"sleep 5"}"#);
+
+        assert_eq!(
+            tracker.claim(
+                "exec_command",
+                &serde_json::json!({
+                    "cmd": "sleep 5",
+                    "sessionId": "reserved-before-start"
+                })
+            ),
+            Some("call-1".to_string())
         );
     }
 

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -67,6 +67,7 @@ pub(crate) struct AgentProviderRequest {
     pub(crate) preamble: String,
     pub(crate) prior_history: Vec<Message>,
     pub(crate) workspace_root: PathBuf,
+    pub(crate) command_sessions: CommandSessionManager,
     pub(crate) skills: Arc<[WorkspaceSkill]>,
     pub(crate) model: String,
     pub(crate) reasoning_effort: String,
@@ -130,10 +131,10 @@ where
         request.run_id.clone(),
         request.claim_id.clone(),
         request.workspace_root.clone(),
+        request.command_sessions,
         tool_call_tracker.clone(),
         request.skills.clone(),
     );
-    let session_shutdown = CommandSessionShutdown::new(tools.command_sessions.clone());
     let agent = completion_client
         .agent(model)
         .preamble(&request.preamble)
@@ -227,39 +228,7 @@ where
         AgentProviderResult::Completed { text: final_text }
     };
 
-    session_shutdown.finish().await;
     result
-}
-
-/// Stops persistent command sessions on the normal path and if this future is
-/// dropped early (for example when claim lease renewal fails).
-struct CommandSessionShutdown {
-    sessions: Option<CommandSessionManager>,
-}
-
-impl CommandSessionShutdown {
-    fn new(sessions: CommandSessionManager) -> Self {
-        Self {
-            sessions: Some(sessions),
-        }
-    }
-
-    async fn finish(mut self) {
-        if let Some(sessions) = self.sessions.as_ref() {
-            sessions.stop_all().await;
-        }
-        self.sessions = None;
-    }
-}
-
-impl Drop for CommandSessionShutdown {
-    fn drop(&mut self) {
-        if let Some(sessions) = self.sessions.take() {
-            // Drop cannot await the async drain in stop_all; terminate is enough
-            // to stop leaked persistent command sessions after lease loss.
-            sessions.terminate_all();
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -3,8 +3,9 @@ use rig::OneOrMany;
 use rig::completion::Message;
 use rig::message::{ImageMediaType, UserContent};
 use sprocket_workspace::{
-    BUILTIN_SKILLS, WorkspaceInstruction, WorkspaceSkill, default_user_skills_dirs,
-    load_workspace_instructions, load_workspace_skills, resolve_workspace_root,
+    BUILTIN_SKILLS, CommandSessionInfo, WorkspaceInstruction, WorkspaceSkill,
+    default_user_skills_dirs, load_workspace_instructions, load_workspace_skills,
+    resolve_workspace_root,
 };
 use std::future::Future;
 use std::sync::Arc;
@@ -64,6 +65,7 @@ fn build_workspace_preamble(
     workspace_path: &str,
     workspace_instructions: &[WorkspaceInstruction],
     skills: &[WorkspaceSkill],
+    command_sessions: &[CommandSessionInfo],
 ) -> String {
     let instruction_block = if workspace_instructions.is_empty() {
         "No AGENTS.md instructions were preloaded for the current workspace.".to_string()
@@ -90,6 +92,31 @@ fn build_workspace_preamble(
             .collect::<Vec<_>>()
             .join("\n");
         format!("<SKILLS>\n{entries}\n</SKILLS>")
+    };
+
+    let command_sessions_block = if command_sessions.is_empty() {
+        "There are no command sessions available from previous agent runs.".to_string()
+    } else {
+        let sessions = command_sessions
+            .iter()
+            .map(|session| {
+                let status = if session.running {
+                    "running".to_string()
+                } else if let Some(error) = &session.error {
+                    format!("finished: {error}")
+                } else {
+                    "finished".to_string()
+                };
+                format!(
+                    "- Session {} ({status}) in {}: {}",
+                    session.session_id, session.cwd, session.command
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "Command sessions from previous agent runs are still available. Use `write_stdin` with the session ID to monitor them or retrieve their final output:\n{sessions}"
+        )
     };
 
     [
@@ -140,6 +167,10 @@ fn build_workspace_preamble(
         "Skills may reference bundled files; for on-disk skills, the read_skill result includes a dir path for reading those with exec_command when needed.",
         "",
         &skills_block,
+        "",
+        "## Previous Command Sessions",
+        "",
+        &command_sessions_block,
         "",
         "## AGENTS.md Spec",
         "",
@@ -570,6 +601,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };
     eprintln!("sprocket-agent: loaded run context {}", run_id);
+    let available_command_sessions = request.command_sessions.available_sessions().await;
 
     let model = context.run.selected_model.clone();
     let reasoning_effort = context.run.reasoning_effort.clone();
@@ -605,8 +637,12 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
         };
         let provider = AgentProvider::default_for_run(&runtime, &context, &run_id, &claim_id);
         let prior_history = deserialize_agent_history(context.agent_history)?;
-        let preamble =
-            build_workspace_preamble(&request.workspace_path, &workspace_instructions, &skills);
+        let preamble = build_workspace_preamble(
+            &request.workspace_path,
+            &workspace_instructions,
+            &skills,
+            &available_command_sessions,
+        );
         Ok((prompt, provider, prior_history, preamble, skills))
     })();
 
@@ -656,6 +692,7 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
                     preamble,
                     prior_history,
                     workspace_root,
+                    command_sessions: request.command_sessions.clone(),
                     skills,
                     model,
                     reasoning_effort,
@@ -703,7 +740,7 @@ mod tests {
                 contents: "---\nname: pdf-processing\ndescription: Handle PDFs\n---\n",
             },
         }];
-        let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
+        let preamble = build_workspace_preamble("/tmp/project", &[], &skills, &[]);
         assert!(preamble.contains("## Skills"));
         assert!(preamble.contains("<SKILLS>"));
         assert!(preamble.contains("- name: pdf-processing"));
@@ -713,7 +750,7 @@ mod tests {
 
     #[test]
     fn preamble_renders_empty_skills_line() {
-        let preamble = build_workspace_preamble("/tmp/project", &[], &[]);
+        let preamble = build_workspace_preamble("/tmp/project", &[], &[], &[]);
         assert!(preamble.contains("## Skills"));
         assert!(preamble.contains("No skills are installed."));
         assert!(!preamble.contains("<SKILLS>"));
@@ -728,7 +765,7 @@ mod tests {
                 contents: "---\nname: demo\ndescription: Line one\n---\n",
             },
         }];
-        let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
+        let preamble = build_workspace_preamble("/tmp/project", &[], &skills, &[]);
         assert!(preamble.contains("description: Line one line two"));
         assert!(!preamble.contains("description: Line one\n"));
     }

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -82,7 +82,6 @@ pub(crate) struct ReadSkillTool {
 
 pub(crate) struct AgentToolSet {
     pub(crate) apply_patch: ApplyPatchTool,
-    pub(crate) command_sessions: CommandSessionManager,
     pub(crate) exec_command: ExecCommandTool,
     pub(crate) read_skill: ReadSkillTool,
     pub(crate) scrape_url: ScrapeUrlTool,
@@ -95,21 +94,20 @@ pub(crate) fn agent_tools(
     run_id: String,
     claim_id: String,
     workspace_root: PathBuf,
+    command_sessions: CommandSessionManager,
     tool_call_tracker: ToolCallTracker,
     skills: Arc<[WorkspaceSkill]>,
 ) -> AgentToolSet {
-    let command_sessions = CommandSessionManager::new(workspace_root.clone());
     let context = AgentToolContext::new(
         runtime,
         run_id,
         claim_id,
         workspace_root,
         tool_call_tracker,
-        command_sessions.clone(),
+        command_sessions,
     );
     AgentToolSet {
         apply_patch: ApplyPatchTool(context.clone()),
-        command_sessions,
         exec_command: ExecCommandTool(context.clone()),
         read_skill: ReadSkillTool {
             context: context.clone(),
@@ -314,19 +312,23 @@ impl rig::tool::Tool for ExecCommandTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let session_id = self.0.command_sessions.reserve_session_id();
+        let mut payload = serde_json::to_value(&args).map_err(tool_error)?;
+        payload["sessionId"] = session_id.clone().into();
         execute_tool_job(
             &self.0.runtime,
             &self.0.run_id,
             &self.0.claim_id,
             Self::NAME,
             &self.0.tool_call_tracker,
-            serde_json::to_value(&args).map_err(tool_error)?,
+            payload,
             |cancellation| async {
                 let output = self
                     .0
                     .command_sessions
-                    .exec_command(
+                    .exec_command_with_session_id(
                         cancellation,
+                        session_id,
                         &args.cmd,
                         &args.workdir,
                         &args.shell,

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -7,6 +7,7 @@ use rig::message::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use sprocket_convex_provider::AuthTokenFetcher;
+use sprocket_workspace::CommandSessionManager;
 
 #[derive(Clone)]
 pub struct RunAgentRequest {
@@ -21,6 +22,7 @@ pub struct RunAgentRequest {
     pub reasoning_effort: String,
     pub service_tier: String,
     pub workspace_path: String,
+    pub command_sessions: CommandSessionManager,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sprocket-server/src/command_sessions.rs
+++ b/crates/sprocket-server/src/command_sessions.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use sprocket_workspace::{CommandSessionInfo, CommandSessionManager};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Default)]
+pub(crate) struct CommandSessionStore {
+    entries: Arc<Mutex<HashMap<String, CommandSessionEntry>>>,
+}
+
+struct CommandSessionEntry {
+    workspace_root: PathBuf,
+    manager: CommandSessionManager,
+}
+
+impl CommandSessionStore {
+    pub(crate) async fn for_thread(
+        &self,
+        thread_id: &str,
+        workspace_root: &Path,
+    ) -> Result<CommandSessionManager> {
+        let mut entries = self.entries.lock().await;
+        if let Some(entry) = entries.get(thread_id) {
+            if entry.workspace_root != workspace_root {
+                return Err(anyhow!(
+                    "thread command sessions belong to a different workspace"
+                ));
+            }
+            return Ok(entry.manager.clone());
+        }
+
+        let manager = CommandSessionManager::new(workspace_root.to_path_buf());
+        entries.insert(
+            thread_id.to_string(),
+            CommandSessionEntry {
+                workspace_root: workspace_root.to_path_buf(),
+                manager: manager.clone(),
+            },
+        );
+        Ok(manager)
+    }
+
+    pub(crate) async fn stop_by_user(&self, thread_id: &str, session_id: &str) -> Result<()> {
+        let manager = self
+            .entries
+            .lock()
+            .await
+            .get(thread_id)
+            .map(|entry| entry.manager.clone());
+        let Some(manager) = manager else {
+            return Ok(());
+        };
+        manager.stop_by_user(session_id).await
+    }
+
+    pub(crate) async fn available_sessions(&self, thread_id: &str) -> Vec<CommandSessionInfo> {
+        let manager = self
+            .entries
+            .lock()
+            .await
+            .get(thread_id)
+            .map(|entry| entry.manager.clone());
+        match manager {
+            Some(manager) => manager.available_sessions().await,
+            None => Vec::new(),
+        }
+    }
+}

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod command_sessions;
 mod config;
 pub mod repo_env;
 mod routes;
@@ -63,6 +64,7 @@ impl StartupInfo {
 #[derive(Clone)]
 pub struct AppState {
     pub auth: Arc<auth::AuthState>,
+    pub(crate) command_sessions: command_sessions::CommandSessionStore,
     pub desktop_login: Arc<auth::DesktopLoginStore>,
     pub workspace_sessions: Arc<workspace_sessions::WorkspaceSessionStore>,
     pub http_base_url: String,
@@ -109,6 +111,7 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
 
     let state = AppState {
         auth,
+        command_sessions: command_sessions::CommandSessionStore::default(),
         desktop_login: auth::DesktopLoginStore::new(),
         workspace_sessions,
         http_base_url: http_base_url.clone(),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{delete, get, post};
 use axum_extra::extract::CookieJar;
 use serde::Deserialize;
 use sprocket_agent::{
@@ -56,7 +56,13 @@ fn static_auth_token_fetcher(token: String) -> AuthTokenFetcher {
 }
 
 pub fn routes() -> axum::Router<AppState> {
-    axum::Router::new().route("/agent/run", post(run_agent_handler))
+    axum::Router::new()
+        .route("/agent/run", post(run_agent_handler))
+        .route(
+            "/agent/commands/{thread_id}/{session_id}",
+            delete(stop_command_handler),
+        )
+        .route("/agent/commands/{thread_id}", get(list_commands_handler))
 }
 
 async fn run_agent_handler(
@@ -74,6 +80,13 @@ async fn run_agent_handler(
         .workspace_path(&payload.workspace_session_id)
         .await
         .map_err(ApiError::bad_request)?;
+    let workspace_root = sprocket_workspace::resolve_workspace_root(&workspace_path)
+        .map_err(ApiError::bad_request)?;
+    let command_sessions = state
+        .command_sessions
+        .for_thread(&payload.thread_id, &workspace_root)
+        .await
+        .map_err(ApiError::bad_request)?;
 
     let auth_token_fetcher = static_auth_token_fetcher(payload.auth_token);
     let request = RunAgentRequest {
@@ -88,6 +101,7 @@ async fn run_agent_handler(
         reasoning_effort: payload.reasoning_effort,
         service_tier: payload.service_tier,
         workspace_path,
+        command_sessions,
     };
 
     let cleanup_request = request.clone();
@@ -131,6 +145,37 @@ async fn run_agent_handler(
         .map_err(|_| ApiError::internal(anyhow!("agent launch task stopped unexpectedly")))?
         .map_err(|error| ApiError::internal(anyhow!(error)))?;
     Ok((StatusCode::ACCEPTED, Json(RunAgentStartResponse { run_id })))
+}
+
+async fn stop_command_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Path((thread_id, session_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    state
+        .command_sessions
+        .stop_by_user(&thread_id, &session_id)
+        .await
+        .map_err(ApiError::not_found)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_commands_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Path(thread_id): Path<String>,
+) -> Result<Json<Vec<sprocket_workspace::CommandSessionInfo>>, ApiError> {
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    Ok(Json(
+        state.command_sessions.available_sessions(&thread_id).await,
+    ))
 }
 
 async fn await_agent_start<F, T, C, CF>(
@@ -187,6 +232,10 @@ impl ApiError {
 
     fn bad_request(error: anyhow::Error) -> Self {
         Self::with_status(StatusCode::BAD_REQUEST, error)
+    }
+
+    fn not_found(error: anyhow::Error) -> Self {
+        Self::with_status(StatusCode::NOT_FOUND, error)
     }
 
     fn internal(error: anyhow::Error) -> Self {

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -394,6 +394,7 @@ mod tests {
 
         let state = AppState {
             auth,
+            command_sessions: crate::command_sessions::CommandSessionStore::default(),
             desktop_login: DesktopLoginStore::new(),
             workspace_sessions: WorkspaceSessionStore::new(temp_dir),
             http_base_url: "http://127.0.0.1:7731".to_string(),

--- a/crates/sprocket-workspace/Cargo.toml
+++ b/crates/sprocket-workspace/Cargo.toml
@@ -14,4 +14,5 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full"] }
 tokio-util = "0.7.18"
+uuid = { version = "1.21.0", features = ["v4"] }
 walkdir = "2.5.0"

--- a/crates/sprocket-workspace/README.md
+++ b/crates/sprocket-workspace/README.md
@@ -23,7 +23,9 @@ fails.
 Command execution has a different trust boundary. Commands start in the
 workspace by default, but they are not sandboxed and may access the wider
 machine with the permissions of the Sprocket process. Output is bounded, and
-cancellation or timeout stops the process tree.
+timeouts stop the process tree. Cancelling an observer (including an agent run)
+detaches it without stopping the command; the session remains available for a
+later observer until it is explicitly terminated or its timeout expires.
 
 Workspace instruction loading follows the project hierarchy so deeper
 instructions can refine root-level guidance without coupling that behavior to

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -25,7 +25,7 @@ pub use skills::{
     read_skill_content,
 };
 pub use tools::{
-    CommandExecOutput, CommandSessionManager, WorkspaceCancellation, WorkspaceOperationCancelled,
-    default_command_shell,
+    CommandExecOutput, CommandSessionInfo, CommandSessionManager, WorkspaceCancellation,
+    WorkspaceOperationCancelled, default_command_shell,
 };
 pub use workspace::resolve_workspace_root;

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use crate::paths::expand_home;
@@ -56,7 +55,6 @@ pub struct WorkspaceOperationCancelled;
 pub struct CommandSessionManager {
     workspace_root: PathBuf,
     sessions: Arc<Mutex<HashMap<String, Arc<CommandSession>>>>,
-    next_session_id: Arc<AtomicU64>,
 }
 
 impl CommandSessionManager {
@@ -64,13 +62,43 @@ impl CommandSessionManager {
         Self {
             workspace_root,
             sessions: Arc::new(Mutex::new(HashMap::new())),
-            next_session_id: Arc::new(AtomicU64::new(1)),
         }
     }
 
     pub async fn exec_command(
         &self,
         cancellation: WorkspaceCancellation,
+        command: &str,
+        workdir: &str,
+        shell: &str,
+        timeout_ms: u64,
+        yield_time_ms: u64,
+        max_output_chars: usize,
+    ) -> Result<CommandExecOutput> {
+        let session_id = self.reserve_session_id();
+        self.exec_command_with_session_id(
+            cancellation,
+            session_id,
+            command,
+            workdir,
+            shell,
+            timeout_ms,
+            yield_time_ms,
+            max_output_chars,
+        )
+        .await
+    }
+
+    /// Reserves an identifier so callers can persist it before the process starts.
+    pub fn reserve_session_id(&self) -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn exec_command_with_session_id(
+        &self,
+        cancellation: WorkspaceCancellation,
+        session_id: String,
         command: &str,
         workdir: &str,
         shell: &str,
@@ -118,10 +146,6 @@ impl CommandSessionManager {
             timeout_ms.max(1),
         ));
 
-        let session_id = self
-            .next_session_id
-            .fetch_add(1, Ordering::Relaxed)
-            .to_string();
         let session = Arc::new(CommandSession {
             id: session_id.clone(),
             command: command.to_string(),
@@ -159,11 +183,7 @@ impl CommandSessionManager {
             .cloned()
             .ok_or_else(|| anyhow!("unknown or completed command session: {session_id}"))?;
 
-        if let Err(error) = cancellation.ensure_active() {
-            let _ = session.terminate();
-            self.sessions.lock().await.remove(session_id);
-            return Err(error);
-        }
+        cancellation.ensure_active()?;
 
         if session.completion.borrow().is_none() && !chars.is_empty() {
             if let Err(error) = session
@@ -176,11 +196,53 @@ impl CommandSessionManager {
             }
         }
         if session.completion.borrow().is_none() && terminate {
-            session.terminate()?;
+            session.terminate("Command was terminated by the agent.")?;
         }
 
         self.observe_session(session, cancellation, yield_time_ms)
             .await
+    }
+
+    /// Stops one process tree without consuming its buffered output. A later
+    /// `write_stdin` call receives the user-stop reason and any remaining output.
+    pub async fn stop_by_user(&self, session_id: &str) -> Result<()> {
+        let session = self.sessions.lock().await.get(session_id).cloned();
+        let Some(session) = session else {
+            return Ok(());
+        };
+        if session.completion.borrow().is_some() {
+            return Ok(());
+        }
+        session.terminate("Command was stopped by the user.")?;
+        let mut completion = session.completion.clone();
+        if completion.borrow().is_none() {
+            tokio::time::timeout(Duration::from_secs(5), completion.changed())
+                .await
+                .context("timed out waiting for the command to stop")?
+                .context("command session closed before reporting that it stopped")?;
+        }
+        Ok(())
+    }
+
+    pub async fn available_sessions(&self) -> Vec<CommandSessionInfo> {
+        let mut available = self
+            .sessions
+            .lock()
+            .await
+            .values()
+            .map(|session| {
+                let completion = session.completion.borrow().clone();
+                CommandSessionInfo {
+                    session_id: session.id.clone(),
+                    command: session.command.clone(),
+                    cwd: session.cwd.clone(),
+                    running: completion.is_none(),
+                    error: completion.and_then(|completion| completion.error),
+                }
+            })
+            .collect::<Vec<_>>();
+        available.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+        available
     }
 
     pub async fn stop_all(&self) {
@@ -192,7 +254,7 @@ impl CommandSessionManager {
             .cloned()
             .collect::<Vec<_>>();
         for session in &sessions {
-            let _ = session.terminate();
+            let _ = session.terminate("Command stopped because Sprocket is shutting down.");
         }
         let _ = tokio::time::timeout(Duration::from_secs(5), async {
             for session in sessions {
@@ -224,20 +286,12 @@ impl CommandSessionManager {
         cancellation: WorkspaceCancellation,
         yield_time_ms: u64,
     ) -> Result<CommandExecOutput> {
-        let completion = match wait_for_completion(
+        let completion = wait_for_completion(
             &session,
             &cancellation,
             yield_time_ms.min(MAX_COMMAND_YIELD_MS),
         )
-        .await
-        {
-            Ok(completion) => completion,
-            Err(error) => {
-                let _ = session.terminate();
-                self.sessions.lock().await.remove(&session.id);
-                return Err(error);
-            }
-        };
+        .await?;
         let output = session.output(completion.clone()).await;
         if completion.is_some() {
             self.sessions.lock().await.remove(&session.id);
@@ -270,16 +324,8 @@ impl CommandSessionManager {
                 self.sessions.lock().await.remove(&session.id);
                 Ok(output)
             }
-            Ok(None) => {
-                let _ = session.terminate();
-                self.sessions.lock().await.remove(&session.id);
-                Err(write_error)
-            }
-            Err(error) => {
-                let _ = session.terminate();
-                self.sessions.lock().await.remove(&session.id);
-                Err(error)
-            }
+            Ok(None) => Err(write_error),
+            Err(error) => Err(error),
         }
     }
 }
@@ -315,9 +361,11 @@ impl CommandSession {
         }
     }
 
-    fn terminate(&self) -> Result<()> {
+    fn terminate(&self, error: &str) -> Result<()> {
         self.control
-            .send(CommandControl::Terminate)
+            .send(CommandControl::Terminate {
+                error: error.to_string(),
+            })
             .map_err(|_| anyhow!("command session {} is no longer running", self.id))
     }
 
@@ -350,7 +398,7 @@ impl CommandSession {
 }
 
 enum CommandControl {
-    Terminate,
+    Terminate { error: String },
 }
 
 struct StdinRequest {
@@ -412,6 +460,8 @@ async fn wait_for_completion(
     }
 
     tokio::select! {
+        // Cancelling an observer detaches it without consuming output or
+        // stopping the process. A later observer resumes from the same cursor.
         _ = cancellation.cancelled() => Err(WorkspaceOperationCancelled.into()),
         result = tokio::time::timeout(
             Duration::from_millis(yield_time_ms),
@@ -444,9 +494,15 @@ async fn supervise_command(
     let (status, timed_out, mut error) = loop {
         tokio::select! {
             control = controls.recv() => match control {
-                Some(CommandControl::Terminate) | None => {
+                Some(CommandControl::Terminate { error }) => {
                     match terminate_child(&mut child, process_id).await {
-                        Ok(status) => break (Some(status), false, None),
+                        Ok(status) => break (Some(status), false, Some(error)),
+                        Err(error) => break (None, false, Some(error.to_string())),
+                    }
+                }
+                None => {
+                    match terminate_child(&mut child, process_id).await {
+                        Ok(status) => break (Some(status), false, Some("Command session closed unexpectedly.".to_string())),
                         Err(error) => break (None, false, Some(error.to_string())),
                     }
                 }
@@ -658,6 +714,17 @@ pub struct CommandExecOutput {
     pub error: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandSessionInfo {
+    pub session_id: String,
+    pub command: String,
+    pub cwd: String,
+    pub running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -864,7 +931,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_poll_removes_and_terminates_session() {
+    async fn cancelled_poll_keeps_session_running() {
         let root = temp_workspace();
         let sessions = CommandSessionManager::new(root.clone());
         let started = sessions
@@ -886,10 +953,60 @@ mod tests {
         sessions
             .write_stdin(cancellation, session_id, "", false, 5_000)
             .await
-            .expect_err("cancelled poll should fail");
+            .expect_err("cancelled poll should detach");
 
-        assert!(!sessions.sessions.lock().await.contains_key(session_id));
+        assert!(sessions.sessions.lock().await.contains_key(session_id));
         sessions.stop_all().await;
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelling_initial_observer_does_not_stop_command() {
+        let root = temp_workspace();
+        let sessions = CommandSessionManager::new(root.clone());
+        let cancellation = WorkspaceCancellation::new();
+        let command = {
+            let sessions = sessions.clone();
+            let cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                sessions
+                    .exec_command(
+                        cancellation,
+                        "sleep 0.1; printf survived",
+                        ".",
+                        &default_command_shell(),
+                        5_000,
+                        5_000,
+                        20_000,
+                    )
+                    .await
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while sessions.available_sessions().await.is_empty() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("command session should start");
+        cancellation.cancel();
+
+        command
+            .await
+            .expect("observer task should join")
+            .expect_err("cancelled observer should detach");
+        let available = sessions.available_sessions().await;
+        let [session] = available.as_slice() else {
+            panic!("command session should remain available");
+        };
+        let session_id = session.session_id.clone();
+        let finished = sessions
+            .write_stdin(WorkspaceCancellation::new(), &session_id, "", false, 5_000)
+            .await
+            .expect("later observer should monitor command");
+
+        assert!(finished.success);
+        assert_eq!(finished.stdout, "survived");
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -950,6 +1067,42 @@ mod tests {
         sessions.terminate_all();
         assert!(sessions.sessions.lock().await.is_empty());
         tokio::time::sleep(Duration::from_millis(300)).await;
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn user_stop_is_reported_to_the_next_observer() {
+        let root = temp_workspace();
+        let sessions = CommandSessionManager::new(root.clone());
+        let started = sessions
+            .exec_command(
+                WorkspaceCancellation::new(),
+                "sleep 5",
+                ".",
+                &default_command_shell(),
+                10_000,
+                10,
+                20_000,
+            )
+            .await
+            .expect("command should start");
+        let session_id = started.session_id.as_deref().unwrap();
+
+        sessions
+            .stop_by_user(session_id)
+            .await
+            .expect("user should be able to stop command");
+        let stopped = sessions
+            .write_stdin(WorkspaceCancellation::new(), session_id, "", false, 5_000)
+            .await
+            .expect("stopped command should remain observable");
+
+        assert!(!stopped.running);
+        assert!(!stopped.success);
+        assert_eq!(
+            stopped.error.as_deref(),
+            Some("Command was stopped by the user.")
+        );
         fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## Summary
- Keep long-running command sessions scoped to a thread so later prompts can monitor them after run cancellation.
- Add local API endpoints and UI controls to list and stop live command sessions.
- Teach the agent preamble about still-available sessions from previous runs.

## Test plan
- [ ] Start a long-running command, cancel the agent run, then continue it from a follow-up prompt
- [ ] Stop a live command from the transcript UI and confirm the next observer sees the stop error
- [ ] Confirm sessions remain available across prompts until timeout or explicit stop