### PR TITLE
feat(ux): Improve artifacts sidebar open, expand, and fullscreen

### DIFF
--- a/apps/web/src/lib/chat/artifacts.ts
+++ b/apps/web/src/lib/chat/artifacts.ts
@@ -10,5 +10,7 @@ export type ArtifactEntry = {
 /** Stored panel state, restored when revisiting a thread. */
 export type ArtifactPanelSnapshot = {
 	open: boolean;
+	/** When true, the panel covers the full Sprocket workspace UI. */
+	expanded: boolean;
 	selectedKey: string | null;
 };

--- a/apps/web/src/lib/components/home/artifact-display.svelte
+++ b/apps/web/src/lib/components/home/artifact-display.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowLeft, Check, Code2, Copy, Eye, Maximize2 } from '@lucide/svelte';
+	import { ArrowLeft, Check, Code2, Copy, Eye, Fullscreen } from '@lucide/svelte';
 	import ChatMarkdown from '$lib/components/chat-markdown.svelte';
 	import type { ArtifactType } from '$convex/lib/validators';
 	import { buildArtifactPreviewDocument } from '$lib/chat/artifact-preview';
@@ -9,11 +9,19 @@
 		artifactType: ArtifactType;
 		content: string;
 		variant?: 'card' | 'full';
-		onExpand?: () => void;
+		/** Enter true browser fullscreen for this artifact (content only). */
+		onOpenFullscreen?: () => void;
 		onBack?: () => void;
 	};
 
-	let { title, artifactType, content, variant = 'card', onExpand, onBack }: Props = $props();
+	let {
+		title,
+		artifactType,
+		content,
+		variant = 'card',
+		onOpenFullscreen,
+		onBack
+	}: Props = $props();
 
 	const previewDocument = $derived(buildArtifactPreviewDocument(artifactType, content));
 	let showSource = $state(false);
@@ -81,14 +89,15 @@
 				{/if}
 			</button>
 		{/if}
-		{#if onExpand}
+		{#if onOpenFullscreen}
 			<button
 				type="button"
 				class="text-muted-foreground hover:text-foreground shrink-0 transition"
-				onclick={onExpand}
+				onclick={onOpenFullscreen}
 				aria-label="Open fullscreen"
+				title="Open fullscreen"
 			>
-				<Maximize2 class="size-4" aria-hidden="true" />
+				<Fullscreen class="size-4" aria-hidden="true" />
 			</button>
 		{/if}
 	</div>

--- a/apps/web/src/lib/components/home/artifact-panel.svelte
+++ b/apps/web/src/lib/components/home/artifact-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { FileCode, FileText, Globe, Maximize2, X } from '@lucide/svelte';
+	import { Expand, FileCode, FileText, Fullscreen, Globe, Shrink, X } from '@lucide/svelte';
 	import ArtifactDisplay from '$lib/components/home/artifact-display.svelte';
 	import type { ArtifactEntry } from '$lib/chat/artifacts';
 	import type { ArtifactType } from '$convex/lib/validators';
@@ -7,13 +7,26 @@
 	type Props = {
 		artifacts: ArtifactEntry[];
 		selectedKey: string | null;
+		/** When true, the panel covers the full Sprocket workspace UI (not browser fullscreen). */
+		expanded: boolean;
 		onSelect: (key: string) => void;
 		onBack: () => void;
-		onExpand: (key: string) => void;
+		/** Enter true browser fullscreen for a single artifact (content only). */
+		onOpenFullscreen: (key: string) => void;
+		onToggleExpanded: () => void;
 		onClose: () => void;
 	};
 
-	let { artifacts, selectedKey, onSelect, onBack, onExpand, onClose }: Props = $props();
+	let {
+		artifacts,
+		selectedKey,
+		expanded,
+		onSelect,
+		onBack,
+		onOpenFullscreen,
+		onToggleExpanded,
+		onClose
+	}: Props = $props();
 
 	const selected = $derived(artifacts.find((artifact) => artifact.key === selectedKey) ?? null);
 
@@ -22,9 +35,27 @@
 		html: Globe,
 		react: FileCode
 	};
+
+	$effect(() => {
+		if (!expanded) return;
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== 'Escape') return;
+			// Artifact screen-fullscreen (browser FS or CSS fallback) owns Escape.
+			if (
+				document.fullscreenElement ||
+				document.querySelector('[data-artifact-screen-fullscreen]')
+			) {
+				return;
+			}
+			event.preventDefault();
+			onToggleExpanded();
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	});
 </script>
 
