### PR TITLE
fix(ui): Close artifacts sidebar by default and auto-open on changes

### DIFF
--- a/apps/web/src/lib/chat/artifacts.test.ts
+++ b/apps/web/src/lib/chat/artifacts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { nextArtifactRevisionWatch, type ArtifactRevision } from './artifacts';
+
+function revision(id: string, currentVersion: number, updatedAt: number): ArtifactRevision {
+	return { id, currentVersion, updatedAt };
+}
+
+describe('nextArtifactRevisionWatch', () => {
+	it('seeds without reporting a change on first observation', () => {
+		const current = [revision('a', 1, 10), revision('b', 2, 20)];
+		const { revisions, changedId } = nextArtifactRevisionWatch(null, current);
+
+		expect(changedId).toBeNull();
+		expect([...revisions.keys()]).toEqual(['a', 'b']);
+	});
+
+	it('reports a newly created artifact', () => {
+		const previous = new Map([['a', revision('a', 1, 10)]]);
+		const { changedId } = nextArtifactRevisionWatch(previous, [
+			revision('a', 1, 10),
+			revision('b', 1, 30)
+		]);
+
+		expect(changedId).toBe('b');
+	});
+
+	it('reports an updated artifact version', () => {
+		const previous = new Map([
+			['a', revision('a', 1, 10)],
+			['b', revision('b', 1, 20)]
+		]);
+		const { changedId } = nextArtifactRevisionWatch(previous, [
+			revision('a', 1, 10),
+			revision('b', 2, 40)
+		]);
+
+		expect(changedId).toBe('b');
+	});
+
+	it('picks the most recently updated artifact when several change', () => {
+		const previous = new Map([
+			['a', revision('a', 1, 10)],
+			['b', revision('b', 1, 20)]
+		]);
+		const { changedId } = nextArtifactRevisionWatch(previous, [
+			revision('a', 2, 50),
+			revision('b', 2, 45)
+		]);
+
+		expect(changedId).toBe('a');
+	});
+
+	it('reports null when nothing changed', () => {
+		const previous = new Map([['a', revision('a', 1, 10)]]);
+		const { changedId } = nextArtifactRevisionWatch(previous, [revision('a', 1, 10)]);
+
+		expect(changedId).toBeNull();
+	});
+
+	it('ignores removals and updatedAt-only noise', () => {
+		const previous = new Map([
+			['a', revision('a', 1, 10)],
+			['b', revision('b', 1, 20)]
+		]);
+		const { changedId, revisions } = nextArtifactRevisionWatch(previous, [revision('a', 1, 99)]);
+
+		expect(changedId).toBeNull();
+		expect([...revisions.keys()]).toEqual(['a']);
+	});
+});

--- a/apps/web/src/lib/chat/artifacts.ts
+++ b/apps/web/src/lib/chat/artifacts.ts
@@ -14,3 +14,47 @@ export type ArtifactPanelSnapshot = {
 	expanded: boolean;
 	selectedKey: string | null;
 };
+
+export const DEFAULT_ARTIFACT_PANEL_SNAPSHOT: ArtifactPanelSnapshot = {
+	open: false,
+	expanded: false,
+	selectedKey: null
+};
+
+/** Revision used to detect creates/updates for auto-opening the panel. */
+export type ArtifactRevision = {
+	id: string;
+	/** Change signal: content writes always bump this. */
+	currentVersion: number;
+	/** Rank key among concurrent changes; not part of equality. */
+	updatedAt: number;
+};
+
+/**
+ * Diffs the latest artifact revisions against a prior snapshot.
+ * When `previous` is null (first observation for a thread), only seeds — never reports a change.
+ */
+export function nextArtifactRevisionWatch(
+	previous: ReadonlyMap<string, ArtifactRevision> | null,
+	current: readonly ArtifactRevision[]
+): { revisions: Map<string, ArtifactRevision>; changedId: string | null } {
+	const revisions = new Map<string, ArtifactRevision>(
+		current.map((artifact) => [artifact.id, artifact])
+	);
+	if (previous === null) {
+		return { revisions, changedId: null };
+	}
+
+	let latestChange: ArtifactRevision | null = null;
+	for (const artifact of current) {
+		const prior = previous.get(artifact.id);
+		if (
+			(!prior || prior.currentVersion !== artifact.currentVersion) &&
+			(!latestChange || artifact.updatedAt >= latestChange.updatedAt)
+		) {
+			latestChange = artifact;
+		}
+	}
+
+	return { revisions, changedId: latestChange?.id ?? null };
+}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { PanelRight } from '@lucide/svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { useAuth, useMutation, useQuery } from 'convex-svelte';
@@ -29,7 +29,12 @@
 	import ThreadTranscript from '$lib/components/home/thread-transcript.svelte';
 	import ArtifactPanel from '$lib/components/home/artifact-panel.svelte';
 	import ArtifactScreenFullscreen from '$lib/components/home/artifact-screen-fullscreen.svelte';
