### PR TITLE
feat(tools): Add ask_question tool for clarifying user choices

### DIFF
--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as agentQuestions from "../agentQuestions.js";
 import type * as agentRuntime from "../agentRuntime.js";
 import type * as authBootstrap from "../authBootstrap.js";
 import type * as billing from "../billing.js";
@@ -20,6 +21,7 @@ import type * as imageUploads from "../imageUploads.js";
 import type * as lib_access from "../lib/access.js";
 import type * as lib_agentErrors from "../lib/agentErrors.js";
 import type * as lib_agentHistory from "../lib/agentHistory.js";
+import type * as lib_agentQuestions from "../lib/agentQuestions.js";
 import type * as lib_assistantParts from "../lib/assistantParts.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_completionStream from "../lib/completionStream.js";
@@ -53,6 +55,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  agentQuestions: typeof agentQuestions;
   agentRuntime: typeof agentRuntime;
   authBootstrap: typeof authBootstrap;
   billing: typeof billing;
@@ -65,6 +68,7 @@ declare const fullApi: ApiFromModules<{
   "lib/access": typeof lib_access;
   "lib/agentErrors": typeof lib_agentErrors;
   "lib/agentHistory": typeof lib_agentHistory;
+  "lib/agentQuestions": typeof lib_agentQuestions;
   "lib/assistantParts": typeof lib_assistantParts;
   "lib/auth": typeof lib_auth;
   "lib/completionStream": typeof lib_completionStream;

--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { AGENT_DECIDE_OPTION_ID } from '@convex/lib/agentQuestions';
+import { initConvexTest, seedOwnedThread } from '@convex/test.setup';
+
+async function startRun(t: ReturnType<typeof initConvexTest>, threadId: Id<'threadRecords'>) {
+	const asUser = t.withIdentity({ subject: 'user_alice' });
+	const executionSecret = 'question-secret';
+	const created = await asUser.mutation(api.agentRuntime.createRun, {
+		submissionId: `sub-question-${Math.random()}`,
+		threadId,
+		prompt: 'Need a choice',
+		imageUploadIds: [],
+		selectedModel: 'gpt-5.6-sol',
+		reasoningEffort: 'medium',
+		serviceTier: 'standard',
+		executionSecret
+	});
+	const claimId = 'claim-question';
+	await t.mutation(api.agentRuntime.start, {
+		runId: created.runId,
+		claimId,
+		executionSecret
+	});
+	await t.mutation(api.agentRuntime.beginToolJob, {
+		runId: created.runId,
+		claimId,
+		kind: 'ask_question',
+		payload: {
+			question: 'placeholder',
+			options: [{ id: 'a', label: 'A' }]
+		},
+		executionSecret
+	});
+	return { asUser, executionSecret, claimId, runId: created.runId };
+}
+
+describe('agentQuestions', () => {
+	it('creates a question with agent_decide, enforces FIFO answers, and times out', async () => {
+		vi.useFakeTimers();
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		await expect(
+			t.mutation(api.agentQuestions.create, {
+				runId,
+				claimId,
+				question: 'x'.repeat(2001),
+				options: [{ id: 'a', label: 'A' }],
+				executionSecret
+			})
+		).rejects.toThrow(/2000/);
+
+		const first = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'First question?',
+			options: [
+				{ id: 'one', label: 'One' },
+				{ id: 'two', label: 'Two' }
+			],
+			timeoutMs: 5_000,
+			executionSecret
+		});
+		expect(first.options.map((option) => option.id)).toEqual([
+			'one',
+			'two',
+			AGENT_DECIDE_OPTION_ID
+		]);
+
+		const second = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Second question?',
+			options: [{ id: 'alpha', label: 'Alpha' }],
+			timeoutMs: 60_000,
+			executionSecret
+		});
+
+		const head = await asUser.query(api.agentQuestions.headPendingForThread, { threadId });
+		expect(head?.questionId).toBe(first.questionId);
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: second.questionId,
+				optionId: 'alpha'
+			})
+		).rejects.toThrow(/earliest pending/);
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: first.questionId,
+				optionId: 'two',
+				text: 'with detail'
+			})
+		).resolves.toMatchObject({
+			status: 'answered',
+			answer: {
+				optionId: 'two',
+				optionLabel: 'Two',
+				text: 'with detail'
+			}
+		});
+
+		expect(
+			(await asUser.query(api.agentQuestions.headPendingForThread, { threadId }))?.questionId
+		).toBe(second.questionId);
+
+		const timed = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Will time out?',
+			options: [{ id: 'x', label: 'X' }],
+			timeoutMs: 1_000,
+			executionSecret
+		});
+
+		await asUser.mutation(api.agentQuestions.answer, {
+			threadId,
+			questionId: second.questionId,
+			text: 'custom only'
+		});
+
+		await t.finishAllScheduledFunctions(() => {
+			vi.advanceTimersByTime(2_000);
+		});
+
+		const timedSnapshot = await t.query(api.agentQuestions.getForExecutor, {
+			runId,
+			questionId: timed.questionId,
+			executionSecret
+		});
+		expect(timedSnapshot?.status).toBe('timedOut');
+
+		vi.useRealTimers();
+	});
+
+	it('cancels pending questions when the run finalizes', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const created = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Still open?',
+			options: [{ id: 'yes', label: 'Yes' }],
+			executionSecret
+		});
+
+		await asUser.mutation(api.agentRuntime.finalizeRun, {
+			runId,
+			text: '',
+			status: 'cancelled'
+		});
+
+		const snapshot = await t.query(api.agentQuestions.getForExecutor, {
+			runId,
+			questionId: created.questionId,
+			executionSecret
+		});
+		expect(snapshot?.status).toBe('cancelled');
+	});
+
+	it('expires overdue heads on answer so FIFO can advance before the scheduler', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-26T12:00:00.000Z'));
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const overdue = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Overdue?',
+			options: [{ id: 'old', label: 'Old' }],
+			timeoutMs: 1_000,
+			executionSecret
+		});
+		const next = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Still live?',
+			options: [{ id: 'new', label: 'New' }],
+			timeoutMs: 60_000,
+			executionSecret
+		});
+
+		vi.setSystemTime(new Date('2026-07-26T12:00:02.000Z'));
+
+		expect(
+			(await asUser.query(api.agentQuestions.headPendingForThread, { threadId }))?.questionId
+		).toBe(next.questionId);
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: overdue.questionId,
+				optionId: 'old'
+			})
+		).rejects.toThrow(/no longer awaiting/);
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: next.questionId,
+				optionId: 'new'
+			})
+		).resolves.toMatchObject({
+			status: 'answered',
+			answer: { optionId: 'new', optionLabel: 'New' }
+		});
+
+		const overdueSnapshot = await t.query(api.agentQuestions.getForExecutor, {
+			runId,
+			questionId: overdue.questionId,
+			executionSecret
+		});
+		expect(overdueSnapshot?.status).toBe('timedOut');
+
+		vi.useRealTimers();
+	});
+});

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -1,0 +1,267 @@
+import type { Doc, Id } from '@convex/_generated/dataModel';
+import { internal } from '@convex/_generated/api';
+import {
+	internalMutation,
+	mutation,
+	query,
+	type MutationCtx,
+	type QueryCtx
+} from '@convex/_generated/server';
+import { v } from 'convex/values';
+import { getOwnedThreadRecord } from '@convex/lib/access';
+import {
+	finalizeQuestionOptions,
+	normalizeQuestionAnswer,
+	validateQuestionText,
+	type AgentQuestionOption
+} from '@convex/lib/agentQuestions';
+import { getExecutionRun, getUserId } from '@convex/lib/auth';
+import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { isRunClaimLeaseActive } from '@convex/lib/runLease';
+import { vAskQuestionOption } from '@convex/lib/validators';
+
+const DEFAULT_QUESTION_TIMEOUT_MS = 30 * 60 * 1000;
+const MIN_QUESTION_TIMEOUT_MS = 1_000;
+const MAX_QUESTION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+type AgentQuestionSnapshot = {
+	threadId: Id<'threadRecords'>;
+	questionId: Id<'agentQuestions'>;
+	question: string;
+	options: AgentQuestionOption[];
+	status: Doc<'agentQuestions'>['status'];
+	answer?: Doc<'agentQuestions'>['answer'];
+	sequence: number;
+	createdAt: number;
+	timeoutAt: number;
+	answeredAt?: number;
+};
+
+function toSnapshot(question: Doc<'agentQuestions'>): AgentQuestionSnapshot {
+	return {
+		threadId: question.threadId,
+		questionId: question._id,
+		question: question.question,
+		options: question.options,
+		status: question.status,
+		...(question.answer ? { answer: question.answer } : {}),
+		sequence: question.sequence,
+		createdAt: question.createdAt,
+		timeoutAt: question.timeoutAt,
+		...(question.answeredAt !== undefined ? { answeredAt: question.answeredAt } : {})
+	};
+}
+
+async function nextThreadSequence(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<number> {
+	const latest = await ctx.db
+		.query('agentQuestions')
+		.withIndex('by_threadId_sequence', (query) => query.eq('threadId', threadId))
+		.order('desc')
+		.first();
+	return (latest?.sequence ?? 0) + 1;
+}
+
+async function listPendingQuestions(
+	ctx: QueryCtx | MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'agentQuestions'>[]> {
+	return await ctx.db
+		.query('agentQuestions')
+		.withIndex('by_threadId_status_sequence', (query) =>
+			query.eq('threadId', threadId).eq('status', 'pending')
+		)
+		.order('asc')
+		.collect();
+}
+
+async function headPendingQuestion(
+	ctx: QueryCtx | MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'agentQuestions'> | null> {
+	const pending = await listPendingQuestions(ctx, threadId);
+	return pending[0] ?? null;
+}
+
+/** First pending question that has not yet reached timeoutAt (UI head). */
+async function headLivePendingQuestion(
+	ctx: QueryCtx | MutationCtx,
+	threadId: Id<'threadRecords'>,
+	now: number
+): Promise<Doc<'agentQuestions'> | null> {
+	const pending = await listPendingQuestions(ctx, threadId);
+	return pending.find((question) => question.timeoutAt > now) ?? null;
+}
+
+/** Mark past-due pending questions timedOut so FIFO can advance before the scheduler fires. */
+async function expireOverduePendingQuestions(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>,
+	now: number
+): Promise<void> {
+	const pending = await listPendingQuestions(ctx, threadId);
+	for (const question of pending) {
+		if (question.timeoutAt > now) {
+			continue;
+		}
+		await ctx.db.patch(question._id, {
+			status: 'timedOut',
+			answeredAt: now
+		});
+	}
+}
+
+export const create = mutation({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		question: v.string(),
+		options: v.array(vAskQuestionOption),
+		timeoutMs: v.optional(v.number()),
+		executionSecret: v.string()
+	},
+	handler: async (
+		ctx,
+		args
+	): Promise<{
+		questionId: Id<'agentQuestions'>;
+		question: string;
+		options: AgentQuestionOption[];
+		timeoutAt: number;
+		sequence: number;
+	}> => {
+		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		assertRunAcceptsModelCompletion(run.status);
+		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+			throw new Error('Run is no longer active.');
+		}
+		if (!run.activeJobId) {
+			throw new Error('Ask question requires an active tool job.');
+		}
+
+		const question = validateQuestionText(args.question);
+		const options = finalizeQuestionOptions(args.options);
+		const timeoutMs = Math.min(
+			MAX_QUESTION_TIMEOUT_MS,
+			Math.max(MIN_QUESTION_TIMEOUT_MS, Math.floor(args.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS))
+		);
+		const createdAt = Date.now();
+		const timeoutAt = createdAt + timeoutMs;
+		const sequence = await nextThreadSequence(ctx, run.threadId);
+
+		const questionId = await ctx.db.insert('agentQuestions', {
+			threadId: run.threadId,
+			runId: run._id,
+			jobId: run.activeJobId,
+			question,
+			options,
+			status: 'pending',
+			createdAt,
+			timeoutAt,
+			sequence
+		});
+
+		await ctx.scheduler.runAfter(timeoutMs, internal.agentQuestions.timeout, { questionId });
+
+		return {
+			questionId,
+			question,
+			options,
+			timeoutAt,
+			sequence
+		};
+	}
+});
+
+export const answer = mutation({
+	args: {
+		threadId: v.id('threadRecords'),
+		questionId: v.id('agentQuestions'),
+		optionId: v.optional(v.string()),
+		text: v.optional(v.string())
+	},
+	handler: async (ctx, args): Promise<AgentQuestionSnapshot> => {
+		const userId = await getUserId(ctx);
+		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+
+		const now = Date.now();
+		await expireOverduePendingQuestions(ctx, args.threadId, now);
+
+		const question = await ctx.db.get(args.questionId);
+		if (!question || question.threadId !== args.threadId) {
+			throw new Error('Question not found.');
+		}
+		if (question.status !== 'pending') {
+			throw new Error('Question is no longer awaiting an answer.');
+		}
+
+		const head = await headPendingQuestion(ctx, args.threadId);
+		if (!head || head._id !== question._id) {
+			throw new Error('Answer the earliest pending question first.');
+		}
+
+		const answer = normalizeQuestionAnswer({
+			options: question.options,
+			optionId: args.optionId,
+			text: args.text
+		});
+		await ctx.db.patch(question._id, {
+			status: 'answered',
+			answer,
+			answeredAt: now
+		});
+
+		return toSnapshot({
+			...question,
+			status: 'answered',
+			answer,
+			answeredAt: now
+		});
+	}
+});
+
+export const timeout = internalMutation({
+	args: {
+		questionId: v.id('agentQuestions')
+	},
+	handler: async (ctx, args): Promise<void> => {
+		const question = await ctx.db.get(args.questionId);
+		if (!question || question.status !== 'pending') {
+			return;
+		}
+		await ctx.db.patch(question._id, {
+			status: 'timedOut',
+			answeredAt: Date.now()
+		});
+	}
+});
+
+export const getForExecutor = query({
+	args: {
+		runId: v.id('runs'),
+		questionId: v.id('agentQuestions'),
+		executionSecret: v.string()
+	},
+	handler: async (ctx, args): Promise<AgentQuestionSnapshot | null> => {
+		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+		const question = await ctx.db.get(args.questionId);
+		if (!question || question.runId !== run._id) {
+			return null;
+		}
+		return toSnapshot(question);
+	}
+});
+
+export const headPendingForThread = query({
+	args: {
+		threadId: v.id('threadRecords')
+	},
+	handler: async (ctx, args): Promise<AgentQuestionSnapshot | null> => {
+		const userId = await getUserId(ctx);
+		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const head = await headLivePendingQuestion(ctx, args.threadId, Date.now());
+		return head ? toSnapshot(head) : null;
+	}
+});

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -113,6 +113,18 @@ async function finalizeRunRecord(
 			completedAt: finalizedJob.completedAt
 		});
 	}
