### PR TITLE
docs(readme): Update description with what makes Sprocket special

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **Goal**: To make the world's best platform for developing hardware and software.
 
-The best and only AI agent for developing both <ins>hardware</ins> and <ins>software</ins>.
-
 Here's what makes Sprocket special:
 
 - The only AI agent that can work on both <ins>hardware</ins> and <ins>software</ins>.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The best and only AI agent for developing both <ins>hardware</ins> and <ins>soft
 
 Here's what makes Sprocket special:
 
+- The only AI agent that can work on both <ins>hardware</ins> and <ins>software</ins>
 - Retrieves best-in-class <ins>context from the web</ins> for everything it does, so it stays <ins>incredibly reliable</ins>.
 - <ins>Buys anything from any website</ins> when you ask, from hardware parts to SaaS subscriptions.
 - Makes <ins>beautifully detailed schematics</ins>, creates your <ins>BOM</ins>, and writes <ins>assembly instructions</ins>.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The best and only AI agent for developing both <ins>hardware</ins> and <ins>soft
 
 Here's what makes Sprocket special:
 
-- The only AI agent that can work on both <ins>hardware</ins> and <ins>software</ins>
+- The only AI agent that can work on both <ins>hardware</ins> and <ins>software</ins>.
 - Retrieves best-in-class <ins>context from the web</ins> for everything it does, so it stays <ins>incredibly reliable</ins>.
 - <ins>Buys anything from any website</ins> when you ask, from hardware parts to SaaS subscriptions.
 - Makes <ins>beautifully detailed schematics</ins>, creates your <ins>BOM</ins>, and writes <ins>assembly instructions</ins>.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Sprocket
 
-**Goal**: To make the world's best platform for developing hardware and software.
+The best and only AI agent for developing both <ins>hardware</ins> and <ins>software</ins>.
 
-Sprocket is a lightweight agent that can <ins>create hardware designs</ins> and write code.
-
-Sprocket retrieves <ins>best-in-class context from the web</ins> for everything it does. It is therefore incredibly reliable.
-In terms of hardware design, Sprocket can make beautiful schematics in React, create your BOM, and create detailed assembly instructions.
-
-And <ins>here's the best part</ins>: Sprocket can (on its own) <ins>buy anything from any website</ins> when you tell it to do so. From hardware parts to SaaS subscriptions.
+- Retrieves best-in-class <ins>context from the web</ins> for everything it does, so it stays <ins>incredibly reliable</ins>.
+- <ins>Buys anything from any website</ins> when you ask, from hardware parts to SaaS subscriptions.
+- Makes <ins>beautifully detailed schematics</ins>, creates your <ins>BOM</ins>, and writes <ins>assembly instructions</ins>.
 
 [Sprocket Demo](https://www.youtube.com/watch?v=E8KWO3Vh9YU)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Sprocket
 
+**Goal**: To make the world's best platform for developing hardware and software.
+
 The best and only AI agent for developing both <ins>hardware</ins> and <ins>software</ins>.
+
+Here's what makes Sprocket special:
 
 - Retrieves best-in-class <ins>context from the web</ins> for everything it does, so it stays <ins>incredibly reliable</ins>.
 - <ins>Buys anything from any website</ins> when you ask, from hardware parts to SaaS subscriptions.


### PR DESCRIPTION
## Summary
- Rewrite the README intro to match the website Sprocket page positioning
- Replace the old prose with feature bullets for web context, buying from any site, and hardware design outputs

## Test plan
- [ ] Skim README rendering on GitHub
- [ ] Confirm demo link and image still work below the new intro

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the README introduction with concise feature bullets that describe Sprocket’s hardware and software capabilities.

The README structure was checked against both the previous and updated revisions. The heading, feature list, demo link, and linked image remain separate and correctly ordered. The potential Markdown layout regression was disproved by the passing before-and-after structure check.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The updated README preserves the expected heading, list, demo link, and image layout when checked against the previous revision.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the T-Rex contract-validation from /home/user/repo using Python 3 against the actual git refs.
- Compared the README demo content and confirmed the before state appeared at lines 9–11 and the after state at lines 12–14, with the required blank-line placement preserved.
- Saved the validation source and both captured command outputs to the artifacts collection.

<a href="https://app.greptile.com/trex/runs/17060902/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(readme): Drop redundant positioning..."](https://github.com/spikonado/sprocket/commit/d8e7e533ea329eb9f5f26f49b8c19f65bdd04bfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49672359)</sub>

<!-- /greptile_comment -->