### PR TITLE
chore(convex): Remove threadUsage migration scaffolding

### DIFF
--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -121,6 +121,36 @@ describe('agentRuntime context accounting', () => {
 		expect((await readThreadUsage(t, threadId))?.totalTokensProcessed ?? 0).toBe(0);
 	});
 
+	it('getByThreadId returns the thread with usage counters merged in', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'merged-shape-secret';
+		const { runId } = await createQueuedRun(
+			asUser,
+			threadId,
+			'merged-shape',
+			executionSecret,
+			'Continue'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret
+		});
+		await asUser.mutation(api.agentRuntime.recordContextUsage, {
+			runId,
+			claimId: 'claim-a',
+			executionSecret,
+			contextTokens: 8_000,
+			processedTokens: 9_000
+		});
+
+		await expect(asUser.query(api.threads.getByThreadId, { threadId })).resolves.toMatchObject({
+			contextTokens: 8_000,
+			totalTokensProcessed: 9_000
+		});
+	});
+
 	it('carries a compacted prefix into later runs without replaying covered history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId, projectId } = await seedOwnedThread(t);

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { api, internal } from '@convex/_generated/api';
+import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import { executionSecretHash } from '@convex/lib/auth';
 import {
@@ -16,18 +16,6 @@ async function readThreadUsage(t: ConvexTestInstance, threadId: Id<'threadRecord
 			.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
 			.unique()
 	);
-}
-
-/** Simulate a pre-migration thread: legacy counters on the record, no usage row. */
-async function seedLegacyUsage(t: ConvexTestInstance, threadId: Id<'threadRecords'>) {
-	await t.run(async (ctx) => {
-		const usageRow = await ctx.db
-			.query('threadUsage')
-			.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
-			.unique();
-		if (usageRow) await ctx.db.delete(usageRow._id);
-		await ctx.db.patch(threadId, { contextTokens: 4_000, totalTokensProcessed: 100_000 });
-	});
 }
 
 describe('agentRuntime context accounting', () => {
@@ -68,9 +56,6 @@ describe('agentRuntime context accounting', () => {
 			})
 		).resolves.toBe(true);
 
-		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
-		expect(thread).not.toHaveProperty('contextTokens');
-		expect(thread).not.toHaveProperty('totalTokensProcessed');
 		expect(await readThreadUsage(t, threadId)).toMatchObject({
 			contextTokens: 8_000,
 			totalTokensProcessed: 259_000
@@ -133,89 +118,7 @@ describe('agentRuntime context accounting', () => {
 				processedTokens: 10
 			})
 		).rejects.toThrow('Invalid token count.');
-		expect(await t.run(async (ctx) => ctx.db.get(threadId))).not.toHaveProperty('contextTokens');
-	});
-
-	it('migrates legacy on-thread counters when the thread is opened', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-		await seedLegacyUsage(t, threadId);
-
-		// Pre-migration reads keep the old response shape.
-		await expect(asUser.query(api.threads.getByThreadId, { threadId })).resolves.toMatchObject({
-			contextTokens: 4_000,
-			totalTokensProcessed: 100_000
-		});
-		await asUser.mutation(api.uiPreferences.setLastThread, { threadId });
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		await t.finishInProgressScheduledFunctions();
-		const migratedThread = await t.run(async (ctx) => ctx.db.get(threadId));
-		expect(migratedThread).not.toHaveProperty('contextTokens');
-		expect(migratedThread).not.toHaveProperty('totalTokensProcessed');
-		expect(await readThreadUsage(t, threadId)).toMatchObject({
-			contextTokens: 4_000,
-			totalTokensProcessed: 100_000
-		});
-	});
-
-	it('folds legacy counters into the first usage write', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-		const executionSecret = 'legacy-fold-secret';
-		const { runId } = await createQueuedRun(
-			asUser,
-			threadId,
-			'legacy-fold',
-			executionSecret,
-			'Continue'
-		);
-		await asUser.mutation(api.agentRuntime.start, {
-			runId,
-			claimId: 'claim-a',
-			executionSecret
-		});
-		await seedLegacyUsage(t, threadId);
-
-		await asUser.mutation(api.agentRuntime.recordContextUsage, {
-			runId,
-			claimId: 'claim-a',
-			executionSecret,
-			contextTokens: 7_000,
-			processedTokens: 10_000
-		});
-
-		const thread = await t.run(async (ctx) => ctx.db.get(threadId));
-		expect(thread).not.toHaveProperty('contextTokens');
-		expect(thread).not.toHaveProperty('totalTokensProcessed');
-		expect(await readThreadUsage(t, threadId)).toMatchObject({
-			contextTokens: 7_000,
-			totalTokensProcessed: 110_000
-		});
-	});
-
-	it('sweeps legacy counters in batches via the cron mutation', async () => {
-		const t = initConvexTest();
-		const { threadId } = await seedOwnedThread(t);
-		const { threadId: otherThreadId } = await seedOwnedThread(t, 'user_bob');
-		await seedLegacyUsage(t, threadId);
-		await seedLegacyUsage(t, otherThreadId);
-
-		await t.mutation(internal.threads.migrateLegacyUsageBatch, {});
-
-		for (const migratedId of [threadId, otherThreadId]) {
-			const thread = await t.run(async (ctx) => ctx.db.get(migratedId));
-			expect(thread).not.toHaveProperty('contextTokens');
-			expect(thread).not.toHaveProperty('totalTokensProcessed');
-			expect(await readThreadUsage(t, migratedId)).toMatchObject({
-				contextTokens: 4_000,
-				totalTokensProcessed: 100_000
-			});
-		}
-
-		await t.mutation(internal.threads.migrateLegacyUsageBatch, {});
-		expect(await readThreadUsage(t, threadId)).toMatchObject({
-			totalTokensProcessed: 100_000
-		});
+		expect((await readThreadUsage(t, threadId))?.totalTokensProcessed ?? 0).toBe(0);
 	});
 
 	it('carries a compacted prefix into later runs without replaying covered history', async () => {

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -9,12 +9,4 @@ crons.interval(
 	internal.imageUploads.cleanupOrphans
 );
 
-// Temporary backstop for the threadUsage migration; delete with the legacy fields.
-crons.interval(
-	'migrate legacy thread usage counters',
-	{ hours: 1 },
-	internal.threads.migrateLegacyUsageBatch,
-	{}
-);
-
 export default crons;

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -42,10 +42,6 @@ export const threadRecordFields = {
 	selectedModel: vModelId,
 	reasoningEffort: vReasoningEffort,
 	serviceTier: vServiceTier,
-	// Legacy; moved to the `threadUsage` table (lib/threadUsage.ts). Delete
-	// once every row is migrated.
-	contextTokens: v.optional(v.number()),
-	totalTokensProcessed: v.optional(v.number()),
 	contextSummary: v.optional(v.string()),
 	contextSummaryThroughRunId: v.optional(v.id('runs')),
 	lastMessageAt: v.number(),
@@ -192,15 +188,6 @@ export const vThreadRecordDoc = v.object({
 	_id: v.id('threadRecords'),
 	_creationTime: v.number(),
 	...threadRecordFields
-});
-
-// getByThreadId merges threadUsage counters into the legacy response shape,
-// so its contract keeps the pre-migration required totalTokensProcessed.
-export const vThreadRecordWithUsageDoc = v.object({
-	_id: v.id('threadRecords'),
-	_creationTime: v.number(),
-	...threadRecordFields,
-	totalTokensProcessed: v.number()
 });
 
 export const vRunDoc = v.object({

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -190,6 +190,16 @@ export const vThreadRecordDoc = v.object({
 	...threadRecordFields
 });
 
+// getByThreadId's live response shape: thread record plus usage counters
+// merged in from the threadUsage table.
+export const vThreadWithUsageDoc = v.object({
+	_id: v.id('threadRecords'),
+	_creationTime: v.number(),
+	...threadRecordFields,
+	contextTokens: v.optional(v.number()),
+	totalTokensProcessed: v.number()
+});
+
 export const vRunDoc = v.object({
 	_id: v.id('runs'),
 	_creationTime: v.number(),

--- a/apps/web/src/convex/lib/threadUsage.ts
+++ b/apps/web/src/convex/lib/threadUsage.ts
@@ -2,8 +2,7 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { DatabaseReader, DatabaseWriter } from '@convex/_generated/server';
 
 // Per-turn counters live here so token writes don't invalidate the
-// thread-scoped subscriptions reading `threadRecords`. Legacy on-thread
-// fields migrate lazily (see PR follow-up checklist); drop them after.
+// thread-scoped subscriptions reading `threadRecords`.
 
 type ThreadUsageValues = {
 	contextTokens: number | undefined;
@@ -24,12 +23,6 @@ function addTokenCounts(left: number, right: number): number {
 	return total;
 }
 
-export function hasLegacyUsageFields(
-	thread: Pick<Doc<'threadRecords'>, 'contextTokens' | 'totalTokensProcessed'>
-): boolean {
-	return thread.contextTokens !== undefined || thread.totalTokensProcessed !== undefined;
-}
-
 async function getUsageRow(
 	db: DatabaseReader,
 	threadId: Id<'threadRecords'>
@@ -40,34 +33,19 @@ async function getUsageRow(
 		.unique();
 }
 
-function toUsageValues(
-	usageRow: Doc<'threadUsage'> | null,
-	thread: Doc<'threadRecords'>
-): ThreadUsageValues {
-	if (usageRow) {
-		return {
-			contextTokens: usageRow.contextTokens,
-			totalTokensProcessed: usageRow.totalTokensProcessed
-		};
-	}
-	return {
-		contextTokens: thread.contextTokens,
-		totalTokensProcessed: thread.totalTokensProcessed ?? 0
-	};
-}
-
-/** Current counters, falling back to unmigrated legacy fields. */
+/** Current counters for a thread. */
 export async function getThreadUsageValues(
 	db: DatabaseReader,
 	thread: Doc<'threadRecords'>
 ): Promise<ThreadUsageValues> {
-	return toUsageValues(await getUsageRow(db, thread._id), thread);
+	const usageRow = await getUsageRow(db, thread._id);
+	return {
+		contextTokens: usageRow?.contextTokens,
+		totalTokensProcessed: usageRow?.totalTokensProcessed ?? 0
+	};
 }
 
-/**
- * Upsert the usage row and apply a delta, folding in (and clearing) any
- * legacy fields in the same transaction. Validates token counts.
- */
+/** Upsert the usage row and apply a delta. Validates token counts. */
 export async function recordThreadUsage(
 	ctx: { db: DatabaseWriter },
 	thread: Doc<'threadRecords'>,
@@ -77,10 +55,12 @@ export async function recordThreadUsage(
 		assertValidTokenCount(args.contextTokens);
 	}
 	const usageRow = await getUsageRow(ctx.db, thread._id);
-	const base = toUsageValues(usageRow, thread);
 	const next: ThreadUsageValues = {
-		contextTokens: args.contextTokens ?? base.contextTokens,
-		totalTokensProcessed: addTokenCounts(base.totalTokensProcessed, args.addProcessedTokens ?? 0)
+		contextTokens: args.contextTokens ?? usageRow?.contextTokens,
+		totalTokensProcessed: addTokenCounts(
+			usageRow?.totalTokensProcessed ?? 0,
+			args.addProcessedTokens ?? 0
+		)
 	};
 	if (usageRow) {
 		await ctx.db.patch(usageRow._id, next);
@@ -89,12 +69,6 @@ export async function recordThreadUsage(
 			threadId: thread._id,
 			userId: thread.userId,
 			...next
-		});
-	}
-	if (hasLegacyUsageFields(thread)) {
-		await ctx.db.patch(thread._id, {
-			contextTokens: undefined,
-			totalTokensProcessed: undefined
 		});
 	}
 }

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -3,7 +3,7 @@ import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord, getOwnedProject } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
-import { vThreadRecordDoc, vThreadSummary } from '@convex/lib/docs';
+import { vThreadSummary, vThreadWithUsageDoc } from '@convex/lib/docs';
 import { getThreadUsageValues } from '@convex/lib/threadUsage';
 import { assertModelConfigurationAllowedForUser } from '@convex/lib/tiers';
 import {
@@ -138,7 +138,7 @@ export const getByThreadId = query({
 	args: {
 		threadId: v.id('threadRecords')
 	},
-	returns: vThreadRecordDoc,
+	returns: vThreadWithUsageDoc,
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -1,15 +1,10 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { internalMutation, mutation, query, type MutationCtx } from '@convex/_generated/server';
+import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
-import { internal } from '@convex/_generated/api';
 import { getOwnedThreadRecord, getOwnedProject } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
-import { vThreadRecordWithUsageDoc, vThreadSummary } from '@convex/lib/docs';
-import {
-	getThreadUsageValues,
-	hasLegacyUsageFields,
-	recordThreadUsage
-} from '@convex/lib/threadUsage';
+import { vThreadRecordDoc, vThreadSummary } from '@convex/lib/docs';
+import { getThreadUsageValues } from '@convex/lib/threadUsage';
 import { assertModelConfigurationAllowedForUser } from '@convex/lib/tiers';
 import {
 	isRunFinalStatus,
@@ -143,51 +138,12 @@ export const getByThreadId = query({
 	args: {
 		threadId: v.id('threadRecords')
 	},
-	returns: vThreadRecordWithUsageDoc,
+	returns: vThreadRecordDoc,
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		// Keep the pre-migration response shape for older clients.
 		const usage = await getThreadUsageValues(ctx.db, thread);
 		return { ...thread, ...usage };
-	}
-});
-
-export const migrateLegacyUsage = internalMutation({
-	args: { threadId: v.id('threadRecords') },
-	returns: v.null(),
-	handler: async (ctx, args) => {
-		const thread = await ctx.db.get(args.threadId);
-		if (!thread || !hasLegacyUsageFields(thread)) {
-			return null;
-		}
-		await recordThreadUsage(ctx, thread, {});
-		return null;
-	}
-});
-
-const LEGACY_USAGE_MIGRATION_BATCH_SIZE = 100;
-
-// Convergence backstop: on-access triggers never reach archived threads.
-// Chained batches driven hourly by crons.ts; delete with the legacy fields.
-export const migrateLegacyUsageBatch = internalMutation({
-	args: { cursor: v.optional(v.union(v.string(), v.null())) },
-	returns: v.null(),
-	handler: async (ctx, args) => {
-		const { page, isDone, continueCursor } = await ctx.db
-			.query('threadRecords')
-			.paginate({ numItems: LEGACY_USAGE_MIGRATION_BATCH_SIZE, cursor: args.cursor ?? null });
-		for (const thread of page) {
-			if (hasLegacyUsageFields(thread)) {
-				await recordThreadUsage(ctx, thread, {});
-			}
-		}
-		if (!isDone) {
-			await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsageBatch, {
-				cursor: continueCursor
-			});
-		}
-		return null;
 	}
 });
 

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,9 +1,7 @@
-import { internal } from '@convex/_generated/api';
 import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vUiPreferencesDoc } from '@convex/lib/docs';
-import { hasLegacyUsageFields } from '@convex/lib/threadUsage';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
 
@@ -26,14 +24,6 @@ export const setLastThread = mutation({
 	returns: v.union(vUiPreferencesDoc, v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
-		// Clients fire this on every thread open — the lazy-migration trigger
-		// for legacy usage counters (queries cannot schedule).
-		const thread = await ctx.db.get(args.threadId);
-		if (thread && thread.userId === userId && hasLegacyUsageFields(thread)) {
-			await ctx.scheduler.runAfter(0, internal.threads.migrateLegacyUsage, {
-				threadId: thread._id
-			});
-		}
 		const existing = await ctx.db
 			.query('uiPreferences')
 			.withIndex('by_userId', (query) => query.eq('userId', userId))


### PR DESCRIPTION
## Summary

Removes the threadUsage lazy-migration scaffolding added in #170. Prod is fully migrated — verified directly against the production deployment (`original-jaguar-930`): **46 `threadRecords` total, 0 still carrying `contextTokens`/`totalTokensProcessed`, 46 matching `threadUsage` rows**.

Removed:

- Legacy optional `contextTokens`/`totalTokensProcessed` from `threadRecordFields` (the fields no longer exist in the schema or the data).
- `vThreadRecordWithUsageDoc`; `getByThreadId` returns `vThreadRecordDoc` again (it still merges the usage counters in — that's the live shape, not migration code).
- `threads.migrateLegacyUsage` and `threads.migrateLegacyUsageBatch` internal mutations, the hourly cron entry, and the `setLastThread` migration trigger.
- Legacy fallback/fold/clear logic in `lib/threadUsage.ts` — it now reads and writes only the `threadUsage` row.
- The three legacy-migration tests (fencing and invalid-input coverage stays).

## Notes

- The `threadUsage` table itself is permanent — this PR only deletes migration-era scaffolding.
- Old clients remain compatible: the `getByThreadId` response shape is unchanged (counters still merged in from `threadUsage`).

## Verification

- `vitest` 238/238
- `convex typecheck`, `prek run -a` — green

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change removes the legacy thread-usage migration scaffolding and returns usage counters from `threadUsage`. The earlier public-query return-contract failure was retested through the authenticated query path and no longer occurs: the response validator accepts both merged counters. However, older thread records that have not received a corresponding `threadUsage` row now lose their stored usage values when opened.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Do not merge until historical usage counters remain available for older thread records.

Opening a legacy thread without a `threadUsage` row replaces its persisted usage values with an absent context count and a zero processed-token total.

**Files Needing Attention:** apps/web/src/convex/lib/threadUsage.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the legacy thread usage scenario and prepared the legacy schema fixture to support the P1 finding.
- Executed the temporary Convex in-memory regression harness through the exact authenticated asUser.query path to verify how counters are handled, confirming that current code does not preserve legacy-only counters.
- Compared pre- and post-conditions by running tests where a threadUsage row is present, and observed that the response includes the expected contextTokens and totalTokensProcessed values.
- Produced proofs for the posted P1 findings and aligned them with the corresponding review comments for findings 0, 1, and 3.

<a href="https://app.greptile.com/trex/runs/17590764/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/convex/lib/threadUsage.ts:41-45
**Legacy usage read has no fallback**

`getThreadUsageValues` only reads `threadUsage` and returns `contextTokens: undefined` plus `totalTokensProcessed: 0` when no row exists. Since this change also removes the legacy-counter migration and fallback behavior, a pre-cleanup `threadRecords` document that still contains historical counters but lacks a migrated usage row is returned with those counters erased. Retain a legacy read fallback until all rows are migrated, or enforce completion of that migration before removing the old representation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(convex): Keep usage counters in the ..."](https://github.com/spikonado/sprocket/commit/fb25888b58aae6fdf7f6378fb0c8dfd4771861ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50745653)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->