### PR TITLE
ci: Switch from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/actions/setup-nix-shell/action.yml
+++ b/.github/actions/setup-nix-shell/action.yml
@@ -1,7 +1,7 @@
 name: Setup Nix shell
 description: >-
-  Mounts the persistent Nix store, installs Nix, and realises the sprocket-shell
-  dev shell profile so later steps can run `nix develop ./sprocket-shell`.
+  Installs Nix and realises the sprocket-shell dev shell profile so later steps
+  can run `nix develop ./sprocket-shell`.
 
 inputs:
   dev-shell:
@@ -12,59 +12,9 @@ inputs:
     required: false
     default: ''
 
-  trusted:
-    description: >-
-      Set to "true" for jobs that hold privileged credentials and only ever run
-      code from a protected branch. Those jobs mount a separate store that no
-      pull-request job can write to.
-    required: false
-    default: 'false'
-
 runs:
   using: composite
   steps:
-    # /nix is empty at this point, so the recursive chmod is O(1).
-    - name: Create Nix store mount point
-      shell: bash
-      run: |
-        sudo mkdir -p /nix/store
-        sudo chmod -R 777 /nix
-
-    # Concurrent jobs all clone the same snapshot and only the first commit
-    # survives, so two shells sharing a disk would leave the loser re-fetching
-    # its closure every run. The shell is part of the key to keep them apart.
-    - name: Derive store name
-      id: store
-      shell: bash
-      env:
-        DEV_SHELL: ${{ inputs.dev-shell }}
-      run: |
-        name="${DEV_SHELL:-default}"
-        echo "name=${name//[^a-zA-Z0-9]/-}" >> "$GITHUB_OUTPUT"
-
-    # Jobs own the mount, so anything they leave in the store runs in every
-    # later job on the same disk: credentialed jobs and forks get their own.
-    # The flake.lock hash retires old closures via the 7-day idle eviction,
-    # since concurrent clone-and-commit makes in-store collection unsafe.
-    - name: Mount Nix store
-      uses: useblacksmith/stickydisk@v1.5.0
-      with:
-        key: >-
-          ${{ github.repository }}-nix-store-${{ inputs.trusted == 'true' && 'trusted'
-          || (github.event.pull_request.head.repo.fork && 'fork' || 'shared')
-          }}-${{ steps.store.outputs.name }}-${{ hashFiles('flake.lock') }}
-        path: /nix
-
-    # A fresh disk is root-owned and the installer needs /nix writable. Only
-    # the top level is touched, so warm multi-gigabyte stores stay a no-op.
-    - name: Ensure Nix store is writable
-      shell: bash
-      run: |
-        sudo mkdir -p /nix/store /nix/var
-        sudo chown "$(id -u):$(id -g)" /nix /nix/store /nix/var
-
-    # Unlike cachix/install-nix-action this unpacks into an existing /nix
-    # instead of refusing to run, which is what lets the store persist.
     - uses: nixbuild/nix-quick-install-action@v35
 
     - name: Build shell environment

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 

--- a/.github/workflows/convex-preview.yml
+++ b/.github/workflows/convex-preview.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 

--- a/.github/workflows/convex-production.yml
+++ b/.github/workflows/convex-production.yml
@@ -16,14 +16,13 @@ concurrency:
 jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 
       - uses: ./.github/actions/setup-nix-shell
         with:
           dev-shell: '.#convex'
-          trusted: 'true'
 
       - name: Install dependencies
         shell: 'nix develop ./sprocket-shell -c bash -e {0}'

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   run_prek:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7.0.1
 


### PR DESCRIPTION
## Summary

- Replace Blacksmith runners with pinned GitHub-hosted `ubuntu-24.04` runners.
- Remove the Blacksmith sticky-disk Nix store integration and its obsolete `trusted` input.
- Keep Nix setup through `nixbuild/nix-quick-install-action@v35` and the local composite action.

## Validation

- `git diff --check`
- `nix develop --command prek run check-yaml check-github-actions check-github-workflows --files .github/actions/setup-nix-shell/action.yml .github/workflows/build-test.yml .github/workflows/convex-preview.yml .github/workflows/convex-production.yml .github/workflows/prek.yml`
- `nix develop --command bun prettier --check .github/actions/setup-nix-shell/action.yml .github/workflows/build-test.yml .github/workflows/convex-preview.yml .github/workflows/convex-production.yml .github/workflows/prek.yml`
- Existing targeted Rust and built-in hook checks passed.

The full JavaScript hook suite was not run locally because this worktree does not have JavaScript dependencies installed (`eslint` and `svelte-kit` were unavailable). No Blacksmith or sticky-disk references remain.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change moves build, validation, preview deployment, and production deployment to GitHub-hosted Ubuntu 24.04 runners and removes the Blacksmith-specific persistent Nix-store configuration. The changed workflow files passed formatting checks, and an executable harness passed for both the default and Convex shell-profile paths before and after the migration. No defects were found.

## T-Rex validation blocked

A full Nix evaluation could not run because the `nix` tool is unavailable in the environment. GitHub-hosted runner allocation is also unavailable, so the Nix installer action and a complete Actions job could not be run. The available uploaded validation references did not include required labels, so they cannot be attached as review evidence.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No merge-blocking behavior or security issue was identified in the changed workflow configuration.

The final review contains no findings. The workflow configuration and shell-profile command paths were exercised by an executable harness, and all changed YAML files passed formatting validation.

**Files Needing Attention:** No files require changes. A follow-up GitHub Actions run can provide additional assurance for the real Nix installer and flake evaluation on an Ubuntu 24.04 runner.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the nix-runner-migration-validation.sh script before and after, and ran the prettier check on the listed files; both runs exited successfully, and the harness confirmed the previous revision's runner and trusted-input configuration, then validated ubuntu-24.04, removal of the trusted input, and working default and Convex shell-profile command paths in this revision.
- Note the blockers: the local environment lacks the nix tool and GitHub runner service, so real nix develop, flake dependency evaluation, and the installer action could not be executed locally; GitHub-hosted runner allocation is unavailable in this environment.

<a href="https://app.greptile.com/trex/runs/17588151/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: Switch from Blacksmith to GitHub-hos..."](https://github.com/spikonado/sprocket/commit/eaac9537eab6976c44c473abf204a9f34202de65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50743113)</sub>

<!-- /greptile_comment -->