### PR TITLE
ci: Persist the Nix store and stop running work that gets thrown away

### DIFF
--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -1,0 +1,42 @@
+name: Setup Nix shell
+description: >-
+  Mounts the persistent Nix store, installs Nix, and realises the sprocket-shell
+  dev shell profile so later steps can run `nix develop --profile sprocket-shell`.
+
+runs:
+  using: composite
+  steps:
+    # The sticky disk needs an existing mount point. /nix is always empty at
+    # this stage, so the recursive chmod is O(1).
+    - name: Create Nix store mount point
+      shell: bash
+      run: |
+        sudo mkdir -p /nix/store
+        sudo chmod -R 777 /nix
+
+    - name: Mount Nix store
+      uses: useblacksmith/stickydisk@v1.4.0
+      with:
+        key: ${{ github.repository }}-nix-store
+        path: /nix
+
+    # A freshly formatted sticky disk is owned by root, and
+    # nix-quick-install-action refuses to run unless /nix is writable by the
+    # runner user. Only the top-level directories are touched so that warm,
+    # multi-gigabyte stores stay a no-op.
+    - name: Ensure Nix store is writable
+      shell: bash
+      run: |
+        sudo mkdir -p /nix/store /nix/var
+        sudo chown "$(id -u):$(id -g)" /nix /nix/store /nix/var
+
+    # Unlike cachix/install-nix-action, this installer unpacks into an existing
+    # /nix (tar --skip-old-files) instead of refusing to run, which is what lets
+    # the store persist across jobs. It enables `nix-command flakes` and
+    # `accept-flake-config` on its own, so the flake's extra-substituters are
+    # still honoured.
+    - uses: nixbuild/nix-quick-install-action@v35
+
+    - name: Build shell environment
+      shell: bash
+      run: nix develop --profile sprocket-shell -c true

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -23,27 +23,17 @@ inputs:
 runs:
   using: composite
   steps:
-    # The sticky disk needs an existing mount point. /nix is always empty at
-    # this stage, so the recursive chmod is O(1).
+    # /nix is empty at this point, so the recursive chmod is O(1).
     - name: Create Nix store mount point
       shell: bash
       run: |
         sudo mkdir -p /nix/store
         sudo chmod -R 777 /nix
 
-    # Jobs run checkout-controlled code as the owner of the mounted store, so
-    # whatever they leave behind runs in every later job on the same disk. Hence
-    # three stores: `trusted` for credentialed jobs that only run protected
-    # branches, `fork` for pull requests carrying code from outside the
-    # repository (Convex Preview runs on pull_request with a deploy key, so
-    # forks must not be able to plant binaries it later executes), and `shared`
-    # for code that someone with write access already controls.
-    #
-    # The flake.lock hash gives each lockfile generation its own disk. In-store
-    # garbage collection is unsafe here (concurrent jobs clone and commit the
-    # same snapshot, so a collection just gets overwritten), and a nixpkgs bump
-    # shares no store paths with its predecessor, so an un-keyed disk would only
-    # grow. This lets the 7-day idle eviction retire old generations instead.
+    # Jobs own the mount, so anything they leave in the store runs in every
+    # later job on the same disk: credentialed jobs and forks get their own.
+    # The flake.lock hash retires old closures via the 7-day idle eviction,
+    # since concurrent clone-and-commit makes in-store collection unsafe.
     - name: Mount Nix store
       uses: useblacksmith/stickydisk@v1.4.0
       with:
@@ -53,19 +43,16 @@ runs:
           }}-${{ hashFiles('flake.lock') }}
         path: /nix
 
-    # A freshly formatted sticky disk is owned by root, and
-    # nix-quick-install-action refuses to run unless /nix is writable by the
-    # runner user. Only the top-level directories are touched so that warm,
-    # multi-gigabyte stores stay a no-op.
+    # A fresh disk is root-owned and the installer needs /nix writable. Only
+    # the top level is touched, so warm multi-gigabyte stores stay a no-op.
     - name: Ensure Nix store is writable
       shell: bash
       run: |
         sudo mkdir -p /nix/store /nix/var
         sudo chown "$(id -u):$(id -g)" /nix /nix/store /nix/var
 
-    # Unlike cachix/install-nix-action, this installer unpacks into an existing
-    # /nix instead of refusing to run, which is what lets the store persist. It
-    # enables `nix-command flakes` and `accept-flake-config` on its own.
+    # Unlike cachix/install-nix-action this unpacks into an existing /nix
+    # instead of refusing to run, which is what lets the store persist.
     - uses: nixbuild/nix-quick-install-action@v35
 
     - name: Build shell environment

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -44,12 +44,32 @@ runs:
     #             (Convex Preview runs on pull_request with a deploy key).
     #   shared  - everything else, i.e. code that someone with write access to
     #             this repository already controls.
