### PR TITLE
perf(convex): Decouple heartbeats from projects.listMine, stabilize ordering

### DIFF
--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -121,6 +121,9 @@ export const agentQuestionFields = {
 
 export const uiPreferencesFields = {
 	userId: v.string(),
+	// Deprecated: only older released clients still write/read this via
+	// setLastThread. New clients resume the latest active thread instead.
+	// Remove once those clients age out.
 	lastThreadId: v.optional(v.id('threadRecords')),
 	theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
 	paymentsEmail: v.optional(v.string())

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -240,7 +240,8 @@ export const vProjectWithExecutorStatus = v.object({
 	_id: v.id('projects'),
 	_creationTime: v.number(),
 	...projectFields,
-	executorStatus: vExecutorStatus
+	// Absent for `listMine({ slim: true })` callers.
+	executorStatus: v.optional(vExecutorStatus)
 });
 
 export const vThreadTranscriptAttachment = v.object({

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -28,6 +28,8 @@ export const projectFields = {
 	userId: v.string(),
 	repositoryKey: v.string(),
 	displayName: v.string(),
+	// Deprecated: executor liveness moved to `projectConnections`. No longer
+	// written; kept optional so pre-migration rows still validate.
 	lastHeartbeatAt: v.optional(v.number()),
 	connectedClientId: v.optional(v.string()),
 	nextExecutorSequence: v.number(),

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -241,11 +241,11 @@ export const vImageUploadDoc = v.object({
 	...imageUploadFields
 });
 
-export const vProjectWithExecutorStatus = v.object({
+export const vProjectListItem = v.object({
 	_id: v.id('projects'),
 	_creationTime: v.number(),
 	...projectFields,
-	// Absent for `listMine({ slim: true })` callers.
+	// Absent for `listMine({ includeExecutorStatus: false })` callers.
 	executorStatus: v.optional(vExecutorStatus)
 });
 

--- a/apps/web/src/convex/lib/projectConnection.test.ts
+++ b/apps/web/src/convex/lib/projectConnection.test.ts
@@ -3,7 +3,7 @@ import type { Id } from '@convex/_generated/dataModel';
 import {
 	EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS,
 	EXECUTOR_HEARTBEAT_TTL_MS,
-	getDetachedConnectionProjectIds,
+	getDetachedConnections,
 	getEffectiveExecutorStatus,
 	shouldRefreshProjectHeartbeat
 } from '@convex/lib/projectConnection';
@@ -11,12 +11,12 @@ import {
 function makeConnection(
 	overrides: Partial<{
 		projectId: Id<'projects'>;
-		clientId?: string;
-		lastHeartbeatAt?: number;
+		clientId: string;
+		lastHeartbeatAt: number;
 	}> = {}
 ) {
 	return {
-		_id: 'conn-1' as never,
+		_id: 'conn-1' as Id<'projectConnections'>,
 		_creationTime: 0,
 		projectId: overrides.projectId ?? ('project-1' as Id<'projects'>),
 		userId: 'user-1',
@@ -40,8 +40,8 @@ describe('projectConnection helpers', () => {
 		expect(getEffectiveExecutorStatus(null, 100_000)).toBe('disconnected');
 	});
 
-	it('returns omitted projects to detach for the same client', () => {
-		const detached = getDetachedConnectionProjectIds(
+	it('returns omitted connections to detach for the same client', () => {
+		const detached = getDetachedConnections(
 			[
 				makeConnection({
 					projectId: 'project-1' as Id<'projects'>,
@@ -60,7 +60,7 @@ describe('projectConnection helpers', () => {
 			['project-2' as Id<'projects'>]
 		);
 
-		expect(detached).toEqual(['project-1']);
+		expect(detached.map((connection) => connection.projectId)).toEqual(['project-1']);
 	});
 
 	it('skips redundant heartbeat writes for the same client until the throttle elapses', () => {

--- a/apps/web/src/convex/lib/projectConnection.test.ts
+++ b/apps/web/src/convex/lib/projectConnection.test.ts
@@ -3,56 +3,57 @@ import type { Id } from '@convex/_generated/dataModel';
 import {
 	EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS,
 	EXECUTOR_HEARTBEAT_TTL_MS,
-	getDetachedProjectIdsForClient,
+	getDetachedConnectionProjectIds,
 	getEffectiveExecutorStatus,
 	shouldRefreshProjectHeartbeat
 } from '@convex/lib/projectConnection';
 
-function makeProject(
+function makeConnection(
 	overrides: Partial<{
-		_id: Id<'projects'>;
-		connectedClientId?: string;
+		projectId: Id<'projects'>;
+		clientId?: string;
 		lastHeartbeatAt?: number;
 	}> = {}
 ) {
 	return {
-		_id: overrides._id ?? ('project-1' as Id<'projects'>),
+		_id: 'conn-1' as never,
 		_creationTime: 0,
+		projectId: overrides.projectId ?? ('project-1' as Id<'projects'>),
 		userId: 'user-1',
-		repositoryKey: 'Workspace',
-		displayName: 'Workspace',
-		lastHeartbeatAt: overrides.lastHeartbeatAt,
-		connectedClientId: overrides.connectedClientId,
-		nextExecutorSequence: 0,
-		lastSeenAt: 0
+		clientId: overrides.clientId ?? 'client-1',
+		lastHeartbeatAt: overrides.lastHeartbeatAt ?? 0
 	};
 }
 
 describe('projectConnection helpers', () => {
 	it('reports disconnected when the heartbeat is stale', () => {
 		const now = 100_000;
-		const project = makeProject({
-			connectedClientId: 'client-1',
+		const connection = makeConnection({
+			clientId: 'client-1',
 			lastHeartbeatAt: now - EXECUTOR_HEARTBEAT_TTL_MS - 1
 		});
 
-		expect(getEffectiveExecutorStatus(project, now)).toBe('disconnected');
+		expect(getEffectiveExecutorStatus(connection, now)).toBe('disconnected');
+	});
+
+	it('reports disconnected when there is no connection row', () => {
+		expect(getEffectiveExecutorStatus(null, 100_000)).toBe('disconnected');
 	});
 
 	it('returns omitted projects to detach for the same client', () => {
-		const detached = getDetachedProjectIdsForClient(
+		const detached = getDetachedConnectionProjectIds(
 			[
-				makeProject({
-					_id: 'project-1' as Id<'projects'>,
-					connectedClientId: 'client-1'
+				makeConnection({
+					projectId: 'project-1' as Id<'projects'>,
+					clientId: 'client-1'
 				}),
-				makeProject({
-					_id: 'project-2' as Id<'projects'>,
-					connectedClientId: 'client-1'
+				makeConnection({
+					projectId: 'project-2' as Id<'projects'>,
+					clientId: 'client-1'
 				}),
-				makeProject({
-					_id: 'project-3' as Id<'projects'>,
-					connectedClientId: 'client-2'
+				makeConnection({
+					projectId: 'project-3' as Id<'projects'>,
+					clientId: 'client-2'
 				})
 			],
 			'client-1',
@@ -64,16 +65,16 @@ describe('projectConnection helpers', () => {
 
 	it('skips redundant heartbeat writes for the same client until the throttle elapses', () => {
 		const now = 100_000;
-		const project = makeProject({
-			connectedClientId: 'client-1',
+		const connection = makeConnection({
+			clientId: 'client-1',
 			lastHeartbeatAt: now - EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS + 1
 		});
 
-		expect(shouldRefreshProjectHeartbeat(project, 'client-1', now)).toBe(false);
+		expect(shouldRefreshProjectHeartbeat(connection, 'client-1', now)).toBe(false);
 		expect(
 			shouldRefreshProjectHeartbeat(
 				{
-					...project,
+					...connection,
 					lastHeartbeatAt: now - EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS
 				},
 				'client-1',
@@ -87,23 +88,14 @@ describe('projectConnection helpers', () => {
 
 		expect(
 			shouldRefreshProjectHeartbeat(
-				makeProject({
-					connectedClientId: 'client-2',
+				makeConnection({
+					clientId: 'client-2',
 					lastHeartbeatAt: now
 				}),
 				'client-1',
 				now
 			)
 		).toBe(true);
-		expect(
-			shouldRefreshProjectHeartbeat(
-				makeProject({
-					connectedClientId: 'client-1',
-					lastHeartbeatAt: undefined
-				}),
-				'client-1',
-				now
-			)
-		).toBe(true);
+		expect(shouldRefreshProjectHeartbeat(null, 'client-1', now)).toBe(true);
 	});
 });

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -3,11 +3,22 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 // Heartbeats write `projectConnections` rows, which no hot list subscription
 // reads, so cadence is no longer expensive there. The TTL exceeds two
 // throttle intervals so a skipped beat never flaps status; staleness is safe
-// because connection state only feeds the executor badge, not execution.
+// because nothing consumes executor status yet — revisit before surfacing a
+// connection badge.
 export const EXECUTOR_HEARTBEAT_TTL_MS = 300_000;
 export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 
 type ProjectConnectionDoc = Doc<'projectConnections'>;
+
+// Pre-split rows carried liveness on the project itself. Read only until a
+// projectConnections row exists; remove with the legacy project fields.
+export function legacyConnectionFromProject(
+	project: Pick<Doc<'projects'>, 'connectedClientId' | 'lastHeartbeatAt'>
+): Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null {
+	return project.connectedClientId && project.lastHeartbeatAt !== undefined
+		? { clientId: project.connectedClientId, lastHeartbeatAt: project.lastHeartbeatAt }
+		: null;
+}
 
 export function getEffectiveExecutorStatus(
 	connection: Pick<ProjectConnectionDoc, 'lastHeartbeatAt'> | null | undefined,

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -9,35 +9,24 @@ export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 
 type ProjectConnectionDoc = Doc<'projectConnections'>;
 
-function isExecutorHeartbeatFresh(lastHeartbeatAt: number | undefined, now: number = Date.now()) {
-	return lastHeartbeatAt !== undefined && now - lastHeartbeatAt <= EXECUTOR_HEARTBEAT_TTL_MS;
-}
-
-function isConnectionLive(
-	connection: Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null | undefined,
-	now: number = Date.now()
-) {
-	return Boolean(connection?.clientId && isExecutorHeartbeatFresh(connection.lastHeartbeatAt, now));
-}
-
 export function getEffectiveExecutorStatus(
-	connection: Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null | undefined,
+	connection: Pick<ProjectConnectionDoc, 'lastHeartbeatAt'> | null | undefined,
 	now: number = Date.now()
 ) {
-	return isConnectionLive(connection, now) ? ('connected' as const) : ('disconnected' as const);
+	return connection && now - connection.lastHeartbeatAt <= EXECUTOR_HEARTBEAT_TTL_MS
+		? ('connected' as const)
+		: ('disconnected' as const);
 }
 
-export function getDetachedConnectionProjectIds(
+export function getDetachedConnections(
 	connections: ProjectConnectionDoc[],
 	clientId: string,
 	attachedProjectIds: Iterable<Id<'projects'>>
 ) {
 	const attachedIds = new Set<string>(attachedProjectIds);
-	return connections
-		.filter(
-			(connection) => connection.clientId === clientId && !attachedIds.has(connection.projectId)
-		)
-		.map((connection) => connection.projectId);
+	return connections.filter(
+		(connection) => connection.clientId === clientId && !attachedIds.has(connection.projectId)
+	);
 }
 
 export function shouldRefreshProjectHeartbeat(

--- a/apps/web/src/convex/lib/projectConnection.ts
+++ b/apps/web/src/convex/lib/projectConnection.ts
@@ -1,69 +1,57 @@
-import type { Doc } from '@convex/_generated/dataModel';
+import type { Doc, Id } from '@convex/_generated/dataModel';
 
-// Heartbeats write and re-run `projects.listMine`, so cadence is expensive.
-// The TTL exceeds two throttle intervals so a skipped beat never flaps
-// status; it's safe to be this stale only because no UI consumes
-// executorStatus yet — revisit before surfacing a connection badge.
+// Heartbeats write `projectConnections` rows, which no hot list subscription
+// reads, so cadence is no longer expensive there. The TTL exceeds two
+// throttle intervals so a skipped beat never flaps status; staleness is safe
+// because connection state only feeds the executor badge, not execution.
 export const EXECUTOR_HEARTBEAT_TTL_MS = 300_000;
 export const EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS = 90_000;
 
-type ProjectDoc = Doc<'projects'>;
+type ProjectConnectionDoc = Doc<'projectConnections'>;
 
 function isExecutorHeartbeatFresh(lastHeartbeatAt: number | undefined, now: number = Date.now()) {
 	return lastHeartbeatAt !== undefined && now - lastHeartbeatAt <= EXECUTOR_HEARTBEAT_TTL_MS;
 }
 
-function isProjectEffectivelyConnected(
-	project: Pick<ProjectDoc, 'connectedClientId' | 'lastHeartbeatAt'>,
+function isConnectionLive(
+	connection: Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null | undefined,
 	now: number = Date.now()
 ) {
-	return Boolean(
-		project.connectedClientId && isExecutorHeartbeatFresh(project.lastHeartbeatAt, now)
-	);
+	return Boolean(connection?.clientId && isExecutorHeartbeatFresh(connection.lastHeartbeatAt, now));
 }
 
 export function getEffectiveExecutorStatus(
-	project: Pick<ProjectDoc, 'connectedClientId' | 'lastHeartbeatAt'>,
+	connection: Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null | undefined,
 	now: number = Date.now()
 ) {
-	return isProjectEffectivelyConnected(project, now)
-		? ('connected' as const)
-		: ('disconnected' as const);
+	return isConnectionLive(connection, now) ? ('connected' as const) : ('disconnected' as const);
 }
 
-export function withEffectiveProjectState<T extends ProjectDoc>(
-	project: T,
-	now: number = Date.now()
-) {
-	return {
-		...project,
-		executorStatus: getEffectiveExecutorStatus(project, now)
-	};
-}
-
-export function getDetachedProjectIdsForClient(
-	projects: ProjectDoc[],
+export function getDetachedConnectionProjectIds(
+	connections: ProjectConnectionDoc[],
 	clientId: string,
-	attachedProjectIds: Iterable<string>
+	attachedProjectIds: Iterable<Id<'projects'>>
 ) {
-	const attachedIds = new Set(attachedProjectIds);
-	return projects
-		.filter((project) => project.connectedClientId === clientId && !attachedIds.has(project._id))
-		.map((project) => project._id);
+	const attachedIds = new Set<string>(attachedProjectIds);
+	return connections
+		.filter(
+			(connection) => connection.clientId === clientId && !attachedIds.has(connection.projectId)
+		)
+		.map((connection) => connection.projectId);
 }
 
 export function shouldRefreshProjectHeartbeat(
-	project: Pick<ProjectDoc, 'connectedClientId' | 'lastHeartbeatAt'>,
+	connection: Pick<ProjectConnectionDoc, 'clientId' | 'lastHeartbeatAt'> | null | undefined,
 	clientId: string,
 	now: number = Date.now()
 ) {
-	if (project.connectedClientId !== clientId) {
+	if (!connection) {
 		return true;
 	}
 
-	if (project.lastHeartbeatAt === undefined) {
+	if (connection.clientId !== clientId) {
 		return true;
 	}
 
-	return now - project.lastHeartbeatAt >= EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS;
+	return now - connection.lastHeartbeatAt >= EXECUTOR_HEARTBEAT_WRITE_THROTTLE_MS;
 }

--- a/apps/web/src/convex/projects.test.ts
+++ b/apps/web/src/convex/projects.test.ts
@@ -161,8 +161,13 @@ describe('projects.heartbeatAttached', () => {
 		const after = await t.run(async (ctx) => ctx.db.get(project!._id));
 		expect(after).toEqual(before);
 
-		const listed = await asUser.query(api.projects.listMine, {});
-		expect(listed.find((entry) => entry._id === project!._id)?.executorStatus).toBe('connected');
+		const connection = await t.run(async (ctx) =>
+			ctx.db
+				.query('projectConnections')
+				.withIndex('by_projectId', (query) => query.eq('projectId', project!._id))
+				.unique()
+		);
+		expect(connection).toMatchObject({ clientId: 'client-1' });
 	});
 
 	it('drops the connection row when the client stops attaching the project', async () => {
@@ -180,13 +185,18 @@ describe('projects.heartbeatAttached', () => {
 			projectIds: []
 		});
 
-		const listed = await asUser.query(api.projects.listMine, {});
-		expect(listed.find((entry) => entry._id === project!._id)?.executorStatus).toBe('disconnected');
+		const connection = await t.run(async (ctx) =>
+			ctx.db
+				.query('projectConnections')
+				.withIndex('by_projectId', (query) => query.eq('projectId', project!._id))
+				.unique()
+		);
+		expect(connection).toBeNull();
 	});
 
 	it('omits executorStatus when includeExecutorStatus is false', async () => {
 		const t = initConvexTest();
-		const asUser = t.withIdentity({ subject: 'user_slim' });
+		const asUser = t.withIdentity({ subject: 'user_no_executor_status' });
 
 		await asUser.mutation(api.projects.upsertSelected, {
 			repositoryKey: 'github.com/spikonado/sprocket',
@@ -194,11 +204,8 @@ describe('projects.heartbeatAttached', () => {
 			connectedClientId: 'client-1'
 		});
 
-		const slim = await asUser.query(api.projects.listMine, { includeExecutorStatus: false });
-		expect(slim).toHaveLength(1);
-		expect(slim[0]).not.toHaveProperty('executorStatus');
-
-		const legacy = await asUser.query(api.projects.listMine, {});
-		expect(legacy[0]?.executorStatus).toBe('connected');
+		const listed = await asUser.query(api.projects.listMine, { includeExecutorStatus: false });
+		expect(listed).toHaveLength(1);
+		expect(listed[0]).not.toHaveProperty('executorStatus');
 	});
 });

--- a/apps/web/src/convex/projects.test.ts
+++ b/apps/web/src/convex/projects.test.ts
@@ -184,7 +184,7 @@ describe('projects.heartbeatAttached', () => {
 		expect(listed.find((entry) => entry._id === project!._id)?.executorStatus).toBe('disconnected');
 	});
 
-	it('omits executorStatus for slim callers', async () => {
+	it('omits executorStatus when includeExecutorStatus is false', async () => {
 		const t = initConvexTest();
 		const asUser = t.withIdentity({ subject: 'user_slim' });
 
@@ -194,7 +194,7 @@ describe('projects.heartbeatAttached', () => {
 			connectedClientId: 'client-1'
 		});
 
-		const slim = await asUser.query(api.projects.listMine, { slim: true });
+		const slim = await asUser.query(api.projects.listMine, { includeExecutorStatus: false });
 		expect(slim).toHaveLength(1);
 		expect(slim[0]).not.toHaveProperty('executorStatus');
 

--- a/apps/web/src/convex/projects.test.ts
+++ b/apps/web/src/convex/projects.test.ts
@@ -111,3 +111,94 @@ describe('projects.upsertSelected', () => {
 		expect(oldProject?.repositoryKey).toBe('github.com/spikonado/old');
 	});
 });
+
+describe('projects.listMine ordering', () => {
+	it('orders by creation, not by which project was re-selected most recently', async () => {
+		const t = initConvexTest();
+		const asUser = t.withIdentity({ subject: 'user_order' });
+
+		const older = await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/older',
+			displayName: 'older',
+			connectedClientId: 'client-1'
+		});
+		const newer = await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/newer',
+			displayName: 'newer',
+			connectedClientId: 'client-1'
+		});
+
+		// Re-selecting the older project must not move it above the newer one.
+		await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/older',
+			displayName: 'older',
+			connectedClientId: 'client-1'
+		});
+
+		const projects = await asUser.query(api.projects.listMine, {});
+		expect(projects.map((project) => project._id)).toEqual([newer!._id, older!._id]);
+	});
+});
+
+describe('projects.heartbeatAttached', () => {
+	it('tracks liveness in projectConnections without mutating the project row', async () => {
+		const t = initConvexTest();
+		const asUser = t.withIdentity({ subject: 'user_heartbeat' });
+
+		const project = await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/sprocket',
+			displayName: 'sprocket',
+			connectedClientId: 'client-1'
+		});
+
+		const before = await t.run(async (ctx) => ctx.db.get(project!._id));
+
+		await asUser.mutation(api.projects.heartbeatAttached, {
+			clientId: 'client-1',
+			projectIds: [project!._id]
+		});
+
+		const after = await t.run(async (ctx) => ctx.db.get(project!._id));
+		expect(after).toEqual(before);
+
+		const listed = await asUser.query(api.projects.listMine, {});
+		expect(listed.find((entry) => entry._id === project!._id)?.executorStatus).toBe('connected');
+	});
+
+	it('drops the connection row when the client stops attaching the project', async () => {
+		const t = initConvexTest();
+		const asUser = t.withIdentity({ subject: 'user_detach' });
+
+		const project = await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/sprocket',
+			displayName: 'sprocket',
+			connectedClientId: 'client-1'
+		});
+
+		await asUser.mutation(api.projects.heartbeatAttached, {
+			clientId: 'client-1',
+			projectIds: []
+		});
+
+		const listed = await asUser.query(api.projects.listMine, {});
+		expect(listed.find((entry) => entry._id === project!._id)?.executorStatus).toBe('disconnected');
+	});
+
+	it('omits executorStatus for slim callers', async () => {
+		const t = initConvexTest();
+		const asUser = t.withIdentity({ subject: 'user_slim' });
+
+		await asUser.mutation(api.projects.upsertSelected, {
+			repositoryKey: 'github.com/spikonado/sprocket',
+			displayName: 'sprocket',
+			connectedClientId: 'client-1'
+		});
+
+		const slim = await asUser.query(api.projects.listMine, { slim: true });
+		expect(slim).toHaveLength(1);
+		expect(slim[0]).not.toHaveProperty('executorStatus');
+
+		const legacy = await asUser.query(api.projects.listMine, {});
+		expect(legacy[0]?.executorStatus).toBe('connected');
+	});
+});

--- a/apps/web/src/convex/projects.ts
+++ b/apps/web/src/convex/projects.ts
@@ -1,10 +1,11 @@
 import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
-import { vProjectDoc, vProjectWithExecutorStatus } from '@convex/lib/docs';
+import { vProjectDoc, vProjectListItem } from '@convex/lib/docs';
 import {
 	getDetachedConnections,
 	getEffectiveExecutorStatus,
+	legacyConnectionFromProject,
 	shouldRefreshProjectHeartbeat
 } from '@convex/lib/projectConnection';
 import type { Doc, Id } from '@convex/_generated/dataModel';
@@ -50,6 +51,17 @@ async function upsertConnection(
 		clientId: args.clientId,
 		lastHeartbeatAt: args.now
 	});
+}
+
+async function getConnectionsForUser(
+	ctx: QueryCtx | MutationCtx,
+	userId: string
+): Promise<Map<Id<'projects'>, Doc<'projectConnections'>>> {
+	const connections = await ctx.db
+		.query('projectConnections')
+		.withIndex('by_userId', (query) => query.eq('userId', userId))
+		.collect();
+	return new Map(connections.map((connection) => [connection.projectId, connection]));
 }
 
 export const upsertSelected = mutation({
@@ -98,13 +110,14 @@ export const upsertSelected = mutation({
 
 export const listMine = query({
 	args: {
-		// Older clients omit this and keep receiving a live `executorStatus`
-		// (computed from `projectConnections`). Slim callers skip the join so
-		// heartbeats don't re-run their subscription.
-		slim: v.optional(v.boolean())
+		// Older released clients omit this and keep receiving a live
+		// `executorStatus`. Callers passing `false` skip the `projectConnections`
+		// read entirely, so heartbeats never re-run their subscription. Once old
+		// clients age out, drop the arg and the `executorStatus` field.
+		includeExecutorStatus: v.optional(v.boolean())
 	},
-	returns: v.array(vProjectWithExecutorStatus),
-	handler: async (ctx, args): Promise<Infer<typeof vProjectWithExecutorStatus>[]> => {
+	returns: v.array(vProjectListItem),
+	handler: async (ctx, args): Promise<Infer<typeof vProjectListItem>[]> => {
 		const userId = await getUserId(ctx);
 		// Order by creation, newest first: every Convex index implicitly ends
 		// with `_creationTime`, so `by_userId` is creation-ordered within a
@@ -114,19 +127,18 @@ export const listMine = query({
 			.withIndex('by_userId', (query) => query.eq('userId', userId))
 			.order('desc')
 			.collect();
-		if (args.slim) {
+		if (args.includeExecutorStatus === false) {
 			return projects;
 		}
 		const now = Date.now();
-		return await Promise.all(
-			projects.map(async (project) => ({
-				...project,
-				executorStatus: getEffectiveExecutorStatus(
-					await getConnectionForProject(ctx, project._id),
-					now
-				)
-			}))
-		);
+		const connectionByProjectId = await getConnectionsForUser(ctx, userId);
+		return projects.map((project) => ({
+			...project,
+			executorStatus: getEffectiveExecutorStatus(
+				connectionByProjectId.get(project._id) ?? legacyConnectionFromProject(project),
+				now
+			)
+		}));
 	}
 });
 
@@ -140,27 +152,18 @@ export const heartbeatAttached = mutation({
 		const userId = await getUserId(ctx);
 		const now = Date.now();
 		const requestedIds = new Set<Id<'projects'>>(args.projectIds);
-		const projects = await ctx.db
-			.query('projects')
-			.withIndex('by_userId', (query) => query.eq('userId', userId))
-			.collect();
-		const ownedProjectIds = new Set(projects.map((project) => project._id));
-		for (const projectId of requestedIds) {
-			if (!ownedProjectIds.has(projectId)) {
-				throw new Error('Project not found.');
-			}
-		}
-
-		const connections = await Promise.all(
-			projects.map((project) => getConnectionForProject(ctx, project._id))
+		// The requested set is small (the attached projects), so validate
+		// ownership per id instead of scanning every project the user has.
+		await Promise.all(
+			[...requestedIds].map(async (projectId) => {
+				const project = await ctx.db.get(projectId);
+				if (!project || project.userId !== userId) {
+					throw new Error('Project not found.');
+				}
+			})
 		);
-		const connectionByProjectId = new Map<Id<'projects'>, Doc<'projectConnections'>>();
-		for (const connection of connections) {
-			if (connection) {
-				connectionByProjectId.set(connection.projectId, connection);
-			}
-		}
 
+		const connectionByProjectId = await getConnectionsForUser(ctx, userId);
 		const detachedConnections = getDetachedConnections(
 			[...connectionByProjectId.values()],
 			args.clientId,

--- a/apps/web/src/convex/projects.ts
+++ b/apps/web/src/convex/projects.ts
@@ -1,13 +1,13 @@
-import { mutation, query, type MutationCtx } from '@convex/_generated/server';
-import { v } from 'convex/values';
+import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
+import { v, type Infer } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vProjectDoc, vProjectWithExecutorStatus } from '@convex/lib/docs';
 import {
-	getDetachedProjectIdsForClient,
-	shouldRefreshProjectHeartbeat,
-	withEffectiveProjectState
+	getDetachedConnectionProjectIds,
+	getEffectiveExecutorStatus,
+	shouldRefreshProjectHeartbeat
 } from '@convex/lib/projectConnection';
-import type { Doc } from '@convex/_generated/dataModel';
+import type { Doc, Id } from '@convex/_generated/dataModel';
 
 async function findProjectForRepository(
 	ctx: MutationCtx,
@@ -20,6 +20,36 @@ async function findProjectForRepository(
 			query.eq('userId', userId).eq('repositoryKey', repositoryKey)
 		)
 		.unique();
+}
+
+async function getConnectionForProject(
+	ctx: QueryCtx | MutationCtx,
+	projectId: Id<'projects'>
+): Promise<Doc<'projectConnections'> | null> {
+	return await ctx.db
+		.query('projectConnections')
+		.withIndex('by_projectId', (query) => query.eq('projectId', projectId))
+		.unique();
+}
+
+async function upsertConnection(
+	ctx: MutationCtx,
+	args: { projectId: Id<'projects'>; userId: string; clientId: string; now: number }
+) {
+	const existing = await getConnectionForProject(ctx, args.projectId);
+	if (existing) {
+		await ctx.db.patch(existing._id, {
+			clientId: args.clientId,
+			lastHeartbeatAt: args.now
+		});
+		return;
+	}
+	await ctx.db.insert('projectConnections', {
+		projectId: args.projectId,
+		userId: args.userId,
+		clientId: args.clientId,
+		lastHeartbeatAt: args.now
+	});
 }
 
 export const upsertSelected = mutation({
@@ -41,42 +71,61 @@ export const upsertSelected = mutation({
 		}
 
 		const now = Date.now();
-		const patch = {
-			repositoryKey,
-			displayName,
-			lastHeartbeatAt: now,
-			connectedClientId: args.connectedClientId,
-			lastSeenAt: now
-		};
-
 		const project = await findProjectForRepository(ctx, userId, repositoryKey);
 
 		if (project) {
-			await ctx.db.patch(project._id, patch);
+			await ctx.db.patch(project._id, { repositoryKey, displayName, lastSeenAt: now });
+			await upsertConnection(ctx, {
+				projectId: project._id,
+				userId,
+				clientId: args.connectedClientId,
+				now
+			});
 			return await ctx.db.get(project._id);
 		}
 
 		const id = await ctx.db.insert('projects', {
 			userId,
 			nextExecutorSequence: 0,
-			...patch
+			repositoryKey,
+			displayName,
+			lastSeenAt: now
 		});
+		await upsertConnection(ctx, { projectId: id, userId, clientId: args.connectedClientId, now });
 		return await ctx.db.get(id);
 	}
 });
 
 export const listMine = query({
-	args: {},
+	args: {
+		// Older clients omit this and keep receiving a live `executorStatus`
+		// (computed from `projectConnections`). Slim callers skip the join so
+		// heartbeats don't re-run their subscription.
+		slim: v.optional(v.boolean())
+	},
 	returns: v.array(vProjectWithExecutorStatus),
-	handler: async (ctx) => {
+	handler: async (ctx, args): Promise<Infer<typeof vProjectWithExecutorStatus>[]> => {
 		const userId = await getUserId(ctx);
+		// Order by creation, newest first: `by_userId` orders by userId then the
+		// system `_id` (which is creation-ordered). Stable across thread activity.
 		const projects = await ctx.db
 			.query('projects')
-			.withIndex('by_userId_lastSeenAt', (query) => query.eq('userId', userId))
+			.withIndex('by_userId', (query) => query.eq('userId', userId))
 			.order('desc')
 			.collect();
+		if (args.slim) {
+			return projects;
+		}
 		const now = Date.now();
-		return projects.map((project) => withEffectiveProjectState(project, now));
+		return await Promise.all(
+			projects.map(async (project) => ({
+				...project,
+				executorStatus: getEffectiveExecutorStatus(
+					await getConnectionForProject(ctx, project._id),
+					now
+				)
+			}))
+		);
 	}
 });
 
@@ -89,7 +138,7 @@ export const heartbeatAttached = mutation({
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		const now = Date.now();
-		const requestedIds = new Set(args.projectIds);
+		const requestedIds = new Set<Id<'projects'>>(args.projectIds);
 		const projects = await ctx.db
 			.query('projects')
 			.withIndex('by_userId', (query) => query.eq('userId', userId))
@@ -100,29 +149,45 @@ export const heartbeatAttached = mutation({
 				throw new Error('Project not found.');
 			}
 		}
-		const detachedProjectIds = getDetachedProjectIdsForClient(
-			projects,
-			args.clientId,
-			requestedIds
+
+		const connections = await Promise.all(
+			projects.map((project) => getConnectionForProject(ctx, project._id))
 		);
-		const detachedProjectIdSet = new Set(detachedProjectIds);
+		const connectionByProjectId = new Map<Id<'projects'>, Doc<'projectConnections'>>();
+		for (const connection of connections) {
+			if (connection) {
+				connectionByProjectId.set(connection.projectId, connection);
+			}
+		}
+
+		const detachedProjectIds = new Set(
+			getDetachedConnectionProjectIds(
+				[...connectionByProjectId.values()],
+				args.clientId,
+				requestedIds
+			)
+		);
 
 		await Promise.all(
 			projects.map(async (project) => {
 				if (requestedIds.has(project._id)) {
-					if (shouldRefreshProjectHeartbeat(project, args.clientId, now)) {
-						await ctx.db.patch(project._id, {
-							connectedClientId: args.clientId,
-							lastHeartbeatAt: now
+					const connection = connectionByProjectId.get(project._id) ?? null;
+					if (shouldRefreshProjectHeartbeat(connection, args.clientId, now)) {
+						await upsertConnection(ctx, {
+							projectId: project._id,
+							userId,
+							clientId: args.clientId,
+							now
 						});
 					}
 					return;
 				}
 
-				if (detachedProjectIdSet.has(project._id)) {
-					await ctx.db.patch(project._id, {
-						connectedClientId: undefined
-					});
+				if (detachedProjectIds.has(project._id)) {
+					const connection = connectionByProjectId.get(project._id);
+					if (connection) {
+						await ctx.db.delete(connection._id);
+					}
 				}
 			})
 		);

--- a/apps/web/src/convex/projects.ts
+++ b/apps/web/src/convex/projects.ts
@@ -3,7 +3,7 @@ import { v, type Infer } from 'convex/values';
 import { getUserId } from '@convex/lib/auth';
 import { vProjectDoc, vProjectWithExecutorStatus } from '@convex/lib/docs';
 import {
-	getDetachedConnectionProjectIds,
+	getDetachedConnections,
 	getEffectiveExecutorStatus,
 	shouldRefreshProjectHeartbeat
 } from '@convex/lib/projectConnection';
@@ -106,8 +106,9 @@ export const listMine = query({
 	returns: v.array(vProjectWithExecutorStatus),
 	handler: async (ctx, args): Promise<Infer<typeof vProjectWithExecutorStatus>[]> => {
 		const userId = await getUserId(ctx);
-		// Order by creation, newest first: `by_userId` orders by userId then the
-		// system `_id` (which is creation-ordered). Stable across thread activity.
+		// Order by creation, newest first: every Convex index implicitly ends
+		// with `_creationTime`, so `by_userId` is creation-ordered within a
+		// user. Stable across thread activity.
 		const projects = await ctx.db
 			.query('projects')
 			.withIndex('by_userId', (query) => query.eq('userId', userId))
@@ -160,37 +161,21 @@ export const heartbeatAttached = mutation({
 			}
 		}
 
-		const detachedProjectIds = new Set(
-			getDetachedConnectionProjectIds(
-				[...connectionByProjectId.values()],
-				args.clientId,
-				requestedIds
-			)
+		const detachedConnections = getDetachedConnections(
+			[...connectionByProjectId.values()],
+			args.clientId,
+			requestedIds
 		);
 
-		await Promise.all(
-			projects.map(async (project) => {
-				if (requestedIds.has(project._id)) {
-					const connection = connectionByProjectId.get(project._id) ?? null;
-					if (shouldRefreshProjectHeartbeat(connection, args.clientId, now)) {
-						await upsertConnection(ctx, {
-							projectId: project._id,
-							userId,
-							clientId: args.clientId,
-							now
-						});
-					}
-					return;
+		await Promise.all([
+			...[...requestedIds].map(async (projectId) => {
+				const connection = connectionByProjectId.get(projectId);
+				if (shouldRefreshProjectHeartbeat(connection, args.clientId, now)) {
+					await upsertConnection(ctx, { projectId, userId, clientId: args.clientId, now });
 				}
-
-				if (detachedProjectIds.has(project._id)) {
-					const connection = connectionByProjectId.get(project._id);
-					if (connection) {
-						await ctx.db.delete(connection._id);
-					}
-				}
-			})
-		);
+			}),
+			...detachedConnections.map((connection) => ctx.db.delete(connection._id))
+		]);
 
 		return true;
 	}

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -30,7 +30,6 @@ export default defineSchema({
 	uiPreferences: defineTable(uiPreferencesFields).index('by_userId', ['userId']),
 	projects: defineTable(projectFields)
 		.index('by_userId', ['userId'])
-		.index('by_userId_lastSeenAt', ['userId', 'lastSeenAt'])
 		.index('by_user_repositoryKey', ['userId', 'repositoryKey']),
 	// Executor liveness lives apart from `projects` so heartbeats don't
 	// invalidate `projects.listMine` subscriptions.

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -32,6 +32,14 @@ export default defineSchema({
 		.index('by_userId', ['userId'])
 		.index('by_userId_lastSeenAt', ['userId', 'lastSeenAt'])
 		.index('by_user_repositoryKey', ['userId', 'repositoryKey']),
+	// Executor liveness lives apart from `projects` so heartbeats don't
+	// invalidate `projects.listMine` subscriptions.
+	projectConnections: defineTable({
+		projectId: v.id('projects'),
+		userId: v.string(),
+		clientId: v.string(),
+		lastHeartbeatAt: v.number()
+	}).index('by_projectId', ['projectId']),
 	threadRecords: defineTable(threadRecordFields)
 		.index('by_userId_lastMessageAt', ['userId', 'lastMessageAt'])
 		.index('by_userId_submissionId', ['userId', 'submissionId']),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -38,7 +38,9 @@ export default defineSchema({
 		userId: v.string(),
 		clientId: v.string(),
 		lastHeartbeatAt: v.number()
-	}).index('by_projectId', ['projectId']),
+	})
+		.index('by_projectId', ['projectId'])
+		.index('by_userId', ['userId']),
 	threadRecords: defineTable(threadRecordFields)
 		.index('by_userId_lastMessageAt', ['userId', 'lastMessageAt'])
 		.index('by_userId_submissionId', ['userId', 'submissionId']),

--- a/apps/web/src/convex/threads.test.ts
+++ b/apps/web/src/convex/threads.test.ts
@@ -32,4 +32,32 @@ describe('threads.listMine ordering', () => {
 		const idleLastMessageAts = threads.slice(1).map((thread) => thread.lastMessageAt);
 		expect([...idleLastMessageAts].sort((a, b) => b - a)).toEqual(idleLastMessageAts);
 	});
+
+	it('keeps multiple running threads in lastMessageAt order among themselves', async () => {
+		const t = initConvexTest();
+		const { asUser, projectId } = await seedOwnedThread(t);
+
+		const makeThread = async (submissionId: string) =>
+			(
+				await asUser.mutation(api.threads.create, {
+					submissionId,
+					projectId,
+					selectedModel: 'gpt-5.6-sol',
+					reasoningEffort: 'medium',
+					serviceTier: 'standard'
+				})
+			).threadId;
+
+		// Two running threads created back to back; the newer one has the higher
+		// lastMessageAt and must lead the pinned group.
+		const runningOlder = await makeThread('thread-running-older');
+		const runningNewer = await makeThread('thread-running-newer');
+		await makeThread('thread-idle');
+		await createQueuedRun(asUser, runningOlder, 'run-older', 'sort-secret');
+		await createQueuedRun(asUser, runningNewer, 'run-newer', 'sort-secret');
+
+		const threads = await asUser.query(api.threads.listMine, {});
+		const runningIds = threads.filter((thread) => thread.hasActiveRun).map((t) => t.threadId);
+		expect(runningIds).toEqual([runningNewer, runningOlder]);
+	});
 });

--- a/apps/web/src/convex/threads.test.ts
+++ b/apps/web/src/convex/threads.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('threads.listMine ordering', () => {
+	it('puts threads with an active run first, then by lastMessageAt', async () => {
+		const t = initConvexTest();
+		const { asUser, projectId, threadId: seeded } = await seedOwnedThread(t);
+
+		const makeThread = async (submissionId: string) =>
+			(
+				await asUser.mutation(api.threads.create, {
+					submissionId,
+					projectId,
+					selectedModel: 'gpt-5.6-sol',
+					reasoningEffort: 'medium',
+					serviceTier: 'standard'
+				})
+			).threadId;
+
+		// Two extra idle threads, then a queued (active) run on the seeded thread.
+		// The seeded thread is the oldest by creation, so it would normally sort
+		// last among same-activity threads; the active run must promote it.
+		await makeThread('thread-idle-a');
+		await makeThread('thread-idle-b');
+		await createQueuedRun(asUser, seeded, 'thread-running-run', 'sort-secret');
+
+		const threads = await asUser.query(api.threads.listMine, {});
+		expect(threads[0]?.threadId).toBe(seeded);
+		expect(threads[0]?.hasActiveRun).toBe(true);
+		// The remaining threads are idle and ordered by lastMessageAt, newest first.
+		const idleLastMessageAts = threads.slice(1).map((thread) => thread.lastMessageAt);
+		expect([...idleLastMessageAts].sort((a, b) => b - a)).toEqual(idleLastMessageAts);
+	});
+});

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -110,7 +110,7 @@ export const listMine = query({
 			.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
 			.order('desc')
 			.collect();
-		return await Promise.all(
+		const summaries = await Promise.all(
 			records.map(async (record) => {
 				const latestRun = await ctx.db
 					.query('runs')
@@ -131,6 +131,10 @@ export const listMine = query({
 				};
 			})
 		);
+		// Running threads first, then most recently active. The index already
+		// returns lastMessageAt-desc, so the comparator only needs to promote
+		// active runs while staying stable for the rest.
+		return summaries.sort((left, right) => Number(right.hasActiveRun) - Number(left.hasActiveRun));
 	}
 });
 

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -17,6 +17,10 @@ export const getMine = query({
 	}
 });
 
+// Deprecated: kept for older released clients, which call it on every thread
+// switch and read `lastThreadId` for session restore. The current client does
+// neither, so it is effectively a no-op for new sessions. Remove with the
+// `lastThreadId` field once those clients age out.
 export const setLastThread = mutation({
 	args: {
 		threadId: v.id('threadRecords')

--- a/apps/web/src/lib/project/threads.test.ts
+++ b/apps/web/src/lib/project/threads.test.ts
@@ -35,10 +35,6 @@ function makeProject(overrides: Partial<Project> = {}): Project {
 		userId: 'user-1',
 		repositoryKey: overrides.repositoryKey ?? overrides.displayName ?? 'Project',
 		displayName: 'Project',
-		executorStatus: 'disconnected',
-		lastHeartbeatAt: undefined,
-		connectedClientId: undefined,
-		lastSeenAt: 0,
 		...overrides
 	};
 }
@@ -116,6 +112,28 @@ describe('project thread helpers', () => {
 		expect(groups.find((group) => group.project._id === 'ws-stale')?.project.displayName).toBe(
 			'Unknown project'
 		);
+	});
+
+	it('keeps projects in their given order regardless of thread activity', () => {
+		const groups = getProjectThreadGroups(
+			[
+				makeProject({ _id: 'ws-older' as Project['_id'], displayName: 'older' }),
+				makeProject({ _id: 'ws-newer' as Project['_id'], displayName: 'newer' })
+			],
+			[
+				// Heavy recent activity on the older project must not reorder it.
+				makeThreadSummary({
+					projectId: 'ws-older' as ThreadSummary['projectId'],
+					lastMessageAt: 100
+				}),
+				makeThreadSummary({
+					projectId: 'ws-newer' as ThreadSummary['projectId'],
+					lastMessageAt: 1
+				})
+			]
+		);
+
+		expect(groups.map((group) => group.project._id)).toEqual(['ws-older', 'ws-newer']);
 	});
 
 	it('excludes archived threads from project groups', () => {

--- a/apps/web/src/lib/project/threads.test.ts
+++ b/apps/web/src/lib/project/threads.test.ts
@@ -8,6 +8,7 @@ import {
 	isActiveThread,
 	isAgentLaunchPending,
 	isLatestRunReadyForThread,
+	pickThreadToRestore,
 	resolveExpiredAgentLaunch,
 	resolvePendingAgentLaunch,
 	resolvePendingAgentLaunchesFromThreads,
@@ -134,6 +135,30 @@ describe('project thread helpers', () => {
 		);
 
 		expect(groups.map((group) => group.project._id)).toEqual(['ws-older', 'ws-newer']);
+	});
+
+	it('restores the most recently active thread, ignoring run state', () => {
+		const runningOlder = makeThreadSummary({
+			threadId: 'thread-record-running' as ThreadSummary['threadId'],
+			lastMessageAt: 10,
+			hasActiveRun: true
+		});
+		const idleNewer = makeThreadSummary({
+			threadId: 'thread-record-idle' as ThreadSummary['threadId'],
+			lastMessageAt: 20
+		});
+		const archivedNewest = makeThreadSummary({
+			threadId: 'thread-record-archived' as ThreadSummary['threadId'],
+			lastMessageAt: 30,
+			threadStatus: 'archived'
+		});
+
+		// Running-first listMine order must not leak into session restore.
+		expect(pickThreadToRestore([runningOlder, idleNewer, archivedNewest])?.threadId).toBe(
+			'thread-record-idle'
+		);
+		expect(pickThreadToRestore([archivedNewest])).toBeNull();
+		expect(pickThreadToRestore([])).toBeNull();
 	});
 
 	it('excludes archived threads from project groups', () => {

--- a/apps/web/src/lib/project/threads.ts
+++ b/apps/web/src/lib/project/threads.ts
@@ -107,6 +107,24 @@ export function findThreadById(
 	return threads.find((thread) => thread.threadId === threadId) ?? null;
 }
 
+/**
+ * Session-restore target: the non-archived thread the user most recently
+ * prompted or got a response in. Deliberately ignores run state — a
+ * background run in another project should not hijack the session on load.
+ */
+export function pickThreadToRestore(threads: ThreadSummary[]): ThreadSummary | null {
+	let latest: ThreadSummary | null = null;
+	for (const thread of threads) {
+		if (!isActiveThread(thread)) {
+			continue;
+		}
+		if (!latest || thread.lastMessageAt > latest.lastMessageAt) {
+			latest = thread;
+		}
+	}
+	return latest;
+}
+
 export function dataForThread<
 	T extends { threadId?: Id<'threadRecords'>; _id?: Id<'threadRecords'> }
 >(data: T | null | undefined, threadId: Id<'threadRecords'> | null): T | null {

--- a/apps/web/src/lib/project/threads.ts
+++ b/apps/web/src/lib/project/threads.ts
@@ -40,8 +40,6 @@ function unknownProject(projectId: Id<'projects'>): Project {
 		userId: '',
 		repositoryKey: 'unknown',
 		displayName: 'Unknown project',
-		executorStatus: 'disconnected',
-		lastSeenAt: 0,
 		localAttachmentAvailability: 'unlinked'
 	};
 }
@@ -51,10 +49,6 @@ function buildProjectThreadGroup(project: Project, threads: ThreadSummary[]): Pr
 	return {
 		project,
 		threads: sortedThreads,
-		latestThreadAt: sortedThreads.reduce(
-			(latest, thread) => Math.max(latest, thread.lastMessageAt),
-			0
-		),
 		activeThreadCount: countActiveThreads(sortedThreads)
 	};
 }
@@ -82,15 +76,10 @@ export function getProjectThreadGroups(projects: Project[], threads: ThreadSumma
 		groups.push(buildProjectThreadGroup(unknownProject(projectId), projectThreads));
 	}
 
-	return groups.sort((left, right) => {
-		const leftSortKey = left.latestThreadAt || left.project.lastSeenAt;
-		const rightSortKey = right.latestThreadAt || right.project.lastSeenAt;
-		if (rightSortKey !== leftSortKey) {
-			return rightSortKey - leftSortKey;
-		}
-
-		return left.project.displayName.localeCompare(right.project.displayName);
-	});
+	// Preserve the project order supplied by `projects.listMine` (creation,
+	// newest first). Thread activity reorders threads within a project, never
+	// the projects themselves.
+	return groups;
 }
 
 function sortThreadsRunningFirst(threads: ThreadSummary[]) {

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -35,8 +35,8 @@ export type Project = {
 	// on pre-migration project rows. Nothing in the current UI consumes them.
 	lastHeartbeatAt?: number;
 	connectedClientId?: string;
-	// Deprecated: still returned by `projects.listMine` for older clients, but
-	// no longer drives ordering.
+	// Still bumped on every project open; older released clients use it to
+	// order their sidebar. The current UI orders projects by creation instead.
 	lastSeenAt?: number;
 	localAttachmentAvailability?: LocalAttachmentAvailability;
 	localAttachmentError?: string;

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -31,6 +31,8 @@ export type Project = {
 	// Deprecated: only returned by `projects.listMine` for older clients that
 	// don't pass `slim: true`. Nothing in the current UI consumes it.
 	executorStatus?: Infer<typeof vExecutorStatus>;
+	// Deprecated: executor liveness moved to `projectConnections`; only present
+	// on pre-migration project rows. Nothing in the current UI consumes them.
 	lastHeartbeatAt?: number;
 	connectedClientId?: string;
 	// Deprecated: still returned by `projects.listMine` for older clients, but

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -29,7 +29,8 @@ export type Project = {
 	displayName: string;
 	workspacePath?: string;
 	// Deprecated: only returned by `projects.listMine` for older clients that
-	// don't pass `slim: true`. Nothing in the current UI consumes it.
+	// don't pass `includeExecutorStatus: false`. Nothing in the current UI
+	// consumes it.
 	executorStatus?: Infer<typeof vExecutorStatus>;
 	// Deprecated: executor liveness moved to `projectConnections`; only present
 	// on pre-migration project rows. Nothing in the current UI consumes them.

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -28,10 +28,14 @@ export type Project = {
 	repositoryKey: string;
 	displayName: string;
 	workspacePath?: string;
-	executorStatus: Infer<typeof vExecutorStatus>;
+	// Deprecated: only returned by `projects.listMine` for older clients that
+	// don't pass `slim: true`. Nothing in the current UI consumes it.
+	executorStatus?: Infer<typeof vExecutorStatus>;
 	lastHeartbeatAt?: number;
 	connectedClientId?: string;
-	lastSeenAt: number;
+	// Deprecated: still returned by `projects.listMine` for older clients, but
+	// no longer drives ordering.
+	lastSeenAt?: number;
 	localAttachmentAvailability?: LocalAttachmentAvailability;
 	localAttachmentError?: string;
 };
@@ -55,7 +59,6 @@ export type ThreadSummary = {
 export type ProjectThreadGroup = {
 	project: Project;
 	threads: ThreadSummary[];
-	latestThreadAt: number;
 	activeThreadCount: number;
 };
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -73,6 +73,7 @@
 		isActiveThread,
 		isAgentLaunchPending,
 		isLatestRunReadyForThread,
+		pickThreadToRestore,
 		resolveExpiredAgentLaunch,
 		resolvePendingAgentLaunch,
 		resolvePendingAgentLaunchesFromThreads,
@@ -375,7 +376,7 @@
 	}
 
 	const projectsQuery = useQuery(api.projects.listMine, () =>
-		getAuthenticatedQueryArgs() === 'skip' ? 'skip' : { slim: true }
+		getAuthenticatedQueryArgs() === 'skip' ? 'skip' : { includeExecutorStatus: false }
 	);
 	const threadsQuery = useQuery(api.threads.listMine, getAuthenticatedQueryArgs);
 	const uiPreferencesQuery = useQuery(api.uiPreferences.getMine, getAuthenticatedQueryArgs);
@@ -1776,9 +1777,7 @@
 		}
 
 		hasResolvedInitialSelection = true;
-		// Resume the most recently active thread; threads.listMine already orders
-		// running-first then by lastMessageAt.
-		const restoredThread = threads.find(isActiveThread);
+		const restoredThread = pickThreadToRestore(threads);
 		if (restoredThread) {
 			const restoredProject = findProjectById(projects, restoredThread.projectId);
 			if (restoredProject) {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -139,7 +139,6 @@
 	const restoreThreadMutation = useMutation(api.threads.restore);
 	const finalizeRun = useMutation(api.agentRuntime.finalizeRun);
 	const answerAgentQuestion = useMutation(api.agentQuestions.answer);
-	const setLastThread = useMutation(api.uiPreferences.setLastThread);
 	const setThemePreference = useMutation(api.uiPreferences.setTheme);
 	const generateImageUploadUrl = useMutation(api.imageUploads.generateUploadUrl);
 	const registerImageUpload = useMutation(api.imageUploads.register);
@@ -225,7 +224,6 @@
 	let nextSubmissionSequence = 0;
 	let hasResolvedInitialSelection = $state(false);
 	let restoredProjectIdToAttach = $state<Id<'projects'> | null>(null);
-	let lastSavedThreadId = $state<Id<'threadRecords'> | null>(null);
 	let lastSyncedComposerThreadId: Id<'threadRecords'> | null = null;
 	let projectSelectionGeneration = $state(0);
 	let pendingCreatedThreadId = $state<Id<'threadRecords'> | null>(null);
@@ -376,7 +374,9 @@
 		return $authState.user && convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip';
 	}
 
-	const projectsQuery = useQuery(api.projects.listMine, getAuthenticatedQueryArgs);
+	const projectsQuery = useQuery(api.projects.listMine, () =>
+		getAuthenticatedQueryArgs() === 'skip' ? 'skip' : { slim: true }
+	);
 	const threadsQuery = useQuery(api.threads.listMine, getAuthenticatedQueryArgs);
 	const uiPreferencesQuery = useQuery(api.uiPreferences.getMine, getAuthenticatedQueryArgs);
 	let workspaceTheme = $state<SprocketTheme>(resolveTheme(null));
@@ -1111,9 +1111,6 @@
 					pendingCreatedThreadId = null;
 					projectSelectionGeneration += 1;
 				}
-				if (lastSavedThreadId === threadId) {
-					lastSavedThreadId = null;
-				}
 				currentError = null;
 			}
 		} catch (error) {
@@ -1640,7 +1637,6 @@
 		pendingCreatedThreadId = null;
 		pendingAgentLaunches = {};
 		restoredProjectIdToAttach = null;
-		lastSavedThreadId = null;
 		ensureSubscriptionAttemptedFor = null;
 		lastSyncedComposerThreadId = null;
 		projectSelectionGeneration += 1;
@@ -1766,7 +1762,6 @@
 	});
 
 	$effect(() => {
-		const uiPreferences = uiPreferencesQuery.data;
 		if (
 			hasResolvedInitialSelection ||
 			!initialProjectLaunchResolved ||
@@ -1776,18 +1771,19 @@
 			return;
 		}
 
-		if (!projectsQuery.data || !threadsQuery.data || uiPreferences === undefined) {
+		if (!projectsQuery.data || !threadsQuery.data) {
 			return;
 		}
 
 		hasResolvedInitialSelection = true;
-		const restoredThread = findThreadById(threads, uiPreferences?.lastThreadId ?? null);
-		if (restoredThread && isActiveThread(restoredThread)) {
+		// Resume the most recently active thread; threads.listMine already orders
+		// running-first then by lastMessageAt.
+		const restoredThread = threads.find(isActiveThread);
+		if (restoredThread) {
 			const restoredProject = findProjectById(projects, restoredThread.projectId);
 			if (restoredProject) {
 				setProjectSelection(restoredProject.repositoryKey, restoredThread.threadId, false, true);
 				restoredProjectIdToAttach = restoredProject._id;
-				lastSavedThreadId = restoredThread.threadId;
 				return;
 			}
 		}
@@ -1854,19 +1850,6 @@
 			draftRepositoryKey === currentRepositoryKey,
 			true
 		);
-	});
-
-	$effect(() => {
-		if (!hasResolvedInitialSelection || !currentThreadId) {
-			return;
-		}
-
-		if (currentThreadId === lastSavedThreadId) {
-			return;
-		}
-
-		lastSavedThreadId = currentThreadId;
-		void setLastThread({ threadId: currentThreadId });
 	});
 
 	$effect(() => {


### PR DESCRIPTION
## What this does

Cuts Convex function-call volume at the root of the biggest fan-out, and lands two sidebar-ordering behavior changes.

**1. Decouple executor heartbeats from `projects.listMine`** (the 132K `heartbeatAttached` / 107K `listMine` loop)
- Executor liveness (`connectedClientId`/`lastHeartbeatAt`) moved from `projects` to a new `projectConnections` table (indexed `by_projectId` and `by_userId`). `upsertSelected` and `heartbeatAttached` write there; detach deletes the row.
- Root cause worth knowing: the heartbeat effect was keyed on `projectsQuery.data`, so every heartbeat write invalidated `listMine`, which refired the effect, which sent another heartbeat immediately. The measured cadence was this loop, not the 90s throttle.
- `projects.listMine` gains `includeExecutorStatus` (omitted = `true`): callers passing `false` skip the `projectConnections` read entirely, so heartbeats never re-run their subscription. The home page passes `false` (nothing in the current UI renders executor status).

**2. Ordering changes**
- `projects.listMine` now orders by creation, newest first (via `by_userId`, whose index implicitly ends in `_creationTime`). Thread activity no longer reshuffles projects. Pins/drag-and-drop ordering come later.
- `threads.listMine` sorts running-first, then `lastMessageAt` desc — a single stable comparator over the existing `by_userId_lastMessageAt` index. `lastMessageAt` only moves on prompt/completed response, never on tool calls or stream chunks.
- `getProjectThreadGroups` preserves the backend's project order instead of re-sorting by thread activity (running-first within a project is unchanged).

**3. Session restore without `setLastThread`**
- The home page no longer writes `uiPreferences.lastThreadId` on every thread switch — a write that invalidated every `getMine` subscriber (101K).
- Restore picks the non-archived thread with the latest `lastMessageAt` via `pickThreadToRestore` — deliberately *not* running-first, so a background run in another project doesn't hijack reload.
- `setLastThread` and the `lastThreadId` field remain as deprecated compat: older released clients call the mutation on every switch and read the field for restore. Both become no-ops as clients update.

## Backward compatibility

- Older clients calling `listMine` with no args get the exact same shape: a live `executorStatus` (computed from `projectConnections`, falling back to the project's pre-split liveness fields until the first heartbeat creates a connection row) plus the optional legacy fields, which Convex still validates from existing rows.
- `heartbeatAttached`/`upsertSelected`/`setLastThread` accept the same args as before.
- Deploy note: `projectConnections` starts empty, so legacy clients may briefly compute `disconnected` until their next heartbeat (≤90s). Nothing renders that status, and the legacy-field fallback covers most rows anyway.

## Cleanup after the migration completes

Once older released clients have aged out (they're the only callers of these), in any order:

1. `uiPreferences.setLastThread` mutation and the `uiPreferencesFields.lastThreadId` field (`convex/uiPreferences.ts:20`, `convex/lib/docs.ts:126`). The field is optional; existing rows keep validating after removal.
2. `projects.listMine`'s `includeExecutorStatus` arg and the legacy branch (`convex/projects.ts:110-129`): drop the arg, return `vProjectDoc[]` directly, and delete `vProjectListItem` (`convex/lib/docs.ts:244`).
3. Legacy liveness fields on `projects`: `lastHeartbeatAt`/`connectedClientId` in `projectFields` (`convex/lib/docs.ts:31-36`) and the `legacyConnectionFromProject` fallback (`convex/lib/projectConnection.ts:13`). A one-off backfill to unset the stale fields on existing rows lets the validator shrink sooner.
4. `projects.lastSeenAt`: still written by `upsertSelected` for old clients' sidebar ordering; stop writing it and make the field optional before dropping.
5. Client-side: `Project.executorStatus`/`lastHeartbeatAt`/`connectedClientId`/`lastSeenAt` in `lib/types/sprocket.ts` become removable with the backend fields.

## Deferred

- Per-thread subscription consolidation (merging `listLiveForThread`/`latestRunForThread`/`artifacts`/`browserSessions`/`agentQuestions` into fewer queries): evaluated and skipped — Convex caches unchanged queries, and a mega-query would re-execute history hydration on every streaming chunk during active runs. The real fan-out was the heartbeat loop.

## Validation

- `vitest --run`: 248 passed (incl. new tests for creation ordering, heartbeat liveness via `projectConnections`, `includeExecutorStatus` shapes, running-first ordering stability, restore targeting)
- `convex typecheck`, `svelte-check`, `bun run build`, `prek run -a` — all clean
- Cleanup + 2 independent code reviews (overall correctness, API/UX) done pre-PR; findings addressed in `fix(convex): Address review — connection scans, restore target, arg naming`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change moves executor heartbeat state into dedicated connection records, so routine liveness updates no longer modify project records. It also keeps projects ordered by creation time, keeps running threads at the top without losing recency ordering within each state, and restores the newest non-archived conversation.

Executable checks confirmed that attach and detach operations leave project documents unchanged, modify only connection records, and reject a project ID belonging to another account without side effects. Session restoration selected the newer active thread over an older running thread and ignored a newer archived thread. No defects remain in the validated behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on focused persistence, authorization, restoration, ordering, and type-check coverage.

Focused executable checks exercised heartbeat attachment, detachment, account ownership rejection, session restoration, project ordering, thread ordering, and project grouping. The affected helper suite and application checks completed successfully.

**Files Needing Attention:** No additional files need attention; the validated areas were projects.ts, projectConnection.ts, threads.ts, project thread helpers, and the home route.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a Convex integration test against the parent implementation and then re-ran the test across attached, detached, and cross-account paths; project documents remained unchanged, connection rows were updated or deleted as appropriate, and a foreign project ID was rejected without side effects.
- Ran a focused Vitest restoration case and confirmed restoration follows the latest non-archived message activity, with the adjacent project-thread helper suite also passing.
- PR-head heartbeat isolation test passed after validating project immutability and the expected attach/delete behavior, using the authored Convex test as the verification source.
- The focused capture tests progressed from an initial misbehavior restoring first-active status to a passing focused restore-selection test, and the exact executable test source is included among the artifacts.

<a href="https://app.greptile.com/trex/runs/19397302/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(convex): Stop pinning legacy compat..."](https://github.com/spikonado/sprocket/commit/b7fe291c1a40cdfd3a2dbc8f29b5e048df5b77c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54353258)</sub>

<!-- /greptile_comment -->