### PR TITLE
feat(ui): Make light mode the default theme

### DIFF
--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -117,7 +117,7 @@ export const agentQuestionFields = {
 export const uiPreferencesFields = {
 	userId: v.string(),
 	lastThreadId: v.optional(v.id('threadRecords')),
-	theme: v.union(v.literal('light'), v.literal('dark')),
+	theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
 	paymentsEmail: v.optional(v.string())
 };
 

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -4,7 +4,7 @@ import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
-const DEFAULT_THEME = 'dark' as const;
+const DEFAULT_THEME = 'light' as const;
 
 export const getMine = query({
 	args: {},

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,25 +1,9 @@
-import { internalMutation, mutation, query } from '@convex/_generated/server';
+import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
-
-export const clearDarkTheme = internalMutation({
-	args: {},
-	returns: v.number(),
-	handler: async (ctx) => {
-		const rows = await ctx.db.query('uiPreferences').collect();
-		let cleared = 0;
-		for (const row of rows) {
-			if (row.theme === 'dark') {
-				await ctx.db.patch(row._id, { theme: undefined });
-				cleared += 1;
-			}
-		}
-		return cleared;
-	}
-});
 
 export const getMine = query({
 	args: {},

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,10 +1,25 @@
-import { mutation, query } from '@convex/_generated/server';
+import { internalMutation, mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
-const DEFAULT_THEME = 'light' as const;
+
+export const clearDarkTheme = internalMutation({
+	args: {},
+	returns: v.number(),
+	handler: async (ctx) => {
+		const rows = await ctx.db.query('uiPreferences').collect();
+		let cleared = 0;
+		for (const row of rows) {
+			if (row.theme === 'dark') {
+				await ctx.db.patch(row._id, { theme: undefined });
+				cleared += 1;
+			}
+		}
+		return cleared;
+	}
+});
 
 export const getMine = query({
 	args: {},
@@ -39,8 +54,7 @@ export const setLastThread = mutation({
 
 		const id = await ctx.db.insert('uiPreferences', {
 			userId,
-			lastThreadId: args.threadId,
-			theme: DEFAULT_THEME
+			lastThreadId: args.threadId
 		});
 		return await ctx.db.get(id);
 	}
@@ -89,7 +103,6 @@ export const setPaymentsEmail = mutation({
 		} else {
 			await ctx.db.insert('uiPreferences', {
 				userId,
-				theme: DEFAULT_THEME,
 				paymentsEmail: email
 			});
 		}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,6 +1,6 @@
 export type SprocketTheme = 'light' | 'dark';
 
-export const DEFAULT_THEME: SprocketTheme = 'dark';
+export const DEFAULT_THEME: SprocketTheme = 'light';
 
 export function isSprocketTheme(value: unknown): value is SprocketTheme {
 	return value === 'light' || value === 'dark';


### PR DESCRIPTION
## Summary

Switches Sprocket's default theme from dark to light.

- `apps/web/src/lib/theme.ts`: `DEFAULT_THEME` is now `'light'` (client-side fallback in `resolveTheme`)
- `apps/web/src/convex/uiPreferences.ts`: server-side `DEFAULT_THEME` is now `'light'` for newly inserted preference rows

Users with an explicit stored preference are unaffected. The entry shells already forced light, and `app.html` boots in light mode, so this makes the default consistent across the app.

## Checks

- `bun run test` ✅
- `prek run -a` ✅
- `bun run build` ✅

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change makes light mode the default while preserving users’ explicit saved theme selections. It also allows UI preference records created by unrelated actions to omit a theme instead of implicitly storing dark mode.

Focused checks passed for creating theme-less preference records, reading them back, updating them later with an explicit theme without losing other fields, preserving existing dark selections, and resolving an absent theme to light.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The exercised preference creation, retrieval, update, explicit dark-theme preservation, and light-theme fallback flows behaved as intended.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the theme.test.ts and uiPreferences.trex.test.ts tests under apps/web; the theme test completed with 1 file and 3 tests passing, and the UI preferences test completed with 1 file and 3 focused Convex integration tests passing, with non-fatal missing-sourcemap warnings for @exalabs/convex-exa.
- The focused tests used the real convex-test schema to insert, query, and patch records, then exercised resolveTheme to verify optional-theme records remain valid and readable, updates retain unrelated fields, explicit dark preferences stay dark, and absent preferences resolve to light.

<a href="https://app.greptile.com/trex/runs/17267262/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(ui): Remove one-off dark theme ..."](https://github.com/spikonado/sprocket/commit/b57f1ac3616f9394a37b2679537d850ffe5a1fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50103596)</sub>

<!-- /greptile_comment -->