+    #
+    # The key also carries a hash of flake.lock, so each lockfile generation
+    # gets its own disk. Nothing here ever runs nix-collect-garbage, and it
+    # cannot safely: each job clones the last snapshot and commits it back when
+    # it finishes, so a job that collected garbage would just be overwritten by
+    # a concurrent job that had cloned the pre-collection snapshot. Without a
+    # per-generation key the store would only ever grow. renovate refreshes
+    # flake.lock every Monday and automerges it, and because these inputs track
+    # nixos-unstable each refresh moves stdenv, which rebuilds everything below
+    # it: comparing the two most recent locked revisions, the runtime closure of
+    # bun and nodejs shares zero of its 63 store paths with its predecessor,
+    # despite both revisions pinning identical package versions. So a whole
+    # closure would be added and none of it dropped, roughly 5 GB a week,
+    # forever, until the disk filled and every Nix workflow failed at once.
+    # Keying by generation instead lets the sticky disk's own 7-day idle
+    # eviction do the collecting: last Monday's disk stops being mounted the
+    # moment the bump merges and is purged a week later, leaving two live
+    # generations at steady state. The cost is that the first jobs after a bump
+    # start from an empty disk and re-fetch the closure once.
     - name: Mount Nix store
       uses: useblacksmith/stickydisk@v1.4.0
       with:
         key: >-
           ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted'
-          || (github.event.pull_request.head.repo.fork && 'fork' || 'shared') }}
+          || (github.event.pull_request.head.repo.fork && 'fork' || 'shared')
+          }}-${{ hashFiles('flake.lock') }}
         path: /nix
 
     # A freshly formatted sticky disk is owned by root, and

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -1,9 +1,17 @@
 name: Setup Nix shell
 description: >-
   Mounts the persistent Nix store, installs Nix, and realises the sprocket-shell
-  dev shell profile so later steps can run `nix develop --profile sprocket-shell`.
+  dev shell profile so later steps can run `nix develop ./sprocket-shell`.
 
 inputs:
+  dev-shell:
+    description: >-
+      Flake installable to realise into the profile, for example ".#convex".
+      Defaults to the flake's default dev shell. Later steps keep referring to
+      the profile by name, so they do not need to repeat this.
+    required: false
+    default: ''
+
   trusted:
     description: >-
       Set to "true" for jobs that hold privileged credentials and only ever run
@@ -52,4 +60,4 @@ runs:
 
     - name: Build shell environment
       shell: bash
-      run: nix develop --profile sprocket-shell -c true
+      run: nix develop ${{ inputs.dev-shell }} --profile sprocket-shell -c true

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -3,6 +3,15 @@ description: >-
   Mounts the persistent Nix store, installs Nix, and realises the sprocket-shell
   dev shell profile so later steps can run `nix develop --profile sprocket-shell`.
 
+inputs:
+  trusted:
+    description: >-
+      Set to "true" for jobs that hold privileged credentials and only ever run
+      code from a protected branch. Those jobs mount a separate store that no
+      pull-request job can write to.
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
@@ -14,10 +23,14 @@ runs:
         sudo mkdir -p /nix/store
         sudo chmod -R 777 /nix
 
+    # Pull-request jobs run checkout-controlled code as the owner of the mounted
+    # store, so anything they leave behind is attacker-controlled. Jobs that
+    # hold privileged credentials therefore mount a store of their own, which
+    # only ever sees code from a protected branch.
     - name: Mount Nix store
       uses: useblacksmith/stickydisk@v1.4.0
       with:
-        key: ${{ github.repository }}-nix-store
+        key: ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted' || 'shared' }}
         path: /nix
 
     # A freshly formatted sticky disk is owned by root, and

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -31,14 +31,25 @@ runs:
         sudo mkdir -p /nix/store
         sudo chmod -R 777 /nix
 
-    # Pull-request jobs run checkout-controlled code as the owner of the mounted
-    # store, so anything they leave behind is attacker-controlled. Jobs that
-    # hold privileged credentials therefore mount a store of their own, which
-    # only ever sees code from a protected branch.
+    # Jobs run checkout-controlled code as the owner of the mounted store, so
+    # whatever they leave behind is executed by every later job on the same
+    # disk. The store is therefore split three ways by who is allowed to write
+    # to it:
+    #
+    #   trusted - jobs holding privileged credentials. Only ever runs code from
+    #             a protected branch.
+    #   fork    - pull requests from forks. They get no secrets, but they do
+    #             execute code from outside the repository, so they must not be
+    #             able to plant binaries that a credentialed job later runs
+    #             (Convex Preview runs on pull_request with a deploy key).
+    #   shared  - everything else, i.e. code that someone with write access to
+    #             this repository already controls.
     - name: Mount Nix store
       uses: useblacksmith/stickydisk@v1.4.0
       with:
