### PR TITLE
fix(agent): Keep runs alive through claim-lease stalls and unbrick threads

### DIFF
--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -225,8 +225,39 @@ describe('agentRuntime.createRun', () => {
 		const abandonedRun = await t.run(async (ctx) => ctx.db.get(abandoned.runId));
 		expect(abandonedRun).toMatchObject({
 			status: 'failed',
-			lastError: 'The agent claim lease expired before the run was finalized.'
+			lastError: 'The local agent stopped responding before this run finished.'
 		});
+		const abandonedResponse = await t.run(async (ctx) =>
+			abandonedRun?.responseMessageId ? ctx.db.get(abandonedRun.responseMessageId) : null
+		);
+		expect(abandonedResponse?.text).toBe(
+			'Run aborted: The local agent stopped responding before this run finished.'
+		);
+	});
+
+	it('rejects a new submission while the latest run holds an active claim', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'active-claim-secret';
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-active-claim', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-active',
+			runId,
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				submissionId: 'sub-during-active-claim',
+				threadId,
+				prompt: 'Second',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				executionSecret: 'during-active-claim-secret'
+			})
+		).rejects.toThrow('Finish or cancel the active run before sending another message.');
 	});
 
 	it('allows a new run after the previous run reaches a final status', async () => {

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
-import { initConvexTest, seedOwnedThread } from './test.setup';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
 
 describe('agentRuntime.createRun', () => {
 	it('rejects an empty prompt with no images', async () => {
@@ -193,6 +193,40 @@ describe('agentRuntime.createRun', () => {
 				executionSecret: 'active-second-secret'
 			})
 		).rejects.toThrow('Finish or cancel the active run before sending another message.');
+	});
+
+	it('marks an abandoned claimed run as failed when a new submission arrives', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'abandoned-secret';
+		const abandoned = await createQueuedRun(asUser, threadId, 'sub-abandoned', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-abandoned',
+			runId: abandoned.runId,
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(abandoned.runId, { claimExpiresAt: Date.now() - 1 });
+		});
+
+		const next = await asUser.mutation(api.agentRuntime.createRun, {
+			submissionId: 'sub-after-abandoned',
+			threadId,
+			prompt: 'Second',
+			imageUploadIds: [],
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard',
+			executionSecret: 'after-abandoned-secret'
+		});
+		expect(next.created).toBe(true);
+		expect(next.runId).not.toBe(abandoned.runId);
+
+		const abandonedRun = await t.run(async (ctx) => ctx.db.get(abandoned.runId));
+		expect(abandonedRun).toMatchObject({
+			status: 'failed',
+			lastError: 'The agent claim lease expired before the run was finalized.'
+		});
 	});
 
 	it('allows a new run after the previous run reaches a final status', async () => {

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -241,9 +241,8 @@ describe('agentRuntime.start', () => {
 		expect(reclaimed.claimExpiresAt).toBeGreaterThan(Date.now());
 
 		const run = await t.run(async (ctx) => ctx.db.get(runId));
-		// Same-claim renewal keeps status and completion attempt sequence: the
-		// takeover cleanup (hidden jobs, cleared response, stream reset) is
-		// only for a different claim.
+		// Same-claim re-start keeps run state; takeover cleanup is only for a
+		// different claim.
 		expect(run).toMatchObject({
 			claimId: 'claim-a',
 			completionAttemptSeq: 2,

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -214,4 +214,40 @@ describe('agentRuntime.start', () => {
 			Date.now() + RUN_CLAIM_LEASE_DURATION_MS + 1_000
 		);
 	});
+
+	it('re-claims with the same claim after a lapse without resetting run state', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'start-reclaim-secret';
+		const { runId } = await createQueuedRun(asUser, threadId, 'sub-reclaim', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-a',
+			runId,
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch(runId, {
+				completionAttemptSeq: 2,
+				claimExpiresAt: Date.now() - 1
+			});
+		});
+
+		const reclaimed = await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-a',
+			runId,
+			executionSecret
+		});
+		expect(reclaimed.claimed).toBe(true);
+		expect(reclaimed.claimExpiresAt).toBeGreaterThan(Date.now());
+
+		const run = await t.run(async (ctx) => ctx.db.get(runId));
+		// Same-claim renewal keeps status and completion attempt sequence: the
+		// takeover cleanup (hidden jobs, cleared response, stream reset) is
+		// only for a different claim.
+		expect(run).toMatchObject({
+			claimId: 'claim-a',
+			completionAttemptSeq: 2,
+			claimExpiresAt: reclaimed.claimExpiresAt
+		});
+	});
 });

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -47,7 +47,7 @@ describe('agentRuntime.start', () => {
 		).resolves.toEqual({ claimed: false });
 	});
 