-	import type { ArtifactPanelSnapshot } from '$lib/chat/artifacts';
+	import {
+		DEFAULT_ARTIFACT_PANEL_SNAPSHOT,
+		nextArtifactRevisionWatch,
+		type ArtifactPanelSnapshot,
+		type ArtifactRevision
+	} from '$lib/chat/artifacts';
 	import ProjectPicker, { type ProjectSelection } from '$lib/components/home/project-picker.svelte';
 	import ProjectSidebar from '$lib/components/home/project-sidebar.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -582,12 +587,13 @@
 	// Panel state snapshots survive thread switches; the live thread always has
 	// an entry after the restore effect below runs.
 	const artifactSnapshots = new SvelteMap<Id<'threadRecords'>, ArtifactPanelSnapshot>();
-	let artifactPanel = $state<ArtifactPanelSnapshot>({
-		open: true,
-		expanded: false,
-		selectedKey: null
-	});
+	let artifactPanel = $state<ArtifactPanelSnapshot>({ ...DEFAULT_ARTIFACT_PANEL_SNAPSHOT });
 	let artifactPanelThreadId: Id<'threadRecords'> | null = null;
+	// Baseline for create/update detection; null means the next observation only seeds.
+	let artifactRevisionWatch: {
+		threadId: Id<'threadRecords'>;
+		revisions: Map<string, ArtifactRevision>;
+	} | null = null;
 
 	$effect(() => {
 		const threadId = currentThreadId;
@@ -597,10 +603,42 @@
 		}
 		artifactPanelThreadId = threadId;
 		artifactFullscreenKey = null;
-		artifactPanel = (threadId && artifactSnapshots.get(threadId)) || {
+		artifactPanel = {
+			...((threadId && artifactSnapshots.get(threadId)) || DEFAULT_ARTIFACT_PANEL_SNAPSHOT)
+		};
+	});
+
+	$effect(() => {
+		const threadId = currentThreadId;
+		const data = artifactsQuery.data;
+		if (!threadId) {
+			artifactRevisionWatch = null;
+			return;
+		}
+		// Drop the prior thread's baseline immediately on switch, even while loading,
+		// so A→B(loading)→A re-seeds instead of treating away-updates as live changes.
+		if (artifactRevisionWatch && artifactRevisionWatch.threadId !== threadId) {
+			artifactRevisionWatch = null;
+		}
+		if (data === undefined) return;
+
+		const current: ArtifactRevision[] = data.map((entry) => ({
+			id: entry.artifact._id as string,
+			currentVersion: entry.artifact.currentVersion,
+			updatedAt: entry.artifact.updatedAt
+		}));
+		const previous = artifactRevisionWatch?.revisions ?? null;
+		const { revisions, changedId } = nextArtifactRevisionWatch(previous, current);
+		artifactRevisionWatch = { threadId, revisions };
+
+		if (!changedId) return;
+		// Avoid depending on panel UI state for re-runs; only follow selection when
+		// opening or when the user is still on the list view.
+		const prior = untrack(() => artifactPanel);
+		artifactPanel = {
+			...prior,
 			open: true,
-			expanded: false,
-			selectedKey: null
+			selectedKey: !prior.open || prior.selectedKey === null ? changedId : prior.selectedKey
 		};
 	});
 


### PR DESCRIPTION
## Summary
- Default the artifacts (right) sidebar to closed
- Auto-open it when an artifact is created or updated in the current thread
- Re-seed revision watching on thread switches so existing artifacts do not surprise-open; only follow selection when opening or when the user is on the list view

## Test plan
- [ ] Open a thread with existing artifacts — right sidebar stays closed
- [ ] Have the agent create an artifact — sidebar opens and selects it
- [ ] Have the agent update an artifact while viewing another — sidebar stays open without hijacking the current selection
- [ ] Have the agent update while on the list view — selection follows the updated artifact
- [ ] Switch threads while an update lands elsewhere — returning does not auto-open for already-seen artifacts
- [ ] Manually toggle the sidebar open/closed still works

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes the artifact sidebar start closed, preserves panel state independently for each thread, and opens the panel when an artifact is created or its content changes. Executed checks disproved the key regression paths: initial artifact loading does not open the panel, creates and content updates are detected, an active artifact selection is preserved, and switching through a loading thread does not treat an away-thread update as a live change.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex confirmed that the revised sidebar now starts closed by comparing the parent and revised implementations and established a per-thread revision baseline.
- T-Rex ran the revision-watch Vitest suite and focused artifact tests, reporting six passing revision-watch tests and eleven passing artifact tests, with zero Svelte errors or warnings.
- T-Rex executed an executable review harness covering initial-load seeding, artifact creation, content updates, active-selection preservation, and an A-to-B loading-to-A thread switch; every asserted transition passed.
- T-Rex inspected the installed query implementation and confirmed previous query data is retained only through an opt-in behavior not configured here, so prior-thread data is not delivered as current data during the thread switch.
- No product code was modified; the only authored file is the review harness, and before/after captures show the sidebar changing from default-open to default-closed with a revision baseline; the executable harness passed first-load seeding, create/update detection, selection preservation, and the stale-data guard.

<a href="https://app.greptile.com/trex/runs/16891951/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ux): Close artifacts sidebar by def..."](https://github.com/spikonado/sprocket/commit/06b8baa523aa90b8c09cf886b33fbd750f8b6d98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49327845)</sub>

<!-- /greptile_comment -->