-        key: ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted' || 'shared' }}
+        key: >-
+          ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted'
+          || (github.event.pull_request.head.repo.fork && 'fork' || 'shared') }}
         path: /nix
 
     # A freshly formatted sticky disk is owned by root, and

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -30,6 +30,18 @@ runs:
         sudo mkdir -p /nix/store
         sudo chmod -R 777 /nix
 
+    # Concurrent jobs all clone the same snapshot and only the first commit
+    # survives, so two shells sharing a disk would leave the loser re-fetching
+    # its closure every run. The shell is part of the key to keep them apart.
+    - name: Derive store name
+      id: store
+      shell: bash
+      env:
+        DEV_SHELL: ${{ inputs.dev-shell }}
+      run: |
+        name="${DEV_SHELL:-default}"
+        echo "name=${name//[^a-zA-Z0-9]/-}" >> "$GITHUB_OUTPUT"
+
     # Jobs own the mount, so anything they leave in the store runs in every
     # later job on the same disk: credentialed jobs and forks get their own.
     # The flake.lock hash retires old closures via the 7-day idle eviction,
@@ -40,7 +52,7 @@ runs:
         key: >-
           ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted'
           || (github.event.pull_request.head.repo.fork && 'fork' || 'shared')
-          }}-${{ hashFiles('flake.lock') }}
+          }}-${{ steps.store.outputs.name }}-${{ hashFiles('flake.lock') }}
         path: /nix
 
     # A fresh disk is root-owned and the installer needs /nix writable. Only

--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -32,37 +32,18 @@ runs:
         sudo chmod -R 777 /nix
 
     # Jobs run checkout-controlled code as the owner of the mounted store, so
-    # whatever they leave behind is executed by every later job on the same
-    # disk. The store is therefore split three ways by who is allowed to write
-    # to it:
+    # whatever they leave behind runs in every later job on the same disk. Hence
+    # three stores: `trusted` for credentialed jobs that only run protected
+    # branches, `fork` for pull requests carrying code from outside the
+    # repository (Convex Preview runs on pull_request with a deploy key, so
+    # forks must not be able to plant binaries it later executes), and `shared`
+    # for code that someone with write access already controls.
     #
-    #   trusted - jobs holding privileged credentials. Only ever runs code from
-    #             a protected branch.
-    #   fork    - pull requests from forks. They get no secrets, but they do
-    #             execute code from outside the repository, so they must not be
-    #             able to plant binaries that a credentialed job later runs
-    #             (Convex Preview runs on pull_request with a deploy key).
-    #   shared  - everything else, i.e. code that someone with write access to
-    #             this repository already controls.
-    #
-    # The key also carries a hash of flake.lock, so each lockfile generation
-    # gets its own disk. Nothing here ever runs nix-collect-garbage, and it
-    # cannot safely: each job clones the last snapshot and commits it back when
-    # it finishes, so a job that collected garbage would just be overwritten by
-    # a concurrent job that had cloned the pre-collection snapshot. Without a
-    # per-generation key the store would only ever grow. renovate refreshes
-    # flake.lock every Monday and automerges it, and because these inputs track
-    # nixos-unstable each refresh moves stdenv, which rebuilds everything below
-    # it: comparing the two most recent locked revisions, the runtime closure of
-    # bun and nodejs shares zero of its 63 store paths with its predecessor,
-    # despite both revisions pinning identical package versions. So a whole
-    # closure would be added and none of it dropped, roughly 5 GB a week,
-    # forever, until the disk filled and every Nix workflow failed at once.
-    # Keying by generation instead lets the sticky disk's own 7-day idle
-    # eviction do the collecting: last Monday's disk stops being mounted the
-    # moment the bump merges and is purged a week later, leaving two live
-    # generations at steady state. The cost is that the first jobs after a bump
-    # start from an empty disk and re-fetch the closure once.
+    # The flake.lock hash gives each lockfile generation its own disk. In-store
+    # garbage collection is unsafe here (concurrent jobs clone and commit the
+    # same snapshot, so a collection just gets overwritten), and a nixpkgs bump
+    # shares no store paths with its predecessor, so an un-keyed disk would only
+    # grow. This lets the 7-day idle eviction retire old generations instead.
     - name: Mount Nix store
       uses: useblacksmith/stickydisk@v1.4.0
       with:
