### PR TITLE
fix(ui): Correct Create/Add Project button label

### DIFF
--- a/apps/web/src/lib/components/home/project-sidebar.svelte
+++ b/apps/web/src/lib/components/home/project-sidebar.svelte
@@ -200,7 +200,7 @@
 		<div class="px-3.5 pb-1">
 			<button type="button" class={sidebarActionButtonClass} onclick={onAddProject}>
 				<FolderOpen class={sidebarActionIconClass} aria-hidden="true" />
-				<span class="truncate">Create/Add</span>
+				<span class="truncate">Create/Add Project</span>
 			</button>
 		</div>
 


### PR DESCRIPTION
## Summary
- Fix the sidebar project action button label to "Create/Add Project" (was incorrectly shortened to "Create/Add" in #147)

## Test plan
- [ ] Open the home sidebar and confirm the button reads "Create/Add Project"
- [ ] Confirm clicking it still opens the add-project flow

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the home sidebar action label to “Create/Add Project.” A Chromium browser check rendered the real sidebar component, confirmed the exact label, and verified that clicking the button still invokes the add-project action once. The web workspace typecheck completed with no errors or warnings.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an isolated render check of the ProjectSidebar using bunx vite and the UI check script to validate its label and click behavior.
- Verified that the button shows the exact label Create/Add Project and that clicking it increments the Add-project callback count from 0 to 1.
- Confirmed the web workspace typecheck reported zero errors and zero warnings.
- Captured artifacts showing the UI state change, including a video of the run and a screenshot after clicking Create/Add Project.

<a href="https://app.greptile.com/trex/runs/16755406/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ux): Correct Create/Add Project butt..."](https://github.com/spikonado/sprocket/commit/d19e198b53a6d2c2ed51ea9679f29bdd61192cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49023212)</sub>

<!-- /greptile_comment -->