### PR TITLE
feat(models): Make Kimi K3 the default model for all tiers

### DIFF
--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -158,7 +158,7 @@ export const modelDefinitions = [
 	}
 ] as const satisfies readonly ModelDefinition[];
 
-export const defaultModelId = 'gpt-5.6-sol' as const;
+export const defaultModelId = 'kimi-k3' as const;
 export const defaultReasoningEffort: SupportedReasoningEffort =
 	getModelDefinition(defaultModelId).defaultReasoningEffort;
 export const defaultServiceTier = 'standard' as const;

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -52,7 +52,7 @@ export const tierLimits: Record<SubscriptionTier, TierLimits> = {
 };
 
 export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModelId[]> = {
-	free: ['gpt-5.6-terra', 'gpt-5.6-luna', 'kimi-k3'],
+	free: ['kimi-k3', 'gpt-5.6-terra', 'gpt-5.6-luna'],
 	pro: modelIds,
 	admin: modelIds
 };


### PR DESCRIPTION
## Summary
- Set the global default model to `kimi-k3` so new chats start on Kimi K3 across tiers
- Put `kimi-k3` first in the free-tier allowlist so tier fallbacks also resolve to it

## Test plan
- [ ] Confirm a new chat on free tier selects Kimi K3 by default
- [ ] Confirm a new chat on pro/admin selects Kimi K3 by default
- [ ] Confirm free-tier users can still switch to Terra and Luna
- [ ] Confirm locked models still show the upgrade prompt for free-tier users

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes Kimi K3 the default model and the free-plan fallback, refreshes the README product description, and improves local startup handling when a port probe times out or binding fails.

The model-selection check confirmed that Kimi K3 uses a supported default reasoning level and that unavailable free-plan model selections resolve to Kimi K3. The timeout check disproved a silent-startup failure: when a listener accepts the pairing request but does not respond, the CLI proceeds to the authoritative bind and correctly stops because the port is occupied. The bind-error check also confirmed that an occupied port produces an actionable `SPROCKET_PORT` message and that the server still starts and returns a healthy response on a free port.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The reviewed changes are safe to merge based on the exercised model-selection and local server startup paths.

The final defect set is empty. Executed checks confirmed the Kimi K3 default and fallback contract, verified that an occupied port cannot be silently reused after a probe timeout, and confirmed normal startup on an available port.

**Files Needing Attention:** No files require follow-up attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Vitest test suite comparing the parent revision against the PR revision; the PR revision passed all Kimi K3 and max-default reasoning assertions, and the focused regression tests (5 tests) also passed.
- Executed the SPROCKET pairing-proof workflow against a listener; the CLI timed out after about 750 ms, then attempted a TCP bind and exited with an occupied-port error, with remediation attempting to set SPROCKET\_PORT, and the parent behavior deferred at the pairing-proof timeout.
- Ran the verification step with T-Rex; the verification completed but local artifact references were not uploaded.
- Reviewed the harness sources and the before/after logs, including the PR-era after-behavior showing Kimi K3 with max support and the 5/5 regression outcome from the focused suite.

<a href="https://app.greptile.com/trex/runs/17188271/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(models): Make Kimi K3 the default m..."](https://github.com/spikonado/sprocket/commit/8dfc6604b2c91b65b2b90c7234ce9a944e908363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49941103)</sub>

<!-- /greptile_comment -->