@@ -83,10 +64,8 @@ runs:
         sudo chown "$(id -u):$(id -g)" /nix /nix/store /nix/var
 
     # Unlike cachix/install-nix-action, this installer unpacks into an existing
-    # /nix (tar --skip-old-files) instead of refusing to run, which is what lets
-    # the store persist across jobs. It enables `nix-command flakes` and
-    # `accept-flake-config` on its own, so the flake's extra-substituters are
-    # still honoured.
+    # /nix instead of refusing to run, which is what lets the store persist. It
+    # enables `nix-command flakes` and `accept-flake-config` on its own.
     - uses: nixbuild/nix-quick-install-action@v35
 
     - name: Build shell environment

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,20 +24,20 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          cmd-format: nix develop --profile sprocket-shell -c {0}
+          cmd-format: nix develop ./sprocket-shell -c {0}
 
       - name: Bun install
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile
 
       - name: Bun build
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun run build
 
       - name: Bun test
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun run test
 
       - name: Cargo test
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: cargo test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,20 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: cachix/install-nix-action@v31.11.0
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-
-      - uses: cachix/cachix-action@v17
-        with:
-          name: spikonado
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and Cache Shell Environment
-        run: |
-          nix develop --profile sprocket-shell -c true
-          cachix push spikonado sprocket-shell
+      - uses: ./.github/actions/setup-nix-shell
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_and_test:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/convex-preview.yml
+++ b/.github/workflows/convex-preview.yml
@@ -15,20 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: cachix/install-nix-action@v31.11.0
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-
-      - uses: cachix/cachix-action@v17
-        with:
-          name: spikonado
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and Cache Shell Environment
-        run: |
-          nix develop --profile sprocket-shell -c true
-          cachix push spikonado sprocket-shell
+      - uses: ./.github/actions/setup-nix-shell
 
       - name: Install dependencies
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'

--- a/.github/workflows/convex-preview.yml
+++ b/.github/workflows/convex-preview.yml
@@ -15,10 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
+      # Deploying Convex only needs bun, so realise the slim shell rather than
+      # the full toolchain.
       - uses: ./.github/actions/setup-nix-shell
+        with:
+          dev-shell: '.#convex'
 
       - name: Install dependencies
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile
 
       - name: Validate preview deploy key
@@ -32,7 +36,7 @@ jobs:
 
       - name: Deploy Convex preview
         working-directory: apps/web
-        shell: 'nix develop --profile ../../sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ../../sprocket-shell -c bash -e {0}'
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_PREVIEW_DEPLOY_KEY }}
           CONVEX_PREVIEW_NAME: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/convex-preview.yml
+++ b/.github/workflows/convex-preview.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      # Deploying Convex only needs bun, so realise the slim shell rather than
-      # the full toolchain.
       - uses: ./.github/actions/setup-nix-shell
         with:
           dev-shell: '.#convex'

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Production deploys must not race each other, and cancelling one midway could
+# leave a half-applied deployment, so queue them instead.
+concurrency:
+  group: convex-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -16,20 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: cachix/install-nix-action@v31.11.0
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-
-      - uses: cachix/cachix-action@v17
-        with:
-          name: spikonado
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and Cache Shell Environment
-        run: |
-          nix develop --profile sprocket-shell -c true
-          cachix push spikonado sprocket-shell
+      - uses: ./.github/actions/setup-nix-shell
 
       - name: Install dependencies
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
 
-# Cancelling a deploy midway could leave it half applied, so queue instead.
 concurrency:
   group: convex-production
   cancel-in-progress: false

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -9,8 +9,7 @@ on:
 permissions:
   contents: read
 
-# Production deploys must not race each other, and cancelling one midway could
-# leave a half-applied deployment, so queue them instead.
+# Cancelling a deploy midway could leave it half applied, so queue instead.
 concurrency:
   group: convex-production
   cancel-in-progress: false
@@ -22,10 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      # This job holds the production deploy key, so it must not consume a Nix
-      # store that pull-request jobs can write to. Realising only the slim
-      # Convex shell keeps that dedicated store small enough to be worth
-      # keeping around.
       - uses: ./.github/actions/setup-nix-shell
         with:
           dev-shell: '.#convex'

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -22,7 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
+      # This job holds the production deploy key, so it must not consume a Nix
+      # store that pull-request jobs can write to.
       - uses: ./.github/actions/setup-nix-shell
