### PR TITLE
fix(agent): Drop orphaned OpenAI item references

### DIFF
--- a/apps/web/src/convex/lib/agentHistory.test.ts
+++ b/apps/web/src/convex/lib/agentHistory.test.ts
@@ -227,14 +227,14 @@ describe('canonical agent history', () => {
 		]);
 	});
 
-	it('preserves assistant text provider metadata in the canonical wire format', () => {
+	it('strips an orphaned OpenAI message reference from canonical history', () => {
 		const history = buildAgentHistoryFromAssistantParts({
 			parts: [
 				{
 					type: 'text',
 					id: 'text-1',
 					text: 'Hello',
-					providerMetadata: { openai: { itemId: 'msg_123' } }
+					providerMetadata: { openai: { itemId: 'msg_123', phase: 'final_answer' } }
 				}
 			],
 			jobs: [],
@@ -248,7 +248,7 @@ describe('canonical agent history', () => {
 					{
 						type: 'text',
 						text: 'Hello',
-						additionalParamsJson: JSON.stringify({ openai: { itemId: 'msg_123' } })
+						additionalParamsJson: JSON.stringify({ openai: { phase: 'final_answer' } })
 					}
 				]
 			}

--- a/apps/web/src/convex/lib/agentHistory.ts
+++ b/apps/web/src/convex/lib/agentHistory.ts
@@ -22,6 +22,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 				id?: string;
 				assistant: AgentHistoryMessage['contents'];
 				results: AgentHistoryMessage['contents'];
+				hasOpenAiReasoningReference: boolean;
 		  }
 		| undefined;
 	let sawAssistantText = false;
@@ -45,7 +46,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 
 	for (const part of parts) {
 		if (part.type === 'tool-result') {
-			turn ??= { assistant: [], results: [] };
+			turn ??= { assistant: [], results: [], hasOpenAiReasoningReference: false };
 			turn.results.push({
 				type: 'toolResult',
 				id: part.callId,
@@ -78,7 +79,8 @@ export function buildAgentHistoryFromAssistantParts(args: {
 		turn ??= {
 			...(partTurnId !== undefined ? { id: partTurnId } : {}),
 			assistant: [],
-			results: []
+			results: [],
+			hasOpenAiReasoningReference: false
 		};
 
 		if (part.type === 'text') {
@@ -89,7 +91,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 			sawAssistantText = true;
 			const providerMetadata = providerMetadataForReplay(
 				part.providerMetadata,
-				args.stripProviderItemReferences
+				args.stripProviderItemReferences || !turn.hasOpenAiReasoningReference
 			);
 			turn.assistant.push({
 				type: 'text',
@@ -121,6 +123,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 					...(itemId !== undefined ? { id: itemId } : {}),
 					blocksJson: JSON.stringify(blocks)
 				});
+				if (itemId?.startsWith('rs_')) turn.hasOpenAiReasoningReference = true;
 			}
 			continue;
 		}
@@ -128,7 +131,7 @@ export function buildAgentHistoryFromAssistantParts(args: {
 		if (part.type === 'tool-call') {
 			const providerMetadata = providerMetadataForReplay(
 				part.providerMetadata,
-				args.stripProviderItemReferences
+				args.stripProviderItemReferences || !turn.hasOpenAiReasoningReference
 			);
 			turn.assistant.push({
 				type: 'toolCall',

--- a/crates/sprocket-convex-provider/src/messages.rs
+++ b/crates/sprocket-convex-provider/src/messages.rs
@@ -83,6 +83,7 @@ pub fn completion_messages_json<'a>(
             }
             Message::Assistant { content, .. } => {
                 let mut parts: Vec<serde_json::Value> = Vec::new();
+                let mut has_openai_reasoning_reference = false;
                 for item in content.iter() {
                     match item {
                         AssistantContent::Text(text) => {
@@ -92,6 +93,9 @@ pub fn completion_messages_json<'a>(
                             });
                             if let Some(provider_options) = &text.additional_params {
                                 part["providerOptions"] = provider_options.clone().into_value();
+                            }
+                            if !has_openai_reasoning_reference {
+                                strip_openai_item_reference(&mut part);
                             }
                             parts.push(part);
                         }
@@ -106,6 +110,9 @@ pub fn completion_messages_json<'a>(
                             let mut openai = serde_json::Map::new();
                             if let Some(id) = &reasoning.id {
                                 openai.insert("itemId".to_string(), id.clone().into());
+                                if id.starts_with("rs_") {
+                                    has_openai_reasoning_reference = true;
+                                }
                             }
                             if let Some(encrypted) = encrypted {
                                 openai.insert(
@@ -139,6 +146,9 @@ pub fn completion_messages_json<'a>(
                             if let Some(provider_options) = &tool_call.additional_params {
                                 part["providerOptions"] = provider_options.clone();
                             }
+                            if !has_openai_reasoning_reference {
+                                strip_openai_item_reference(&mut part);
+                            }
                             parts.push(part);
                         }
                         _ => {
@@ -160,6 +170,31 @@ pub fn completion_messages_json<'a>(
     }
 
     Ok(serde_json::Value::Array(messages))
+}
+
+fn strip_openai_item_reference(part: &mut serde_json::Value) {
+    let Some(provider_options) = part
+        .get_mut("providerOptions")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    let Some(openai) = provider_options
+        .get_mut("openai")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    openai.remove("itemId");
+    if openai.is_empty() {
+        provider_options.remove("openai");
+    }
+    if provider_options.is_empty() {
+        part.as_object_mut()
+            .expect("model message part")
+            .remove("providerOptions");
+    }
 }
 
 fn tool_result_name<'a>(
@@ -250,7 +285,10 @@ pub(crate) fn instructions_text(request: &CompletionRequest) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use rig::completion::{CompletionRequest, Message};
-    use rig::message::{AdditionalParams, AssistantContent, ImageMediaType, Text, UserContent};
+    use rig::message::{
+        AdditionalParams, AssistantContent, ImageMediaType, Reasoning, ReasoningContent, Text,
+        UserContent,
+    };
 
     use super::{build_model_messages, instructions_text, normalize_convex_json_numbers};
 
@@ -369,14 +407,14 @@ mod tests {
     }
 
     #[test]
-    fn preserves_assistant_text_provider_options() {
+    fn strips_orphaned_openai_item_reference_from_assistant_text() {
         let messages = vec![Message::Assistant {
             id: None,
             content: vec![AssistantContent::Text(Text {
                 text: "Grounded answer".to_string(),
                 additional_params: AdditionalParams::from_entries([(
                     "openai",
-                    serde_json::json!({ "itemId": "msg_123" }),
+                    serde_json::json!({ "itemId": "msg_123", "phase": "final_answer" }),
                 )]),
             })],
         }];
@@ -385,7 +423,48 @@ mod tests {
 
         assert_eq!(
             structured[0]["content"][0]["providerOptions"],
-            serde_json::json!({ "openai": { "itemId": "msg_123" } })
+            serde_json::json!({ "openai": { "phase": "final_answer" } })
+        );
+    }
+
+    #[test]
+    fn preserves_openai_item_reference_after_reasoning_reference() {
+        let messages = vec![Message::Assistant {
+            id: None,
+            content: vec![
+                AssistantContent::Reasoning(Reasoning {
+                    id: Some("rs_123".to_string()),
+                    content: vec![ReasoningContent::Text {
+                        text: String::new(),
+                        signature: None,
+                    }],
+                }),
+                AssistantContent::Text(Text {
+                    text: "Grounded answer".to_string(),
+                    additional_params: AdditionalParams::from_entries([(
+                        "openai",
+                        serde_json::json!({ "itemId": "msg_123" }),
+                    )]),
+                }),
+            ],
+        }];
+
+        let structured = build_model_messages(&completion_request(messages)).expect("structured");
+
+        assert_eq!(
+            structured[0]["content"],
+            serde_json::json!([
+                {
+                    "type": "reasoning",
+                    "text": "",
+                    "providerOptions": { "openai": { "itemId": "rs_123" } }
+                },
+                {
+                    "type": "text",
+                    "text": "Grounded answer",
+                    "providerOptions": { "openai": { "itemId": "msg_123" } }
+                }
+            ])
         );
     }
 


### PR DESCRIPTION
## What changed

- drop OpenAI `msg_*` and tool item references when the assistant turn has no preceding `rs_*` reasoning reference
- keep valid reasoning and dependent item references in their original order
- apply the check when rebuilding canonical history and again when serializing Rig messages
- preserve unrelated provider metadata and leave other providers untouched

## Why

The OpenAI Responses API rejects a stored message reference when its required reasoning item is missing. AI SDK converts any stored `providerOptions.openai.itemId` into an item reference, but it cannot tell whether our persisted history dropped the earlier reasoning item. The serializer now removes only the orphaned OpenAI reference instead of sending a request that OpenAI will reject.

## Checks

- `nix develop -c bash -lc 'cd apps/web && bun run test -- src/convex/lib/agentHistory.test.ts src/convex/lib/completionStream.test.ts'`
- `nix develop -c cargo test -p sprocket-convex-provider messages::tests`
- `nix develop -c bash -lc 'cargo fmt --check && cargo test -p sprocket-convex-provider'`
- `nix develop -c bash -lc 'cd apps/web && bunx eslint src/convex/lib/agentHistory.ts src/convex/lib/agentHistory.test.ts'`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents orphaned OpenAI item references from being replayed while preserving references backed by preceding reasoning items and retaining unrelated provider metadata.
- Tracks OpenAI reasoning references independently within each assistant turn.
- Sanitizes canonical Convex history and Rust-side Rig message serialization.
- Adds focused TypeScript and Rust coverage for orphaned and valid reference handling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The changed TypeScript and Rust paths consistently remove OpenAI item IDs only before an `rs_*` reasoning reference is present in the current assistant turn, preserve unrelated metadata, and leave other provider metadata untouched.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/agentHistory.ts | Adds per-turn reasoning-reference tracking and selectively removes orphaned OpenAI item IDs while preserving other metadata. |
| crates/sprocket-convex-provider/src/messages.rs | Mirrors the orphan-reference filtering when serializing Rig assistant messages and retains valid ordered references. |
| apps/web/src/convex/lib/agentHistory.test.ts | Updates canonical-history coverage to verify orphan removal, metadata preservation, and valid reasoning-backed replay. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P[Persisted assistant parts] --> C[Canonical history builder]
  C --> R[Rig assistant message]
  R --> S[Convex provider serializer]
  S --> Q{Preceding OpenAI rs_* reference?}
  Q -- Yes --> K[Keep dependent itemId]
  Q -- No --> D[Drop itemId and preserve other metadata]
  K --> O[OpenAI completion request]
  D --> O
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Drop orphaned OpenAI item re..."](https://github.com/spikonado/sprocket/commit/6339bf6b76bea71dd949b0fbffd9f9d09d32f310) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54733580)</sub>

**Context used:**

- Knowledge Base — [Convex Backend](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-backend.md)
- Knowledge Base — [sprocket-convex-provider](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/sprocket-convex-provider.md)

<!-- /greptile_comment -->