### PR TITLE
fix(cli): Treat loopback probe timeout as no running server

### DIFF
--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -172,7 +172,10 @@ async fn open_running_web_app(
             "Port {} is already used by another service; set SPROCKET_PORT to a free port",
             server.port
         ),
-        Err(error) if error.is_connect() => return Ok(false),
+        // No Sprocket server proved itself. Windows filter drivers can swallow
+        // SYNs to dead loopback ports, so a timeout is not a fatal signal here;
+        // the subsequent TCP bind is the authoritative check.
+        Err(error) if error.is_connect() || error.is_timeout() => return Ok(false),
         Err(error) => return Err(error).context("failed to check for a running Sprocket server"),
     };
     let pairing_proof = response

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -10,6 +10,7 @@ pub use config::{DEFAULT_DEV_WEB_URL, DEFAULT_PORT, SESSION_COOKIE_NAME, ServerC
 use static_dir::is_valid_static_dir;
 pub use static_dir::{INSTALLED_WEB_DIR, resolve_static_dir};
 
+use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -136,14 +137,19 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     };
 
     let dev_web_url = config.api_only.then(default_dev_web_url).flatten();
-    let listener = tokio::net::TcpListener::bind(config.bind_address())
-        .await
-        .with_context(|| {
-            format!(
-                "failed to bind {}; set SPROCKET_PORT to a free port",
-                config.bind_address()
-            )
-        })?;
+    let listener = match tokio::net::TcpListener::bind(config.bind_address()).await {
+        Ok(listener) => listener,
+        Err(error) => {
+            let hint = match error.kind() {
+                // Covers a real port conflict and Windows WSAEACCES on reserved port ranges.
+                ErrorKind::AddrInUse | ErrorKind::PermissionDenied => {
+                    "the port may already be in use or reserved; set SPROCKET_PORT to a free port"
+                }
+                _ => "check that SPROCKET_HOST and SPROCKET_PORT form a valid, available address",
+            };
+            return Err(error).context(format!("failed to bind {}: {hint}", config.bind_address()));
+        }
+    };
 
     if options.quiet {
         println!("SPROCKET_LISTENING={}", startup.listen_url);

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -14,6 +14,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use axum::Json;
 use axum::Router;
 use axum::http::StatusCode;
@@ -135,7 +136,14 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     };
 
     let dev_web_url = config.api_only.then(default_dev_web_url).flatten();
-    let listener = tokio::net::TcpListener::bind(config.bind_address()).await?;
+    let listener = tokio::net::TcpListener::bind(config.bind_address())
+        .await
+        .with_context(|| {
+            format!(
+                "failed to bind {}; set SPROCKET_PORT to a free port",
+                config.bind_address()
+            )
+        })?;
 
     if options.quiet {
         println!("SPROCKET_LISTENING={}", startup.listen_url);


### PR DESCRIPTION
## Problem

On Windows, `sprocket` / `sprocket --web` failed immediately with:

```
Error: failed to check for a running Sprocket server

Caused by:
    0: error sending request for url (http://127.0.0.1:17731/api/auth/pairing-proof)
    1: operation timed out
```

The CLI probes `127.0.0.1:17731` before starting, to detect an already-running server. It assumes a dead loopback port fails fast with `ECONNREFUSED` (reqwest's `is_connect()`). On Windows, WFP filter drivers (AV/endpoint protection, VPN kill-switches) can swallow SYNs to dead loopback ports, so the probe instead hits its 750 ms timeout. A timeout is not an `is_connect()` error, so the CLI aborted on a perfectly free port. Verified on the affected machine: nothing listening on 17731, port not in any WinNAT reserved range, yet TCP connects to it hang instead of being refused.

## Fix

- **`sprocket-cli`**: treat probe timeouts like refusals — no server proved its identity, so proceed to start one. The subsequent TCP bind is the authoritative port check anyway.
- **`sprocket-server`**: wrap the bind failure with context — `failed to bind 127.0.0.1:17731; set SPROCKET_PORT to a free port` — so the real port-conflict case produces an actionable error (and Windows' `WSAEACCES` reserved-range case becomes diagnosable).

## Validation

- `cargo test -p sprocket-cli -p sprocket-server` — all pass
- `prek run -a` — all pass

On the affected machine the probe will now waste at most 750 ms, then bind successfully and start normally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change allows CLI startup to continue after a loopback health probe times out and improves guidance when the server cannot bind its configured address.

Runtime checks exercised a listener that accepted but did not answer the CLI probe; the CLI continued to the authoritative bind attempt and reported the occupied-port guidance with the underlying OS error. Separate checks confirmed invalid host configuration reports host-and-port guidance while preserving the resolver cause. The focused CLI and server test suites passed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains in the changed startup paths.

The loopback timeout path, occupied-port handling, and invalid-address handling were exercised at runtime and produced the intended behavior with actionable error context.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the uploaded runtime-check script against the built CLI and server binaries to validate startup behavior.
- The probe sequence included a live loopback listener that accepted the probe, timed out, and allowed the CLI to attempt a bind, which reported 'failed to bind 127.0.0.1:35221' with 'Address already in use (os error 98)'.
- Ran the focused sprocket-cli and sprocket-server tests; all 37 tests passed.
- Checked timeout continuation and guidance paths using a blackhole loopback and invalid-address server output; observed expected messages and non-aborting startup.
- Reviewed the artifacts documenting the runtime-check, probe, and test results to verify the evidence.

<a href="https://app.greptile.com/trex/runs/17077173/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): Tailor bind error advice to..."](https://github.com/spikonado/sprocket/commit/b20d0e85d1b6fbddf762dce59a52a04246442084) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49704044)</sub>

<!-- /greptile_comment -->