+	const pendingQuestions = await ctx.db
+		.query('agentQuestions')
+		.withIndex('by_runId_sequence', (query) => query.eq('runId', run._id))
+		.collect();
+	for (const question of pendingQuestions) {
+		if (question.status === 'pending') {
+			await ctx.db.patch(question._id, {
+				status: 'cancelled',
+				answeredAt: completedAt
+			});
+		}
+	}
 	if (alreadyFinal) {
 		if (run.activeJobId) {
 			await ctx.db.patch(run._id, { activeJobId: undefined });

--- a/apps/web/src/convex/lib/agentQuestions.test.ts
+++ b/apps/web/src/convex/lib/agentQuestions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	AGENT_DECIDE_OPTION_ID,
+	AGENT_DECIDE_OPTION_LABEL,
+	MAX_OPTION_ID_CHARS,
+	MAX_OPTION_LABEL_CHARS,
+	MAX_QUESTION_CHARS,
+	canSubmitQuestionAnswer,
+	finalizeQuestionOptions,
+	normalizeQuestionAnswer,
+	validateQuestionText
+} from '@convex/lib/agentQuestions';
+
+describe('agentQuestions helpers', () => {
+	it('finalizes options with agent_decide appended', () => {
+		const options = finalizeQuestionOptions([
+			{ id: 'yes', label: 'Yes' },
+			{ id: 'no', label: 'No' }
+		]);
+		expect(options).toHaveLength(3);
+		expect(options.at(-1)).toEqual({
+			id: AGENT_DECIDE_OPTION_ID,
+			label: AGENT_DECIDE_OPTION_LABEL
+		});
+	});
+
+	it('rejects overlong question and option fields', () => {
+		expect(() => validateQuestionText('x'.repeat(MAX_QUESTION_CHARS + 1))).toThrow(/2000/);
+		expect(() =>
+			finalizeQuestionOptions([{ id: 'x'.repeat(MAX_OPTION_ID_CHARS + 1), label: 'Ok' }])
+		).toThrow(/20/);
+		expect(() =>
+			finalizeQuestionOptions([{ id: 'ok', label: 'x'.repeat(MAX_OPTION_LABEL_CHARS + 1) }])
+		).toThrow(/200/);
+	});
+
+	it('normalizes option, extension, and custom answers', () => {
+		const options = finalizeQuestionOptions([{ id: 'ship', label: 'Ship it' }]);
+		expect(normalizeQuestionAnswer({ options, optionId: 'ship' })).toEqual({
+			optionId: 'ship',
+			optionLabel: 'Ship it'
+		});
+		expect(normalizeQuestionAnswer({ options, optionId: 'ship', text: '  tonight  ' })).toEqual({
+			optionId: 'ship',
+			optionLabel: 'Ship it',
+			text: 'tonight'
+		});
+		expect(normalizeQuestionAnswer({ options, text: 'custom' })).toEqual({
+			text: 'custom'
+		});
+		expect(() => normalizeQuestionAnswer({ options })).toThrow(/Select an option/);
+	});
+
+	it('gates composer submit for question answers', () => {
+		expect(canSubmitQuestionAnswer({ selectedOptionId: null, text: '' })).toBe(false);
+		expect(canSubmitQuestionAnswer({ selectedOptionId: 'a', text: '' })).toBe(true);
+		expect(canSubmitQuestionAnswer({ selectedOptionId: null, text: 'custom' })).toBe(true);
+	});
+});

--- a/apps/web/src/convex/lib/agentQuestions.ts
+++ b/apps/web/src/convex/lib/agentQuestions.ts
@@ -1,0 +1,112 @@
+export const AGENT_DECIDE_OPTION_ID = 'agent_decide';
+export const AGENT_DECIDE_OPTION_LABEL = 'Let me (the agent) decide';
+
+export const MAX_QUESTION_CHARS = 2000;
+export const MAX_OPTION_ID_CHARS = 20;
+export const MAX_OPTION_LABEL_CHARS = 200;
+const MIN_AGENT_OPTIONS = 1;
+const MAX_AGENT_OPTIONS = 4;
+
+export type AgentQuestionOption = {
+	id: string;
+	label: string;
+};
+
+export type AgentQuestionAnswer = {
+	optionId?: string;
+	optionLabel?: string;
+	text?: string;
+};
+
+function agentDecideOption(): AgentQuestionOption {
+	return {
+		id: AGENT_DECIDE_OPTION_ID,
+		label: AGENT_DECIDE_OPTION_LABEL
+	};
+}
+
+export function validateQuestionText(question: string): string {
+	const trimmed = question.trim();
+	if (!trimmed) {
+		throw new Error('Question cannot be empty.');
+	}
+	if (trimmed.length > MAX_QUESTION_CHARS) {
+		throw new Error(`Question cannot exceed ${MAX_QUESTION_CHARS} characters.`);
+	}
+	return trimmed;
+}
+
+function validateAgentOptions(options: AgentQuestionOption[]): AgentQuestionOption[] {
+	if (options.length < MIN_AGENT_OPTIONS || options.length > MAX_AGENT_OPTIONS) {
+		throw new Error(
+			`Provide between ${MIN_AGENT_OPTIONS} and ${MAX_AGENT_OPTIONS} options (the agent-decide option is added automatically).`
+		);
+	}
+
+	const seen = new Set<string>();
+	const normalized: AgentQuestionOption[] = [];
+	for (const option of options) {
+		const id = option.id.trim();
+		const label = option.label.trim();
+		if (!id) {
+			throw new Error('Option id cannot be empty.');
+		}
+		if (!label) {
+			throw new Error('Option label cannot be empty.');
+		}
+		if (id.length > MAX_OPTION_ID_CHARS) {
+			throw new Error(`Option id cannot exceed ${MAX_OPTION_ID_CHARS} characters.`);
+		}
+		if (label.length > MAX_OPTION_LABEL_CHARS) {
+			throw new Error(`Option label cannot exceed ${MAX_OPTION_LABEL_CHARS} characters.`);
+		}
+		if (id === AGENT_DECIDE_OPTION_ID) {
+			throw new Error(`Option id '${AGENT_DECIDE_OPTION_ID}' is reserved.`);
+		}
+		if (seen.has(id)) {
+			throw new Error(`Duplicate option id '${id}'.`);
+		}
+		seen.add(id);
+		normalized.push({ id, label });
+	}
+	return normalized;
+}
+
+export function finalizeQuestionOptions(options: AgentQuestionOption[]): AgentQuestionOption[] {
+	return [...validateAgentOptions(options), agentDecideOption()];
+}
+
+export function normalizeQuestionAnswer(args: {
+	options: AgentQuestionOption[];
+	optionId?: string;
+	text?: string;
+}): AgentQuestionAnswer {
+	const text = args.text?.trim() || undefined;
+	const optionId = args.optionId?.trim() || undefined;
+
+	if (!optionId && !text) {
+		throw new Error('Select an option or provide an answer.');
+	}
+
+	if (!optionId) {
+		return { text };
+	}
+
+	const option = args.options.find((entry) => entry.id === optionId);
+	if (!option) {
+		throw new Error(`Unknown option id '${optionId}'.`);
+	}
+
+	return {
+		optionId: option.id,
+		optionLabel: option.label,
+		...(text ? { text } : {})
+	};
+}
+
+export function canSubmitQuestionAnswer(args: {
+	selectedOptionId: string | null | undefined;
+	text: string;
+}): boolean {
+	return Boolean(args.selectedOptionId?.trim()) || Boolean(args.text.trim());
+}

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -64,9 +64,28 @@ export const vReadSkillPayload = v.object({
 	name: v.string()
 });
 
+export const vAskQuestionOption = v.object({
+	id: v.string(),
+	label: v.string()
+});
+
+export const vAskQuestionPayload = v.object({
+	question: v.string(),
+	options: v.array(vAskQuestionOption),
+	yieldTimeMs: v.optional(v.number()),
+	timeoutMs: v.optional(v.number())
+});
+
+export const vAwaitQuestionPayload = v.object({
+	questionId: v.id('agentQuestions'),
+	yieldTimeMs: v.optional(v.number())
+});
+
 export const vExecutorJobPayload = v.union(
 	v.object({}),
 	vApplyPatchPayload,
+	vAskQuestionPayload,
+	vAwaitQuestionPayload,
 	vExecCommandPayload,
 	vReadSkillPayload,
 	vScrapeUrlPayload,
@@ -130,10 +149,26 @@ export const vReadSkillResult = v.object({
 	truncated: v.optional(v.boolean())
 });
 
+export const vAskQuestionAnswer = v.object({
+	optionId: v.optional(v.string()),
+	optionLabel: v.optional(v.string()),
+	text: v.optional(v.string())
+});
+
+export const vAskQuestionResult = v.object({
+	questionId: v.id('agentQuestions'),
+	question: v.string(),
+	options: v.array(vAskQuestionOption),
+	pending: v.boolean(),
+	timedOut: v.boolean(),
+	answer: v.optional(vAskQuestionAnswer)
+});
+
 export const vExecutorJobResult = v.union(
 	v.string(),
 	v.array(vWorkspaceInstruction),
 	vApplyPatchResult,
+	vAskQuestionResult,
 	vCommandExecResult,
 	vReadSkillResult,
 	vScrapeUrlResult,
@@ -163,12 +198,21 @@ export function isRunFinalStatus(
 
 export const vExecutorJobKind = v.union(
 	v.literal('apply_patch'),
+	v.literal('ask_question'),
+	v.literal('await_question'),
 	v.literal('exec_command'),
 	v.literal('get_workspace_instructions'),
 	v.literal('read_skill'),
 	v.literal('scrape_url'),
 	v.literal('web_search'),
 	v.literal('write_stdin')
+);
+
+export const vAgentQuestionStatus = v.union(
+	v.literal('pending'),
+	v.literal('answered'),
+	v.literal('timedOut'),
+	v.literal('cancelled')
 );
 
 export const vExecutorJobStatus = v.union(

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -1,6 +1,9 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 import {
+	vAgentQuestionStatus,
+	vAskQuestionAnswer,
+	vAskQuestionOption,
 	vExecutorJobKind,
 	vExecutorJobPayload,
 	vExecutorJobResult,
@@ -138,5 +141,21 @@ export default defineSchema({
 		.index('by_workspaceSessionId_sequence', ['workspaceSessionId', 'sequence'])
 		.index('by_threadId_sequence', ['threadId', 'sequence'])
 		.index('by_runId_sequence', ['runId', 'sequence'])
-		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence'])
+		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence']),
+	agentQuestions: defineTable({
+		threadId: v.id('threadRecords'),
+		runId: v.id('runs'),
+		jobId: v.id('executorJobs'),
+		question: v.string(),
+		options: v.array(vAskQuestionOption),
+		status: vAgentQuestionStatus,
+		answer: v.optional(vAskQuestionAnswer),
+		createdAt: v.number(),
+		timeoutAt: v.number(),
+		answeredAt: v.optional(v.number()),
+		sequence: v.number()
+	})
+		.index('by_runId_sequence', ['runId', 'sequence'])
+		.index('by_threadId_sequence', ['threadId', 'sequence'])
+		.index('by_threadId_status_sequence', ['threadId', 'status', 'sequence'])
 });

--- a/apps/web/src/lib/chat/tool-icons.ts
+++ b/apps/web/src/lib/chat/tool-icons.ts
@@ -1,7 +1,9 @@
 import {
 	BookOpen,
+	CircleQuestionMark,
 	FileDiff,
 	Globe,
+	Hourglass,
 	NotebookPen,
 	ScrollText,
 	Search,
@@ -13,6 +15,8 @@ import {
 
 const TOOL_KIND_ICONS: Record<string, LucideIcon> = {
 	apply_patch: FileDiff,
+	ask_question: CircleQuestionMark,
+	await_question: Hourglass,
 	check_docs: BookOpen,
 	exec_command: Terminal,
 	get_workspace_instructions: ScrollText,

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -2,12 +2,18 @@
 	import { ArrowUp, ImagePlus, Square, X } from '@lucide/svelte';
 	import { useAuth, useQuery } from 'convex-svelte';
 	import { api } from '$convex/_generated/api';
+	import type { Id } from '$convex/_generated/dataModel';
 	import OptionSelector from '$lib/components/option-selector.svelte';
 	import ProviderLogo from '$lib/components/provider-logo.svelte';
 	import ReasoningServiceSelector from '$lib/components/reasoning-service-selector.svelte';
 	import { shouldSubmitComposerFromKeydown } from '$lib/chat/composer';
 	import { applySkillSelection, filterSkills, getActiveDollarQuery } from '$lib/chat/dollar-skills';
 	import type { SkillSummary } from '$lib/types/sprocket';
+	import {
+		AGENT_DECIDE_OPTION_ID,
+		canSubmitQuestionAnswer,
+		type AgentQuestionOption
+	} from '$convex/lib/agentQuestions';
 	import {
 		defaultModelId,
 		defaultReasoningEffort,
@@ -29,6 +35,12 @@
 		type ComposerAttachment
 	} from '$lib/chat/attachments';
 
+	export type PendingAgentQuestion = {
+		questionId: Id<'agentQuestions'>;
+		question: string;
+		options: AgentQuestionOption[];
+	};
+
 	type Props = {
 		prompt?: string;
 		attachments: ComposerAttachment[];
@@ -38,6 +50,8 @@
 		selectedModel?: CatalogModelId;
 		selectedReasoningEffort?: SupportedReasoningEffort;
 		selectedServiceTier?: SupportedServiceTier;
+		pendingQuestion?: PendingAgentQuestion | null;
+		selectedQuestionOptionId?: string | null;
 		canSend: boolean;
 		isSubmitting: boolean;
 		isStarting: boolean;
@@ -67,6 +81,8 @@
 		selectedModel = $bindable(defaultModelId),
 		selectedReasoningEffort = $bindable<SupportedReasoningEffort>(defaultReasoningEffort),
 		selectedServiceTier = $bindable<SupportedServiceTier>(defaultServiceTier),
+		pendingQuestion = null,
+		selectedQuestionOptionId = $bindable<string | null>(null),
 		canSend,
 		isSubmitting,
 		isStarting,
@@ -113,13 +129,36 @@
 	let skillsCacheKey: string | null | undefined = undefined;
 	let optionElements = $state<Array<HTMLElement | null>>([]);
 
+	const answeringQuestion = $derived(pendingQuestion != null);
+	const composerLocked = $derived((isRunning && !answeringQuestion) || isSubmitting);
 	const hasMessageContent = $derived(Boolean(prompt.trim()) || attachments.length > 0);
+	const canAnswerQuestion = $derived(
+		canSubmitQuestionAnswer({
+			selectedOptionId: selectedQuestionOptionId,
+			text: prompt
+		})
+	);
+	const canSubmitContent = $derived(answeringQuestion ? canAnswerQuestion : hasMessageContent);
 	const attachmentsPending = $derived(
 		attachments.some((attachment) => attachment.status !== 'ready')
 	);
 	const canAttachMore = $derived(
-		attachments.length < MAX_IMAGE_ATTACHMENTS && !isRunning && !isSubmitting
+		attachments.length < MAX_IMAGE_ATTACHMENTS && !composerLocked && !answeringQuestion
 	);
+
+	let trackedPendingQuestionId = $state<string | null>(null);
+	$effect(() => {
+		const nextId = pendingQuestion?.questionId ?? null;
+		if (nextId !== trackedPendingQuestionId) {
+			trackedPendingQuestionId = nextId;
+			selectedQuestionOptionId = null;
+			// Drop answer draft when the pending question changes or clears so it
+			// cannot leak into the next question or a later normal send.
+			if (prompt.trim()) {
+				prompt = '';
+			}
+		}
+	});
 	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
 	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
 	const contextPercent = $derived(
@@ -136,7 +175,7 @@
 			: 0
 	);
 	const dollarQuery = $derived(getActiveDollarQuery(prompt, caretPosition));
-	const skillsPopupOpen = $derived(dollarQuery !== null && !skillsDismissed);
+	const skillsPopupOpen = $derived(dollarQuery !== null && !skillsDismissed && !answeringQuestion);
 	const filteredSkills = $derived(dollarQuery === null ? [] : filterSkills(skills, dollarQuery));
 	const activeOptionId = $derived(
 		skillsPopupOpen && filteredSkills.length > 0
@@ -222,7 +261,7 @@
 		const files = Array.from(event.clipboardData?.files ?? []).filter((file) =>
 			file.type.startsWith('image/')
 		);
-		if (files.length === 0 || isRunning || isSubmitting) {
+		if (files.length === 0 || isRunning || isSubmitting || answeringQuestion) {
 			return;
 		}
 		event.preventDefault();
@@ -289,11 +328,11 @@
 
 		if (
 			!canSend ||
-			!canSubmitWithModel ||
+			(!answeringQuestion && !canSubmitWithModel) ||
 			isSubmitting ||
-			isRunning ||
-			!hasMessageContent ||
-			attachmentsPending
+			composerLocked ||
+			!canSubmitContent ||
+			(!answeringQuestion && attachmentsPending)
 		) {
 			return;
 		}
@@ -304,6 +343,10 @@
 
 		event.preventDefault();
 		onSubmit();
+	}
+
+	function toggleQuestionOption(optionId: string) {
+		selectedQuestionOptionId = selectedQuestionOptionId === optionId ? null : optionId;
 	}
 
 	function handleModelChange(modelId: CatalogModelId) {
@@ -410,7 +453,38 @@
 		<div class={composerShellClass}>
 			<div class={composerInnerClass}>
 				<div class="relative flex min-h-33 flex-col px-4 pt-4 pb-2.5">
-					{#if attachments.length > 0}
+					{#if pendingQuestion}
+						<div class="mb-3" role="group" aria-label="Agent question">
+							<p class="text-foreground text-[14px] leading-6 font-medium">
+								{pendingQuestion.question}
+							</p>
+							<ul class="mt-2 flex flex-col gap-1.5" aria-label="Answer options">
+								{#each pendingQuestion.options as option (option.id)}
+									{@const isAgentDecide = option.id === AGENT_DECIDE_OPTION_ID}
+									{@const isSelected = selectedQuestionOptionId === option.id}
+									<li>
+										<button
+											type="button"
+											class={`w-full rounded-lg border px-3 py-2 text-left text-[13px] leading-5 transition ${
+												isSelected
+													? 'border-foreground/40 bg-hover-fill-strong text-foreground'
+													: isAgentDecide
+														? 'border-border/70 text-muted-foreground/80 hover:text-muted-foreground hover:bg-hover-fill'
+														: 'border-border text-muted-foreground hover:text-foreground hover:bg-hover-fill'
+											}`}
+											aria-pressed={isSelected}
+											onclick={() => {
+												toggleQuestionOption(option.id);
+											}}
+										>
+											{option.label}
+										</button>
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+					{#if attachments.length > 0 && !answeringQuestion}
 						<ul class="mb-3 flex flex-wrap items-center gap-2" aria-label="Attached images">
 							{#each attachments as attachment (attachment.localId)}
 								<li
@@ -449,7 +523,7 @@
 										type="button"
 										class="bg-foreground/70 text-background hover:bg-foreground/90 absolute top-1 right-1 flex size-4.5 cursor-pointer items-center justify-center rounded-full transition disabled:cursor-not-allowed disabled:opacity-40"
 										aria-label="Remove {attachment.name}"
-										disabled={isRunning || isSubmitting}
+										disabled={composerLocked}
 										onclick={() => onRemoveAttachment(attachment.localId)}
 									>
 										<X class="size-3" aria-hidden="true" />
@@ -493,8 +567,8 @@
 											id="composer-skill-option-{index}"
 											class={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition ${
 												highlightedIndex === index
-													? 'text-foreground bg-[var(--hover-fill-strong)]'
-													: 'text-muted-foreground hover:text-foreground hover:bg-[var(--hover-fill)]'
+													? 'text-foreground bg-hover-fill-strong'
+													: 'text-muted-foreground hover:text-foreground hover:bg-hover-fill'
 											}`}
 											role="option"
 											aria-selected={highlightedIndex === index}
@@ -519,8 +593,10 @@
 							bind:value={prompt}
 							rows="1"
 							class="text-foreground placeholder:text-muted-foreground field-sizing-content max-h-40 min-h-17 w-full resize-none overflow-y-auto border-0 bg-transparent px-0 py-0 text-[14px] leading-6 outline-none"
-							placeholder="Ask anything, @tag files/directories, or use $ to show available skills"
-							disabled={isRunning || isSubmitting}
+							placeholder={answeringQuestion
+								? 'Add detail, or type a custom answer'
+								: 'Ask anything, @tag files/directories, or use $ to show available skills'}
+							disabled={composerLocked}
 							role="combobox"
 							aria-autocomplete="list"
 							aria-haspopup="listbox"
@@ -569,16 +645,14 @@
 								<ImagePlus class="size-4" aria-hidden="true" />
 							</button>
 
-							<div
-								class="mx-1 hidden h-4 w-px shrink-0 bg-[var(--hover-fill-strong)] sm:block"
-							></div>
+							<div class="bg-hover-fill-strong mx-1 hidden h-4 w-px shrink-0 sm:block"></div>
 
 							<OptionSelector
 								bind:value={selectedModel}
 								options={tierModelOptions}
 								ariaLabel="Select model"
 								menuTitle="Model"
-								disabled={isRunning || modelCatalog === undefined}
+								disabled={composerLocked || answeringQuestion || modelCatalog === undefined}
 								searchable
 								onValueChange={handleModelChange}
 								className="z-20 shrink-0"
@@ -589,16 +663,14 @@
 								{/snippet}
 							</OptionSelector>
 
-							<div
-								class="mx-1 hidden h-4 w-px shrink-0 bg-[var(--hover-fill-strong)] sm:block"
-							></div>
+							<div class="bg-hover-fill-strong mx-1 hidden h-4 w-px shrink-0 sm:block"></div>
 
 							{#if selectedCatalogModel}
 								<ReasoningServiceSelector
 									model={selectedCatalogModel}
 									bind:reasoningEffort={selectedReasoningEffort}
 									bind:serviceTier={selectedServiceTier}
-									disabled={isRunning}
+									disabled={composerLocked || answeringQuestion}
 									className="z-20 shrink-0"
 								/>
 							{/if}
@@ -620,7 +692,7 @@
 								</button>
 								<div
 									id="context-window-details"
-									class="border-border bg-popover invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border p-4 opacity-0 shadow-[var(--composer-shadow)] transition duration-150 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100"
+									class="border-border bg-popover invisible absolute right-0 bottom-full z-50 mb-3 w-76 translate-y-1 rounded-xl border p-4 opacity-0 shadow-(--composer-shadow) transition duration-150 group-focus-within/context:visible group-focus-within/context:translate-y-0 group-focus-within/context:opacity-100 group-hover/context:visible group-hover/context:translate-y-0 group-hover/context:opacity-100"
 									role="tooltip"
 								>
 									<div class="flex items-center justify-between gap-4 text-[13px]">
@@ -631,7 +703,7 @@
 											)}</span
 										>
 									</div>
-									<div class="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--hover-fill)]">
+									<div class="bg-hover-fill mt-3 h-1.5 overflow-hidden rounded-full">
 										<div
 											class="bg-accent h-full rounded-full transition-[width] duration-300"
 											style={`width: ${contextPercent}%`}
@@ -659,17 +731,18 @@
 								>
 									<Square class="size-3.5 fill-current" />
 								</button>
-							{:else}
+							{/if}
+							{#if answeringQuestion || !isRunning}
 								<button
 									type="button"
 									class="bg-primary/90 text-primary-foreground hover:bg-primary flex h-10 w-10 items-center justify-center rounded-full transition-all duration-150 hover:scale-105 enabled:cursor-pointer disabled:pointer-events-none disabled:opacity-30 disabled:hover:scale-100"
 									onclick={onSubmit}
 									disabled={!canSend ||
-										!canSubmitWithModel ||
+										(!answeringQuestion && !canSubmitWithModel) ||
 										isSubmitting ||
-										!hasMessageContent ||
-										attachmentsPending}
-									aria-label="Send message"
+										!canSubmitContent ||
+										(!answeringQuestion && attachmentsPending)}
+									aria-label={answeringQuestion ? 'Submit answer' : 'Send message'}
 								>
 									<ArrowUp class="size-4" />
 								</button>

--- a/apps/web/src/lib/components/home/settings-account.svelte
+++ b/apps/web/src/lib/components/home/settings-account.svelte
@@ -72,10 +72,7 @@
 						Couldn’t load your subscription right now.
 					</p>
 				{:else}
-					<div
-						class="mt-3.5 h-4 w-16 animate-pulse rounded bg-[var(--hover-fill)]"
-						aria-hidden="true"
-					></div>
+					<div class="bg-hover-fill mt-3.5 h-4 w-16 animate-pulse rounded" aria-hidden="true"></div>
 				{/if}
 			</div>
 

--- a/apps/web/src/lib/components/home/settings-sidebar.svelte
+++ b/apps/web/src/lib/components/home/settings-sidebar.svelte
@@ -23,9 +23,8 @@
 
 	const navItemClass =
 		'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-[13px] transition';
-	const navItemActiveClass = 'bg-[var(--hover-fill-strong)] text-foreground';
-	const navItemIdleClass =
-		'text-muted-foreground hover:bg-[var(--hover-fill)] hover:text-foreground';
+	const navItemActiveClass = 'bg-hover-fill-strong text-foreground';
+	const navItemIdleClass = 'text-muted-foreground hover:bg-hover-fill hover:text-foreground';
 </script>
 
 <aside class="app-sidebar-panel">
@@ -33,7 +32,7 @@
 		<div class="flex items-center justify-between gap-2 px-3.5 pt-3 pb-3">
 			<button
 				type="button"
-				class="text-muted-foreground hover:text-foreground inline-flex h-8 items-center gap-2 rounded-lg px-2 text-[13px] transition hover:bg-[var(--hover-fill)]"
+				class="text-muted-foreground hover:text-foreground hover:bg-hover-fill inline-flex h-8 items-center gap-2 rounded-lg px-2 text-[13px] transition"
 				onclick={onBack}
 			>
 				<ArrowLeft class="size-3.5" aria-hidden="true" />

--- a/apps/web/src/lib/components/home/settings-usage.svelte
+++ b/apps/web/src/lib/components/home/settings-usage.svelte
@@ -65,14 +65,14 @@
 				</p>
 			{:else if usageQuery.isLoading || usageQuery.data === undefined}
 				<div class="animate-pulse space-y-10" aria-hidden="true">
-					<div class="h-4 w-24 rounded bg-[var(--hover-fill)]"></div>
+					<div class="bg-hover-fill h-4 w-24 rounded"></div>
 					{#each usageMeters as meter (meter.id)}
 						<div class="space-y-5">
-							<div class="h-3 w-28 rounded bg-[var(--hover-fill)]"></div>
+							<div class="bg-hover-fill h-3 w-28 rounded"></div>
 							{#each usagePeriods as period (period)}
 								<div class="space-y-2">
-									<div class="h-3.5 w-full rounded bg-[var(--hover-fill)]"></div>
-									<div class="h-1.5 w-full rounded-full bg-[var(--hover-fill)]"></div>
+									<div class="bg-hover-fill h-3.5 w-full rounded"></div>
+									<div class="bg-hover-fill h-1.5 w-full rounded-full"></div>
 								</div>
 							{/each}
 						</div>
@@ -123,7 +123,7 @@
 										)}
 									</p>
 									<div
-										class="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--hover-fill)]"
+										class="bg-hover-fill mt-2 h-1.5 overflow-hidden rounded-full"
 										role="progressbar"
 										aria-label={`${meter.label} — ${periodLabels[meterWindow.period]}`}
 										aria-valuemin={0}

--- a/apps/web/src/lib/components/home/sidebar-top-actions.svelte
+++ b/apps/web/src/lib/components/home/sidebar-top-actions.svelte
@@ -12,7 +12,7 @@
 
 <button
 	type="button"
-	class="text-muted-foreground hover:text-foreground inline-flex size-7 shrink-0 items-center justify-center rounded-md transition hover:bg-[var(--hover-fill)]"
+	class="text-muted-foreground hover:text-foreground hover:bg-hover-fill inline-flex size-7 shrink-0 items-center justify-center rounded-md transition"
 	aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
 	title={theme === 'dark' ? 'Light mode' : 'Dark mode'}
 	onclick={() => onThemeChange(theme === 'dark' ? 'light' : 'dark')}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -74,6 +74,10 @@
 		switch (toolKey) {
 			case 'apply_patch':
 				return 'Changed Files';
+			case 'ask_question':
+				return 'Asked Questions';
+			case 'await_question':
+				return 'Waiting for Answers';
 			case 'check_docs':
 				return 'Checked Docs';
 			case 'exec_command':
@@ -117,6 +121,10 @@
 		switch (name) {
 			case 'apply_patch':
 				return summarizePatchInput(input) ?? 'Patch';
+			case 'ask_question':
+				return typeof fields?.question === 'string' ? fields.question : 'Question';
+			case 'await_question':
+				return 'Waiting for answer';
 			case 'check_docs':
 				return typeof fields?.query === 'string'
 					? fields.query
@@ -409,7 +417,7 @@
 													</button>
 												{:else}
 													<span
-														class="text-muted-foreground inline-flex items-center rounded-xl border border-[var(--hairline)] bg-[var(--hover-fill)] px-3 py-2 text-xs"
+														class="text-muted-foreground border-hairline bg-hover-fill inline-flex items-center rounded-xl border px-3 py-2 text-xs"
 													>
 														{attachment.name} (unavailable)
 													</span>

--- a/apps/web/src/lib/components/home/workspace-picker.svelte
+++ b/apps/web/src/lib/components/home/workspace-picker.svelte
@@ -257,7 +257,7 @@
 			tabindex="-1"
 			onkeydown={handleDialogKeydown}
 		>
-			<div class="border-b border-[var(--hairline)] px-2.5 py-1.5">
+			<div class="border-hairline border-b px-2.5 py-1.5">
 				<div class="relative flex items-center">
 					<div class="text-muted-foreground pointer-events-none flex items-center ps-2">
 						<FolderPlus class="size-4" />
@@ -277,7 +277,7 @@
 					{/if}
 					<button
 						type="button"
-						class="border-border text-foreground absolute inset-e-2 top-1/2 -translate-y-1/2 rounded-md border bg-[var(--hover-fill)] px-2 py-1 text-[12px] transition hover:bg-[var(--hover-fill-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+						class="border-border text-foreground bg-hover-fill hover:bg-hover-fill-strong absolute inset-e-2 top-1/2 -translate-y-1/2 rounded-md border px-2 py-1 text-[12px] transition disabled:cursor-not-allowed disabled:opacity-40"
 						disabled={!canSubmit || isSubmitting}
 						onclick={() => {
 							void confirmSelection();
@@ -294,11 +294,11 @@
 			</div>
 
 			{#if recentWorkspaces.length > 0}
-				<div class="flex flex-wrap gap-1.5 border-b border-[var(--hairline)] px-3 py-2">
+				<div class="border-hairline flex flex-wrap gap-1.5 border-b px-3 py-2">
 					{#each recentWorkspaces as recent (recent.workspacePath)}
 						<button
 							type="button"
-							class="text-muted-foreground hover:text-foreground rounded-md px-2 py-0.5 text-[11px] transition hover:bg-[var(--hover-fill)]"
+							class="text-muted-foreground hover:text-foreground hover:bg-hover-fill rounded-md px-2 py-0.5 text-[11px] transition"
 							onclick={() => {
 								selectRecentWorkspace(recent);
 							}}
@@ -320,8 +320,8 @@
 							type="button"
 							class={`flex min-h-8 w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition ${
 								highlightedPath === entry.fullPath
-									? 'text-foreground bg-[var(--hover-fill-strong)]'
-									: 'text-muted-foreground hover:text-foreground hover:bg-[var(--hover-fill)]'
+									? 'text-foreground bg-hover-fill-strong'
+									: 'text-muted-foreground hover:text-foreground hover:bg-hover-fill'
 							}`}
 							role="option"
 							aria-selected={highlightedPath === entry.fullPath}
@@ -347,7 +347,7 @@
 			{/if}
 
 			<footer
-				class="text-muted-foreground flex items-center justify-between gap-3 border-t border-[var(--hairline)] px-3 py-2 text-[11px]"
+				class="text-muted-foreground border-hairline flex items-center justify-between gap-3 border-t px-3 py-2 text-[11px]"
 			>
 				<div class="flex flex-wrap items-center gap-3">
 					<span>↑↓ Navigate</span>

--- a/apps/web/src/lib/components/home/workspace-sidebar.svelte
+++ b/apps/web/src/lib/components/home/workspace-sidebar.svelte
@@ -41,7 +41,7 @@
 
 	const DEFAULT_VISIBLE_THREAD_COUNT = 3;
 	const sidebarActionButtonClass =
-		'flex h-9 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium tracking-[-0.02em] text-foreground transition hover:bg-[var(--hover-fill)] hover:text-foreground';
+		'flex h-9 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 text-[13px] font-medium tracking-[-0.02em] text-foreground transition hover:bg-hover-fill hover:text-foreground';
 	const sidebarActionIconClass = 'size-4 shrink-0 text-muted-foreground';
 	let expandedProjects = $state<Record<string, boolean>>({});
 	let collapsedProjects = $state<Record<string, boolean>>({});
@@ -211,7 +211,7 @@
 
 			{#if groups.length === 0}
 				<div
-					class="text-muted-foreground rounded-3xl border border-dashed border-[var(--hairline)] bg-[var(--hover-fill)] px-4 py-4 text-sm leading-6"
+					class="text-muted-foreground bg-hover-fill rounded-3xl border border-dashed border-[var(--hairline)] px-4 py-4 text-sm leading-6"
 				>
 					Choose a project to start organizing threads.
 				</div>
@@ -266,7 +266,7 @@
 
 								<button
 									type="button"
-									class="text-muted-foreground hover:text-foreground absolute top-0.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md opacity-0 transition group-hover:opacity-100 hover:bg-[var(--hover-fill)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+									class="text-muted-foreground hover:text-foreground hover:bg-hover-fill absolute top-0.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md opacity-0 transition group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
 									onclick={() => {
 										if (group.localWorkspaceAvailability === 'available') {
 											onStartThreadDraft(group.workspaceName);
@@ -326,7 +326,7 @@
 														<input
 															bind:this={renameInput}
 															bind:value={renameDraft}
-															class="border-border text-foreground focus:border-ring h-9 w-full rounded-lg border bg-[var(--hover-fill)] px-2 text-[13px] outline-none"
+															class="border-border text-foreground focus:border-ring bg-hover-fill h-9 w-full rounded-lg border px-2 text-[13px] outline-none"
 															aria-label="Rename thread"
 															onkeydown={(event) => {
 																if (event.key === 'Escape') {
@@ -345,7 +345,7 @@
 															type="button"
 															class={`${sidebarActionButtonClass} pr-8 ${
 																isSelected
-																	? 'text-foreground bg-[var(--hover-fill)]'
+																	? 'text-foreground bg-hover-fill'
 																	: 'text-muted-foreground'
 															}`}
 															aria-current={isSelected ? 'page' : undefined}
@@ -379,7 +379,7 @@
 														</button>
 														<button
 															type="button"
-															class={`text-muted-foreground hover:text-foreground absolute top-1.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md transition hover:bg-[var(--hover-fill)] focus-visible:opacity-100 ${
+															class={`text-muted-foreground hover:text-foreground hover:bg-hover-fill absolute top-1.5 right-1 inline-flex h-6 w-6 items-center justify-center rounded-md transition focus-visible:opacity-100 ${
 																isSelected
 																	? 'opacity-100'
 																	: 'opacity-0 group-focus-within/thread:opacity-100 group-hover/thread:opacity-100'
@@ -446,7 +446,7 @@
 	>
 		<button
 			type="button"
-			class="text-foreground hover:text-foreground flex w-full px-3 py-1.5 text-left text-[13px] transition hover:bg-[var(--hover-fill)]"
+			class="text-foreground hover:text-foreground hover:bg-hover-fill flex w-full px-3 py-1.5 text-left text-[13px] transition"
 			role="menuitem"
 			onclick={() => {
 				beginRename(contextMenu!.threadId, contextMenu!.title);

--- a/apps/web/src/lib/components/option-selector.svelte
+++ b/apps/web/src/lib/components/option-selector.svelte
@@ -167,7 +167,7 @@
 		bind:this={triggerElement}
 		type="button"
 		class={cn(
-			'focus-visible:ring-ring/60 text-muted-foreground inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-transparent bg-transparent px-2 text-sm font-medium transition outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
+			'focus-visible:ring-ring/60 text-muted-foreground hover:bg-hover-fill inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-transparent bg-transparent px-2 text-sm font-medium transition outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
 			!optionIcon && 'gap-1',
 			triggerClassName
 		)}
@@ -220,8 +220,8 @@
 						type="button"
 						class={cn(
 							'focus-visible:ring-ring/60 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left outline-none focus-visible:ring-2',
-							locked ? 'cursor-not-allowed opacity-45' : 'hover:bg-[var(--hover-fill)]',
-							!locked && option.id === value && 'bg-[var(--hover-fill)]'
+							locked ? 'cursor-not-allowed opacity-45' : 'hover:bg-hover-fill',
+							!locked && option.id === value && 'bg-hover-fill'
 						)}
 						aria-pressed={!locked && option.id === value}
 						aria-disabled={locked}

--- a/apps/web/src/lib/components/reasoning-service-selector.svelte
+++ b/apps/web/src/lib/components/reasoning-service-selector.svelte
@@ -82,7 +82,7 @@
 	<button
 		bind:this={triggerElement}
 		type="button"
-		class="focus-visible:ring-ring/60 text-muted-foreground inline-flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-[15px] transition outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
+		class="focus-visible:ring-ring/60 text-muted-foreground hover:bg-hover-fill inline-flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-[15px] transition outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50"
 		aria-haspopup="dialog"
 		aria-expanded={isOpen}
 		aria-label="Select reasoning effort and service tier"
@@ -111,7 +111,7 @@
 				{#each model.reasoningEfforts as effort (effort)}
 					<button
 						type="button"
-						class="focus-visible:ring-ring/60 text-foreground flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2"
+						class="focus-visible:ring-ring/60 text-foreground hover:bg-hover-fill flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none focus-visible:ring-2"
 						aria-pressed={effort === reasoningEffort}
 						onclick={() => selectReasoning(effort)}
 					>
@@ -135,7 +135,7 @@
 				{#each model.serviceTiers as tier (tier)}
 					<button
 						type="button"
-						class="focus-visible:ring-ring/60 text-foreground flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none hover:bg-[var(--hover-fill)] focus-visible:ring-2"
+						class="focus-visible:ring-ring/60 text-foreground hover:bg-hover-fill flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left text-sm outline-none focus-visible:ring-2"
 						aria-pressed={tier === serviceTier}
 						onclick={() => selectServiceTier(tier)}
 					>

--- a/apps/web/src/lib/components/ui/button/button.svelte
+++ b/apps/web/src/lib/components/ui/button/button.svelte
@@ -21,7 +21,7 @@
 
 	const variantClass = $derived(
 		variant === 'outline'
-			? 'border-border bg-surface/80 text-foreground hover:bg-[var(--hover-fill)]'
+			? 'border-border bg-surface/80 text-foreground hover:bg-hover-fill'
 			: 'bg-primary text-primary-foreground hover:opacity-90'
 	);
 </script>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1053,9 +1053,11 @@
 				...(answerText ? { text: answerText } : {})
 			});
 		} catch (error) {
-			prompt = submittedPrompt;
-			selectedQuestionOptionId = submittedOptionId;
-			currentError = error instanceof Error ? error.message : String(error);
+			if (currentThreadId === threadId) {
+				prompt = submittedPrompt;
+				selectedQuestionOptionId = submittedOptionId;
+				currentError = error instanceof Error ? error.message : String(error);
+			}
 		} finally {
 			answeringAgentQuestion = false;
 		}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -131,6 +131,7 @@
 	const archiveThreadMutation = useMutation(api.threads.archive);
 	const restoreThreadMutation = useMutation(api.threads.restore);
 	const finalizeRun = useMutation(api.agentRuntime.finalizeRun);
+	const answerAgentQuestion = useMutation(api.agentQuestions.answer);
 	const setLastThread = useMutation(api.uiPreferences.setLastThread);
 	const setThemePreference = useMutation(api.uiPreferences.setTheme);
 	const generateImageUploadUrl = useMutation(api.imageUploads.generateUploadUrl);
@@ -185,6 +186,8 @@
 	let selectedReasoningEffort = $state<SupportedReasoningEffort>(defaultReasoningEffort);
 	let selectedServiceTier = $state<SupportedServiceTier>(defaultServiceTier);
 	let prompt = $state('');
+	let selectedQuestionOptionId = $state<string | null>(null);
+	let answeringAgentQuestion = $state(false);
 	let composerAttachments = $state<ComposerAttachment[]>([]);
 	let currentError = $state<string | null>(null);
 	let executorClientId = $state<string | null>(null);
@@ -450,6 +453,10 @@
 	);
 	const liveMessagesQuery = useQuery(api.messages.listLiveForThread, authenticatedThreadQueryArgs);
 	const latestRunQuery = useQuery(api.chat.latestRunForThread, authenticatedThreadQueryArgs);
+	const pendingAgentQuestionQuery = useQuery(
+		api.agentQuestions.headPendingForThread,
+		authenticatedThreadQueryArgs
+	);
 	const queryError = $derived.by(() => {
 		for (const query of [
 			modelCatalogQuery,
@@ -459,7 +466,8 @@
 			activeThreadQuery,
 			historyMessagesQuery,
 			liveMessagesQuery,
-			latestRunQuery
+			latestRunQuery,
+			pendingAgentQuestionQuery
 		]) {
 			if (query.error) {
 				return query.error;
@@ -526,6 +534,9 @@
 		};
 	});
 	const currentLatestRunData = $derived(dataForThread(latestRunQuery.data, currentThreadId));
+	const pendingAgentQuestion = $derived(
+		dataForThread(pendingAgentQuestionQuery.data, currentThreadId)
+	);
 	const currentHistoryMessagesData = $derived(
 		dataForThread(historyMessagesQuery.data, currentThreadId)
 	);
@@ -624,10 +635,10 @@
 		Boolean(
 			currentWorkspaceSessionId &&
 			currentWorkspaceSession?.localWorkspaceAvailability === 'available' &&
-			!isRunning &&
 			!isSubmittingPrompt &&
+			!answeringAgentQuestion &&
 			!hasPendingAgentLaunch &&
-			isLatestRunReady
+			((!isRunning && isLatestRunReady) || pendingAgentQuestion)
 		)
 	);
 	const desiredAttachedWorkspaceSessionIds = $derived.by<Id<'workspaceSessions'>[]>(() =>
@@ -1017,7 +1028,45 @@
 		}
 	}
 
+	async function submitAgentQuestionAnswer() {
+		const question = pendingAgentQuestion;
+		const threadId = currentThreadId;
+		if (!question || !threadId || answeringAgentQuestion) {
+			return;
+		}
+		if (!selectedQuestionOptionId && !prompt.trim()) {
+			return;
+		}
+
+		answeringAgentQuestion = true;
+		currentError = null;
+		const submittedPrompt = prompt;
+		const submittedOptionId = selectedQuestionOptionId;
+		const answerText = submittedPrompt.trim();
+		prompt = '';
+		selectedQuestionOptionId = null;
+		try {
+			await answerAgentQuestion({
+				threadId,
+				questionId: question.questionId,
+				...(submittedOptionId ? { optionId: submittedOptionId } : {}),
+				...(answerText ? { text: answerText } : {})
+			});
+		} catch (error) {
+			prompt = submittedPrompt;
+			selectedQuestionOptionId = submittedOptionId;
+			currentError = error instanceof Error ? error.message : String(error);
+		} finally {
+			answeringAgentQuestion = false;
+		}
+	}
+
 	async function submitPrompt() {
+		if (pendingAgentQuestion) {
+			await submitAgentQuestionAnswer();
+			return;
+		}
+
 		if (isSubmittingPrompt) {
 			return;
 		}
@@ -1911,8 +1960,10 @@
 						bind:selectedModel
 						bind:selectedReasoningEffort
 						bind:selectedServiceTier
+						pendingQuestion={pendingAgentQuestion}
+						bind:selectedQuestionOptionId
 						{canSend}
-						isSubmitting={isSubmittingPrompt || hasPendingAgentLaunch}
+						isSubmitting={isSubmittingPrompt || hasPendingAgentLaunch || answeringAgentQuestion}
 						isStarting={hasPendingAgentLaunch}
 						{isRunning}
 						elapsedLabel={isRunning ? formatElapsedDuration(elapsedSeconds) : null}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1053,7 +1053,10 @@
 				...(answerText ? { text: answerText } : {})
 			});
 		} catch (error) {
-			if (currentThreadId === threadId) {
+			if (
+				currentThreadId === threadId &&
+				pendingAgentQuestion?.questionId === question.questionId
+			) {
 				prompt = submittedPrompt;
 				selectedQuestionOptionId = submittedOptionId;
 				currentError = error instanceof Error ? error.message : String(error);

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -318,6 +318,22 @@ impl RuntimeClient {
         decode_function_result(result, "agentRuntime:isFinished")
     }
 
+    pub(crate) async fn subscribe(
+        &self,
+        function: &str,
+        mut args: BTreeMap<String, Value>,
+    ) -> anyhow::Result<QuerySubscription> {
+        self.add_execution_secret(&mut args);
+        self.client.subscribe(function, args).await
+    }
+
+    pub(crate) fn decode_subscription_update<T: for<'de> Deserialize<'de>>(
+        result: FunctionResult,
+        function: &str,
+    ) -> anyhow::Result<T> {
+        decode_function_result(result, function)
+    }
+
     pub(crate) async fn finalize_run(
         &self,
         run_id: &str,

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -6,6 +6,8 @@ use rig::completion::CompletionModel;
 
 pub(crate) const AGENT_TOOL_NAMES: &[&str] = &[
     "apply_patch",
+    "ask_question",
+    "await_question",
     "exec_command",
     "read_skill",
     "scrape_url",

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -138,6 +138,8 @@ where
         .agent(model)
         .preamble(&request.preamble)
         .tool(tools.apply_patch)
+        .tool(tools.ask_question)
+        .tool(tools.await_question)
         .tool(tools.exec_command)
         .tool(tools.read_skill)
         .tool(tools.scrape_url)

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -1,6 +1,7 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use convex::Value;
 use futures::StreamExt;
@@ -11,12 +12,23 @@ use sprocket_workspace::{
     CommandSessionManager, WorkspaceCancellation, WorkspaceSkill, apply_workspace_patch,
     default_command_shell, read_skill_content,
 };
+use tokio::time::{Instant, sleep};
 
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_COMMAND_YIELD_MS: u64 = 10_000;
 const DEFAULT_COMMAND_MAX_OUTPUT_CHARS: usize = 20_000;
 const DEFAULT_STDIN_YIELD_MS: u64 = 5_000;
 const DEFAULT_WEB_SEARCH_RESULTS: u32 = 5;
+const DEFAULT_ASK_QUESTION_YIELD_MS: u64 = 10 * 60 * 1000;
+const DEFAULT_ASK_QUESTION_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const DEFAULT_AWAIT_QUESTION_YIELD_MS: u64 = 5_000;
+const MAX_QUESTION_CHARS: usize = 2000;
+const MAX_OPTION_ID_CHARS: usize = 20;
+const MAX_OPTION_LABEL_CHARS: usize = 200;
+const MIN_AGENT_OPTIONS: usize = 1;
+const MAX_AGENT_OPTIONS: usize = 4;
+const AGENT_DECIDE_OPTION_ID: &str = "agent_decide";
+const GET_QUESTION_FUNCTION: &str = "agentQuestions:getForExecutor";
 
 use crate::convex::RuntimeClient;
 use crate::hooks::ToolCallTracker;
@@ -63,6 +75,12 @@ impl AgentToolContext {
 pub(crate) struct ApplyPatchTool(AgentToolContext);
 
 #[derive(Clone)]
+pub(crate) struct AskQuestionTool(AgentToolContext);
+
+#[derive(Clone)]
+pub(crate) struct AwaitQuestionTool(AgentToolContext);
+
+#[derive(Clone)]
 pub(crate) struct ExecCommandTool(AgentToolContext);
 
 #[derive(Clone)]
@@ -82,6 +100,8 @@ pub(crate) struct ReadSkillTool {
 
 pub(crate) struct AgentToolSet {
     pub(crate) apply_patch: ApplyPatchTool,
+    pub(crate) ask_question: AskQuestionTool,
+    pub(crate) await_question: AwaitQuestionTool,
     pub(crate) command_sessions: CommandSessionManager,
     pub(crate) exec_command: ExecCommandTool,
     pub(crate) read_skill: ReadSkillTool,
@@ -109,6 +129,8 @@ pub(crate) fn agent_tools(
     );
     AgentToolSet {
         apply_patch: ApplyPatchTool(context.clone()),
+        ask_question: AskQuestionTool(context.clone()),
+        await_question: AwaitQuestionTool(context.clone()),
         command_sessions,
         exec_command: ExecCommandTool(context.clone()),
         read_skill: ReadSkillTool {
@@ -167,6 +189,43 @@ fn is_default_stdin_yield_ms(yield_time_ms: &u64) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+fn default_ask_question_yield_ms() -> u64 {
+    DEFAULT_ASK_QUESTION_YIELD_MS
+}
+
+fn default_ask_question_timeout_ms() -> u64 {
+    DEFAULT_ASK_QUESTION_TIMEOUT_MS
+}
+
+fn default_await_question_yield_ms() -> u64 {
+    DEFAULT_AWAIT_QUESTION_YIELD_MS
+}
+
+fn is_default_ask_question_yield_ms(yield_time_ms: &u64) -> bool {
+    *yield_time_ms == DEFAULT_ASK_QUESTION_YIELD_MS
+}
+
+fn is_default_ask_question_timeout_ms(timeout_ms: &u64) -> bool {
+    *timeout_ms == DEFAULT_ASK_QUESTION_TIMEOUT_MS
+}
+
+fn is_default_await_question_yield_ms(yield_time_ms: &u64) -> bool {
+    *yield_time_ms == DEFAULT_AWAIT_QUESTION_YIELD_MS
+}
+
+fn ask_question_parameters() -> serde_json::Value {
+    let mut schema = json!(schemars::schema_for!(AskQuestionArgs));
+    schema["properties"]["yieldTimeMs"]["default"] = json!(DEFAULT_ASK_QUESTION_YIELD_MS);
+    schema["properties"]["timeoutMs"]["default"] = json!(DEFAULT_ASK_QUESTION_TIMEOUT_MS);
+    schema
+}
+
+fn await_question_parameters() -> serde_json::Value {
+    let mut schema = json!(schemars::schema_for!(AwaitQuestionArgs));
+    schema["properties"]["yieldTimeMs"]["default"] = json!(DEFAULT_AWAIT_QUESTION_YIELD_MS);
+    schema
 }
 
 fn exec_command_parameters() -> serde_json::Value {
@@ -298,6 +357,82 @@ pub(crate) struct ReadSkillArgs {
     name: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct AskQuestionOption {
+    /// Stable option identifier returned with the user's answer.
+    id: String,
+    /// Option text shown to the user.
+    label: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct AskQuestionArgs {
+    /// Question shown above the composer.
+    question: String,
+    /// Answer choices. Provide 1-4 options; a "Let me (the agent) decide" option is appended automatically.
+    options: Vec<AskQuestionOption>,
+    /// Wait for an answer before yielding a questionId, in milliseconds. Use 0 to return immediately.
+    #[serde(
+        rename = "yieldTimeMs",
+        default = "default_ask_question_yield_ms",
+        skip_serializing_if = "is_default_ask_question_yield_ms"
+    )]
+    #[schemars(default = "default_ask_question_yield_ms")]
+    yield_time_ms: u64,
+    /// Expire the unanswered question after this many milliseconds.
+    #[serde(
+        rename = "timeoutMs",
+        default = "default_ask_question_timeout_ms",
+        skip_serializing_if = "is_default_ask_question_timeout_ms"
+    )]
+    #[schemars(default = "default_ask_question_timeout_ms")]
+    timeout_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct AwaitQuestionArgs {
+    /// Question identifier returned by ask_question when still pending.
+    #[serde(rename = "questionId")]
+    question_id: String,
+    /// Wait for an answer or timeout, in milliseconds.
+    #[serde(
+        rename = "yieldTimeMs",
+        default = "default_await_question_yield_ms",
+        skip_serializing_if = "is_default_await_question_yield_ms"
+    )]
+    #[schemars(default = "default_await_question_yield_ms")]
+    yield_time_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuestionAnswer {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    option_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    option_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QuestionSnapshot {
+    question_id: String,
+    question: String,
+    options: Vec<AskQuestionOption>,
+    status: String,
+    answer: Option<QuestionAnswer>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateQuestionResponse {
+    question_id: String,
+    question: String,
+    options: Vec<AskQuestionOption>,
+}
+
 impl rig::tool::Tool for ExecCommandTool {
     const NAME: &'static str = "exec_command";
     type Error = AgentToolError;
@@ -380,6 +515,125 @@ impl rig::tool::Tool for WriteStdinTool {
                     .await
                     .map_err(tool_error)?;
                 serde_json::to_value(output).map_err(tool_error)
+            },
+        )
+        .await
+    }
+}
+
+impl rig::tool::Tool for AskQuestionTool {
+    const NAME: &'static str = "ask_question";
+    type Error = AgentToolError;
+    type Args = AskQuestionArgs;
+    type Output = serde_json::Value;
+
+    fn description(&self) -> String {
+        format!(
+            "Ask the user a multiple-choice question above the composer. Waits up to yieldTimeMs for an answer, otherwise returns a questionId for await_question."
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        ask_question_parameters()
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let prepared = prepare_ask_question(&args)?;
+        let payload = serde_json::to_value(&args).map_err(tool_error)?;
+        execute_tool_job(
+            &self.0.runtime,
+            &self.0.run_id,
+            &self.0.claim_id,
+            Self::NAME,
+            &self.0.tool_call_tracker,
+            payload,
+            |cancellation| {
+                let runtime = self.0.runtime.clone();
+                let run_id = self.0.run_id.clone();
+                let claim_id = self.0.claim_id.clone();
+                async move {
+                    let created = create_agent_question(
+                        &runtime,
+                        &run_id,
+                        &claim_id,
+                        &prepared.question,
+                        &prepared.options,
+                        args.timeout_ms,
+                    )
+                    .await?;
+                    observe_question(
+                        &runtime,
+                        &run_id,
+                        &created.question_id,
+                        &created.question,
+                        &created.options,
+                        args.yield_time_ms,
+                        cancellation,
+                    )
+                    .await
+                }
+            },
+        )
+        .await
+    }
+}
+
+impl rig::tool::Tool for AwaitQuestionTool {
+    const NAME: &'static str = "await_question";
+    type Error = AgentToolError;
+    type Args = AwaitQuestionArgs;
+    type Output = serde_json::Value;
+
+    fn description(&self) -> String {
+        "Wait for a previously yielded ask_question result. Poll with yieldTimeMs until answered, timed out, or still pending."
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        await_question_parameters()
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        if args.question_id.trim().is_empty() {
+            return Err(AgentToolError::Message(
+                "questionId cannot be empty".to_string(),
+            ));
+        }
+        let payload = serde_json::to_value(&args).map_err(tool_error)?;
+        execute_tool_job(
+            &self.0.runtime,
+            &self.0.run_id,
+            &self.0.claim_id,
+            Self::NAME,
+            &self.0.tool_call_tracker,
+            payload,
+            |cancellation| {
+                let runtime = self.0.runtime.clone();
+                let run_id = self.0.run_id.clone();
+                let question_id = args.question_id.clone();
+                async move {
+                    let snapshot = fetch_question_snapshot(&runtime, &run_id, &question_id).await?;
+                    let Some(snapshot) = snapshot else {
+                        return Err(AgentToolError::Message(format!(
+                            "Unknown questionId '{question_id}'"
+                        )));
+                    };
+                    // Avoid racing the yield deadline against a slow first subscription
+                    // update when the question is already terminal.
+                    if snapshot.status != "pending" {
+                        return question_result_from_snapshot(&snapshot);
+                    }
+                    observe_question(
+                        &runtime,
+                        &run_id,
+                        &snapshot.question_id,
+                        &snapshot.question,
+                        &snapshot.options,
+                        args.yield_time_ms,
+                        cancellation,
+                    )
+                    .await
+                }
             },
         )
         .await
@@ -578,6 +832,235 @@ pub(crate) fn resolve_read_skill(
     Ok(value)
 }
 
+#[derive(Clone, Debug)]
+struct PreparedAskQuestion {
+    question: String,
+    options: Vec<AskQuestionOption>,
+}
+
+fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, AgentToolError> {
+    let question = args.question.trim();
+    if question.is_empty() {
+        return Err(AgentToolError::Message(
+            "Question cannot be empty.".to_string(),
+        ));
+    }
+    if question.len() > MAX_QUESTION_CHARS {
+        return Err(AgentToolError::Message(format!(
+            "Question cannot exceed {MAX_QUESTION_CHARS} characters."
+        )));
+    }
+    if args.options.len() < MIN_AGENT_OPTIONS || args.options.len() > MAX_AGENT_OPTIONS {
+        return Err(AgentToolError::Message(format!(
+            "Provide between {MIN_AGENT_OPTIONS} and {MAX_AGENT_OPTIONS} options (the agent-decide option is added automatically)."
+        )));
+    }
+
+    let mut seen = HashSet::new();
+    let mut options = Vec::with_capacity(args.options.len());
+    for option in &args.options {
+        let id = option.id.trim();
+        let label = option.label.trim();
+        if id.is_empty() {
+            return Err(AgentToolError::Message(
+                "Option id cannot be empty.".to_string(),
+            ));
+        }
+        if label.is_empty() {
+            return Err(AgentToolError::Message(
+                "Option label cannot be empty.".to_string(),
+            ));
+        }
+        if id.len() > MAX_OPTION_ID_CHARS {
+            return Err(AgentToolError::Message(format!(
+                "Option id cannot exceed {MAX_OPTION_ID_CHARS} characters."
+            )));
+        }
+        if label.len() > MAX_OPTION_LABEL_CHARS {
+            return Err(AgentToolError::Message(format!(
+                "Option label cannot exceed {MAX_OPTION_LABEL_CHARS} characters."
+            )));
+        }
+        if id == AGENT_DECIDE_OPTION_ID {
+            return Err(AgentToolError::Message(format!(
+                "Option id '{AGENT_DECIDE_OPTION_ID}' is reserved."
+            )));
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(AgentToolError::Message(format!(
+                "Duplicate option id '{id}'."
+            )));
+        }
+        options.push(AskQuestionOption {
+            id: id.to_string(),
+            label: label.to_string(),
+        });
+    }
+
+    Ok(PreparedAskQuestion {
+        question: question.to_string(),
+        options,
+    })
+}
+
+async fn create_agent_question(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+    question: &str,
+    options: &[AskQuestionOption],
+    timeout_ms: u64,
+) -> Result<CreateQuestionResponse, AgentToolError> {
+    let mut args = BTreeMap::new();
+    args.insert("runId".to_string(), run_id.to_string().into());
+    args.insert("claimId".to_string(), claim_id.to_string().into());
+    args.insert("question".to_string(), question.to_string().into());
+    args.insert(
+        "options".to_string(),
+        Value::try_from(serde_json::to_value(options).map_err(tool_error)?).map_err(tool_error)?,
+    );
+    args.insert("timeoutMs".to_string(), Value::Float64(timeout_ms as f64));
+    runtime
+        .mutation_json("agentQuestions:create", args)
+        .await
+        .map_err(tool_error)
+}
+
+async fn fetch_question_snapshot(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    question_id: &str,
+) -> Result<Option<QuestionSnapshot>, AgentToolError> {
+    let mut args = BTreeMap::new();
+    args.insert("runId".to_string(), run_id.to_string().into());
+    args.insert("questionId".to_string(), question_id.to_string().into());
+    runtime
+        .query_json(GET_QUESTION_FUNCTION, args)
+        .await
+        .map_err(tool_error)
+}
+
+fn pending_question_result(
+    question_id: &str,
+    question: &str,
+    options: &[AskQuestionOption],
+) -> serde_json::Value {
+    json!({
+        "questionId": question_id,
+        "question": question,
+        "options": options,
+        "pending": true,
+        "timedOut": false,
+    })
+}
+
+fn question_result_from_snapshot(
+    snapshot: &QuestionSnapshot,
+) -> Result<serde_json::Value, AgentToolError> {
+    match snapshot.status.as_str() {
+        "pending" => Ok(pending_question_result(
+            &snapshot.question_id,
+            &snapshot.question,
+            &snapshot.options,
+        )),
+        "answered" => Ok(json!({
+            "questionId": snapshot.question_id,
+            "question": snapshot.question,
+            "options": snapshot.options,
+            "pending": false,
+            "timedOut": false,
+            "answer": snapshot.answer,
+        })),
+        "timedOut" => Ok(json!({
+            "questionId": snapshot.question_id,
+            "question": snapshot.question,
+            "options": snapshot.options,
+            "pending": false,
+            "timedOut": true,
+        })),
+        "cancelled" => Err(AgentToolError::Cancelled),
+        other => Err(AgentToolError::Message(format!(
+            "Unexpected question status '{other}'"
+        ))),
+    }
+}
+
+async fn observe_question(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    question_id: &str,
+    question: &str,
+    options: &[AskQuestionOption],
+    yield_time_ms: u64,
+    cancellation: WorkspaceCancellation,
+) -> Result<serde_json::Value, AgentToolError> {
+    let mut args = BTreeMap::new();
+    args.insert("runId".to_string(), run_id.to_string().into());
+    args.insert("questionId".to_string(), question_id.to_string().into());
+    let mut updates = runtime
+        .subscribe(GET_QUESTION_FUNCTION, args)
+        .await
+        .map_err(tool_error)?;
+
+    let deadline = if yield_time_ms == 0 {
+        None
+    } else {
+        Some(Instant::now() + Duration::from_millis(yield_time_ms))
+    };
+
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(AgentToolError::Cancelled);
+        }
+
+        let update = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(AgentToolError::Cancelled),
+            // Prefer subscription updates over the yield deadline so an answer/timeout
+            // that arrives in the same tick is not reported as still pending.
+            update = updates.next() => update,
+            _ = async {
+                if let Some(deadline) = deadline {
+                    sleep(deadline.saturating_duration_since(Instant::now())).await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            }, if deadline.is_some() => {
+                // Last-chance read: an answer may have landed without the
+                // subscription delivering before the yield deadline.
+                if let Some(snapshot) =
+                    fetch_question_snapshot(runtime, run_id, question_id).await?
+                {
+                    if snapshot.status != "pending" {
+                        return question_result_from_snapshot(&snapshot);
+                    }
+                }
+                return Ok(pending_question_result(question_id, question, options));
+            },
+        };
+
+        let Some(update) = update else {
+            return Err(AgentToolError::Message(
+                "question subscription closed".to_string(),
+            ));
+        };
+        let snapshot: Option<QuestionSnapshot> =
+            RuntimeClient::decode_subscription_update(update, GET_QUESTION_FUNCTION)
+                .map_err(tool_error)?;
+        let Some(snapshot) = snapshot else {
+            return Err(AgentToolError::Message(format!(
+                "Unknown questionId '{question_id}'"
+            )));
+        };
+        if snapshot.status != "pending" {
+            return question_result_from_snapshot(&snapshot);
+        }
+        if yield_time_ms == 0 {
+            return Ok(pending_question_result(question_id, question, options));
+        }
+    }
+}
+
 /// Runs a tool's work as a Convex action, aborting the wait when the run is
 /// cancelled. The action itself keeps running server-side; its job record is
 /// reconciled by the normal completion flow.
@@ -729,6 +1212,73 @@ mod tests {
     use sprocket_workspace::{SkillSource, WorkspaceSkill};
 
     use super::*;
+
+    #[test]
+    fn prepare_ask_question_normalizes_and_enforces_limits() {
+        let prepared = prepare_ask_question(&AskQuestionArgs {
+            question: "Which database?".to_string(),
+            options: vec![
+                AskQuestionOption {
+                    id: "pg".to_string(),
+                    label: "Postgres".to_string(),
+                },
+                AskQuestionOption {
+                    id: "sqlite".to_string(),
+                    label: "SQLite".to_string(),
+                },
+            ],
+            yield_time_ms: DEFAULT_ASK_QUESTION_YIELD_MS,
+            timeout_ms: DEFAULT_ASK_QUESTION_TIMEOUT_MS,
+        })
+        .expect("valid question");
+
+        assert_eq!(prepared.options.len(), 2);
+        assert_eq!(prepared.options[0].id, "pg");
+        assert_eq!(prepared.options[1].id, "sqlite");
+
+        let too_long_question = "x".repeat(MAX_QUESTION_CHARS + 1);
+        let error = prepare_ask_question(&AskQuestionArgs {
+            question: too_long_question,
+            options: vec![AskQuestionOption {
+                id: "a".to_string(),
+                label: "A".to_string(),
+            }],
+            yield_time_ms: 0,
+            timeout_ms: DEFAULT_ASK_QUESTION_TIMEOUT_MS,
+        })
+        .expect_err("overlong question");
+        assert!(error.to_string().contains("2000"));
+
+        let reserved = prepare_ask_question(&AskQuestionArgs {
+            question: "Pick one".to_string(),
+            options: vec![AskQuestionOption {
+                id: AGENT_DECIDE_OPTION_ID.to_string(),
+                label: "Nope".to_string(),
+            }],
+            yield_time_ms: 0,
+            timeout_ms: DEFAULT_ASK_QUESTION_TIMEOUT_MS,
+        })
+        .expect_err("reserved id");
+        assert!(reserved.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn ask_question_defaults_are_omitted_from_payload() {
+        let args: AskQuestionArgs = serde_json::from_value(serde_json::json!({
+            "question": "Ship it?",
+            "options": [{ "id": "yes", "label": "Yes" }]
+        }))
+        .expect("minimal ask_question args");
+        assert_eq!(args.yield_time_ms, DEFAULT_ASK_QUESTION_YIELD_MS);
+        assert_eq!(args.timeout_ms, DEFAULT_ASK_QUESTION_TIMEOUT_MS);
+        assert_eq!(
+            serde_json::to_value(&args).unwrap(),
+            serde_json::json!({
+                "question": "Ship it?",
+                "options": [{ "id": "yes", "label": "Yes" }]
+            })
+        );
+    }
 
     #[test]
     fn exec_command_defaults_are_explicit_but_omitted_from_payload() {

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -845,7 +845,7 @@ fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, A
             "Question cannot be empty.".to_string(),
         ));
     }
-    if question.len() > MAX_QUESTION_CHARS {
+    if question.chars().count() > MAX_QUESTION_CHARS {
         return Err(AgentToolError::Message(format!(
             "Question cannot exceed {MAX_QUESTION_CHARS} characters."
         )));
@@ -871,12 +871,12 @@ fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, A
                 "Option label cannot be empty.".to_string(),
             ));
         }
-        if id.len() > MAX_OPTION_ID_CHARS {
+        if id.chars().count() > MAX_OPTION_ID_CHARS {
             return Err(AgentToolError::Message(format!(
                 "Option id cannot exceed {MAX_OPTION_ID_CHARS} characters."
             )));
         }
-        if label.len() > MAX_OPTION_LABEL_CHARS {
+        if label.chars().count() > MAX_OPTION_LABEL_CHARS {
             return Err(AgentToolError::Message(format!(
                 "Option label cannot exceed {MAX_OPTION_LABEL_CHARS} characters."
             )));
@@ -1248,6 +1248,19 @@ mod tests {
         })
         .expect_err("overlong question");
         assert!(error.to_string().contains("2000"));
+
+        // Multibyte Unicode must be counted by characters, matching Convex validation.
+        let unicode_question = "é".repeat(MAX_QUESTION_CHARS);
+        prepare_ask_question(&AskQuestionArgs {
+            question: unicode_question,
+            options: vec![AskQuestionOption {
+                id: "a".to_string(),
+                label: "café".to_string(),
+            }],
+            yield_time_ms: 0,
+            timeout_ms: DEFAULT_ASK_QUESTION_TIMEOUT_MS,
+        })
+        .expect("unicode within character limits");
 
         let reserved = prepare_ask_question(&AskQuestionArgs {
             question: "Pick one".to_string(),


### PR DESCRIPTION
## Summary
- Add `ask_question` / `await_question` agent tools with exec_command-style `yieldTimeMs` sync/async waiting and `timeoutMs` expiry
- Persist pending questions in Convex, show the FIFO head above the composer for option/custom answers (no user chat message), and cancel open questions when a run ends
- Auto-append a "Let me (the agent) decide" option and enforce question/option length limits

## Test plan
- [ ] Agent calls `ask_question` sync (default yield) and UI shows question + options above composer
- [ ] Select an option and Send; agent receives structured answer without a new user prompt message
- [ ] Select option + extension text, and custom text-only answers
- [ ] `yieldTimeMs: 0` yields `questionId`; `await_question` resolves after answer or timeout
- [ ] Multiple async questions queue FIFO; answering a non-head question is rejected
- [ ] Cancel run clears pending questions
- [ ] `bunx vitest --run src/convex/agentQuestions.test.ts src/convex/lib/agentQuestions.test.ts`
- [ ] `cargo test -p sprocket-agent ask_question`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a durable agent-question workflow spanning the Rust tool runtime, Convex state, and Svelte composer.
- Introduces `ask_question` and `await_question` with configurable yield and timeout behavior.
- Persists FIFO question state and handles answers, expiry, and run cancellation.
- Displays pending questions in the composer and supports option or custom-text answers.
- Aligns Unicode length validation across Rust and Convex and guards answer restoration by thread and question identity.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain in the fixes related to the previous review threads.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The agent-question-flow-server.log shows Convex rejecting function setup because WORKOS\_CLIENT\_ID was unset.
- The agent-question-flow-browser.log records real Chromium requests and two 401 responses from /api/auth/desktop-bootstrap, indicating an authentication failure path.
- The browser capture also shows the rendered pairing-screen text, confirming the observed UI state at the blocker surface.
- Paired screenshots and the video document the same real-app blocker surface, so it is not possible to conclude whether submitting an answer would remove the user prompt bubble.

<a href="https://app.greptile.com/trex/runs/15969575/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/tools.rs | Adds question tools, validation, Convex creation/subscription handling, and structured pending or terminal results. |
| apps/web/src/convex/agentQuestions.ts | Implements durable question creation, FIFO answering, timeout handling, executor reads, and authenticated UI reads. |
| apps/web/src/routes/+page.svelte | Connects pending-question queries and answer mutations to thread-aware composer state. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Renders pending questions and safely resets option and draft state when the active question changes. |
| apps/web/src/convex/agentRuntime.ts | Cancels outstanding questions when their owning run reaches a terminal state. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Agent
  participant R as Rust tool runtime
  participant C as Convex
  participant U as Web composer
  A->>R: ask_question
  R->>C: Create pending question
  C-->>U: Live FIFO head
  U->>C: Submit option/text answer
  C-->>R: Subscription update
  R-->>A: Structured answer
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): Restore failed question answers..."](https://github.com/spikonado/sprocket/commit/9ae6e145d7a44db2739a6e965f4cb3d0c290385d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47462485)</sub>

<!-- /greptile_comment -->