### PR TITLE
feat(models): Add GPT-5.6 Luna and Terra to the free tier

### DIFF
--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -52,7 +52,7 @@ export const tierLimits: Record<SubscriptionTier, TierLimits> = {
 };
 
 export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModelId[]> = {
-	free: ['kimi-k3'],
+	free: ['gpt-5.6-terra', 'gpt-5.6-luna', 'kimi-k3'],
 	pro: modelIds,
 	admin: modelIds
 };


### PR DESCRIPTION
## Summary
- Unlock `gpt-5.6-terra` and `gpt-5.6-luna` on the free subscription tier alongside `kimi-k3`

## Test plan
- [ ] As a free-tier user, confirm Luna and Terra appear unlocked in the model picker
- [ ] As a free-tier user, start a chat with Luna and with Terra and confirm both run
- [ ] Confirm Sol and other paid-only models remain locked on free
- [ ] Confirm Pro/Admin still have access to the full model catalog

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change expands the Free plan model selection to include GPT-5.6 Terra and GPT-5.6 Luna alongside Kimi K3. The entitlement helpers were executed directly and confirmed that Free users can use all three configured models, remain unable to select GPT-5.6 Sol, remain limited to the Standard service tier, and fall back to GPT-5.6 Terra when requesting a model outside their plan.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the Free-tier entitlement runtime test in a temporary workspace, and it exited with code 1 because the parent revision's Free allowlist contained only 'kimi-k3'.
- I re-ran the same test in the real workspace, and it exited with code 0, with the test passing and validating the Free-tier entitlement logic through the tier helpers.
- Before the PR, running the entitlement test in the temporary workspace exited with 1 and showed the free list as \["kimi-k3"\], indicating the entitlement contract did not hold yet.
- After the PR, running the same command in the real workspace exited with 0 and one test passed.

<a href="https://app.greptile.com/trex/runs/16871694/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(models): Add GPT-5.6 Luna and Terra..."](https://github.com/spikonado/sprocket/commit/2462092babb40952fcf3268cb38e5308779c3b2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49286327)</sub>

<!-- /greptile_comment -->