+        with:
+          trusted: 'true'
 
       - name: Install dependencies
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -23,13 +23,16 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       # This job holds the production deploy key, so it must not consume a Nix
-      # store that pull-request jobs can write to.
+      # store that pull-request jobs can write to. Realising only the slim
+      # Convex shell keeps that dedicated store small enough to be worth
+      # keeping around.
       - uses: ./.github/actions/setup-nix-shell
         with:
+          dev-shell: '.#convex'
           trusted: 'true'
 
       - name: Install dependencies
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile
 
       - name: Validate production deploy key
@@ -43,7 +46,7 @@ jobs:
 
       - name: Deploy Convex production
         working-directory: apps/web
-        shell: 'nix develop --profile ../../sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ../../sprocket-shell -c bash -e {0}'
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_PRODUCTION_DEPLOY_KEY }}
           CONVEX_DEPLOY_MESSAGE: Production deploy for ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -21,6 +21,15 @@ on:
 permissions:
   contents: read
 
+# Every successful main build kicks off a dev release. When several land in
+# quick succession, the older ones are thrown away by the freshness guards in
+# `publish` regardless, so cancel them before they burn five native build jobs
+# (two of which are macOS runners). Tag and manual releases get their own group
+# and are never cancelled.
+concurrency:
+  group: npm-release-${{ github.event_name == 'workflow_run' && 'main-dev' || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
+
 jobs:
   prepare:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -21,9 +21,6 @@ on:
 permissions:
   contents: read
 
-# Superseded dev releases are discarded by the freshness guards in `publish`
-# anyway, so cancel them before they burn five native builds. Tag and manual
-# releases get their own group and are never cancelled.
 concurrency:
   group: npm-release-${{ github.event_name == 'workflow_run' && 'main-dev' || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_run' }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -21,11 +21,9 @@ on:
 permissions:
   contents: read
 
-# Every successful main build kicks off a dev release. When several land in
-# quick succession, the older ones are thrown away by the freshness guards in
-# `publish` regardless, so cancel them before they burn five native build jobs
-# (two of which are macOS runners). Tag and manual releases get their own group
-# and are never cancelled.
+# Superseded dev releases are discarded by the freshness guards in `publish`
+# anyway, so cancel them before they burn five native builds. Tag and manual
+# releases get their own group and are never cancelled.
 concurrency:
   group: npm-release-${{ github.event_name == 'workflow_run' && 'main-dev' || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'workflow_run' }}

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -24,16 +24,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          cmd-format: nix develop --profile sprocket-shell -c {0}
+          cmd-format: nix develop ./sprocket-shell -c {0}
 
       - name: Install dependencies
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile
 
       - name: Run prek
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: prek run -a
 
       - name: Run fmt
-        shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
+        shell: 'nix develop ./sprocket-shell -c bash -e {0}'
         run: nix fmt

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   run_prek:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -16,20 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - uses: cachix/install-nix-action@v31.11.0
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-
-      - uses: cachix/cachix-action@v17
-        with:
-          name: spikonado
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build and Cache Shell Environment
-        run: |
-          nix develop --profile sprocket-shell -c true
-          cachix push spikonado sprocket-shell
+      - uses: ./.github/actions/setup-nix-shell
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -26,6 +26,17 @@ jobs:
         with:
           cmd-format: nix develop --profile sprocket-shell -c {0}
 
+      # Only `lint` and `check` run here, and neither declares `outputs` in
+      # turbo.json, so a cache hit just replays the recorded result. Nothing is
+      # restored into target/, which keeps this from fighting rust-cache.
+      - name: Cache Turborepo
+        uses: actions/cache@v6.1.0
+        with:
+          path: .turbo
+          key: turbo-prek-${{ github.sha }}
+          restore-keys: |
+            turbo-prek-
+
       - name: Install dependencies
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -26,17 +26,6 @@ jobs:
         with:
           cmd-format: nix develop --profile sprocket-shell -c {0}
 
-      # Only `lint` and `check` run here, and neither declares `outputs` in
-      # turbo.json, so a cache hit just replays the recorded result. Nothing is
-      # restored into target/, which keeps this from fighting rust-cache.
-      - name: Cache Turborepo
-        uses: actions/cache@v6.1.0
-        with:
-          path: .turbo
-          key: turbo-prek-${{ github.sha }}
-          restore-keys: |
-            turbo-prek-
-
       - name: Install dependencies
         shell: 'nix develop --profile sprocket-shell -c bash -e {0}'
         run: bun install --frozen-lockfile

--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,8 @@
       {
         formatter = pkgs.nixfmt-tree;
 
-        # Deploying Convex only needs `bun install` and `bunx convex deploy`.
-        # Pulling in the default shell for that would drag along the Rust
-        # toolchain, clang and the Electron runtime libraries, which is roughly
-        # 5 GiB of closure to get hold of `bun`.
+        # Convex only needs `bun install` and `bunx convex deploy`. The
+        # default shell costs ~5 GiB of closure to get hold of `bun`.
         devShells.convex = pkgs.mkShell {
           packages = with pkgs; [
             bun

--- a/flake.nix
+++ b/flake.nix
@@ -43,8 +43,6 @@
       {
         formatter = pkgs.nixfmt-tree;
 
-        # Convex only needs `bun install` and `bunx convex deploy`. The
-        # default shell costs ~5 GiB of closure to get hold of `bun`.
         devShells.convex = pkgs.mkShell {
           packages = with pkgs; [
             bun

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,17 @@
       {
         formatter = pkgs.nixfmt-tree;
 
+        # Deploying Convex only needs `bun install` and `bunx convex deploy`.
+        # Pulling in the default shell for that would drag along the Rust
+        # toolchain, clang and the Electron runtime libraries, which is roughly
+        # 5 GiB of closure to get hold of `bun`.
+        devShells.convex = pkgs.mkShell {
+          packages = with pkgs; [
+            bun
+            nodejs_24
+          ];
+        };
+
         devShells.default = pkgs.mkShell.override { stdenv = pkgs.clangStdenv; } {
           packages =
             with pkgs;


### PR DESCRIPTION
Every Nix job in this repo re-downloaded the same ~287 store paths from `cache.nixos.org` before it could do any real work. Nothing is ever built, it is pure download, and it is the single largest line item in our CI bill.

Profiling the last 30 days with the Blacksmith CLI:

| workflow | 30d spend | Nix bootstrap, typical run |
| --- | --- | --- |
| Build and Test | $11.23 | 20.3% |
| Prek | $7.54 | 39% |
| Convex Preview | $3.02 | 55.3% |
| Convex Production | $0.57 | ~55% |

The median cost is bad; the tail is much worse. When the upstream CDN is slow the step falls off a cliff: three Prek runs spent 25, 30 and 49 minutes in it, at 0.6% CPU the whole time (one single store path stalled for 242s). Across the four workflows, 29 runs in 30 days blew past 5x their workflow median, and the excess alone is **$3.90/mo**.

### Persisting `/nix`

`/nix` now comes from a Blacksmith sticky disk, which hot-loads in about three seconds regardless of size, so the download stops happening at all. `cachix/install-nix-action` refuses to run when `/nix` already exists, so this switches to `nixbuild/nix-quick-install-action`, which unpacks into an existing store (`tar --skip-old-files`) and turns on `nix-command flakes` and `accept-flake-config` on its own, preserving current behaviour.

All four workflows shared the same preamble, so it now lives in one composite action.

**Measured on this branch** (`workflow_dispatch` run against an already-populated disk):

| | before | warm |
| --- | --- | --- |
| `copying path` lines | 287 | **0** |
| fetches from `cache.nixos.org` | 286 | **0** |
| sticky disk mount | n/a | 582ms |

There are three disk keys, split by who is allowed to write to the store. Jobs run checkout-controlled code as the owner of the mount, so whatever they leave in `/nix` is executed by every later job on the same disk. Convex Production holds `CONVEX_PRODUCTION_DEPLOY_KEY` and only ever runs `main`, so it gets a `trusted` store of its own. Pull requests from forks run code from outside the repository and Convex Preview runs on `pull_request` with a deploy key, so forks write to a `fork` store that no credentialed job ever mounts. Everything else shares one store, written only by code that someone with write access to this repository already controls. Each job gets its own clone of the last snapshot, so workflows running in parallel on a PR do not conflict, and the store is content addressed and additive, so a lost commit just means one closure gets re-fetched.

Cachix is dropped along the way. It served exactly **one of the 287 paths** (a 107 KiB `nix-shell-env`) and 39 of the last 40 runs logged `Nothing to push - all store paths are already on Cachix`, while costing ~5.4s per run and spiking to 225s once. The flake still lists the public cache as a substituter, so a cold disk is no worse off than today.

### Keeping the disks from growing forever

The key also carries `hashFiles('flake.lock')`, so each lockfile generation gets its own disk.

Nothing collects garbage in the store, and nothing safely can: each job clones the last snapshot and commits it back on completion, so a job that ran `nix-collect-garbage` would simply be overwritten by a concurrent job that had cloned the pre-collection snapshot. The existing `concurrency` groups do not help, since they are scoped per workflow per ref and Prek and Build and Test still overlap freely.

That matters more than it sounds, because these inputs track `nixos-unstable` and renovate has `lockFileMaintenance` enabled with `automerge: true` on `schedule:earlyMondays`. Every Monday the lockfile jumps a week of unstable, unattended. Each jump moves `stdenv`, which rebuilds everything below it. Comparing the two most recently locked revisions:

| | `e7a3ca8` (07-13) | `e2587ca` (07-25) |
| --- | --- | --- |
| paths in closure | 62 | 63 |
| size | 0.34 GiB | 0.34 GiB |
| **paths shared with the other revision** | **0** | **0** |

Identical package versions on both sides (`bun-1.3.13`, `nodejs-24.18.0`), entirely different store hashes. Nothing carries over. Un-keyed, the shared disk would gain a full closure every week and drop nothing, roughly 5 GB each Monday, until it overtook the entire CI bill inside two months and eventually filled, failing every Nix workflow at once with an `ENOSPC` nobody could trace to a bot-merged lockfile bump.

Keying by generation hands the collecting to the sticky disk's own 7-day idle eviction: last Monday's disk stops being mounted the moment the bump merges and is purged a week later, so two generations are live at steady state and growth is bounded. The cost is one cold start per bump, when the first jobs re-fetch the closure into an empty disk, worth about $0.02 a week.

### A slim dev shell for Convex

The Convex jobs only run `bun install` and `bunx convex deploy`, yet they realised the default dev shell to get there, dragging in the Rust toolchain, clang and the Electron runtime libraries. Measured with `nix path-info -S`, that is **4.95 GiB across 287 store paths where 0.67 GiB across 47 will do**.

```nix
devShells.convex = pkgs.mkShell {
  packages = with pkgs; [ bun nodejs_24 ];
};
```

This is what makes the dedicated Convex Production store affordable: sized at the full closure it would cost about $2.67/mo to protect a workflow that spends $0.57/mo in total; at the slim closure it is about $0.36.

The downstream steps also stop passing `--profile`. That flag *stores into* a profile, and with no installable it re-evaluates the flake's default shell and overwrites whatever was there, which would have quietly pulled the full closure straight back in on the next step. I verified this against a scratch flake with two marked shells: realising `.#convex` into the profile and then running `nix develop --profile ./p` returned `WHICH_SHELL=FULL` and rewrote the profile. Passing the profile path as the installable is the documented way to reuse a recorded environment, returns `SLIM` as intended, and skips a redundant flake evaluation per step everywhere else too.

### Not doing work that gets discarded

Prek and Build and Test had no `concurrency` block, so superseded pushes ran to completion. Cancellation is gated on `pull_request` so main and merge_group runs always finish. Small on its own (7 superseded runs in 30 days).

npm Release matters more than its run count suggests. Every successful main build starts a dev release, and when several land close together the older ones build five native targets, two on macOS runners, purely for the freshness guards in `publish` to throw the result away. Those now get cancelled before the build starts, while tag and manual releases keep their own group and are never cancelled. Convex Production gets a queue instead of cancellation, since killing a deploy partway through could leave it half applied.

### One disk per shell

Concurrent jobs all clone the same snapshot and only the first commit survives, so a disk shared by two different shells leaves the loser re-fetching its closure on every run. This showed up as soon as the slim Convex shell landed: Convex Preview finishes in ~32s and won the commit every time, pinning the shared disk to its 47-path closure, while Prek and Build and Test re-downloaded ~two thirds of theirs on each run.

| | cold | next run, one shared disk | next run, one disk per shell |
| --- | --- | --- | --- |
| Convex Preview | 97 paths | 0 | 0 |
| Prek | 296 paths | 199 | 0 |
| Build and Test | 287 paths | 192 | 0 |

Before the slim shell this was harmless, since every job realised the same closure and the winner's store was equivalent. The disk key now includes the shell it holds, so the two never collide.

### What this costs

| | |
| --- | --- |
| Stall tail eliminated | +$3.90/mo |
| Median bootstrap, ~5s x 1,159 nix jobs | +$0.77/mo |
| Concurrency | +$0.10/mo |
| Default shell disk, 2 x 5.3 GB @ $0.50/GB/mo | -$5.30/mo |
| Convex preview disk, 2 x 0.72 GB | -$0.72/mo |
| Convex production disk, 2 x 0.72 GB | -$0.72/mo |
| **Net** | **~-$1.97/mo** |

The money is honestly a rounding error on a $22.90/mo bill. The reason to do this is that a lint job can no longer take 49 minutes.

Note the warm Nix step still costs 15s, of which 8s is `nix-quick-install-action` re-fetching its own nix tarball from GitHub releases on every run. That is worth attacking separately.

### Reverted

The Turborepo cache commit is reverted. It restored, but at 1603 bytes: `lint` and `check` declare no `outputs`, so turbo only stores their captured logs, and the one visible speedup between runs (`Run prek` 32s to 15s) came from rust-cache warming instead. Actions caches are also scoped by ref, so a PR can only read what main has seeded, and turbo 2.0 made the workspace root an implicit dependency of every package. That left ~3s per run of save and restore for no measured gain. Worth revisiting with a remote cache, which would sidestep the ref scoping.

### Worth knowing

- Earlier pushes on this branch left orphaned disks behind, first `spikonado/sprocket-nix-store` and then the un-generationed `-shared` key. Each is ~5.3 GB and bills for the 7 days it takes to auto-evict, about $0.62 apiece. No action needed, they purge themselves.
- Attacking the root cause instead of the symptom, moving `nixpkgs.url` off `nixos-unstable` onto a stable release channel would cut the weekly churn to near zero, since stable channels only take backports and `stdenv` stays put. That changes which package versions are available, so it is a separate decision.
- `CACHIX_AUTH_TOKEN` is no longer referenced anywhere and can be removed from repository secrets.

Validated locally with `check-jsonschema` (both schemas, matching the `check-github-workflows` / `check-github-actions` hooks), Prettier, and the repo's own `nix fmt`, plus a real `nix eval` / `nix develop` of the new shell.

### Deliberately left alone

- **Prek and Build and Test still run on `push: main`** (23.1% of Prek's spend). The `pull_request` event already tests `refs/pull/N/merge`, so this is duplicate work, but it is a real post-merge safety net and dropping it is your call. Related: `merge_group:` is declared in both workflows but has never fired in 453 runs.
- **Convex Preview has no path filter** and deploys on every PR; about half of merged PRs touch nothing Convex-related. Skipping those risks leaving a frontend preview without a backend, so it needs a decision rather than a guess.
- **npm Release stays on GitHub-hosted runners**, since #98 moved it there on purpose.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces CI bootstrap work by persisting trust-separated Nix stores and reusing realized shell profiles.
- Adds a composite action that mounts a sticky disk, installs Nix, and realizes a shell-specific profile keyed by trust class, shell, and lockfile generation.
- Separates fork, shared, and production store namespaces, with Convex Production explicitly using the trusted namespace.
- Adds a slim Convex development shell and updates workflows to reuse the recorded profile.
- Removes Cachix setup and adds cancellation or queueing policies for superseded workflows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Baseline checks were executed to confirm no standalone Convex command is available in the environment, while a repository-local bunx convex --version command runs successfully.
- - Nix before/after captures were run, showing that both Nix discovery and the exact profile realization/reuse command are blocked at executable lookup.
- - A validation harness was generated to record commands, working directories, command outputs, and exit codes, enabling reproducible verification.
- - Artifacts capturing the above runs were produced and organized to support review, including logs and the validation harness script.

<a href="https://app.greptile.com/trex/runs/16358745/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/setup-nix-shell/action.yml | Introduces shell- and lockfile-specific persistent Nix stores partitioned into fork, shared, and trusted namespaces. |
| .github/workflows/build-test.yml | Reuses the composite Nix setup and profile while cancelling superseded pull-request runs. |
| .github/workflows/convex-preview.yml | Uses the slim Convex shell and routes fork pull requests away from stores consumed by non-fork preview jobs. |
| .github/workflows/convex-production.yml | Queues deployments and explicitly mounts the production-only trusted Convex store. |
| .github/workflows/npm-release.yml | Cancels superseded main development releases while retaining independent tag and manual release groups. |
| .github/workflows/prek.yml | Reuses the persistent default shell and cancels superseded pull-request lint runs. |
| flake.nix | Adds a reduced Convex shell containing Bun and Node.js without the default shell's Rust, Clang, and Electron dependencies. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
ForkPR[Fork pull request] --> ForkStore["fork / shell / lock hash"]
SameRepoPR[Same-repository PR] --> SharedStore["shared / shell / lock hash"]
MainCI[Main and merge-group CI] --> SharedStore
Production[Convex Production on main] --> TrustedStore["trusted / convex / lock hash"]
ForkStore --> ForkJobs[Fork jobs without repository secrets]
SharedStore --> SharedJobs[Build, test, prek, and preview]
TrustedStore --> ProductionDeploy[Production deploy credential]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Update npm-release.yml"](https://github.com/spikonado/sprocket/commit/337b2ba20b6faa91c7bfe96911873094d722f02d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48168079)</sub>

<!-- /greptile_comment -->