### PR TITLE
fix(desktop): Package web assets outside asar for the local server

### DIFF
--- a/apps/desktop/main.mjs
+++ b/apps/desktop/main.mjs
@@ -183,7 +183,8 @@ async function startLocalServer() {
 	const host = serverHost;
 	const dataDir = getLocalDataDir();
 	const serverBinary = getServerBinaryPath();
-	const staticDir = isDevelopment ? undefined : path.join(__dirname, 'web/dist');
+	// extraResources (not asar): the Rust server must read these from disk.
+	const staticDir = isDevelopment ? undefined : path.join(process.resourcesPath, 'web');
 	const fallbackBaseUrl = `http://${host}:${port}`;
 	if (await attachToRunningServer(fallbackBaseUrl, dataDir)) {
 		return serverBaseUrl;

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,14 +25,7 @@
 			"main.mjs",
 			"preload.cjs",
 			"local-config.mjs",
-			"package.json",
-			{
-				"from": "../web/dist/",
-				"to": "web/dist/",
-				"filter": [
-					"**/*"
-				]
-			}
+			"package.json"
 		],
 		"extraResources": [
 			{
@@ -41,6 +34,13 @@
 				"filter": [
 					"sprocket",
 					"sprocket.exe"
+				]
+			},
+			{
+				"from": "../web/dist/",
+				"to": "web/",
+				"filter": [
+					"**/*"
 				]
 			}
 		],


### PR DESCRIPTION
## Summary
- Packaged desktop apps put the web UI inside `app.asar`, but Electron passes that path to the Rust local server, which cannot read asar files and exits with code 1 (`Web app files not found`).
- Ship the web build via electron-builder `extraResources` as `resources/web/` and point the packaged `--static-dir` at `process.resourcesPath/web`.
- Fixes AppImage/DMG/NSIS startup for the same root cause (verified against the v0.2.3 Linux AppImage layout).

## Test plan
- [ ] Run a packaged Linux AppImage (or extract + start with `resources/web` on disk) and confirm the local server stays up and `/` returns 200
- [ ] Confirm asar-path `--static-dir` still fails without this packaging change
- [ ] Spot-check macOS/Windows installer packaging still includes `resources/web/index.html` beside `resources/server/`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Moves the packaged web build into Electron’s `resources/web` directory and configures the local server to serve assets from that disk location instead of the ASAR archive.

The Linux unpacked application was exercised with its packaged server binary. `/api/health` and `/` both returned HTTP 200, and the HTML served at `/` exactly matched `resources/web/index.html`. The web asset tree is present outside `app.asar`, with no web entries retained in the archive.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The executable test script for the packaged sidecar web workflow was authored and prepared for review.
- A layout capture was taken showing packaged web assets and asar\_web\_entries=0 before running the test.
- The test was executed in an isolated directory and the runtime run produced health\_status=200, root\_status=200, byte equality, and exit code 0 on the selected port.

<a href="https://app.greptile.com/trex/runs/16715834/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): Package web assets outside..."](https://github.com/spikonado/sprocket/commit/f56e6d2ceccef71f5af7ee4246e8881481399b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48941882)</sub>

<!-- /greptile_comment -->