### PR TITLE
fix(models): Lower Luna and Terra usage weights after price cuts

### DIFF
--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -64,10 +64,10 @@ export const modelDefinitions = [
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
 		usageWeights: {
-			input: 0.0025,
-			cacheRead: 0.00025,
-			cacheWrite: 0.003125,
-			output: 0.015,
+			input: 0.002,
+			cacheRead: 0.0002,
+			cacheWrite: 0.0025,
+			output: 0.012,
 			fastMultiplier: 2
 		}
 	},
@@ -81,10 +81,10 @@ export const modelDefinitions = [
 		defaultReasoningEffort: 'medium',
 		serviceTiers: serviceTierIds,
 		usageWeights: {
-			input: 0.001,
-			cacheRead: 0.0001,
-			cacheWrite: 0.00125,
-			output: 0.006,
+			input: 0.0002,
+			cacheRead: 0.00002,
+			cacheWrite: 0.00025,
+			output: 0.0012,
 			fastMultiplier: 2
 		}
 	},


### PR DESCRIPTION
## Summary
- Reduce `gpt-5.6-luna` usage weights by 80% to match the new OpenAI API prices ($0.20/$0.02/$0.25/$1.20 per 1M tokens)
- Reduce `gpt-5.6-terra` usage weights by 20% to match the new OpenAI API prices ($2.00/$0.20/$2.50/$12.00 per 1M tokens)
- Leave Sol and other models unchanged

## Test plan
- [ ] Confirm Luna completion usage units are ~20% of the previous charge for the same token mix
- [ ] Confirm Terra completion usage units are ~80% of the previous charge for the same token mix
- [ ] Confirm Sol usage charging is unchanged
- [ ] Spot-check usage meter progress after a short Luna/Terra chat

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change reduces usage weights for GPT-5.6 Terra and GPT-5.6 Luna while retaining the fast-tier multiplier. The executed pricing check confirmed the selected standard-tier charges use the updated weights and that fast-tier charges double them. However, malformed negative token counts produce negative model-usage charges, which can reduce rather than consume a user’s quota.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until model-usage accounting rejects or neutralizes invalid negative token counts.

The updated Terra and Luna pricing and fast-tier behavior were exercised successfully, but the production usage calculator returned a negative charge for negative token inputs and the charging path accepts those values.

**Files Needing Attention:** apps/web/src/convex/lib/models.ts needs defensive token validation, and apps/web/src/convex/lib/rateLimits.ts should enforce non-negative token values at the charging boundary.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the corresponding review comment.
- Created an isolated pricing-accounting Vitest source for reviewer inspection.
- Attached the Pricing-accounting Vitest execution output log for review, with a URL available for access.
- Observed that 4 tests ran: 3 passed and 1 failed; the failure involved a negativeTokens path that produced a negative value, signaling an unsafe billing path in the test run.
- Documented that the Terra/Luna weights and fastMultiplier values are consistent for the selected sums, and that the related test artifacts were uploaded for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/16873722/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/web/src/convex/lib/models.ts`, line 196-202 ([link](https://github.com/spikonado/sprocket/blob/8de1d25cc2d7e4b1fa00dfac9afc529fef48bf17/apps/web/src/convex/lib/models.ts#L196-L202)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Negative token fields create negative usage charges**

   `completionUsageUnits` calculates directly from each supplied token field without requiring non-negative values. The charging mutation accepts every field as `v.number()` and passes the resulting count to the rate limiter, so a malformed usage record can produce a negative charge rather than consuming quota. Reject non-finite or negative token counts at the charging boundary and defensively validate them before calculating usage units.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Isolated pricing-accounting Vitest source](https://app.greptile.com/trex/artifacts/58a7af42-be33-4ca2-88d5-5d455ecd6acf)**

   - Exact ephemeral Vitest source that imports the production calculator and covers standard, fast, zero, and negative token inputs.

   **[Pricing-accounting Vitest execution output](https://app.greptile.com/trex/artifacts/6c5d4eca-1d5c-4f23-86bf-72248a00419a)**

   - Actual Vitest output showing three pricing/zero assertions passed and the negative-unit assertion failed, proving the defect.

   <a href="https://app.greptile.com/trex/runs/16873722/artifacts?artifact=58a7af42-be33-4ca2-88d5-5d455ecd6acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/convex/lib/models.ts
   Line: 196-202

   Comment:
   **Negative token fields create negative usage charges**

   `completionUsageUnits` calculates directly from each supplied token field without requiring non-negative values. The charging mutation accepts every field as `v.number()` and passes the resulting count to the rate limiter, so a malformed usage record can produce a negative charge rather than consuming quota. Reject non-finite or negative token counts at the charging boundary and defensively validate them before calculating usage units.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Negative token fields create negative model-usage charges**

   - **Bug**
     - The executed isolated test supplied all-negative token fields and `completionUsageUnits('gpt-5.6-terra', 'standard', ...)` returned `-16`; the assertion requiring a non-negative charge failed. `chargeModelUsageLimits` accepts each field with `v.number()` and passes this computed count to `rateLimiter.limit`, so malformed or unexpected usage can reduce rather than consume a user's model-usage meter.
   - **Cause**
     - `completionUsageUnits` multiplies and ceilings supplied token values without validating or clamping each component to a non-negative finite number. The mutation validator only enforces numeric type, not range.
   - **Fix**
     - Validate every token field as a finite non-negative number at the accounting boundary, and defensively clamp or reject invalid values in `completionUsageUnits` before calculating the weighted sum. Add a regression test covering negative and non-finite inputs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/convex/lib/models.ts:196-202
**Negative token fields create negative usage charges**

`completionUsageUnits` calculates directly from each supplied token field without requiring non-negative values. The charging mutation accepts every field as `v.number()` and passes the resulting count to the rate limiter, so a malformed usage record can produce a negative charge rather than consuming quota. Reject non-finite or negative token counts at the charging boundary and defensively validate them before calculating usage units.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): Lower Luna and Terra usage ..."](https://github.com/spikonado/sprocket/commit/8de1d25cc2d7e4b1fa00dfac9afc529fef48bf17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49290203)</sub>

<!-- /greptile_comment -->