-<aside class="flex h-screen min-h-0 w-full flex-col border-l">
+<aside class="bg-background flex h-full min-h-0 w-full flex-col {expanded ? '' : 'border-l'}">
 	<div class="flex items-center gap-1 border-b px-2 py-1.5">
 		<span
 			class="bg-muted text-foreground rounded-md px-2.5 py-1 text-xs font-medium"
@@ -35,7 +66,21 @@
 		<div class="flex-1"></div>
 		<button
 			type="button"
-			class="text-muted-foreground hover:text-foreground transition"
+			class="text-muted-foreground hover:text-foreground rounded-md p-1 transition"
+			onclick={onToggleExpanded}
+			aria-label={expanded ? 'Exit full workspace' : 'Expand to full workspace'}
+			title={expanded ? 'Exit full workspace' : 'Expand to full workspace'}
+			aria-pressed={expanded}
+		>
+			{#if expanded}
+				<Shrink class="size-4" aria-hidden="true" />
+			{:else}
+				<Expand class="size-4" aria-hidden="true" />
+			{/if}
+		</button>
+		<button
+			type="button"
+			class="text-muted-foreground hover:text-foreground rounded-md p-1 transition"
 			onclick={onClose}
 			aria-label="Close panel"
 		>
@@ -49,7 +94,7 @@
 				artifactType={selected.artifactType}
 				content={selected.content}
 				variant="full"
-				onExpand={() => onExpand(selected.key)}
+				onOpenFullscreen={() => onOpenFullscreen(selected.key)}
 				{onBack}
 			/>
 		</div>
@@ -58,10 +103,7 @@
 			{#each artifacts as artifact (artifact.key)}
 				{@const TypeIcon = TYPE_ICONS[artifact.artifactType]}
 				<div
-					class="group hover:bg-muted flex items-center gap-2 rounded-md px-2 py-1.5 {selectedKey ===
-					artifact.key
-						? 'bg-muted'
-						: ''}"
+					class="group hover:bg-muted focus-within:bg-muted flex items-center gap-2 rounded-md px-2 py-1.5"
 				>
 					<button
 						type="button"
@@ -73,11 +115,12 @@
 					</button>
 					<button
 						type="button"
-						class="text-muted-foreground hover:text-foreground shrink-0 opacity-0 transition group-hover:opacity-100"
-						onclick={() => onExpand(artifact.key)}
+						class="text-muted-foreground hover:text-foreground shrink-0 opacity-0 transition group-focus-within:opacity-100 group-hover:opacity-100 focus:opacity-100"
+						onclick={() => onOpenFullscreen(artifact.key)}
 						aria-label={`Open ${artifact.title} fullscreen`}
+						title="Open fullscreen"
 					>
-						<Maximize2 class="size-3.5" aria-hidden="true" />
+						<Fullscreen class="size-3.5" aria-hidden="true" />
 					</button>
 				</div>
 			{:else}

--- a/apps/web/src/lib/components/home/artifact-screen-fullscreen.svelte
+++ b/apps/web/src/lib/components/home/artifact-screen-fullscreen.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { onMount, tick, untrack } from 'svelte';
+	import { X } from '@lucide/svelte';
+	import ChatMarkdown from '$lib/components/chat-markdown.svelte';
+	import type { ArtifactEntry } from '$lib/chat/artifacts';
+	import { buildArtifactPreviewDocument } from '$lib/chat/artifact-preview';
+
+	type Props = {
+		artifact: ArtifactEntry;
+		onClose: () => void;
+	};
+
+	let { artifact, onClose }: Props = $props();
+
+	const previewDocument = $derived(
+		buildArtifactPreviewDocument(artifact.artifactType, artifact.content)
+	);
+
+	let rootEl: HTMLDivElement | null = $state(null);
+	/** Shown only when the Fullscreen API is unavailable or rejects (iframe Escape cannot reach us). */
+	let showFallbackClose = $state(false);
+
+	onMount(() => {
+		const el = rootEl;
+		if (!el) return;
+
+		let active = true;
+		// Click handler requests FS on documentElement before this mounts; treat any
+		// current fullscreen session as ours so we don't re-request (and bounce) later.
+		let wasFullscreen = Boolean(document.fullscreenElement);
+		const previouslyFocused =
+			document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+		const close = () => {
+			if (!active) return;
+			active = false;
+			untrack(() => {
+				onClose();
+			});
+		};
+
+		const onFullscreenChange = () => {
+			if (document.fullscreenElement) {
+				wasFullscreen = true;
+				untrack(() => {
+					showFallbackClose = false;
+				});
+				return;
+			}
+			if (wasFullscreen) {
+				close();
+			}
+		};
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== 'Escape') return;
+			// Claim Escape so an expanded workspace panel underneath does not also collapse.
+			event.stopImmediatePropagation();
+			// Browser fullscreen already exits on Escape; fullscreenchange handles close.
+			if (document.fullscreenElement || wasFullscreen) return;
+			event.preventDefault();
+			close();
+		};
+
+		document.addEventListener('fullscreenchange', onFullscreenChange);
+		window.addEventListener('keydown', onKeyDown, true);
+
+		void tick().then(() => {
+			if (active) el.focus();
+		});
+
+		// Parent requests fullscreen in the user-gesture click handler. If that
+		// failed or was skipped, expose a dismiss control — do not re-request here
+		// (Firefox will deny it outside the gesture and can bounce the session).
+		const fallbackTimer = window.setTimeout(() => {
+			if (!active || document.fullscreenElement) return;
+			untrack(() => {
+				showFallbackClose = true;
+			});
+		}, 250);
+
+		return () => {
+			active = false;
+			window.clearTimeout(fallbackTimer);
+			document.removeEventListener('fullscreenchange', onFullscreenChange);
+			window.removeEventListener('keydown', onKeyDown, true);
+			if (document.fullscreenElement) {
+				void document.exitFullscreen?.().catch(() => {});
+			}
+			const focusTarget = previouslyFocused;
+			void tick().then(() => {
+				if (focusTarget?.isConnected) focusTarget.focus();
+			});
+		};
+	});
+</script>
+
+<div
+	bind:this={rootEl}
+	data-artifact-screen-fullscreen=""
+	class="bg-background fixed inset-0 z-200 flex h-screen w-screen flex-col outline-none"
+	role="dialog"
+	aria-modal="true"
+	aria-label={`${artifact.title} fullscreen. Press Escape to exit.`}
+	tabindex="-1"
+>
+	{#if previewDocument}
+		<iframe
+			title={`${artifact.title} preview`}
+			srcdoc={previewDocument}
+			sandbox="allow-scripts"
+			class="block h-full w-full flex-1 bg-white"
+		></iframe>
+	{:else}
+		<div class="min-h-0 flex-1 overflow-auto p-6">
+			<ChatMarkdown content={artifact.content} className="text-sm text-foreground" />
+		</div>
+	{/if}
+	{#if showFallbackClose}
+		<button
+			type="button"
+			class="bg-background/90 text-muted-foreground hover:text-foreground absolute top-3 right-3 z-10 rounded-md border p-2 transition"
+			onclick={() => onClose()}
+			aria-label="Exit fullscreen"
+		>
+			<X class="size-4" aria-hidden="true" />
+		</button>
+	{/if}
+</div>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -2110,14 +2110,13 @@
 		{/if}
 
 		{#if fullscreenArtifact}
-			{#key fullscreenArtifact.key}
-				<ArtifactScreenFullscreen
-					artifact={fullscreenArtifact}
-					onClose={() => {
-						artifactFullscreenKey = null;
-					}}
-				/>
-			{/key}
+			<!-- No {#key}: remounting would exit document fullscreen during artifact switches. -->
+			<ArtifactScreenFullscreen
+				artifact={fullscreenArtifact}
+				onClose={() => {
+					artifactFullscreenKey = null;
+				}}
+			/>
 		{/if}
 
 		{#if desktopApi && projectPickerOpen}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -28,7 +28,7 @@
 	import SettingsUsage from '$lib/components/home/settings-usage.svelte';
 	import ThreadTranscript from '$lib/components/home/thread-transcript.svelte';
 	import ArtifactPanel from '$lib/components/home/artifact-panel.svelte';
-	import ArtifactDisplay from '$lib/components/home/artifact-display.svelte';
+	import ArtifactScreenFullscreen from '$lib/components/home/artifact-screen-fullscreen.svelte';
 	import type { ArtifactPanelSnapshot } from '$lib/chat/artifacts';
 	import ProjectPicker, { type ProjectSelection } from '$lib/components/home/project-picker.svelte';
 	import ProjectSidebar from '$lib/components/home/project-sidebar.svelte';
@@ -582,7 +582,11 @@
 	// Panel state snapshots survive thread switches; the live thread always has
 	// an entry after the restore effect below runs.
 	const artifactSnapshots = new SvelteMap<Id<'threadRecords'>, ArtifactPanelSnapshot>();
-	let artifactPanel = $state<ArtifactPanelSnapshot>({ open: false, selectedKey: null });
+	let artifactPanel = $state<ArtifactPanelSnapshot>({
+		open: true,
+		expanded: false,
+		selectedKey: null
+	});
 	let artifactPanelThreadId: Id<'threadRecords'> | null = null;
 
 	$effect(() => {
@@ -592,29 +596,17 @@
 			artifactSnapshots.set(artifactPanelThreadId, artifactPanel);
 		}
 		artifactPanelThreadId = threadId;
+		artifactFullscreenKey = null;
 		artifactPanel = (threadId && artifactSnapshots.get(threadId)) || {
-			open: false,
+			open: true,
+			expanded: false,
 			selectedKey: null
 		};
 	});
 
-	const selectedArtifactKey = $derived(artifactPanel.selectedKey);
 	const fullscreenArtifact = $derived(
 		threadArtifacts.find((artifact) => artifact.key === artifactFullscreenKey) ?? null
 	);
-	// New artifacts open the panel while their run is live; loads and thread
-	// switches leave it alone.
-	let seenArtifactKeys = new SvelteSet<string>();
-	$effect(() => {
-		const latest = threadArtifacts.at(-1);
-		if (!latest || !isRunning) {
-			seenArtifactKeys = new SvelteSet(threadArtifacts.map((artifact) => artifact.key));
-			return;
-		}
-		if (seenArtifactKeys.has(latest.key)) return;
-		seenArtifactKeys.add(latest.key);
-		artifactPanel = { open: true, selectedKey: latest.key };
-	});
 	const currentComposerScope = $derived(getComposerScope(currentThreadId, currentProjectId));
 	const estimatedServerNow = $derived(
 		latestRunServerClock && latestRunServerClock.runId === (runState?._id ?? null)
@@ -1957,9 +1949,14 @@
 {:else}
 	<div class="relative h-screen overflow-hidden">
 		<div
-			class="app-workspace-shell grid h-screen overflow-hidden {settingsOpen || !artifactPanel.open
-				? 'grid-cols-[292px_minmax(0,1fr)]'
-				: 'grid-cols-[292px_minmax(0,1fr)_26rem]'}"
+			class="app-workspace-shell grid h-screen grid-cols-[292px_minmax(0,1fr)] overflow-hidden {!settingsOpen &&
+			artifactPanel.open &&
+			!artifactPanel.expanded
+				? 'pr-[20rem]'
+				: ''}"
+			inert={fullscreenArtifact || (artifactPanel.open && artifactPanel.expanded)
+				? true
+				: undefined}
 		>
 			{#if settingsOpen}
 				<SettingsSidebar
@@ -2004,15 +2001,14 @@
 			{/if}
 
 			<main class="relative flex h-screen min-h-0 min-w-0 flex-col overflow-hidden">
-				{#if !settingsOpen}
+				{#if !settingsOpen && !artifactPanel.open}
 					<button
 						type="button"
 						class="text-muted-foreground hover:text-foreground hover:bg-muted absolute top-3 right-3 z-100 inline-flex items-center justify-center rounded-md p-2 transition"
 						onclick={() => {
-							artifactPanel = { ...artifactPanel, open: !artifactPanel.open };
+							artifactPanel = { ...artifactPanel, open: true };
 						}}
-						aria-label={artifactPanel.open ? 'Close artifacts panel' : 'Open artifacts panel'}
-						aria-pressed={artifactPanel.open}
+						aria-label="Open artifacts panel"
 					>
 						<PanelRight class="size-4" aria-hidden="true" />
 					</button>
@@ -2076,39 +2072,52 @@
 					/>
 				{/if}
 			</main>
+		</div>
 
-			{#if !settingsOpen && artifactPanel.open}
+		{#if !settingsOpen && artifactPanel.open}
+			<div
+				class={artifactPanel.expanded
+					? 'bg-background fixed inset-0 z-50'
+					: 'absolute inset-y-0 right-0 z-40 w-[20rem]'}
+				inert={fullscreenArtifact ? true : undefined}
+			>
 				<ArtifactPanel
 					artifacts={threadArtifacts}
-					selectedKey={selectedArtifactKey}
+					selectedKey={artifactPanel.selectedKey}
+					expanded={artifactPanel.expanded}
 					onSelect={(key) => {
 						artifactPanel = { ...artifactPanel, selectedKey: key };
 					}}
 					onBack={() => {
 						artifactPanel = { ...artifactPanel, selectedKey: null };
 					}}
-					onExpand={(key) => {
+					onOpenFullscreen={(key) => {
 						artifactFullscreenKey = key;
+						// Request in the click gesture so Firefox keeps true browser
+						// fullscreen; the overlay only observes/exits the session.
+						if (!document.fullscreenElement) {
+							void document.documentElement.requestFullscreen?.().catch(() => {});
+						}
+					}}
+					onToggleExpanded={() => {
+						artifactPanel = { ...artifactPanel, expanded: !artifactPanel.expanded };
 					}}
 					onClose={() => {
-						artifactPanel = { ...artifactPanel, open: false };
-					}}
-				/>
-			{/if}
-		</div>
-
-		{#if fullscreenArtifact}
-			<div class="bg-background/95 fixed inset-0 z-100 flex flex-col p-4">
-				<ArtifactDisplay
-					title={fullscreenArtifact.title}
-					artifactType={fullscreenArtifact.artifactType}
-					content={fullscreenArtifact.content}
-					variant="full"
-					onBack={() => {
-						artifactFullscreenKey = null;
+						artifactPanel = { ...artifactPanel, open: false, expanded: false };
 					}}
 				/>
 			</div>
+		{/if}
+
+		{#if fullscreenArtifact}
+			{#key fullscreenArtifact.key}
+				<ArtifactScreenFullscreen
+					artifact={fullscreenArtifact}
+					onClose={() => {
+						artifactFullscreenKey = null;
+					}}
+				/>
+			{/key}
 		{/if}
 
 		{#if desktopApi && projectPickerOpen}


### PR DESCRIPTION
## Summary
- Default the artifacts sidebar open, hide the open toggle while it's visible, and drop auto-open-on-new-artifact behavior
- Add a workspace expand control beside close so the panel can cover the full Sprocket UI
- Use true browser fullscreen for artifact content (content-only), requested in the click gesture so Firefox doesn't bounce out

## Test plan
- [ ] Artifacts sidebar is open by default on load / new threads
- [ ] Open toggle is hidden while the sidebar is open; X closes it and restores the toggle
- [ ] Expand (left of X) covers the full Sprocket workspace; Escape / Shrink returns to the side panel
- [ ] Artifact fullscreen covers the real screen with only artifact content; Escape exits
- [ ] In Firefox, fullscreen stays full-screen (does not drop back under the browser chrome after ~1s)
- [ ] Closing the sidebar or switching threads clears artifact fullscreen cleanly

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change keeps the artifact sidebar open by default, adds a full-workspace artifact view, and introduces content-only browser fullscreen.

Chromium rendering checks exercised switching directly from fullscreen artifact A to B, closing the fullscreen overlay with Escape while the workspace remains expanded, and exiting the expanded workspace with Escape when no overlay is open. All three interactions behaved as intended.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

Rendered browser checks confirmed the fullscreen lifecycle and keyboard behavior work correctly across artifact switching and workspace expansion.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Playwright fullscreen behavior harness to compare the prior keyed-remount lifecycle with the current persistent-overlay lifecycle.
- Observed that the legacy baseline exited browser fullscreen when switching from artifact A to B, while the current implementation kept fullscreen active and displayed artifact B.
- Confirmed Escape closes the artifact overlay while retaining expanded-workspace mode, and exits expanded-workspace mode when no overlay is present.
- No newly confirmed defect was found, and the executable harness recorded all observed states for the requested hypotheses.

<a href="https://app.greptile.com/trex/runs/16870771/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ux): Keep browser fullscreen when sw..."](https://github.com/spikonado/sprocket/commit/8643073f40bed162eefdea6d96250424919df5fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49283564)</sub>

<!-- /greptile_comment -->