### PR TITLE
perf(convex): Cut function call volume from hot subscriptions and timers

### DIFF
--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -40,6 +40,7 @@ import type * as lib_runLease from "../lib/runLease.js";
 import type * as lib_runs from "../lib/runs.js";
 import type * as lib_threadMessages from "../lib/threadMessages.js";
 import type * as lib_threadTranscript from "../lib/threadTranscript.js";
+import type * as lib_threadUsage from "../lib/threadUsage.js";
 import type * as lib_tiers from "../lib/tiers.js";
 import type * as lib_uiModelCatalog from "../lib/uiModelCatalog.js";
 import type * as lib_usageMeters from "../lib/usageMeters.js";
@@ -92,6 +93,7 @@ declare const fullApi: ApiFromModules<{
   "lib/runs": typeof lib_runs;
   "lib/threadMessages": typeof lib_threadMessages;
   "lib/threadTranscript": typeof lib_threadTranscript;
+  "lib/threadUsage": typeof lib_threadUsage;
   "lib/tiers": typeof lib_tiers;
   "lib/uiModelCatalog": typeof lib_uiModelCatalog;
   "lib/usageMeters": typeof lib_usageMeters;

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -141,14 +141,12 @@ describe('agentRuntime context accounting', () => {
 		const { asUser, threadId } = await seedOwnedThread(t);
 		await seedLegacyUsage(t, threadId);
 
-		// The merged read keeps the old response shape before migration.
+		// Pre-migration reads keep the old response shape.
 		await expect(asUser.query(api.threads.getByThreadId, { threadId })).resolves.toMatchObject({
 			contextTokens: 4_000,
 			totalTokensProcessed: 100_000
 		});
-		// Opening the thread (clients fire setLastThread) schedules the migration.
 		await asUser.mutation(api.uiPreferences.setLastThread, { threadId });
-		// convex-test fires scheduled functions on a macrotask before tracking them.
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		await t.finishInProgressScheduledFunctions();
 		const migratedThread = await t.run(async (ctx) => ctx.db.get(threadId));
@@ -214,7 +212,6 @@ describe('agentRuntime context accounting', () => {
 			});
 		}
 
-		// Clean table: the sweep is a no-op.
 		await t.mutation(internal.threads.migrateLegacyUsageBatch, {});
 		expect(await readThreadUsage(t, threadId)).toMatchObject({
 			totalTokensProcessed: 100_000

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { api } from '@convex/_generated/api';
+import { api, internal } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import { executionSecretHash } from '@convex/lib/auth';
 import {
@@ -192,6 +192,32 @@ describe('agentRuntime context accounting', () => {
 		expect(await readThreadUsage(t, threadId)).toMatchObject({
 			contextTokens: 7_000,
 			totalTokensProcessed: 110_000
+		});
+	});
+
+	it('sweeps legacy counters in batches via the cron mutation', async () => {
+		const t = initConvexTest();
+		const { threadId } = await seedOwnedThread(t);
+		const { threadId: otherThreadId } = await seedOwnedThread(t, 'user_bob');
+		await seedLegacyUsage(t, threadId);
+		await seedLegacyUsage(t, otherThreadId);
+
+		await t.mutation(internal.threads.migrateLegacyUsageBatch, {});
+
+		for (const migratedId of [threadId, otherThreadId]) {
+			const thread = await t.run(async (ctx) => ctx.db.get(migratedId));
+			expect(thread).not.toHaveProperty('contextTokens');
+			expect(thread).not.toHaveProperty('totalTokensProcessed');
+			expect(await readThreadUsage(t, migratedId)).toMatchObject({
+				contextTokens: 4_000,
+				totalTokensProcessed: 100_000
+			});
+		}
+
+		// Clean table: the sweep is a no-op.
+		await t.mutation(internal.threads.migrateLegacyUsageBatch, {});
+		expect(await readThreadUsage(t, threadId)).toMatchObject({
+			totalTokensProcessed: 100_000
 		});
 	});
 

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -18,6 +18,18 @@ async function readThreadUsage(t: ConvexTestInstance, threadId: Id<'threadRecord
 	);
 }
 
+/** Simulate a pre-migration thread: legacy counters on the record, no usage row. */
+async function seedLegacyUsage(t: ConvexTestInstance, threadId: Id<'threadRecords'>) {
+	await t.run(async (ctx) => {
+		const usageRow = await ctx.db
+			.query('threadUsage')
+			.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+			.unique();
+		if (usageRow) await ctx.db.delete(usageRow._id);
+		await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
+	});
+}
+
 describe('agentRuntime context accounting', () => {
 	it('fences compaction and usage writes to the active claim', async () => {
 		const t = initConvexTest();
@@ -124,26 +136,10 @@ describe('agentRuntime context accounting', () => {
 		expect(await t.run(async (ctx) => ctx.db.get(threadId))).not.toHaveProperty('contextTokens');
 	});
 
-	it('migrates legacy on-thread counters on access', async () => {
+	it('migrates legacy on-thread counters when the thread is opened', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
-		const executionSecret = 'legacy-usage-secret';
-		const { runId } = await createQueuedRun(
-			asUser,
-			threadId,
-			'legacy-usage',
-			executionSecret,
-			'Continue'
-		);
-		// Simulate a pre-migration row: legacy counters on the thread, no usage row.
-		await t.run(async (ctx) => {
-			const usageRow = await ctx.db
-				.query('threadUsage')
-				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
-				.unique();
-			if (usageRow) await ctx.db.delete(usageRow._id);
-			await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
-		});
+		await seedLegacyUsage(t, threadId);
 
 		// The merged read keeps the old response shape before migration.
 		await expect(asUser.query(api.threads.getByThreadId, { threadId })).resolves.toMatchObject({
@@ -161,24 +157,6 @@ describe('agentRuntime context accounting', () => {
 		expect(await readThreadUsage(t, threadId)).toMatchObject({
 			contextTokens: 4_000,
 			totalTokensProcessed: 100_000
-		});
-
-		// Writes after migration accumulate onto the migrated totals.
-		await asUser.mutation(api.agentRuntime.start, {
-			runId,
-			claimId: 'claim-a',
-			executionSecret
-		});
-		await asUser.mutation(api.agentRuntime.recordContextUsage, {
-			runId,
-			claimId: 'claim-a',
-			executionSecret,
-			contextTokens: 5_000,
-			processedTokens: 6_000
-		});
-		expect(await readThreadUsage(t, threadId)).toMatchObject({
-			contextTokens: 5_000,
-			totalTokensProcessed: 106_000
 		});
 	});
 
@@ -198,14 +176,7 @@ describe('agentRuntime context accounting', () => {
 			claimId: 'claim-a',
 			executionSecret
 		});
-		await t.run(async (ctx) => {
-			const usageRow = await ctx.db
-				.query('threadUsage')
-				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
-				.unique();
-			if (usageRow) await ctx.db.delete(usageRow._id);
-			await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
-		});
+		await seedLegacyUsage(t, threadId);
 
 		await asUser.mutation(api.agentRuntime.recordContextUsage, {
 			runId,

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,7 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
 import { executionSecretHash } from '@convex/lib/auth';
-import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+import {
+	createQueuedRun,
+	initConvexTest,
+	seedOwnedThread,
+	type ConvexTestInstance
+} from './test.setup';
+
+async function readThreadUsage(t: ConvexTestInstance, threadId: Id<'threadRecords'>) {
+	return await t.run(async (ctx) =>
+		ctx.db
+			.query('threadUsage')
+			.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+			.unique()
+	);
+}
 
 describe('agentRuntime context accounting', () => {
 	it('fences compaction and usage writes to the active claim', async () => {
@@ -42,7 +57,9 @@ describe('agentRuntime context accounting', () => {
 		).resolves.toBe(true);
 
 		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
-		expect(thread).toMatchObject({
+		expect(thread).not.toHaveProperty('contextTokens');
+		expect(thread).not.toHaveProperty('totalTokensProcessed');
+		expect(await readThreadUsage(t, threadId)).toMatchObject({
 			contextTokens: 8_000,
 			totalTokensProcessed: 259_000
 		});
@@ -74,7 +91,7 @@ describe('agentRuntime context accounting', () => {
 				persistForFutureRuns: true
 			})
 		).resolves.toBe(false);
-		expect(await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextTokens)).toBe(8_000);
+		expect((await readThreadUsage(t, threadId))?.contextTokens).toBe(8_000);
 		expect(await t.run(async (ctx) => (await ctx.db.get(threadId))?.contextSummary)).toBeFalsy();
 	});
 
@@ -105,6 +122,106 @@ describe('agentRuntime context accounting', () => {
 			})
 		).rejects.toThrow('Invalid token count.');
 		expect(await t.run(async (ctx) => ctx.db.get(threadId))).not.toHaveProperty('contextTokens');
+	});
+
+	it('migrates legacy on-thread counters on access', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'legacy-usage-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'legacy-usage',
+			executionSecret,
+			'Continue'
+		);
+		// Simulate a pre-migration row: legacy counters on the thread, no usage row.
+		await t.run(async (ctx) => {
+			const usageRow = await ctx.db
+				.query('threadUsage')
+				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+				.unique();
+			if (usageRow) await ctx.db.delete(usageRow._id);
+			await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
+		});
+
+		// The merged read keeps the old response shape before migration.
+		await expect(asUser.query(api.threads.getByThreadId, { threadId })).resolves.toMatchObject({
+			contextTokens: 4_000,
+			totalTokensProcessed: 100_000
+		});
+		// Opening the thread (clients fire setLastThread) schedules the migration.
+		await asUser.mutation(api.uiPreferences.setLastThread, { threadId });
+		// convex-test fires scheduled functions on a macrotask before tracking them.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await t.finishInProgressScheduledFunctions();
+		const migratedThread = await t.run(async (ctx) => ctx.db.get(threadId));
+		expect(migratedThread).not.toHaveProperty('contextTokens');
+		expect(migratedThread).not.toHaveProperty('totalTokensProcessed');
+		expect(await readThreadUsage(t, threadId)).toMatchObject({
+			contextTokens: 4_000,
+			totalTokensProcessed: 100_000
+		});
+
+		// Writes after migration accumulate onto the migrated totals.
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
+		});
+		await asUser.mutation(api.agentRuntime.recordContextUsage, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret,
+			contextTokens: 5_000,
+			processedTokens: 6_000
+		});
+		expect(await readThreadUsage(t, threadId)).toMatchObject({
+			contextTokens: 5_000,
+			totalTokensProcessed: 106_000
+		});
+	});
+
+	it('folds legacy counters into the first usage write', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'legacy-fold-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'legacy-fold',
+			executionSecret,
+			'Continue'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			const usageRow = await ctx.db
+				.query('threadUsage')
+				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+				.unique();
+			if (usageRow) await ctx.db.delete(usageRow._id);
+			await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
+		});
+
+		await asUser.mutation(api.agentRuntime.recordContextUsage, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret,
+			contextTokens: 7_000,
+			processedTokens: 10_000
+		});
+
+		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
+		expect(thread).not.toHaveProperty('contextTokens');
+		expect(thread).not.toHaveProperty('totalTokensProcessed');
+		expect(await readThreadUsage(t, threadId)).toMatchObject({
+			contextTokens: 7_000,
+			totalTokensProcessed: 110_000
+		});
 	});
 
 	it('carries a compacted prefix into later runs without replaying covered history', async () => {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -13,6 +13,7 @@ import {
 	vGetContextResult
 } from '@convex/lib/docs';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
+import { assertValidTokenCount, recordThreadUsage } from '@convex/lib/threadUsage';
 import {
 	areImageUploadIdsEqual,
 	attachImageUploads,
@@ -540,6 +541,7 @@ export const saveContextCompaction = mutation({
 		}
 		assertValidTokenCount(args.processedTokens);
 		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
+		await recordThreadUsage(ctx, thread, { addProcessedTokens: args.processedTokens });
 		let durableSummary:
 			{ contextSummary: string; contextSummaryThroughRunId: Id<'runs'> } | undefined;
 		if (args.persistForFutureRuns) {
@@ -562,10 +564,9 @@ export const saveContextCompaction = mutation({
 				};
 			}
 		}
-		await ctx.db.patch(thread._id, {
-			...(durableSummary ?? {}),
-			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed, args.processedTokens)
-		});
+		if (durableSummary) {
+			await ctx.db.patch(thread._id, durableSummary);
+		}
 		return true;
 	}
 });
@@ -585,27 +586,13 @@ export const recordContextUsage = mutation({
 		assertValidTokenCount(args.contextTokens);
 		assertValidTokenCount(args.processedTokens);
 		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
-		await ctx.db.patch(thread._id, {
+		await recordThreadUsage(ctx, thread, {
 			contextTokens: args.contextTokens,
-			totalTokensProcessed: addTokenCounts(thread.totalTokensProcessed, args.processedTokens)
+			addProcessedTokens: args.processedTokens
 		});
 		return true;
 	}
 });
-
-function assertValidTokenCount(value: number): void {
-	if (!Number.isSafeInteger(value) || value < 0) {
-		throw new Error('Invalid token count.');
-	}
-}
-
-function addTokenCounts(left: number, right: number): number {
-	assertValidTokenCount(left);
-	assertValidTokenCount(right);
-	const total = left + right;
-	assertValidTokenCount(total);
-	return total;
-}
 
 export const registerCompletionAttempt = mutation({
 	args: {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -13,7 +13,7 @@ import {
 	vGetContextResult
 } from '@convex/lib/docs';
 import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
-import { assertValidTokenCount, recordThreadUsage } from '@convex/lib/threadUsage';
+import { recordThreadUsage } from '@convex/lib/threadUsage';
 import {
 	areImageUploadIdsEqual,
 	attachImageUploads,
@@ -539,7 +539,6 @@ export const saveContextCompaction = mutation({
 		if (!args.summary.trim()) {
 			throw new Error('Invalid context compaction.');
 		}
-		assertValidTokenCount(args.processedTokens);
 		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
 		await recordThreadUsage(ctx, thread, { addProcessedTokens: args.processedTokens });
 		let durableSummary:
@@ -583,8 +582,6 @@ export const recordContextUsage = mutation({
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) return false;
-		assertValidTokenCount(args.contextTokens);
-		assertValidTokenCount(args.processedTokens);
 		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
 		await recordThreadUsage(ctx, thread, {
 			contextTokens: args.contextTokens,

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -53,6 +53,9 @@ const SUMMARIZE_ACCEPTANCE_CHECK_INTERVAL_MS = 5_000;
 // flush, so a fixed-interval poll mostly burns query calls. Only poll when the
 // provider stream has been silent (long model-thinking gaps carry no flush).
 const COMPLETION_ACCEPTANCE_CHECK_LULL_MS = 10_000;
+// Non-persisted parts (tool-input deltas, step boundaries) postpone the lull
+// without producing any fenced flush, so cap the gap between polls regardless.
+const COMPLETION_ACCEPTANCE_CHECK_MAX_INTERVAL_MS = 30_000;
 // Persisting a growing message rewrites and reactively rereads the whole document.
 // Keep the UI responsive without paying that cost for every token-sized provider delta.
 const COMPLETION_STREAM_FLUSH_INTERVAL_MS = 500;
@@ -367,6 +370,7 @@ async function collectStreamingCompletion(
 	try {
 		let nextPart = iterator.next();
 		let lastStreamPartAt = Date.now();
+		let lastAcceptanceCheckAt = lastStreamPartAt;
 		let nextAcceptanceCheckAt = lastStreamPartAt + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
 		while (true) {
 			if (pendingEvents.length > 0 && nextFlushAt !== undefined && Date.now() >= nextFlushAt) {
@@ -405,11 +409,18 @@ async function collectStreamingCompletion(
 			}
 			if (next.type === 'acceptance-check') {
 				const now = Date.now();
-				if (now - lastStreamPartAt >= COMPLETION_ACCEPTANCE_CHECK_LULL_MS) {
+				if (
+					now - lastStreamPartAt >= COMPLETION_ACCEPTANCE_CHECK_LULL_MS ||
+					now - lastAcceptanceCheckAt >= COMPLETION_ACCEPTANCE_CHECK_MAX_INTERVAL_MS
+				) {
 					await assertCompletionStillAccepted(ctx, attempt);
+					lastAcceptanceCheckAt = now;
 					nextAcceptanceCheckAt = now + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
 				} else {
-					nextAcceptanceCheckAt = lastStreamPartAt + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
+					nextAcceptanceCheckAt = Math.min(
+						lastStreamPartAt + COMPLETION_ACCEPTANCE_CHECK_LULL_MS,
+						lastAcceptanceCheckAt + COMPLETION_ACCEPTANCE_CHECK_MAX_INTERVAL_MS
+					);
 				}
 				continue;
 			}

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -48,7 +48,7 @@ type CompletionActionResult = Pick<GenerateTextResult, 'text' | 'usage' | 'toolC
 type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
 
-const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 5_000;
+const SUMMARIZE_ACCEPTANCE_CHECK_INTERVAL_MS = 5_000;
 // While streaming, supersede/cancel fences are enforced on every persisted
 // flush, so a fixed-interval poll mostly burns query calls. Only poll when the
 // provider stream has been silent (long model-thinking gaps carry no flush).
@@ -643,7 +643,7 @@ async function waitForCompletionWithAcceptance<T>(
 	while (true) {
 		const outcome = await Promise.race([
 			completion.then((value) => ({ type: 'completed' as const, value })),
-			delay(COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS).then(() => ({ type: 'check' as const }))
+			delay(SUMMARIZE_ACCEPTANCE_CHECK_INTERVAL_MS).then(() => ({ type: 'check' as const }))
 		]);
 		if (outcome.type === 'completed') return outcome.value;
 		try {

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -49,12 +49,11 @@ type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
 
 const SUMMARIZE_ACCEPTANCE_CHECK_INTERVAL_MS = 5_000;
-// While streaming, supersede/cancel fences are enforced on every persisted
-// flush, so a fixed-interval poll mostly burns query calls. Only poll when the
-// provider stream has been silent (long model-thinking gaps carry no flush).
+// Every persisted flush is already fenced against cancel/supersede, so only
+// poll while the provider stream is silent (no flushes happening).
 const COMPLETION_ACCEPTANCE_CHECK_LULL_MS = 10_000;
-// Non-persisted parts (tool-input deltas, step boundaries) postpone the lull
-// without producing any fenced flush, so cap the gap between polls regardless.
+// Non-persisted parts (tool-input deltas) postpone the lull without producing
+// fenced flushes, so cap the gap regardless.
 const COMPLETION_ACCEPTANCE_CHECK_MAX_INTERVAL_MS = 30_000;
 // Persisting a growing message rewrites and reactively rereads the whole document.
 // Keep the UI responsive without paying that cost for every token-sized provider delta.

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -48,10 +48,14 @@ type CompletionActionResult = Pick<GenerateTextResult, 'text' | 'usage' | 'toolC
 type CompletionRequest = Parameters<typeof generateText>[0];
 type SharedCompletionRequest = Omit<CompletionRequest, 'prompt' | 'messages'>;
 
-const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 1_000;
+const COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS = 5_000;
+// While streaming, supersede/cancel fences are enforced on every persisted
+// flush, so a fixed-interval poll mostly burns query calls. Only poll when the
+// provider stream has been silent (long model-thinking gaps carry no flush).
+const COMPLETION_ACCEPTANCE_CHECK_LULL_MS = 10_000;
 // Persisting a growing message rewrites and reactively rereads the whole document.
 // Keep the UI responsive without paying that cost for every token-sized provider delta.
-const COMPLETION_STREAM_FLUSH_INTERVAL_MS = 250;
+const COMPLETION_STREAM_FLUSH_INTERVAL_MS = 500;
 // AI SDK retries only retryable provider failures and honors Retry-After headers.
 // Allow a longer recovery window for short provider rate-limit bursts.
 const MODEL_PROVIDER_MAX_RETRIES = 5;
@@ -362,7 +366,8 @@ async function collectStreamingCompletion(
 	const iterator = result.stream[Symbol.asyncIterator]();
 	try {
 		let nextPart = iterator.next();
-		let nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
+		let lastStreamPartAt = Date.now();
+		let nextAcceptanceCheckAt = lastStreamPartAt + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
 		while (true) {
 			if (pendingEvents.length > 0 && nextFlushAt !== undefined && Date.now() >= nextFlushAt) {
 				await flush();
@@ -399,8 +404,13 @@ async function collectStreamingCompletion(
 				if (acceptanceTimer !== undefined) clearTimeout(acceptanceTimer);
 			}
 			if (next.type === 'acceptance-check') {
-				await assertCompletionStillAccepted(ctx, attempt);
-				nextAcceptanceCheckAt = Date.now() + COMPLETION_ACCEPTANCE_CHECK_INTERVAL_MS;
+				const now = Date.now();
+				if (now - lastStreamPartAt >= COMPLETION_ACCEPTANCE_CHECK_LULL_MS) {
+					await assertCompletionStillAccepted(ctx, attempt);
+					nextAcceptanceCheckAt = now + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
+				} else {
+					nextAcceptanceCheckAt = lastStreamPartAt + COMPLETION_ACCEPTANCE_CHECK_LULL_MS;
+				}
 				continue;
 			}
 			if (next.type === 'flush') {
@@ -410,6 +420,7 @@ async function collectStreamingCompletion(
 			if (next.value.done) break;
 			const part = next.value.value;
 			nextPart = iterator.next();
+			lastStreamPartAt = Date.now();
 			switch (part.type) {
 				case 'text-start':
 					updateText(part.id, '', part.providerMetadata as JsonValue | undefined);

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -9,4 +9,13 @@ crons.interval(
 	internal.imageUploads.cleanupOrphans
 );
 
+// Temporary: convergence backstop for the threadUsage lazy migration. Delete
+// once the legacy on-thread counters are removed from the schema.
+crons.interval(
+	'migrate legacy thread usage counters',
+	{ hours: 1 },
+	internal.threads.migrateLegacyUsageBatch,
+	{}
+);
+
 export default crons;

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -9,8 +9,7 @@ crons.interval(
 	internal.imageUploads.cleanupOrphans
 );
 
-// Temporary: convergence backstop for the threadUsage lazy migration. Delete
-// once the legacy on-thread counters are removed from the schema.
+// Temporary backstop for the threadUsage migration; delete with the legacy fields.
 crons.interval(
 	'migrate legacy thread usage counters',
 	{ hours: 1 },

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -195,6 +195,18 @@ export const vThreadRecordDoc = v.object({
 	...threadRecordFields
 });
 
+/**
+ * threads.getByThreadId merges the threadUsage counters back into the legacy
+ * response shape for older clients, so its contract keeps the pre-migration
+ * required `totalTokensProcessed` even while the table field is optional.
+ */
+export const vThreadRecordWithUsageDoc = v.object({
+	_id: v.id('threadRecords'),
+	_creationTime: v.number(),
+	...threadRecordFields,
+	totalTokensProcessed: v.number()
+});
+
 export const vRunDoc = v.object({
 	_id: v.id('runs'),
 	_creationTime: v.number(),

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -42,12 +42,22 @@ export const threadRecordFields = {
 	selectedModel: vModelId,
 	reasoningEffort: vReasoningEffort,
 	serviceTier: vServiceTier,
+	// Legacy token accounting. Per-turn counters now live in `threadUsage` so
+	// token writes stop invalidating every thread-scoped subscription. Kept
+	// optional until the lazy migration (lib/threadUsage.ts) has moved all rows.
 	contextTokens: v.optional(v.number()),
-	totalTokensProcessed: v.number(),
+	totalTokensProcessed: v.optional(v.number()),
 	contextSummary: v.optional(v.string()),
 	contextSummaryThroughRunId: v.optional(v.id('runs')),
 	lastMessageAt: v.number(),
 	archivedAt: v.optional(v.number())
+};
+
+export const threadUsageFields = {
+	threadId: v.id('threadRecords'),
+	userId: v.string(),
+	contextTokens: v.optional(v.number()),
+	totalTokensProcessed: v.number()
 };
 
 export const runFields = {

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -42,9 +42,8 @@ export const threadRecordFields = {
 	selectedModel: vModelId,
 	reasoningEffort: vReasoningEffort,
 	serviceTier: vServiceTier,
-	// Legacy token accounting. Per-turn counters now live in `threadUsage` so
-	// token writes stop invalidating every thread-scoped subscription. Kept
-	// optional until the lazy migration (lib/threadUsage.ts) has moved all rows.
+	// Legacy; moved to the `threadUsage` table (lib/threadUsage.ts). Delete
+	// once every row is migrated.
 	contextTokens: v.optional(v.number()),
 	totalTokensProcessed: v.optional(v.number()),
 	contextSummary: v.optional(v.string()),
@@ -195,11 +194,8 @@ export const vThreadRecordDoc = v.object({
 	...threadRecordFields
 });
 
-/**
- * threads.getByThreadId merges the threadUsage counters back into the legacy
- * response shape for older clients, so its contract keeps the pre-migration
- * required `totalTokensProcessed` even while the table field is optional.
- */
+// getByThreadId merges threadUsage counters into the legacy response shape,
+// so its contract keeps the pre-migration required totalTokensProcessed.
 export const vThreadRecordWithUsageDoc = v.object({
 	_id: v.id('threadRecords'),
 	_creationTime: v.number(),

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -3,6 +3,8 @@ import type { Doc } from '@convex/_generated/dataModel';
 // Heartbeats both write and reactively re-run `projects.listMine` on every
 // connected client, so cadence is expensive. The TTL comfortably exceeds two
 // throttle intervals so one skipped/hidden-tab beat never flaps the status.
+// This staleness is currently invisible: no UI consumes executorStatus yet —
+// revisit the TTL before surfacing a connected/disconnected badge.
 export const EXECUTOR_HEARTBEAT_TTL_MS = 300_000;
 export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -1,10 +1,9 @@
 import type { Doc } from '@convex/_generated/dataModel';
 
-// Heartbeats both write and reactively re-run `projects.listMine` on every
-// connected client, so cadence is expensive. The TTL comfortably exceeds two
-// throttle intervals so one skipped/hidden-tab beat never flaps the status.
-// This staleness is currently invisible: no UI consumes executorStatus yet —
-// revisit the TTL before surfacing a connected/disconnected badge.
+// Heartbeats write and re-run `projects.listMine`, so cadence is expensive.
+// The TTL exceeds two throttle intervals so a skipped beat never flaps
+// status; it's safe to be this stale only because no UI consumes
+// executorStatus yet — revisit before surfacing a connection badge.
 export const EXECUTOR_HEARTBEAT_TTL_MS = 300_000;
 export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -1,7 +1,10 @@
 import type { Doc } from '@convex/_generated/dataModel';
 
-export const EXECUTOR_HEARTBEAT_TTL_MS = 45_000;
-export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 20_000;
+// Heartbeats both write and reactively re-run `projects.listMine` on every
+// connected client, so cadence is expensive. The TTL comfortably exceeds two
+// throttle intervals so one skipped/hidden-tab beat never flaps the status.
+export const EXECUTOR_HEARTBEAT_TTL_MS = 300_000;
+export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 
 type ProjectDoc = Doc<'projects'>;
 

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -1,4 +1,7 @@
-export const RUN_CLAIM_LEASE_DURATION_MS = 60_000;
+// Longer leases mean fewer renewal writes; every renewal reactively re-runs
+// thread/run subscriptions for every connected client. The trade-off is a
+// longer worst-case wait before a dead executor's run can be taken over.
+export const RUN_CLAIM_LEASE_DURATION_MS = 120_000;
 
 type ClaimableRun = {
 	status: string;

--- a/apps/web/src/convex/lib/runLease.ts
+++ b/apps/web/src/convex/lib/runLease.ts
@@ -1,6 +1,5 @@
-// Longer leases mean fewer renewal writes; every renewal reactively re-runs
-// thread/run subscriptions for every connected client. The trade-off is a
-// longer worst-case wait before a dead executor's run can be taken over.
+// Every renewal re-runs thread/run subscriptions, so fewer is cheaper; the
+// trade is a longer wait before a dead executor's run can be taken over.
 export const RUN_CLAIM_LEASE_DURATION_MS = 120_000;
 
 type ClaimableRun = {

--- a/apps/web/src/convex/lib/threadUsage.ts
+++ b/apps/web/src/convex/lib/threadUsage.ts
@@ -1,6 +1,5 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import type { DatabaseReader, DatabaseWriter, MutationCtx } from '@convex/_generated/server';
-import { internal } from '@convex/_generated/api';
+import type { DatabaseReader, DatabaseWriter } from '@convex/_generated/server';
 
 /**
  * Per-turn token counters live here instead of on `threadRecords`: a context
@@ -8,23 +7,24 @@ import { internal } from '@convex/_generated/api';
  * invalidates every thread-scoped subscription for every connected client.
  *
  * Legacy `contextTokens`/`totalTokensProcessed` fields on `threadRecords` are
- * migrated lazily: reads fall back to them and schedule `migrateLegacyUsage`,
- * writes fold them in atomically. Once every row is migrated the fields can be
+ * migrated lazily: reads fall back to them, opening a thread schedules
+ * `threads.migrateLegacyUsage` (queries cannot schedule), and usage writes
+ * fold them in atomically. Once every row is migrated the fields can be
  * dropped from the schema.
  */
 
-export type ThreadUsageValues = {
+type ThreadUsageValues = {
 	contextTokens: number | undefined;
 	totalTokensProcessed: number;
 };
 
-export function assertValidTokenCount(value: number): void {
+function assertValidTokenCount(value: number): void {
 	if (!Number.isSafeInteger(value) || value < 0) {
 		throw new Error('Invalid token count.');
 	}
 }
 
-export function addTokenCounts(left: number, right: number): number {
+function addTokenCounts(left: number, right: number): number {
 	assertValidTokenCount(left);
 	assertValidTokenCount(right);
 	const total = left + right;
@@ -38,18 +38,6 @@ export function hasLegacyUsageFields(
 	return thread.contextTokens !== undefined || thread.totalTokensProcessed !== undefined;
 }
 
-/**
- * Kick the lazy migration when an access path encounters an unmigrated row.
- * Only mutations can schedule; read paths fall back to the legacy values via
- * `getThreadUsageValues` until some write/open migrates the row.
- */
-export async function scheduleLegacyUsageMigration(
-	ctx: MutationCtx,
-	threadId: Id<'threadRecords'>
-): Promise<void> {
-	await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsage, { threadId });
-}
-
 async function getUsageRow(
 	db: DatabaseReader,
 	threadId: Id<'threadRecords'>
@@ -60,12 +48,10 @@ async function getUsageRow(
 		.unique();
 }
 
-/** Current counters for a thread, falling back to unmigrated legacy fields. */
-export async function getThreadUsageValues(
-	db: DatabaseReader,
+function toUsageValues(
+	usageRow: Doc<'threadUsage'> | null,
 	thread: Doc<'threadRecords'>
-): Promise<ThreadUsageValues> {
-	const usageRow = await getUsageRow(db, thread._id);
+): ThreadUsageValues {
 	if (usageRow) {
 		return {
 			contextTokens: usageRow.contextTokens,
@@ -78,28 +64,29 @@ export async function getThreadUsageValues(
 	};
 }
 
+/** Current counters for a thread, falling back to unmigrated legacy fields. */
+export async function getThreadUsageValues(
+	db: DatabaseReader,
+	thread: Doc<'threadRecords'>
+): Promise<ThreadUsageValues> {
+	return toUsageValues(await getUsageRow(db, thread._id), thread);
+}
+
 /**
  * Upsert the usage row and apply a delta, folding in any legacy fields still
  * on the thread document (and clearing them) in the same transaction.
+ * Token counts are validated here; callers don't need to pre-validate.
  */
 export async function recordThreadUsage(
-	ctx: { db: DatabaseReader & DatabaseWriter },
+	ctx: { db: DatabaseWriter },
 	thread: Doc<'threadRecords'>,
 	args: { contextTokens?: number; addProcessedTokens?: number }
-): Promise<ThreadUsageValues> {
+): Promise<void> {
 	if (args.contextTokens !== undefined) {
 		assertValidTokenCount(args.contextTokens);
 	}
 	const usageRow = await getUsageRow(ctx.db, thread._id);
-	const base: ThreadUsageValues = usageRow
-		? {
-				contextTokens: usageRow.contextTokens,
-				totalTokensProcessed: usageRow.totalTokensProcessed
-			}
-		: {
-				contextTokens: thread.contextTokens,
-				totalTokensProcessed: thread.totalTokensProcessed ?? 0
-			};
+	const base = toUsageValues(usageRow, thread);
 	const next: ThreadUsageValues = {
 		contextTokens: args.contextTokens ?? base.contextTokens,
 		totalTokensProcessed: addTokenCounts(base.totalTokensProcessed, args.addProcessedTokens ?? 0)
@@ -119,5 +106,4 @@ export async function recordThreadUsage(
 			totalTokensProcessed: undefined
 		});
 	}
-	return next;
 }

--- a/apps/web/src/convex/lib/threadUsage.ts
+++ b/apps/web/src/convex/lib/threadUsage.ts
@@ -1,17 +1,9 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { DatabaseReader, DatabaseWriter } from '@convex/_generated/server';
 
-/**
- * Per-turn token counters live here instead of on `threadRecords`: a context
- * meter only needs the active thread's viewer, while a hot thread document
- * invalidates every thread-scoped subscription for every connected client.
- *
- * Legacy `contextTokens`/`totalTokensProcessed` fields on `threadRecords` are
- * migrated lazily: reads fall back to them, opening a thread schedules
- * `threads.migrateLegacyUsage` (queries cannot schedule), and usage writes
- * fold them in atomically. Once every row is migrated the fields can be
- * dropped from the schema.
- */
+// Per-turn counters live here so token writes don't invalidate the
+// thread-scoped subscriptions reading `threadRecords`. Legacy on-thread
+// fields migrate lazily (see PR follow-up checklist); drop them after.
 
 type ThreadUsageValues = {
 	contextTokens: number | undefined;
@@ -64,7 +56,7 @@ function toUsageValues(
 	};
 }
 
-/** Current counters for a thread, falling back to unmigrated legacy fields. */
+/** Current counters, falling back to unmigrated legacy fields. */
 export async function getThreadUsageValues(
 	db: DatabaseReader,
 	thread: Doc<'threadRecords'>
@@ -73,9 +65,8 @@ export async function getThreadUsageValues(
 }
 
 /**
- * Upsert the usage row and apply a delta, folding in any legacy fields still
- * on the thread document (and clearing them) in the same transaction.
- * Token counts are validated here; callers don't need to pre-validate.
+ * Upsert the usage row and apply a delta, folding in (and clearing) any
+ * legacy fields in the same transaction. Validates token counts.
  */
 export async function recordThreadUsage(
 	ctx: { db: DatabaseWriter },

--- a/apps/web/src/convex/lib/threadUsage.ts
+++ b/apps/web/src/convex/lib/threadUsage.ts
@@ -1,0 +1,123 @@
+import type { Doc, Id } from '@convex/_generated/dataModel';
+import type { DatabaseReader, DatabaseWriter, MutationCtx } from '@convex/_generated/server';
+import { internal } from '@convex/_generated/api';
+
+/**
+ * Per-turn token counters live here instead of on `threadRecords`: a context
+ * meter only needs the active thread's viewer, while a hot thread document
+ * invalidates every thread-scoped subscription for every connected client.
+ *
+ * Legacy `contextTokens`/`totalTokensProcessed` fields on `threadRecords` are
+ * migrated lazily: reads fall back to them and schedule `migrateLegacyUsage`,
+ * writes fold them in atomically. Once every row is migrated the fields can be
+ * dropped from the schema.
+ */
+
+export type ThreadUsageValues = {
+	contextTokens: number | undefined;
+	totalTokensProcessed: number;
+};
+
+export function assertValidTokenCount(value: number): void {
+	if (!Number.isSafeInteger(value) || value < 0) {
+		throw new Error('Invalid token count.');
+	}
+}
+
+export function addTokenCounts(left: number, right: number): number {
+	assertValidTokenCount(left);
+	assertValidTokenCount(right);
+	const total = left + right;
+	assertValidTokenCount(total);
+	return total;
+}
+
+export function hasLegacyUsageFields(
+	thread: Pick<Doc<'threadRecords'>, 'contextTokens' | 'totalTokensProcessed'>
+): boolean {
+	return thread.contextTokens !== undefined || thread.totalTokensProcessed !== undefined;
+}
+
+/**
+ * Kick the lazy migration when an access path encounters an unmigrated row.
+ * Only mutations can schedule; read paths fall back to the legacy values via
+ * `getThreadUsageValues` until some write/open migrates the row.
+ */
+export async function scheduleLegacyUsageMigration(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<void> {
+	await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsage, { threadId });
+}
+
+async function getUsageRow(
+	db: DatabaseReader,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'threadUsage'> | null> {
+	return await db
+		.query('threadUsage')
+		.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+		.unique();
+}
+
+/** Current counters for a thread, falling back to unmigrated legacy fields. */
+export async function getThreadUsageValues(
+	db: DatabaseReader,
+	thread: Doc<'threadRecords'>
+): Promise<ThreadUsageValues> {
+	const usageRow = await getUsageRow(db, thread._id);
+	if (usageRow) {
+		return {
+			contextTokens: usageRow.contextTokens,
+			totalTokensProcessed: usageRow.totalTokensProcessed
+		};
+	}
+	return {
+		contextTokens: thread.contextTokens,
+		totalTokensProcessed: thread.totalTokensProcessed ?? 0
+	};
+}
+
+/**
+ * Upsert the usage row and apply a delta, folding in any legacy fields still
+ * on the thread document (and clearing them) in the same transaction.
+ */
+export async function recordThreadUsage(
+	ctx: { db: DatabaseReader & DatabaseWriter },
+	thread: Doc<'threadRecords'>,
+	args: { contextTokens?: number; addProcessedTokens?: number }
+): Promise<ThreadUsageValues> {
+	if (args.contextTokens !== undefined) {
+		assertValidTokenCount(args.contextTokens);
+	}
+	const usageRow = await getUsageRow(ctx.db, thread._id);
+	const base: ThreadUsageValues = usageRow
+		? {
+				contextTokens: usageRow.contextTokens,
+				totalTokensProcessed: usageRow.totalTokensProcessed
+			}
+		: {
+				contextTokens: thread.contextTokens,
+				totalTokensProcessed: thread.totalTokensProcessed ?? 0
+			};
+	const next: ThreadUsageValues = {
+		contextTokens: args.contextTokens ?? base.contextTokens,
+		totalTokensProcessed: addTokenCounts(base.totalTokensProcessed, args.addProcessedTokens ?? 0)
+	};
+	if (usageRow) {
+		await ctx.db.patch(usageRow._id, next);
+	} else {
+		await ctx.db.insert('threadUsage', {
+			threadId: thread._id,
+			userId: thread.userId,
+			...next
+		});
+	}
+	if (hasLegacyUsageFields(thread)) {
+		await ctx.db.patch(thread._id, {
+			contextTokens: undefined,
+			totalTokensProcessed: undefined
+		});
+	}
+	return next;
+}

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -13,6 +13,7 @@ import {
 	subscriptionFields,
 	threadMessageFields,
 	threadRecordFields,
+	threadUsageFields,
 	uiPreferencesFields
 } from '@convex/lib/docs';
 import {
@@ -34,6 +35,7 @@ export default defineSchema({
 	threadRecords: defineTable(threadRecordFields)
 		.index('by_userId_lastMessageAt', ['userId', 'lastMessageAt'])
 		.index('by_userId_submissionId', ['userId', 'submissionId']),
+	threadUsage: defineTable(threadUsageFields).index('by_threadId', ['threadId']),
 	runs: defineTable(runFields)
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
 		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -1,9 +1,14 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { mutation, query, type MutationCtx } from '@convex/_generated/server';
+import { internalMutation, mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord, getOwnedProject } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
 import { vThreadRecordDoc, vThreadSummary } from '@convex/lib/docs';
+import {
+	getThreadUsageValues,
+	hasLegacyUsageFields,
+	recordThreadUsage
+} from '@convex/lib/threadUsage';
 import { assertModelConfigurationAllowedForUser } from '@convex/lib/tiers';
 import {
 	isRunFinalStatus,
@@ -84,8 +89,12 @@ export const create = mutation({
 			selectedModel: args.selectedModel,
 			reasoningEffort: args.reasoningEffort,
 			serviceTier: args.serviceTier,
-			totalTokensProcessed: 0,
 			lastMessageAt: now
+		});
+		await ctx.db.insert('threadUsage', {
+			threadId: recordId,
+			userId,
+			totalTokensProcessed: 0
 		});
 
 		return {
@@ -136,7 +145,29 @@ export const getByThreadId = query({
 	returns: vThreadRecordDoc,
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
-		return await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		// Surface counters on the thread document shape so existing clients keep
+		// working; they are stored separately to keep token writes off this read.
+		const usage = await getThreadUsageValues(ctx.db, thread);
+		return { ...thread, ...usage };
+	}
+});
+
+/**
+ * Lazy migration step for legacy on-thread token counters. Scheduled when an
+ * unmigrated thread is opened (uiPreferences.setLastThread) and folded in by
+ * usage writes; idempotent and a no-op once the legacy fields are cleared.
+ */
+export const migrateLegacyUsage = internalMutation({
+	args: { threadId: v.id('threadRecords') },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const thread = await ctx.db.get(args.threadId);
+		if (!thread || !hasLegacyUsageFields(thread)) {
+			return null;
+		}
+		await recordThreadUsage(ctx, thread, {});
+		return null;
 	}
 });
 

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -147,18 +147,12 @@ export const getByThreadId = query({
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		// Surface counters on the thread document shape so existing clients keep
-		// working; they are stored separately to keep token writes off this read.
+		// Keep the pre-migration response shape for older clients.
 		const usage = await getThreadUsageValues(ctx.db, thread);
 		return { ...thread, ...usage };
 	}
 });
 
-/**
- * Lazy migration step for legacy on-thread token counters. Scheduled when an
- * unmigrated thread is opened (uiPreferences.setLastThread) and folded in by
- * usage writes; idempotent and a no-op once the legacy fields are cleared.
- */
 export const migrateLegacyUsage = internalMutation({
 	args: { threadId: v.id('threadRecords') },
 	returns: v.null(),
@@ -174,12 +168,8 @@ export const migrateLegacyUsage = internalMutation({
 
 const LEGACY_USAGE_MIGRATION_BATCH_SIZE = 100;
 
-/**
- * Convergence backstop for the lazy migration: the on-open and on-write
- * triggers can never reach archived or abandoned threads. Chains through the
- * table in batches until clean; driven hourly by crons.ts. Temporary — delete
- * together with the legacy fields once the sweep reports zero rows.
- */
+// Convergence backstop: on-access triggers never reach archived threads.
+// Chained batches driven hourly by crons.ts; delete with the legacy fields.
 export const migrateLegacyUsageBatch = internalMutation({
 	args: { cursor: v.optional(v.union(v.string(), v.null())) },
 	returns: v.null(),

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -1,9 +1,10 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { internalMutation, mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
+import { internal } from '@convex/_generated/api';
 import { getOwnedThreadRecord, getOwnedProject } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
-import { vThreadRecordDoc, vThreadSummary } from '@convex/lib/docs';
+import { vThreadRecordWithUsageDoc, vThreadSummary } from '@convex/lib/docs';
 import {
 	getThreadUsageValues,
 	hasLegacyUsageFields,
@@ -142,7 +143,7 @@ export const getByThreadId = query({
 	args: {
 		threadId: v.id('threadRecords')
 	},
-	returns: vThreadRecordDoc,
+	returns: vThreadRecordWithUsageDoc,
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
@@ -167,6 +168,35 @@ export const migrateLegacyUsage = internalMutation({
 			return null;
 		}
 		await recordThreadUsage(ctx, thread, {});
+		return null;
+	}
+});
+
+const LEGACY_USAGE_MIGRATION_BATCH_SIZE = 100;
+
+/**
+ * Convergence backstop for the lazy migration: the on-open and on-write
+ * triggers can never reach archived or abandoned threads. Chains through the
+ * table in batches until clean; driven hourly by crons.ts. Temporary — delete
+ * together with the legacy fields once the sweep reports zero rows.
+ */
+export const migrateLegacyUsageBatch = internalMutation({
+	args: { cursor: v.optional(v.union(v.string(), v.null())) },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const { page, isDone, continueCursor } = await ctx.db
+			.query('threadRecords')
+			.paginate({ numItems: LEGACY_USAGE_MIGRATION_BATCH_SIZE, cursor: args.cursor ?? null });
+		for (const thread of page) {
+			if (hasLegacyUsageFields(thread)) {
+				await recordThreadUsage(ctx, thread, {});
+			}
+		}
+		if (!isDone) {
+			await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsageBatch, {
+				cursor: continueCursor
+			});
+		}
 		return null;
 	}
 });

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -2,6 +2,7 @@ import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
+import { hasLegacyUsageFields, scheduleLegacyUsageMigration } from '@convex/lib/threadUsage';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
 const DEFAULT_THEME = 'dark' as const;
@@ -25,6 +26,12 @@ export const setLastThread = mutation({
 	returns: v.union(vUiPreferencesDoc, v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
+		// Clients fire this on every thread open, making it the lazy-migration
+		// trigger for legacy on-thread token counters (queries cannot schedule).
+		const thread = await ctx.db.get(args.threadId);
+		if (thread && thread.userId === userId && hasLegacyUsageFields(thread)) {
+			await scheduleLegacyUsageMigration(ctx, thread._id);
+		}
 		const existing = await ctx.db
 			.query('uiPreferences')
 			.withIndex('by_userId', (query) => query.eq('userId', userId))

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,8 +1,9 @@
+import { internal } from '@convex/_generated/api';
 import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
-import { hasLegacyUsageFields, scheduleLegacyUsageMigration } from '@convex/lib/threadUsage';
+import { hasLegacyUsageFields } from '@convex/lib/threadUsage';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
 const DEFAULT_THEME = 'dark' as const;
@@ -30,7 +31,9 @@ export const setLastThread = mutation({
 		// trigger for legacy on-thread token counters (queries cannot schedule).
 		const thread = await ctx.db.get(args.threadId);
 		if (thread && thread.userId === userId && hasLegacyUsageFields(thread)) {
-			await scheduleLegacyUsageMigration(ctx, thread._id);
+			await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsage, {
+				threadId: thread._id
+			});
 		}
 		const existing = await ctx.db
 			.query('uiPreferences')

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -27,8 +27,8 @@ export const setLastThread = mutation({
 	returns: v.union(vUiPreferencesDoc, v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
-		// Clients fire this on every thread open, making it the lazy-migration
-		// trigger for legacy on-thread token counters (queries cannot schedule).
+		// Clients fire this on every thread open — the lazy-migration trigger
+		// for legacy usage counters (queries cannot schedule).
 		const thread = await ctx.db.get(args.threadId);
 		if (thread && thread.userId === userId && hasLegacyUsageFields(thread)) {
 			await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsage, {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1923,8 +1923,7 @@
 			projectIds: projectIdsKey ? (projectIdsKey.split('\0') as Id<'projects'>[]) : []
 		};
 
-		// Hidden tabs stop beating; the server TTL outlasts long background
-		// periods, and returning to the foreground beats immediately.
+		// Hidden tabs stop beating; the server TTL outlasts background periods.
 		const enqueueHeartbeat = () => {
 			if (document.visibilityState === 'hidden') return;
 			void projectAttachmentHeartbeatQueue.enqueue(request).catch(() => {});

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1923,14 +1923,23 @@
 			projectIds: projectIdsKey ? (projectIdsKey.split('\0') as Id<'projects'>[]) : []
 		};
 
-		void projectAttachmentHeartbeatQueue.enqueue(request).catch(() => {});
-
-		const intervalId = window.setInterval(() => {
+		// Hidden tabs stop beating; the server TTL outlasts long background
+		// periods, and returning to the foreground beats immediately.
+		const enqueueHeartbeat = () => {
+			if (document.visibilityState === 'hidden') return;
 			void projectAttachmentHeartbeatQueue.enqueue(request).catch(() => {});
-		}, EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS);
+		};
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === 'visible') enqueueHeartbeat();
+		};
+
+		enqueueHeartbeat();
+		const intervalId = window.setInterval(enqueueHeartbeat, EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS);
+		document.addEventListener('visibilitychange', handleVisibilityChange);
 
 		return () => {
 			window.clearInterval(intervalId);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
 			projectAttachmentHeartbeatQueue.cancelPending();
 		};
 	});

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -19,8 +19,8 @@ use crate::types::{RunAgentRequest, deserialize_agent_history};
 
 // Keep RUN_CLAIM_LEASE_DURATION synchronized with
 // apps/web/src/convex/lib/runLease.ts (RUN_CLAIM_LEASE_DURATION_MS).
-const RUN_CLAIM_LEASE_DURATION: Duration = Duration::from_secs(60);
-const RUN_CLAIM_RENEW_INTERVAL: Duration = Duration::from_secs(20);
+const RUN_CLAIM_LEASE_DURATION: Duration = Duration::from_secs(120);
+const RUN_CLAIM_RENEW_INTERVAL: Duration = Duration::from_secs(40);
 const RUN_CLAIM_RENEW_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(8);
 const RUN_CLAIM_EXPIRY_SAFETY_MARGIN: Duration = Duration::from_secs(5);
 const RUN_CLAIM_RENEW_RETRY_DELAY: Duration = Duration::from_millis(250);
@@ -976,7 +976,9 @@ mod claim_lease_tests {
                 async { Ok((true, Instant::now())) }
             },
             async {
-                sleep(Duration::from_secs(50)).await;
+                // Outlasts two renewal intervals so a post-reclaim renewal
+                // happens before the work completes.
+                sleep(Duration::from_secs(100)).await;
                 "done"
             },
         )

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -976,8 +976,7 @@ mod claim_lease_tests {
                 async { Ok((true, Instant::now())) }
             },
             async {
-                // Outlasts two renewal intervals so a post-reclaim renewal
-                // happens before the work completes.
+                // Outlasts two renewal intervals so a post-reclaim renewal happens first.
                 sleep(Duration::from_secs(100)).await;
                 "done"
             },


### PR DESCRIPTION
## Summary

Cuts Convex function-call volume (~2.1M/month currently) by removing the four biggest re-execution amplifiers, while keeping older deployed clients (web/desktop frontend bundles and Rust agent binaries) fully compatible with the new backend:

- **Token counters off `threadRecords`** — `contextTokens`/`totalTokensProcessed` now live in a new `threadUsage` table, so per-turn token writes no longer invalidate all 8 thread-scoped subscriptions (`threads.getByThreadId`, `messages.listHistoryForThread`, `messages.listLiveForThread`, `chat.latestRunForThread`, `artifacts`, `browserSessions`, `agentQuestions`, `threads.listMine`). Migration is lazy and backwards-compatible (details below).
- **Run claim lease 60s → 120s, renewal 20s → 40s** (`runLease.ts` + `crates/sprocket-agent/src/run.rs`, kept in sync) — halves `renewClaim` writes and the `latestRunForThread`/`listLive`/`listMine` re-executions each one causes. The composer stop button (`finalizeRun`) remains the immediate escape hatch for a wedged run.
- **Executor heartbeat TTL 45s → 300s, write throttle 20s → 90s**, and hidden tabs stop beating (immediate beat on refocus) — cuts `projects.heartbeatAttached` (278K) and the `projects.listMine` re-runs each beat triggers.
- **Lull-based completion acceptance polling** — `completionActor` was polled every 1s during streaming (118K); every persisted flush is already fenced against cancel/supersede, so polls now happen only after ≥10s of provider-stream silence, hard-capped at 30s during continuous non-persisted streaming. Compaction summarize loop 1s → 5s.
- **Stream flush 250ms → 500ms** — halves `mergeAssistantStreamEvents` and the resulting `listLiveForThread` re-executions; text/reasoning parts and tool calls still flush eagerly at boundaries.

## Legacy schema compatibility & migration

Old rows keep `contextTokens`/`totalTokensProcessed` as optional fields on `threadRecords`. Old clients keep working because:

- `threads.getByThreadId` merges counters back into the exact pre-migration response shape (return validator keeps `totalTokensProcessed` required).
- Opening a thread (`uiPreferences.setLastThread`, fired on every thread switch) schedules `threads.migrateLegacyUsage`; usage writes (`recordContextUsage`/`saveContextCompaction`) fold legacy counters into the usage row atomically.
- An hourly batched cron sweep (`threads.migrateLegacyUsageBatch`, cursor-chained, follows the `cleanupOrphans` pattern) is the convergence backstop for archived/abandoned threads the on-access triggers can never reach.
- Old Rust agents are unaffected: `getContext`'s token fields go optional but `ThreadRecordSnapshot` only deserializes `_id`/`projectId`/`title`; function signatures are unchanged; renewal/lease timing is compatible in both deploy orders.

## Follow-up: delete after all threads are migrated

Once the hourly sweep reports zero rows with legacy fields (dashboard: no `threadRecords` docs with `contextTokens`/`totalTokensProcessed` set):

1. Remove `contextTokens` and `totalTokensProcessed` from `threadRecordFields` in `convex/lib/docs.ts`, and delete the `vThreadRecordWithUsageDoc` validator (revert `getByThreadId` to `vThreadRecordDoc`).
2. Simplify `lib/threadUsage.ts`: drop `toUsageValues`' legacy fallback, `hasLegacyUsageFields`, and the legacy-clearing patch in `recordThreadUsage`.
3. Delete `threads.migrateLegacyUsage`, `threads.migrateLegacyUsageBatch`, the cron entry in `crons.ts`, and the migration hook in `uiPreferences.setLastThread`.
4. Simplify `threads.getByThreadId` to return the record directly (no counter merge).
5. Remove the legacy-migration tests in `agentRuntime.context.test.ts` (keep the fencing/invalid-input coverage).

## Verification

- `vitest` 241/241 (incl. new tests for on-open migration, write-fold migration, batched sweep, and fencing)
- `cargo test -p sprocket-agent` 39/39
- `convex typecheck`, `svelte-check`, `prek run -a` (eslint/prettier/fmt), `bun run build` — all green
- Code reviewed by two independent subagents; findings fixed (30s acceptance-poll cap, cron convergence, tightened return validator)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change reduces backend churn by storing token counters separately from thread records, extending run and project-heartbeat intervals, and pausing project heartbeats while a browser tab is hidden.

The following failure hypotheses were exercised and did not occur:
- Legacy token counters retained their totals through concurrent first writes and scheduled migration, while thread responses remained compatible and user access stayed isolated.
- A continuous stream of non-persisted tool-input deltas still checks cancellation or supersession within 30 seconds rather than postponing checks indefinitely.
- After executor loss, the lease remains exclusively owned until expiry, a replacement executor can take over, and the stale executor cannot renew or reclaim it.
- Hidden tabs stop sending project heartbeats and immediately send one when returning to the foreground.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

Focused execution verified token-usage migration and access isolation, bounded completion acceptance polling, exclusive lease takeover after executor loss, and hidden-tab heartbeat recovery without reproducing a correctness or security failure.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored and ran the thread-usage migration contract test against an in-memory Convex fixture with seeded legacy counters, concurrent first-use writes, and lazy migration.
- Ran a timing probe comparing commit 7ec34cf with the current completion implementation; the first acceptance check occurs exactly at 30,000 ms in the current code, and 14 tests covering completion and fencing passed.
- Executed lease-related tests, including a lease reclamation integration test, Rust lease-driver tests with paused time, and a browser visibility harness plus backend tests; all suites reported success.
- Executed thread usage migration test logs and existing coverage run; the migration test exited 0 with 1 passing test and the existing coverage suite exited 0 with 6 passing tests.
- Validated the post-change completion timing logic for the maximum-interval path, ensuring acceptance checks fire at cap time and that cancelled, terminal, expired-lease, stale-attempt, and stream-superseded states are rejected while persisted data is fenced.

<a href="https://app.greptile.com/trex/runs/17263877/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["style(convex): Trim migration and tuning..."](https://github.com/spikonado/sprocket/commit/6073a16fb087c5e0e905a2e0e435fb3bd555bd9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50092282)</sub>

<!-- /greptile_comment -->