### PR TITLE
docs: Align Sprocket's descriptions in various places

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Sprocket is an agentic platform that streamlines hardware and software development.
 - It's goal is to give its users and AI agents the best possible experience when creating apps, robots, devices, and the systems that glue them together.
-- Sprocket should work seamlessly across different hardware platforms, operating systems, and Sprocket's own cloud for robotics development.
+- Sprocket should work seamlessly across different hardware platforms, operating systems, and Sprocket's own cloud for hardware and software development.
 
 ## Available Testing Commands
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Sprocket Architecture
 
-Sprocket is a local-first agentic development environment for robotics. Its web
-interface and durable conversation state are cloud-connected, while filesystem
-access and command execution stay on the user's machine.
+Sprocket is an agentic platform for streamlining hardware and software
+development. Its web interface and durable conversation state are
+cloud-connected, while filesystem access and command execution stay on the
+user's machine.
 
 This document describes the stable system boundaries and data flows. User setup
 belongs in [README.md](README.md); crate-specific implementation notes live in

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -24,7 +24,7 @@ const VERSION: &str = match option_env!("SPROCKET_VERSION") {
 #[derive(Debug, Parser)]
 #[command(
     name = "sprocket",
-    about = "Sprocket robotics development platform",
+    about = "Agentic platform for streamlining hardware and software development",
     version = VERSION,
     arg_required_else_help = false
 )]

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@spikonado/sprocket",
 	"version": "0.2.0",
-	"description": "Sprocket: Agentic platform for streamlining robotics development",
+	"description": "Agentic platform for streamlining hardware and software development",
 	"license": "Apache-2.0",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## Summary
- Replace robotics-only product framing with the hardware and software platform positioning from the README / GitHub description
- Align CLI `--help` about text and npm package description with the GitHub repo short description
- Drop "local-first" from the architecture overview

## Test plan
- [ ] Confirm `sprocket --help` shows the updated about text after a CLI rebuild
- [ ] Spot-check `AGENTS.md`, `ARCHITECTURE.md`, and `npm/sprocket/package.json` for consistent wording

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates Sprocket’s product positioning across contributor guidance, architecture documentation, CLI help text, and npm package metadata. The compiled CLI was rebuilt with locked dependencies and confirmed to display the new hardware-and-software description; the npm package metadata was parsed and confirmed to use the same wording. The check also confirmed that the previous robotics-only wording was replaced in these user-facing surfaces.

No defects were found. Safe to merge.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The exact contract-watching wording was validated to be 'Agentic platform for streamlining hardware and software development'.
- The before-state CLI text and npm description were reviewed to establish the baseline from the parent revision.
- The validation script source and its log were inspected to confirm the contract-check logic and its explicit use in validation.
- The after-state CLI help line was reviewed and found to match the npm description and show PASS in the output.

<a href="https://app.greptile.com/trex/runs/16596758/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Align Sprocket copy with hardware ..."](https://github.com/spikonado/sprocket/commit/0069afcae1988b486d4640070dd13aed6176eb19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48720969)</sub>

<!-- /greptile_comment -->