-	it('rejects completion writes and terminal cleanup after a claim expires', async () => {
+	it('rejects completion writes after a claim expires but lets the owner terminalize the run', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const executionSecret = 'start-expired-writes-secret';
@@ -77,12 +77,22 @@ describe('agentRuntime.start', () => {
 		await expect(
 			asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
 				runId,
-				claimId: 'claim-expired',
+				claimId: 'claim-someone-else',
 				text: 'stale failure',
 				lastError: 'claim expired',
 				executionSecret
 			})
 		).resolves.toBe(false);
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
+				runId,
+				claimId: 'claim-expired',
+				text: 'stale failure',
+				lastError: 'claim expired',
+				executionSecret
+			})
+		).resolves.toBe(true);
+		expect(await t.run(async (ctx) => (await ctx.db.get(runId))?.status)).toBe('failed');
 	});
 
 	it('takes over an expired claim, hides in-flight jobs, and clears partial response', async () => {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -192,6 +192,10 @@ export const createRun = mutation({
 		runId: v.id('runs'),
 		promptMessageId: v.id('threadMessages')
 	}),
+	// Beyond inserting the run, this mutation reconciles the thread: a
+	// previous run that is still in a claimed status but whose lease lapsed
+	// was abandoned by its executor, so it is terminalized as failed here —
+	// otherwise it would block every later submission forever.
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await assertModelConfigurationAllowedForUser(ctx, userId, {
@@ -259,14 +263,10 @@ export const createRun = mutation({
 			isClaimedRunStatus(latestRun.status) &&
 			!isRunClaimLeaseActive(latestRun, Date.now())
 		) {
-			// A claimed run whose lease lapsed was abandoned by its executor
-			// (crash or connectivity loss) without being terminalized. Mark it
-			// failed so the thread is not blocked from starting another run;
-			// its partial output stays visible.
 			await finalizeRunRecord(ctx, userId, latestRun, {
-				text: 'Run abandoned: the local agent stopped responding before this run finished.',
+				text: 'Run aborted: The local agent stopped responding before this run finished.',
 				status: 'failed',
-				lastError: 'The agent claim lease expired before the run was finalized.'
+				lastError: 'The local agent stopped responding before this run finished.'
 			});
 		} else {
 			assertThreadCanStartRun(latestRun?.status);

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -254,7 +254,23 @@ export const createRun = mutation({
 			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', args.threadId))
 			.order('desc')
 			.first();
-		assertThreadCanStartRun(latestRun?.status);
+		if (
+			latestRun &&
+			isClaimedRunStatus(latestRun.status) &&
+			!isRunClaimLeaseActive(latestRun, Date.now())
+		) {
+			// A claimed run whose lease lapsed was abandoned by its executor
+			// (crash or connectivity loss) without being terminalized. Mark it
+			// failed so the thread is not blocked from starting another run;
+			// its partial output stays visible.
+			await finalizeRunRecord(ctx, userId, latestRun, {
+				text: 'Run abandoned: the local agent stopped responding before this run finished.',
+				status: 'failed',
+				lastError: 'The agent claim lease expired before the run was finalized.'
+			});
+		} else {
+			assertThreadCanStartRun(latestRun?.status);
+		}
 
 		const runId = await ctx.db.insert('runs', {
 			threadId: args.threadId,
@@ -878,7 +894,7 @@ export const finalizeClaimFailure = mutation({
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const userId = run.userId;
-		if (!canFinalizeAfterClaimFailure(run, args.claimId, Date.now())) {
+		if (!canFinalizeAfterClaimFailure(run, args.claimId)) {
 			return false;
 		}
 		return finalizeRunRecord(ctx, userId, run, {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -192,10 +192,8 @@ export const createRun = mutation({
 		runId: v.id('runs'),
 		promptMessageId: v.id('threadMessages')
 	}),
-	// Beyond inserting the run, this mutation reconciles the thread: a
-	// previous run that is still in a claimed status but whose lease lapsed
-	// was abandoned by its executor, so it is terminalized as failed here —
-	// otherwise it would block every later submission forever.
+	// Also terminalizes a previous claimed run whose lease lapsed — it was
+	// abandoned by its executor and would block every later submission.
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await assertModelConfigurationAllowedForUser(ctx, userId, {

--- a/apps/web/src/convex/lib/agentHistory.test.ts
+++ b/apps/web/src/convex/lib/agentHistory.test.ts
@@ -180,10 +180,8 @@ describe('canonical agent history', () => {
 	});
 
 	it('answers tool calls from jobs that never finished with an interrupted result', () => {
-		// An executor that vanished mid-job leaves a claimed job with no
-		// result. A dangling tool call is not a valid transcript (providers
-		// reject replaying it), so the next agent loading this history must
-		// see an interrupted result instead.
+		// Providers reject replaying a dangling tool call, so the next agent
+		// must see an interrupted result instead.
 		const history = buildCanonicalAgentHistory({
 			messages: [
 				{

--- a/apps/web/src/convex/lib/agentHistory.test.ts
+++ b/apps/web/src/convex/lib/agentHistory.test.ts
@@ -179,6 +179,56 @@ describe('canonical agent history', () => {
 		]);
 	});
 
+	it('answers tool calls from jobs that never finished with an interrupted result', () => {
+		// An executor that vanished mid-job leaves a claimed job with no
+		// result. A dangling tool call is not a valid transcript (providers
+		// reject replaying it), so the next agent loading this history must
+		// see an interrupted result instead.
+		const history = buildCanonicalAgentHistory({
+			messages: [
+				{
+					_id: 'message-1',
+					runId: 'run-1',
+					runStatus: 'failed',
+					type: 'response',
+					text: '',
+					parts: [],
+					attachments: []
+				}
+			] as unknown as Parameters<typeof buildCanonicalAgentHistory>[0]['messages'],
+			jobs: [
+				{
+					_id: 'job-1',
+					runId: 'run-1',
+					hidden: false,
+					sequence: 0,
+					kind: 'exec_command',
+					payload: { cmd: 'sleep 60' },
+					status: 'claimed'
+				}
+			] as unknown as Parameters<typeof buildCanonicalAgentHistory>[0]['jobs']
+		});
+
+		expect(history.map((message) => message.role)).toEqual(['assistant', 'user']);
+		expect(history[0]?.contents).toMatchObject([
+			{ type: 'toolCall', callId: 'executor-job:job-1' }
+		]);
+		expect(history[1]?.contents).toMatchObject([
+			{
+				type: 'toolResult',
+				callId: 'executor-job:job-1',
+				items: [
+					{
+						text: JSON.stringify({
+							error: 'The agent stopped before this tool call finished.',
+							status: 'cancelled'
+						})
+					}
+				]
+			}
+		]);
+	});
+
 	it('preserves assistant text provider metadata in the canonical wire format', () => {
 		const history = buildAgentHistoryFromAssistantParts({
 			parts: [

--- a/apps/web/src/convex/lib/assistantParts.test.ts
+++ b/apps/web/src/convex/lib/assistantParts.test.ts
@@ -320,4 +320,38 @@ describe('assistant tool parts', () => {
 		expect(hydrated[0]).toMatchObject({ name: 'exec_command', input: { cmd: 'new' } });
 		expect(hydrated[0]).not.toBe(parts[0]);
 	});
+
+	it('pairs a tool call from an unfinished job with an interrupted result', () => {
+		const hydrated = ensureAssistantToolPartsFromJobs(
+			[],
+			[
+				{
+					id: 'job-1',
+					kind: 'exec_command',
+					payload: { cmd: 'sleep 60' },
+					status: 'claimed'
+				}
+			]
+		);
+
+		// Providers reject replaying a tool call without its result, so a
+		// dangling call would break the transcript the next agent loads.
+		expect(hydrated).toEqual([
+			{
+				type: 'tool-call',
+				callId: 'executor-job:job-1',
+				name: 'exec_command',
+				input: { cmd: 'sleep 60' }
+			},
+			{
+				type: 'tool-result',
+				callId: 'executor-job:job-1',
+				name: 'exec_command',
+				output: {
+					error: 'The agent stopped before this tool call finished.',
+					status: 'cancelled'
+				}
+			}
+		]);
+	});
 });

--- a/apps/web/src/convex/lib/assistantParts.test.ts
+++ b/apps/web/src/convex/lib/assistantParts.test.ts
@@ -334,8 +334,7 @@ describe('assistant tool parts', () => {
 			]
 		);
 
-		// Providers reject replaying a tool call without its result, so a
-		// dangling call would break the transcript the next agent loads.
+		// Providers reject replaying a dangling tool call.
 		expect(hydrated).toEqual([
 			{
 				type: 'tool-call',

--- a/apps/web/src/convex/lib/assistantParts.ts
+++ b/apps/web/src/convex/lib/assistantParts.ts
@@ -328,7 +328,7 @@ function removeAbandonedAssistantTurns(
 	);
 	const removedCallIds = new Set(abandonedCalls.map((part) => part.callId));
 
-	return parts.filter((part) => {
+	const retainedParts = parts.filter((part) => {
 		if (part.type === 'tool-result') {
 			return !removedCallIds.has(part.callId);
 		}
@@ -337,4 +337,30 @@ function removeAbandonedAssistantTurns(
 		}
 		return part.type !== 'tool-call' || !removedCallIds.has(part.callId);
 	});
+
+	// A tool call without a result (e.g. the agent stopped mid-execution) is
+	// not a valid model transcript: providers reject replaying it. Pair every
+	// dangling call with an interrupted result instead of dropping it, so the
+	// work that did happen stays visible.
+	const answeredCallIds = new Set(
+		retainedParts
+			.filter((part): part is AssistantToolResultPart => part.type === 'tool-result')
+			.map((part) => part.callId)
+	);
+	const pairedParts: AssistantPart[] = [];
+	for (const part of retainedParts) {
+		pairedParts.push(part);
+		if (part.type === 'tool-call' && !answeredCallIds.has(part.callId)) {
+			pairedParts.push({
+				type: 'tool-result',
+				callId: part.callId,
+				name: part.name,
+				output: assistantToolResultErrorOutput(
+					'cancelled',
+					'The agent stopped before this tool call finished.'
+				)
+			});
+		}
+	}
+	return pairedParts;
 }

--- a/apps/web/src/convex/lib/assistantParts.ts
+++ b/apps/web/src/convex/lib/assistantParts.ts
@@ -338,10 +338,8 @@ function removeAbandonedAssistantTurns(
 		return part.type !== 'tool-call' || !removedCallIds.has(part.callId);
 	});
 
-	// A tool call without a result (e.g. the agent stopped mid-execution) is
-	// not a valid model transcript: providers reject replaying it. Pair every
-	// dangling call with an interrupted result instead of dropping it, so the
-	// work that did happen stays visible.
+	// Providers reject replaying a tool call without its result; pair dangling
+	// calls with an interrupted result instead of dropping the work.
 	const answeredCallIds = new Set(
 		retainedParts
 			.filter((part): part is AssistantToolResultPart => part.type === 'tool-result')

--- a/apps/web/src/convex/lib/runLease.test.ts
+++ b/apps/web/src/convex/lib/runLease.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	RUN_CLAIM_LEASE_DURATION_MS,
+	canFinalizeAfterClaimFailure,
 	canRegisterCompletionAttempt,
 	ownsActiveRunClaim,
 	canStartRunWithClaim,
@@ -72,5 +73,15 @@ describe('run claim leases', () => {
 		expect(isCurrentCompletionAttempt(run, 'claim-a', 2)).toBe(true);
 		expect(isCurrentCompletionAttempt(run, 'claim-a', 3)).toBe(false);
 		expect(isCurrentCompletionAttempt(run, 'claim-b', 2)).toBe(false);
+	});
+
+	it('lets the current claim owner terminalize its run even after the lease lapses', () => {
+		const expired = { status: 'awaiting_executor', claimId: 'claim-a', claimExpiresAt: 100 };
+		expect(canFinalizeAfterClaimFailure(expired, 'claim-a')).toBe(true);
+		expect(canFinalizeAfterClaimFailure(expired, 'claim-b')).toBe(false);
+		expect(canFinalizeAfterClaimFailure({ status: 'failed', claimId: 'claim-a' }, 'claim-a')).toBe(
+			false
+		);
+		expect(canFinalizeAfterClaimFailure({ status: 'queued' }, 'claim-a')).toBe(false);
 	});
 });

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -31,12 +31,14 @@ export function ownsActiveRunClaim(run: ClaimableRun, claimId: string, now: numb
 	return run.claimId === claimId && isRunClaimLeaseActive(run, now);
 }
 
-export function canFinalizeAfterClaimFailure(
-	run: ClaimableRun,
-	claimId: string,
-	now: number
-): boolean {
-	return ownsActiveRunClaim(run, claimId, now);
+export function canFinalizeAfterClaimFailure(run: ClaimableRun, claimId: string): boolean {
+	// The current claim owner may always terminalize its own run, even after
+	// the lease lapsed. Requiring an active lease here strands runs in a
+	// claimed status forever when the executor only manages to report the
+	// failure after expiry (e.g. reconnecting to the backend), which blocks
+	// the thread from ever starting another run. A takeover changes claimId,
+	// so cleanup from a stale executor stays rejected.
+	return isClaimedRunStatus(run.status) && run.claimId === claimId;
 }
 
 export function claimExpiresAt(now: number): number {

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -32,12 +32,9 @@ export function ownsActiveRunClaim(run: ClaimableRun, claimId: string, now: numb
 }
 
 export function canFinalizeAfterClaimFailure(run: ClaimableRun, claimId: string): boolean {
-	// The current claim owner may always terminalize its own run, even after
-	// the lease lapsed. Requiring an active lease here strands runs in a
-	// claimed status forever when the executor only manages to report the
-	// failure after expiry (e.g. reconnecting to the backend), which blocks
-	// the thread from ever starting another run. A takeover changes claimId,
-	// so cleanup from a stale executor stays rejected.
+	// Requiring an active lease here would strand runs whose executor only
+	// reports the failure after expiry. A takeover changes claimId, so stale
+	// executors stay rejected.
 	return isClaimedRunStatus(run.status) && run.claimId === claimId;
 }
 

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -17,3 +17,6 @@ sprocket-workspace = { path = "../sprocket-workspace" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["macros", "sync", "time"] }
 uuid = { version = "1.21.0", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { version = "1.52.1", features = ["rt", "test-util"] }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -415,6 +415,24 @@ async fn renew_claim_once(
     .map(|response| (response.renewed, request_started_at))
 }
 
+/// Tries to re-claim the run with the same claim after the lease lapsed. The
+/// server accepts this only if nobody else took over and the run is still in
+/// a claimed status, so it is safe to attempt exactly once.
+async fn reclaim_run_once(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+) -> anyhow::Result<(bool, Instant)> {
+    let request_started_at = Instant::now();
+    timeout(
+        RUN_CLAIM_ATTEMPT_TIMEOUT,
+        runtime.start_run(run_id, claim_id),
+    )
+    .await
+    .map_err(|_| anyhow!("reclaim attempt timed out"))?
+    .map(|start| (start.claimed, request_started_at))
+}
+
 /// Renews the claim lease via `attempt`, retrying transient failures for as
 /// long as the remaining lease window can still fit another attempt. A
 /// renewed lease moves the deadline forward, so temporary backend
@@ -474,17 +492,25 @@ where
 /// (retries stop once another attempt could not land before the deadline) and
 /// is accepted in exchange for surviving backend unavailability.
 ///
+/// When the server reports the lease as gone, the claim is re-`start`ed once:
+/// a lapse with no takeover (suspend, CPU starvation, network drop) lets the
+/// same claim continue, while a real takeover or a terminal run refuses the
+/// re-claim and the lease failure is returned.
+///
 /// Only claim/lease failures are returned as `Err`; the operation's value
 /// (including its own errors) is wrapped in `Ok`.
-async fn drive_claim_lease<R, RFut, F, T>(
+async fn drive_claim_lease<R, RFut, C, CFut, F, T>(
     run_id: &str,
     lease_started_at: Instant,
     mut renew: R,
+    mut reclaim: C,
     operation: F,
 ) -> anyhow::Result<T>
 where
     R: FnMut(Instant) -> RFut,
     RFut: Future<Output = anyhow::Result<(bool, Instant)>>,
+    C: FnMut() -> CFut,
+    CFut: Future<Output = anyhow::Result<(bool, Instant)>>,
     F: Future<Output = T>,
 {
     let mut lease_deadline = lease_started_at + RUN_CLAIM_LEASE_DURATION;
@@ -501,7 +527,19 @@ where
                         next_renewal_at = renewal_started_at + RUN_CLAIM_RENEW_INTERVAL;
                     }
                     Ok((false, _)) => {
-                        return Err(anyhow!("claim lease for run {run_id} was lost"));
+                        match reclaim().await {
+                            Ok((true, reclaim_started_at)) => {
+                                eprintln!(
+                                    "sprocket-agent: re-claimed run {run_id} after the claim lease lapsed"
+                                );
+                                lease_deadline = reclaim_started_at + RUN_CLAIM_LEASE_DURATION;
+                                next_renewal_at = reclaim_started_at + RUN_CLAIM_RENEW_INTERVAL;
+                            }
+                            Ok((false, _)) => {
+                                return Err(anyhow!("claim lease for run {run_id} was lost"));
+                            }
+                            Err(error) => return Err(error),
+                        }
                     }
                     Err(error) => return Err(error),
                 }
@@ -529,6 +567,7 @@ where
                 renew_claim_once(runtime, run_id, claim_id)
             })
         },
+        || reclaim_run_once(runtime, run_id, claim_id),
         operation,
     )
     .await
@@ -808,6 +847,10 @@ mod claim_lease_tests {
         RUN_CLAIM_RENEW_INTERVAL, drive_claim_lease, renew_claim_with,
     };
 
+    async fn reclaim_refused() -> anyhow::Result<(bool, Instant)> {
+        Ok((false, Instant::now()))
+    }
+
     /// Regression: a renewal tick that fires late because the task was
     /// starved (CPU saturation, slow reconnect) must not fail an otherwise
     /// healthy run. The first renewal below takes longer than the renew
@@ -829,6 +872,7 @@ mod claim_lease_tests {
                     Ok((true, request_started_at))
                 }
             },
+            reclaim_refused,
             async {
                 sleep(Duration::from_secs(50)).await;
                 "done"
@@ -858,6 +902,7 @@ mod claim_lease_tests {
                     Ok((true, request_started_at))
                 }
             },
+            reclaim_refused,
             async {
                 sleep(Duration::from_secs(100)).await;
                 "done"
@@ -918,10 +963,59 @@ mod claim_lease_tests {
             "run-taken-over",
             Instant::now(),
             |_lease_deadline| async { Ok((false, Instant::now())) },
+            reclaim_refused,
             std::future::pending(),
         )
         .await;
         let error = result.unwrap_err().to_string();
         assert!(error.contains("was lost"), "{error}");
+    }
+
+    /// After a genuine lease lapse with no takeover (suspend, starvation,
+    /// network drop), the same claim re-`start`s and the run continues.
+    #[tokio::test(start_paused = true)]
+    async fn reclaimed_lease_resumes_renewals() {
+        let renewals = AtomicUsize::new(0);
+        let reclaims = AtomicUsize::new(0);
+        let result = drive_claim_lease(
+            "run-reclaim",
+            Instant::now(),
+            |_lease_deadline| {
+                let attempt = renewals.fetch_add(1, Ordering::SeqCst);
+                let request_started_at = Instant::now();
+                async move {
+                    if attempt == 0 {
+                        return Ok((false, request_started_at));
+                    }
+                    Ok((true, request_started_at))
+                }
+            },
+            || {
+                reclaims.fetch_add(1, Ordering::SeqCst);
+                async { Ok((true, Instant::now())) }
+            },
+            async {
+                sleep(Duration::from_secs(50)).await;
+                "done"
+            },
+        )
+        .await;
+        assert_eq!(result.ok(), Some("done"));
+        assert_eq!(reclaims.load(Ordering::SeqCst), 1);
+        assert!(renewals.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_fails_the_run_when_the_reclaim_fails() {
+        let result: anyhow::Result<()> = drive_claim_lease(
+            "run-reclaim-unreachable",
+            Instant::now(),
+            |_lease_deadline| async { Ok((false, Instant::now())) },
+            || async { Err(anyhow!("reclaim attempt timed out")) },
+            std::future::pending(),
+        )
+        .await;
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("reclaim attempt timed out"), "{error}");
     }
 }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -415,9 +415,8 @@ async fn renew_claim_once(
     .map(|response| (response.renewed, request_started_at))
 }
 
-/// Tries to re-claim the run with the same claim after the lease lapsed. The
-/// server accepts this only if nobody else took over and the run is still in
-/// a claimed status, so it is safe to attempt exactly once.
+/// Re-claims the run with the same claim after a lease lapse; the server
+/// accepts only if nobody else took over.
 async fn reclaim_run_once(
     runtime: &RuntimeClient,
     run_id: &str,
@@ -433,10 +432,8 @@ async fn reclaim_run_once(
     .map(|start| (start.claimed, request_started_at))
 }
 
-/// Renews the claim lease via `attempt`, retrying transient failures for as
-/// long as the remaining lease window can still fit another attempt. A
-/// renewed lease moves the deadline forward, so temporary backend
-/// unavailability must not fail the run while there is still time to renew.
+/// Retries transient renewal failures while the lease window can still fit
+/// another attempt.
 async fn renew_claim_with<F, Fut>(
     run_id: &str,
     lease_deadline: Instant,
@@ -475,27 +472,11 @@ where
 
 /// Runs `operation` while renewing the claim lease.
 ///
-/// Renewals are anchored to when the last successful renewal request started
-/// rather than to a free-running interval: a renewal that completes slowly
-/// (e.g. while reconnecting to the backend) must not push the next renewal
-/// past the lease deadline. A renewal anchor that is already in the past
-/// fires immediately.
-///
-/// The local lease deadline is a conservative estimate (request start + lease
-/// duration); the server is the authority on lease ownership. Renewals are
-/// therefore attempted even when a scheduling stall (CPU saturation, slow
-/// reconnect) pushed the tick past that estimate: the server answers whether
-/// the lease is still owned, and must not be preemptively declared lost.
-///
-/// Renewing runs inside the select arm, so `operation` is not polled while
-/// renewal attempts are in flight. That pause is bounded by the lease window
-/// (retries stop once another attempt could not land before the deadline) and
-/// is accepted in exchange for surviving backend unavailability.
-///
-/// When the server reports the lease as gone, the claim is re-`start`ed once:
-/// a lapse with no takeover (suspend, CPU starvation, network drop) lets the
-/// same claim continue, while a real takeover or a terminal run refuses the
-/// re-claim and the lease failure is returned.
+/// Renewals are anchored to the last successful renewal request start, so a
+/// slow renewal (reconnect, CPU starvation) cannot push the next one past
+/// the lease deadline. The server is the authority on lease ownership, so
+/// renewals are attempted even past the conservative local deadline estimate,
+/// and a reported loss is retried once via re-claim before giving up.
 ///
 /// Only claim/lease failures are returned as `Err`; the operation's value
 /// (including its own errors) is wrapped in `Ok`.
@@ -762,10 +743,8 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
     {
         Ok(result) => result,
         Err(error) => {
-            // A renewal tick can race the operation's own finalization: if the
-            // run already reached a terminal state server-side, there is
-            // nothing to abort and the lease error must not be reported as a
-            // failure.
+            // A renewal tick can race the operation's own finalization; a run
+            // that already finished server-side must not be reported as failed.
             match runtime.run_finished(&run_id).await {
                 Ok(true) => Ok(()),
                 _ => abort_after_claim(&runtime, &run_id, &claim_id, error).await,
@@ -851,11 +830,8 @@ mod claim_lease_tests {
         Ok((false, Instant::now()))
     }
 
-    /// Regression: a renewal tick that fires late because the task was
-    /// starved (CPU saturation, slow reconnect) must not fail an otherwise
-    /// healthy run. The first renewal below takes longer than the renew
-    /// interval, pushing the next tick past the point where a conservative
-    /// local pre-check would refuse to renew.
+    /// Regression: a starved renewal tick (CPU saturation, slow reconnect)
+    /// must not fail an otherwise healthy run.
     #[tokio::test(start_paused = true)]
     async fn scheduling_stall_after_a_successful_renewal_does_not_fail_the_run() {
         let renewals = AtomicUsize::new(0);
@@ -883,9 +859,8 @@ mod claim_lease_tests {
         assert!(renewals.load(Ordering::SeqCst) >= 2);
     }
 
-    /// The local lease deadline is only an estimate; when a stall pushes a
-    /// renewal tick past it, the renewal must still be attempted and the
-    /// server decides whether the lease is still owned.
+    /// The local deadline is only an estimate; a renewal tick pushed past it
+    /// must still be attempted.
     #[tokio::test(start_paused = true)]
     async fn renewal_is_attempted_after_the_estimated_lease_deadline() {
         let renewals = AtomicUsize::new(0);
@@ -928,10 +903,8 @@ mod claim_lease_tests {
         let error = result.unwrap_err().to_string();
         assert!(error.contains("initial attempt failed"), "{error}");
         // Keeps renewing while another attempt can still land before the
-        // lease deadline.
+        // lease deadline, then stops.
         assert!(attempts.load(Ordering::SeqCst) >= 3);
-        // ...but not past the point where another attempt could not land
-        // before it.
         assert!(
             Instant::now()
                 >= started_at + RUN_CLAIM_LEASE_DURATION
@@ -971,8 +944,8 @@ mod claim_lease_tests {
         assert!(error.contains("was lost"), "{error}");
     }
 
-    /// After a genuine lease lapse with no takeover (suspend, starvation,
-    /// network drop), the same claim re-`start`s and the run continues.
+    /// After a lease lapse with no takeover, the same claim re-`start`s and
+    /// the run continues.
     #[tokio::test(start_paused = true)]
     async fn reclaimed_lease_resumes_renewals() {
         let renewals = AtomicUsize::new(0);

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -9,7 +9,7 @@ use sprocket_workspace::{
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::{Instant, MissedTickBehavior, sleep, timeout};
+use tokio::time::{Instant, sleep, sleep_until, timeout};
 use uuid::Uuid;
 
 use crate::RunContextResponse;
@@ -23,6 +23,7 @@ const RUN_CLAIM_LEASE_DURATION: Duration = Duration::from_secs(60);
 const RUN_CLAIM_RENEW_INTERVAL: Duration = Duration::from_secs(20);
 const RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(8);
 const RUN_CLAIM_EXPIRY_SAFETY_MARGIN: Duration = Duration::from_secs(5);
+const RUN_CLAIM_RENEW_RETRY_DELAY: Duration = Duration::from_millis(250);
 const RUN_CLAIM_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(8);
 const FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 const START_FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2_500);
@@ -414,66 +415,97 @@ async fn renew_claim_once(
     .map(|response| (response.renewed, request_started_at))
 }
 
+/// Renews the claim lease, retrying transient failures for as long as the
+/// remaining lease window can still fit another attempt. A renewed lease
+/// moves the deadline forward, so temporary backend unavailability must not
+/// fail the run while there is still time to renew.
 async fn renew_claim(
     runtime: &RuntimeClient,
     run_id: &str,
     claim_id: &str,
+    lease_deadline: Instant,
 ) -> anyhow::Result<(bool, Instant)> {
-    match renew_claim_once(runtime, run_id, claim_id).await {
-        Ok(outcome) => Ok(outcome),
-        Err(first_error) => {
-            eprintln!(
-                "sprocket-agent: claim renewal failed for run {}; retrying: {}",
-                run_id, first_error
-            );
-            renew_claim_once(runtime, run_id, claim_id)
-                .await
-                .map_err(|retry_error| {
-                    anyhow!(
-                        "failed to renew claim for run {run_id} after retry: {retry_error}; initial attempt failed: {first_error}"
-                    )
-                })
+    renew_claim_with(run_id, lease_deadline, || {
+        renew_claim_once(runtime, run_id, claim_id)
+    })
+    .await
+}
+
+async fn renew_claim_with<F, Fut>(
+    run_id: &str,
+    lease_deadline: Instant,
+    mut attempt: F,
+) -> anyhow::Result<(bool, Instant)>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<(bool, Instant)>>,
+{
+    let mut first_error: Option<String> = None;
+    loop {
+        match attempt().await {
+            Ok(outcome) => return Ok(outcome),
+            Err(error) => {
+                let retry_window_fits = Instant::now()
+                    + RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT
+                    + RUN_CLAIM_EXPIRY_SAFETY_MARGIN
+                    < lease_deadline;
+                if !retry_window_fits {
+                    return Err(match &first_error {
+                        Some(first) => anyhow!(
+                            "failed to renew claim for run {run_id} before the lease window closed: {error}; initial attempt failed: {first}"
+                        ),
+                        None => anyhow!("failed to renew claim for run {run_id}: {error}"),
+                    });
+                }
+                first_error.get_or_insert_with(|| error.to_string());
+                eprintln!(
+                    "sprocket-agent: claim renewal failed for run {run_id}; retrying: {error}"
+                );
+                sleep(RUN_CLAIM_RENEW_RETRY_DELAY).await;
+            }
         }
     }
 }
 
 /// Runs `operation` while renewing the claim lease.
 ///
+/// Renewals are anchored to when the last successful renewal request started
+/// rather than to a free-running interval: a renewal that completes slowly
+/// (e.g. while reconnecting to the backend) must not push the next renewal
+/// past the lease deadline. A renewal anchor that is already in the past
+/// fires immediately.
+///
+/// The local lease deadline is a conservative estimate (request start + lease
+/// duration); the server is the authority on lease ownership. Renewals are
+/// therefore attempted even when a scheduling stall (CPU saturation, slow
+/// reconnect) pushed the tick past that estimate: the server answers whether
+/// the lease is still owned, and must not be preemptively declared lost.
+///
 /// Only claim/lease failures are returned as `Err`; the operation's value
 /// (including its own errors) is wrapped in `Ok`.
-async fn run_with_claim_lease<F, T>(
-    runtime: &RuntimeClient,
+async fn drive_claim_lease<R, RFut, F, T>(
     run_id: &str,
-    claim_id: &str,
     lease_started_at: Instant,
+    mut renew: R,
     operation: F,
 ) -> anyhow::Result<T>
 where
+    R: FnMut(Instant) -> RFut,
+    RFut: Future<Output = anyhow::Result<(bool, Instant)>>,
     F: Future<Output = T>,
 {
     let mut lease_deadline = lease_started_at + RUN_CLAIM_LEASE_DURATION;
-    let mut renewals = tokio::time::interval_at(
-        Instant::now() + RUN_CLAIM_RENEW_INTERVAL,
-        RUN_CLAIM_RENEW_INTERVAL,
-    );
-    renewals.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut next_renewal_at = lease_started_at + RUN_CLAIM_RENEW_INTERVAL;
     tokio::pin!(operation);
 
     loop {
         tokio::select! {
             biased;
-            _ = renewals.tick() => {
-                let renewal_budget = RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT * 2
-                    + RUN_CLAIM_EXPIRY_SAFETY_MARGIN;
-                if Instant::now() + renewal_budget >= lease_deadline {
-                    return Err(anyhow!("claim lease for run {run_id} cannot be renewed safely before expiry"));
-                }
-                match renew_claim(runtime, run_id, claim_id).await {
+            _ = sleep_until(next_renewal_at) => {
+                match renew(lease_deadline).await {
                     Ok((true, renewal_started_at)) => {
-                        if Instant::now() + RUN_CLAIM_EXPIRY_SAFETY_MARGIN >= lease_deadline {
-                            return Err(anyhow!("claim renewal for run {run_id} was not confirmed safely before expiry"));
-                        }
                         lease_deadline = renewal_started_at + RUN_CLAIM_LEASE_DURATION;
+                        next_renewal_at = renewal_started_at + RUN_CLAIM_RENEW_INTERVAL;
                     }
                     Ok((false, _)) => {
                         return Err(anyhow!("claim lease for run {run_id} was lost"));
@@ -484,6 +516,25 @@ where
             result = &mut operation => return Ok(result),
         }
     }
+}
+
+async fn run_with_claim_lease<F, T>(
+    runtime: &RuntimeClient,
+    run_id: &str,
+    claim_id: &str,
+    lease_started_at: Instant,
+    operation: F,
+) -> anyhow::Result<T>
+where
+    F: Future<Output = T>,
+{
+    drive_claim_lease(
+        run_id,
+        lease_started_at,
+        |lease_deadline| renew_claim(runtime, run_id, claim_id, lease_deadline),
+        operation,
+    )
+    .await
 }
 
 pub async fn start_agent_run(request: RunAgentRequest) -> anyhow::Result<AgentRun> {
@@ -735,5 +786,128 @@ mod tests {
         let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
         assert!(preamble.contains("description: Line one line two"));
         assert!(!preamble.contains("description: Line one\n"));
+    }
+}
+
+#[cfg(test)]
+mod claim_lease_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use anyhow::anyhow;
+    use tokio::time::{Instant, sleep};
+
+    use super::{
+        RUN_CLAIM_LEASE_DURATION, RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT, RUN_CLAIM_RENEW_INTERVAL,
+        drive_claim_lease, renew_claim_with,
+    };
+
+    /// Regression: a renewal tick that fires late because the task was
+    /// starved (CPU saturation, slow reconnect) must not fail an otherwise
+    /// healthy run. The first renewal below takes longer than the renew
+    /// interval, pushing the next tick past the point where a conservative
+    /// local pre-check would refuse to renew.
+    #[tokio::test(start_paused = true)]
+    async fn scheduling_stall_after_a_successful_renewal_does_not_fail_the_run() {
+        let renewals = AtomicUsize::new(0);
+        let result = drive_claim_lease(
+            "run-stalled-tick",
+            Instant::now(),
+            |_lease_deadline| {
+                let attempt = renewals.fetch_add(1, Ordering::SeqCst);
+                let request_started_at = Instant::now();
+                async move {
+                    if attempt == 0 {
+                        sleep(RUN_CLAIM_RENEW_INTERVAL + Duration::from_secs(25)).await;
+                    }
+                    Ok((true, request_started_at))
+                }
+            },
+            async {
+                sleep(Duration::from_secs(50)).await;
+                "done"
+            },
+        )
+        .await;
+        assert_eq!(result.ok(), Some("done"));
+        assert!(renewals.load(Ordering::SeqCst) >= 2);
+    }
+
+    /// The local lease deadline is only an estimate; when a stall pushes a
+    /// renewal tick past it, the renewal must still be attempted and the
+    /// server decides whether the lease is still owned.
+    #[tokio::test(start_paused = true)]
+    async fn renewal_is_attempted_after_the_estimated_lease_deadline() {
+        let renewals = AtomicUsize::new(0);
+        let result = drive_claim_lease(
+            "run-past-estimated-deadline",
+            Instant::now(),
+            |_lease_deadline| {
+                let attempt = renewals.fetch_add(1, Ordering::SeqCst);
+                let request_started_at = Instant::now();
+                async move {
+                    if attempt == 0 {
+                        sleep(RUN_CLAIM_LEASE_DURATION + Duration::from_secs(10)).await;
+                    }
+                    Ok((true, request_started_at))
+                }
+            },
+            async {
+                sleep(Duration::from_secs(100)).await;
+                "done"
+            },
+        )
+        .await;
+        assert_eq!(result.ok(), Some("done"));
+        assert!(renewals.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn renewal_failures_retry_until_the_lease_window_closes() {
+        let attempts = AtomicUsize::new(0);
+        let started_at = Instant::now();
+        let result = renew_claim_with("run-flaky", started_at + RUN_CLAIM_LEASE_DURATION, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async {
+                sleep(RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT).await;
+                Err(anyhow!("claim renewal timed out"))
+            }
+        })
+        .await;
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("initial attempt failed"), "{error}");
+        // Keeps renewing while another attempt can still land before the
+        // lease deadline.
+        assert!(attempts.load(Ordering::SeqCst) >= 3);
+        assert!(Instant::now() <= started_at + RUN_CLAIM_LEASE_DURATION);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn lost_lease_is_not_retried() {
+        let attempts = AtomicUsize::new(0);
+        let result = renew_claim_with(
+            "run-lost",
+            Instant::now() + RUN_CLAIM_LEASE_DURATION,
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { Ok((false, Instant::now())) }
+            },
+        )
+        .await;
+        assert_eq!(result.ok().map(|(renewed, _)| renewed), Some(false));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_fails_the_run_when_the_lease_is_lost() {
+        let result: anyhow::Result<()> = drive_claim_lease(
+            "run-taken-over",
+            Instant::now(),
+            |_lease_deadline| async { Ok((false, Instant::now())) },
+            std::future::pending(),
+        )
+        .await;
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("was lost"), "{error}");
     }
 }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -415,22 +415,10 @@ async fn renew_claim_once(
     .map(|response| (response.renewed, request_started_at))
 }
 
-/// Renews the claim lease, retrying transient failures for as long as the
-/// remaining lease window can still fit another attempt. A renewed lease
-/// moves the deadline forward, so temporary backend unavailability must not
-/// fail the run while there is still time to renew.
-async fn renew_claim(
-    runtime: &RuntimeClient,
-    run_id: &str,
-    claim_id: &str,
-    lease_deadline: Instant,
-) -> anyhow::Result<(bool, Instant)> {
-    renew_claim_with(run_id, lease_deadline, || {
-        renew_claim_once(runtime, run_id, claim_id)
-    })
-    .await
-}
-
+/// Renews the claim lease via `attempt`, retrying transient failures for as
+/// long as the remaining lease window can still fit another attempt. A
+/// renewed lease moves the deadline forward, so temporary backend
+/// unavailability must not fail the run while there is still time to renew.
 async fn renew_claim_with<F, Fut>(
     run_id: &str,
     lease_deadline: Instant,
@@ -480,6 +468,11 @@ where
 /// therefore attempted even when a scheduling stall (CPU saturation, slow
 /// reconnect) pushed the tick past that estimate: the server answers whether
 /// the lease is still owned, and must not be preemptively declared lost.
+///
+/// Renewing runs inside the select arm, so `operation` is not polled while
+/// renewal attempts are in flight. That pause is bounded by the lease window
+/// (retries stop once another attempt could not land before the deadline) and
+/// is accepted in exchange for surviving backend unavailability.
 ///
 /// Only claim/lease failures are returned as `Err`; the operation's value
 /// (including its own errors) is wrapped in `Ok`.
@@ -531,7 +524,11 @@ where
     drive_claim_lease(
         run_id,
         lease_started_at,
-        |lease_deadline| renew_claim(runtime, run_id, claim_id, lease_deadline),
+        move |lease_deadline| {
+            renew_claim_with(run_id, lease_deadline, move || {
+                renew_claim_once(runtime, run_id, claim_id)
+            })
+        },
         operation,
     )
     .await
@@ -725,7 +722,16 @@ pub async fn run_agent(run: AgentRun) -> anyhow::Result<()> {
     .await
     {
         Ok(result) => result,
-        Err(error) => abort_after_claim(&runtime, &run_id, &claim_id, error).await,
+        Err(error) => {
+            // A renewal tick can race the operation's own finalization: if the
+            // run already reached a terminal state server-side, there is
+            // nothing to abort and the lease error must not be reported as a
+            // failure.
+            match runtime.run_finished(&run_id).await {
+                Ok(true) => Ok(()),
+                _ => abort_after_claim(&runtime, &run_id, &claim_id, error).await,
+            }
+        }
     }
 }
 
@@ -798,8 +804,8 @@ mod claim_lease_tests {
     use tokio::time::{Instant, sleep};
 
     use super::{
-        RUN_CLAIM_LEASE_DURATION, RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT, RUN_CLAIM_RENEW_INTERVAL,
-        drive_claim_lease, renew_claim_with,
+        RUN_CLAIM_EXPIRY_SAFETY_MARGIN, RUN_CLAIM_LEASE_DURATION, RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT,
+        RUN_CLAIM_RENEW_INTERVAL, drive_claim_lease, renew_claim_with,
     };
 
     /// Regression: a renewal tick that fires late because the task was
@@ -879,6 +885,14 @@ mod claim_lease_tests {
         // Keeps renewing while another attempt can still land before the
         // lease deadline.
         assert!(attempts.load(Ordering::SeqCst) >= 3);
+        // ...but not past the point where another attempt could not land
+        // before it.
+        assert!(
+            Instant::now()
+                >= started_at + RUN_CLAIM_LEASE_DURATION
+                    - RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT
+                    - RUN_CLAIM_EXPIRY_SAFETY_MARGIN
+        );
         assert!(Instant::now() <= started_at + RUN_CLAIM_LEASE_DURATION);
     }
 


### PR DESCRIPTION
## Problem

A healthy agent run died mid-work and bricked its thread. From the incident logs:

1. **The run was killed without a renewal even being attempted.** `run_with_claim_lease` scheduled renewals on a free-running `tokio::time::interval` with `MissedTickBehavior::Delay`. Because renewal requests are awaited *inside* the select arm, tokio reschedules the next tick at `now + period` after the arm finishes — so any scheduling stall (CPU saturation from a tool-launched `cargo test`, slow Convex WebSocket reconnect) shifts every later tick. When a tick finally fired ~40s after the previous renewal, the conservative local pre-check (`now + 21s >= lease_deadline`) refused to even attempt a renewal and aborted the run: `claim lease ... cannot be renewed safely before expiry` — even though the previous renewal had succeeded and the server is the authority on lease ownership.

2. **The run could not be terminalized, bricking the thread.** `finalizeClaimFailure` required an *active* lease server-side, but the lease had lapsed by the time cleanup arrived, so it returned `false`. The run stayed in `awaiting_executor` forever — nothing reaps claimed runs — and `assertThreadCanStartRun` then rejected every later submission on the thread.

3. **`finalizeFailedStart` looped uselessly.** The next submission's `createRun` deterministically failed (thread blocked), so no run existed for the new execution secret and the startup-failure cleanup retried `has not observed submission` until its deadline.

4. **A dangling tool call could break the thread's transcript for good.** A run stopped mid-job left a `claimed` executorJob whose tool call had no result. A dangling assistant tool call is not a valid model transcript (providers reject replaying it), so the next agent loading that history crashed.

## Fix

**Agent (`crates/sprocket-agent/src/run.rs`)**
- Renewals are anchored to the last successful renewal request start via `sleep_until` — no interval drift; a past-due anchor fires immediately.
- Deleted the local pre-check that refused to renew near/past the estimated deadline, and the post-check that second-guessed slow confirmations. Renewals are always attempted at least once; the server answers whether the lease is still owned.
- Transient renewal failures retry while the lease window can still fit another attempt (~35s of blip tolerance, up from 16s).
- A lease error no longer masks a run that already finalized server-side (`run_finished` check before aborting).
- A `renewed=false` answer now triggers one same-claim re-`start`: after a genuine lapse with no takeover (suspend, starvation, network drop) the run continues with a fresh lease; a real takeover or terminal run still refuses and aborts.

**Server (`apps/web/src/convex`)**
- `finalizeClaimFailure` only requires the current claim owner + claimed status — takeover changes `claimId`, so stale executors stay rejected, but the owner can always terminalize its own run after a lapse.
- `createRun` terminalizes a claimed run whose lease lapsed as failed (user-visible `Run aborted: The local agent stopped responding…`) instead of throwing and bricking the thread.
- Assistant-part reconciliation pairs every resultless tool call with an interrupted (`cancelled`) tool-result, keeping interrupted work visible while producing a replayable transcript.

## Tests

- 7 paused-time Rust tests pinning the regressions: stall after a successful renewal, renewal attempted past the estimated deadline, retry window bounds, lease loss not retried, re-claim resume, re-claim failure, takeover abort.
- Convex tests: owner cleanup after lease expiry (and stale-executor rejection), abandoned-run finalization by `createRun` (plus response-text assertion), rejection while the latest run holds an active claim, same-claim re-start after lapse without takeover cleanup, dangling tool-call pairing in both `assistantParts` and canonical `agentHistory`.

## Checks

`cargo test` (all), `bun run test` (185 web + 4 npm), `bun run build`, `prek run -a` — all pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes run claims resilient to renewal stalls and repairs abandoned-run transcripts.
- Anchors lease renewals to successful request starts, retries transient failures, and supports safe same-claim reclamation.
- Allows expired claim owners to terminalize abandoned runs while preserving takeover fencing.
- Finalizes expired claimed runs when a new submission arrives.
- Reconciles dangling tool calls with cancelled results so provider history remains replayable.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general contract validation proof completed with exit status 0 and produced the full test run output along with the extracted seven-case results.

<a href="https://app.greptile.com/trex/runs/16421279/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/run.rs | Reworks lease scheduling, transient renewal retries, same-claim reclamation, and finalization-race handling with paused-time regression tests. |
| apps/web/src/convex/agentRuntime.ts | Terminalizes abandoned claimed runs during new submissions and permits matching claim owners to report failure after expiry. |
| apps/web/src/convex/lib/runLease.ts | Relaxes failure finalization from active-lease ownership to matching ownership in a claimed state. |
| apps/web/src/convex/lib/assistantParts.ts | Pairs retained resultless tool calls with synthetic cancelled results to keep canonical histories valid. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant A as Local agent
participant C as Convex
participant U as User
A->>C: start(run, claimId)
C-->>A: claimed with lease
loop While run is active
    A->>C: renewClaim
    alt Renewal succeeds
        C-->>A: renewed
    else Lease lapsed without takeover
        C-->>A: "renewed=false"
        A->>C: start(run, same claimId)
        C-->>A: reclaimed
    else Claim lost or run finalized
        C-->>A: refused
        A->>C: finalizeClaimFailure
    end
end
opt User submits after abandoned lease
    U->>C: createRun
    C->>C: Finalize abandoned run
    C->>C: Pair dangling tool calls with cancelled results
    C-->>U: Create replacement run
end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(agent): Trim verbose comments added..."](https://github.com/spikonado/sprocket/commit/4670088f29812f465ca792b824442a7ecc80b654) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48366137)</sub>

<!-- /greptile_comment -->