### PR TITLE
docs(readme): Add link to demo and update project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 **Goal**: To make the world's best platform for developing hardware and software.
 
-Sprocket is currently a lightweight coding agent that writes high-quality code, and retrieves best-in-class context from the web and open-source projects.
+Sprocket is a lightweight agent that can <ins>create hardware designs</ins> and write code.
+
+Sprocket retrieves <ins>best-in-class context from the web</ins> for everything it does. It is therefore incredibly reliable.
+In terms of hardware design, Sprocket can make beautiful schematics in React, create your BOM, and create detailed assembly instructions.
+
+And <ins>here's the best part</ins>: Sprocket can (on its own) <ins>buy anything from any website</ins> when you tell it to do so. From hardware parts to SaaS subscriptions.
+
+![Sprocket Demo](https://www.youtube.com/watch?v=E8KWO3Vh9YU)
 
 ![Sprocket](./assets/sprocket.png)
-
-![Sprocket Dark](./assets/sprocket-dark.png)
 
 ## Using Sprocket
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In terms of hardware design, Sprocket can make beautiful schematics in React, cr
 
 And <ins>here's the best part</ins>: Sprocket can (on its own) <ins>buy anything from any website</ins> when you tell it to do so. From hardware parts to SaaS subscriptions.
 
-![Sprocket Demo](https://www.youtube.com/watch?v=E8KWO3Vh9YU)
+[Sprocket Demo](https://www.youtube.com/watch?v=E8KWO3Vh9YU)
 
 ![Sprocket](./assets/sprocket.png)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The README now describes Sprocket’s hardware-design and purchasing capabilities and adds a YouTube demo link. The demo link was verified to return HTTP 200 and render as a clickable link. However, the remaining product screenshot at `README.md:14` points to unresolved Git LFS pointer content, so visitors cannot view the image.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Do not merge until the README screenshot is restored as a valid image or replaced with a reliably hosted image.

The product demo link works as intended, but the main README screenshot cannot render for repository visitors because its referenced asset is not image data.

**Files Needing Attention:** README.md, assets/sprocket.png
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached it to review comment 0.
- T-Rex produced a proof for another posted P1 finding and attached it to review comment 1.
- T-Rex ran the requested verification for general contract validation, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **README demo image points to a non-image YouTube watch page**

   - **Bug**
     - `![Sprocket Demo](https://www.youtube.com/watch?v=E8KWO3Vh9YU)` at `README.md:12` is rendered by GitHub as an image element, but its canonical source is a YouTube HTML watch page. GitHub Camo rejects the source with HTTP 400 and `Non-Image content-type returned`, so the README does not display a usable demo image.
   - **Cause**
     - Markdown image syntax requires image media, while the supplied URL responds with `text/html; charset=utf-8` and an HTML document.
   - **Fix**
     - Replace the image source with an actual image/thumbnail URL (optionally wrapped in a normal link to the YouTube video), or replace the image syntax with a standard Markdown link to the video.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Retained README screenshot is a Git LFS pointer rather than an image**

   - **Bug**
     - `README.md:14` renders `./assets/sprocket.png`, but the tracked file is only 132 bytes of Git LFS pointer text rather than PNG/JPEG bytes. Users viewing the repository cannot receive a displayable screenshot.
   - **Cause**
     - `assets/sprocket.png` is tracked with the LFS filter but its image object is not present/resolved in the repository checkout/content served by GitHub.
   - **Fix**
     - Restore and commit the actual LFS object so `assets/sprocket.png` contains valid PNG data, or replace the reference with a reliably hosted non-LFS image.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:14
**README screenshot resolves to LFS pointer text**

`./assets/sprocket.png` is only a 132-byte Git LFS pointer rather than PNG image data, and GitHub serves the raw file as `text/plain`. The retained screenshot therefore cannot display for README visitors. Restore the actual LFS object or replace this reference with a reliably hosted image.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Update README.md"](https://github.com/spikonado/sprocket/commit/57a5ed1248f515a2002a6bd597ea85171790439f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49503518)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->