### PR TITLE
fix(agent): Retry transient completion failures and clarify provider errors

### DIFF
--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -162,8 +162,95 @@ describe('agentRuntime.createRun', () => {
 				text: 'Run failed before the model started.',
 				lastError: 'startup timed out'
 			})
-		).resolves.toBe(true);
+		).resolves.toBe('finalized');
 		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('failed');
+	});
+
+	it('reports pending while the submission has no run yet', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeFailedStart, {
+				submissionId: 'sub-not-created-yet',
+				threadId,
+				prompt: 'Reconcile me',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				executionSecret: 'some-secret',
+				text: 'Run failed before the model started.',
+				lastError: 'startup timed out'
+			})
+		).resolves.toBe('pending');
+	});
+
+	it('tells the losing launch of a racing submission to stand down', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const args = {
+			submissionId: 'sub-raced',
+			threadId,
+			prompt: 'Two launches, one submission',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+		const created = await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret: 'loser-secret'
+		});
+		// The winning launch resumes the submission and rebinds its capability.
+		await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret: 'winner-secret'
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeFailedStart, {
+				...args,
+				executionSecret: 'loser-secret',
+				text: 'Run failed before the model started.',
+				lastError: 'lost the launch race'
+			})
+		).resolves.toBe('observed');
+		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('queued');
+	});
+
+	it('leaves a claimed run to its executor', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'claimed-secret';
+		const args = {
+			submissionId: 'sub-claimed',
+			threadId,
+			prompt: 'Already running',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+		const created = await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret
+		});
+		await t.mutation(api.agentRuntime.start, {
+			runId: created.runId,
+			claimId: 'claim-claimed',
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeFailedStart, {
+				...args,
+				executionSecret,
+				text: 'Run failed before the model started.',
+				lastError: 'late cleanup'
+			})
+		).resolves.toBe('observed');
+		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('running');
 	});
 
 	it('rejects a second run while the thread has an active run', async () => {

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -186,6 +186,40 @@ describe('agentRuntime.createRun', () => {
 		).resolves.toBe('pending');
 	});
 
+	it('reports pending for a rebound secret when the caller identity is gone', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const args = {
+			submissionId: 'sub-rebound-anonymous',
+			threadId,
+			prompt: 'Two launches, one submission',
+			imageUploadIds: [] as Id<'imageUploads'>[],
+			selectedModel: 'gpt-5.6-sol' as const,
+			reasoningEffort: 'medium' as const,
+			serviceTier: 'standard' as const
+		};
+		await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret: 'loser-secret'
+		});
+		await asUser.mutation(api.agentRuntime.createRun, {
+			...args,
+			executionSecret: 'winner-secret'
+		});
+
+		// Without an identity the mutation cannot tell a rebound run from a
+		// missing one. The executor avoids this path by standing down on the
+		// createRun conflict error instead.
+		await expect(
+			t.mutation(api.agentRuntime.finalizeFailedStart, {
+				...args,
+				executionSecret: 'loser-secret',
+				text: 'Run failed before the model started.',
+				lastError: 'lost the launch race'
+			})
+		).resolves.toBe('pending');
+	});
+
 	it('tells the losing launch of a racing submission to stand down', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
@@ -215,7 +249,7 @@ describe('agentRuntime.createRun', () => {
 				text: 'Run failed before the model started.',
 				lastError: 'lost the launch race'
 			})
-		).resolves.toBe('observed');
+		).resolves.toBe('standDown');
 		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('queued');
 	});
 
@@ -249,8 +283,34 @@ describe('agentRuntime.createRun', () => {
 				text: 'Run failed before the model started.',
 				lastError: 'late cleanup'
 			})
-		).resolves.toBe('observed');
+		).resolves.toBe('standDown');
 		expect(await t.run(async (ctx) => (await ctx.db.get(created.runId))?.status)).toBe('running');
+	});
+
+	it('keeps the submission conflict message readable for the losing launch', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const created = await createQueuedRun(asUser, threadId, 'sub-owned', 'owner-secret');
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-owner',
+			runId: created.runId,
+			executionSecret: 'owner-secret'
+		});
+
+		// The executor matches on this exact text when standing down a racing
+		// launch, so it must survive production error masking.
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				submissionId: 'sub-owned',
+				threadId,
+				prompt: 'Do the thing',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				executionSecret: 'intruder-secret'
+			})
+		).rejects.toThrow('Submission belongs to a different active executor.');
 	});
 
 	it('rejects a second run while the thread has an active run', async () => {

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -862,10 +862,8 @@ export const finalizeFailedStart = mutation({
 			}
 			return 'pending';
 		}
-		if (run.status !== 'queued' || run.executionSecretHash !== secretHash) {
-			return 'observed';
-		}
 		if (
+			run.status !== 'queued' ||
 			run.threadId !== args.threadId ||
 			run.selectedModel !== args.selectedModel ||
 			run.reasoningEffort !== args.reasoningEffort ||

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -1,6 +1,6 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
-import { v, type Infer } from 'convex/values';
+import { ConvexError, v, type Infer } from 'convex/values';
 import { getOwnedRun, getOwnedThreadRecord, getOwnedProject } from '@convex/lib/access';
 import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
 import { getModelDefinition } from '@convex/lib/models';
@@ -223,7 +223,9 @@ export const createRun = mutation({
 					(isClaimedRunStatus(existingRun.status) &&
 						!isRunClaimLeaseActive(existingRun, Date.now()));
 				if (!canRecoverExecutor) {
-					throw new Error('Submission belongs to a different active executor.');
+					// ConvexError keeps this text readable in production; the losing
+					// launch's startup cleanup recognizes it and stands down.
+					throw new ConvexError('Submission belongs to a different active executor.');
 				}
 				await ctx.db.patch(existingRun._id, { executionSecretHash: secretHash });
 			}
@@ -235,7 +237,7 @@ export const createRun = mutation({
 				!existingRun.promptMessageId ||
 				!existingRun.completionStreamStateId
 			) {
-				throw new Error('Submission belongs to a different or incomplete run.');
+				throw new ConvexError('Submission belongs to a different or incomplete run.');
 			}
 			const existingPrompt = await ctx.db.get(existingRun.promptMessageId);
 			if (
@@ -604,10 +606,10 @@ export const registerCompletionAttempt = mutation({
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		assertRunAcceptsModelCompletion(run.status);
 		if (!isRunClaimLeaseActive(run, Date.now())) {
-			throw new Error(RUN_NO_LONGER_ACTIVE);
+			throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 		}
 		if (!canRegisterCompletionAttempt(run, args.claimId, args.attemptSeq)) {
-			throw new Error(COMPLETION_STREAM_SUPERSEDED);
+			throw new ConvexError(COMPLETION_STREAM_SUPERSEDED);
 		}
 		await ctx.db.patch(args.runId, { completionAttemptSeq: args.attemptSeq });
 		// Completion turns stamp parts with turnId = streamId, so a retry can
@@ -674,7 +676,7 @@ export const mergeAssistantStreamEvents = mutation({
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		assertRunAcceptsModelCompletion(run.status);
 		if (!isRunClaimLeaseActive(run, Date.now())) {
-			throw new Error(RUN_NO_LONGER_ACTIVE);
+			throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 		}
 		// Fence every write: periodic acceptance checks alone leave a window
 		// where a superseded attempt could still append after a newer one registers.
@@ -830,12 +832,14 @@ export const finalizeFailedStart = mutation({
 		lastError: v.string(),
 		executionSecret: v.string()
 	},
-	// `finalized`: the queued run was terminalized. `pending`: no run is
-	// visible yet for the capability; the caller should retry while createRun
-	// may still be in flight. `observed`: the run already belongs to an active
-	// executor (a racing launch rebound it) or is past the queued stage, so
-	// the caller must stand down without terminalizing it.
-	returns: v.union(v.literal('finalized'), v.literal('pending'), v.literal('observed')),
+	// `finalized`: the queued run was terminalized. `pending`: nothing is
+	// visible for the capability; either createRun is still in flight or, when
+	// the caller's identity is gone, a rebound run cannot be told apart from a
+	// missing one, so the caller keeps retrying until its deadline.
+	// `standDown`: the run belongs to an active executor (a racing launch
+	// rebound it) or is past the queued stage, so the caller stops without
+	// terminalizing it.
+	returns: v.union(v.literal('finalized'), v.literal('pending'), v.literal('standDown')),
 	handler: async (ctx, args) => {
 		// The browser identity can be gone by the time this cleanup runs; the
 		// execution secret is the capability. A secret match on a still-queued
@@ -847,17 +851,18 @@ export const finalizeFailedStart = mutation({
 			.unique();
 		if (!run) {
 			// A racing launch may already have rebound the run to its own
-			// secret; tell the loser to stand down instead of retrying forever.
-			if (ctx.auth.getUserIdentity() !== null) {
-				const userId = await getUserId(ctx);
+			// secret; when the caller is still authenticated, tell the loser to
+			// stand down instead of retrying until its deadline.
+			const identity = await ctx.auth.getUserIdentity();
+			if (identity !== null) {
 				const submittedRun = await ctx.db
 					.query('runs')
 					.withIndex('by_userId_submissionId', (query) =>
-						query.eq('userId', userId).eq('submissionId', args.submissionId)
+						query.eq('userId', identity.subject).eq('submissionId', args.submissionId)
 					)
 					.unique();
 				if (submittedRun) {
-					return 'observed';
+					return 'standDown';
 				}
 			}
 			return 'pending';
@@ -870,7 +875,7 @@ export const finalizeFailedStart = mutation({
 			run.serviceTier !== args.serviceTier ||
 			!run.promptMessageId
 		) {
-			return 'observed';
+			return 'standDown';
 		}
 		const promptMessage = await ctx.db.get(run.promptMessageId);
 		if (
@@ -878,7 +883,7 @@ export const finalizeFailedStart = mutation({
 			promptMessage.text !== args.prompt.trim() ||
 			!areImageUploadIdsEqual(promptMessage.imageUploadIds, args.imageUploadIds)
 		) {
-			return 'observed';
+			return 'standDown';
 		}
 		await finalizeRunRecord(ctx, run.userId, run, {
 			text: args.text,
@@ -931,7 +936,7 @@ export const beginToolJob = mutation({
 		const userId = run.userId;
 		assertRunAcceptsModelCompletion(run.status);
 		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
-			throw new Error('Run is no longer active.');
+			throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 		}
 		const project = await getOwnedProject(ctx.db, userId, run.projectId);
 

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -830,23 +830,49 @@ export const finalizeFailedStart = mutation({
 		lastError: v.string(),
 		executionSecret: v.string()
 	},
-	returns: v.boolean(),
+	// `finalized`: the queued run was terminalized. `pending`: no run is
+	// visible yet for the capability; the caller should retry while createRun
+	// may still be in flight. `observed`: the run already belongs to an active
+	// executor (a racing launch rebound it) or is past the queued stage, so
+	// the caller must stand down without terminalizing it.
+	returns: v.union(v.literal('finalized'), v.literal('pending'), v.literal('observed')),
 	handler: async (ctx, args) => {
+		// The browser identity can be gone by the time this cleanup runs; the
+		// execution secret is the capability. A secret match on a still-queued
+		// run means it is waiting on this executor, so terminalizing is safe.
 		const secretHash = await executionSecretHash(args.executionSecret);
 		const run = await ctx.db
 			.query('runs')
 			.withIndex('by_executionSecretHash', (query) => query.eq('executionSecretHash', secretHash))
 			.unique();
+		if (!run) {
+			// A racing launch may already have rebound the run to its own
+			// secret; tell the loser to stand down instead of retrying forever.
+			if (ctx.auth.getUserIdentity() !== null) {
+				const userId = await getUserId(ctx);
+				const submittedRun = await ctx.db
+					.query('runs')
+					.withIndex('by_userId_submissionId', (query) =>
+						query.eq('userId', userId).eq('submissionId', args.submissionId)
+					)
+					.unique();
+				if (submittedRun) {
+					return 'observed';
+				}
+			}
+			return 'pending';
+		}
+		if (run.status !== 'queued' || run.executionSecretHash !== secretHash) {
+			return 'observed';
+		}
 		if (
-			!run ||
-			run.status !== 'queued' ||
 			run.threadId !== args.threadId ||
 			run.selectedModel !== args.selectedModel ||
 			run.reasoningEffort !== args.reasoningEffort ||
 			run.serviceTier !== args.serviceTier ||
 			!run.promptMessageId
 		) {
-			return false;
+			return 'observed';
 		}
 		const promptMessage = await ctx.db.get(run.promptMessageId);
 		if (
@@ -854,13 +880,14 @@ export const finalizeFailedStart = mutation({
 			promptMessage.text !== args.prompt.trim() ||
 			!areImageUploadIdsEqual(promptMessage.imageUploadIds, args.imageUploadIds)
 		) {
-			return false;
+			return 'observed';
 		}
-		return finalizeRunRecord(ctx, run.userId, run, {
+		await finalizeRunRecord(ctx, run.userId, run, {
 			text: args.text,
 			status: 'failed',
 			lastError: args.lastError
 		});
+		return 'finalized';
 	}
 });
 

--- a/apps/web/src/convex/completion.test.ts
+++ b/apps/web/src/convex/completion.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APICallError } from 'ai';
+import { ConvexError } from 'convex/values';
+import { api } from '@convex/_generated/api';
+import type { Id } from '@convex/_generated/dataModel';
+import { COMPLETION_STREAM_SUPERSEDED } from '@convex/lib/completionStream';
+import { toModelCompletionConvexError } from '@convex/lib/agentErrors';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock('ai', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('ai')>();
+	return { ...actual, streamText: streamTextMock };
+});
+
+function emptyCompletionStream() {
+	return (async function* () {})();
+}
+
+function rejected<T>(promise: Promise<T>): Promise<T> {
+	promise.catch(() => {});
+	return promise;
+}
+
+function streamTextFailure(error: unknown) {
+	const rejection = Promise.reject(error);
+	rejection.catch(() => {});
+	return {
+		stream: emptyCompletionStream(),
+		text: rejected(Promise.reject(error)),
+		usage: rejected(Promise.reject(error)),
+		finalStep: rejected(Promise.reject(error)),
+		toolCalls: rejected(Promise.reject(error))
+	};
+}
+
+async function startClaimedRun(
+	t: ReturnType<typeof initConvexTest>,
+	asUser: Awaited<ReturnType<typeof seedOwnedThread>>['asUser'],
+	threadId: Id<'threadRecords'>
+) {
+	const executionSecret = 'completion-secret';
+	const created = await createQueuedRun(asUser, threadId, 'sub-completion', executionSecret);
+	await t.mutation(api.agentRuntime.start, {
+		runId: created.runId,
+		claimId: 'claim-completion',
+		executionSecret
+	});
+	return { runId: created.runId, executionSecret };
+}
+
+function completeArgs(runId: Id<'runs'>, executionSecret: string) {
+	return {
+		modelId: 'gpt-5.6-sol' as const,
+		prompt: 'Hello',
+		streamRunId: runId,
+		claimId: 'claim-completion',
+		attemptSeq: 1,
+		streamId: 'stream-completion',
+		executionSecret
+	};
+}
+
+describe('completion.complete', () => {
+	beforeEach(() => {
+		streamTextMock.mockReset();
+	});
+
+	it('surfaces provider billing errors instead of masking them as Server Error', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+		streamTextMock.mockReturnValue(
+			streamTextFailure(
+				new APICallError({
+					message: 'You exceeded your current quota, please check your plan and billing details.',
+					url: 'https://api.openai.com/v1/responses',
+					requestBodyValues: {},
+					statusCode: 429,
+					responseBody: JSON.stringify({
+						error: {
+							message:
+								'You exceeded your current quota, please check your plan and billing details.',
+							type: 'insufficient_quota',
+							code: 'insufficient_quota'
+						}
+					})
+				})
+			)
+		);
+
+		const failure = await t
+			.action(api.completion.complete, completeArgs(runId, executionSecret))
+			.then(
+				() => {
+					throw new Error('expected the completion action to fail');
+				},
+				(error: unknown) => error
+			);
+		expect(failure).toBeInstanceOf(ConvexError);
+		expect((failure as Error).message).toContain('exceeded your current quota');
+		expect((failure as Error).message).not.toContain('Request ID');
+	});
+
+	it('reports provider 5xx failures with their status code', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+		streamTextMock.mockReturnValue(
+			streamTextFailure(
+				new APICallError({
+					message: 'Bad Gateway',
+					url: 'https://api.openai.com/v1/responses',
+					requestBodyValues: {},
+					statusCode: 502
+				})
+			)
+		);
+
+		const failure = await t
+			.action(api.completion.complete, completeArgs(runId, executionSecret))
+			.then(
+				() => {
+					throw new Error('expected the completion action to fail');
+				},
+				(error: unknown) => error
+			);
+		expect(failure).toBeInstanceOf(ConvexError);
+		expect((failure as Error).message).toContain('HTTP 502');
+		expect((failure as Error).message).toContain('Bad Gateway');
+	});
+
+	it('keeps control-flow errors as plain errors for the executor', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+		streamTextMock.mockReturnValue(streamTextFailure(new Error(COMPLETION_STREAM_SUPERSEDED)));
+
+		const failure = await t
+			.action(api.completion.complete, completeArgs(runId, executionSecret))
+			.then(
+				() => {
+					throw new Error('expected the completion action to fail');
+				},
+				(error: unknown) => error
+			);
+		expect((failure as Error).message).toContain(COMPLETION_STREAM_SUPERSEDED);
+	});
+});
+
+describe('toModelCompletionConvexError', () => {
+	const context = { modelId: 'gpt-5.6-sol', serviceTier: 'standard' };
+
+	it('passes through cancellation and lease-loss control flow unchanged', () => {
+		const cancelled = new Error('Run is cancelled.');
+		expect(toModelCompletionConvexError(cancelled, context)).toBe(cancelled);
+		const inactive = new Error('Run is no longer active.');
+		expect(toModelCompletionConvexError(inactive, context)).toBe(inactive);
+		const superseded = new Error(COMPLETION_STREAM_SUPERSEDED);
+		expect(toModelCompletionConvexError(superseded, context)).toBe(superseded);
+	});
+
+	it('strips the Convex uncaught-error prefix before classifying', () => {
+		const error = new Error(
+			`Uncaught Error: ${COMPLETION_STREAM_SUPERSEDED}\n\tat handler (../convex/completion.ts:1:1)`
+		);
+		expect(toModelCompletionConvexError(error, context)).toBe(error);
+	});
+
+	it('detects billing failures from the AI SDK retry chain', () => {
+		const quota = new APICallError({
+			message: 'You exceeded your current quota, please check your plan and billing details.',
+			url: 'https://api.openai.com/v1/responses',
+			requestBodyValues: {},
+			statusCode: 429,
+			data: { error: { code: 'insufficient_quota' } }
+		});
+		const wrapped = new Error('RetryError: failed after retries', { cause: quota });
+		const converted = toModelCompletionConvexError(wrapped, context);
+		expect(converted).toBeInstanceOf(ConvexError);
+		expect(converted.message).toContain('billing');
+	});
+});

--- a/apps/web/src/convex/completion.test.ts
+++ b/apps/web/src/convex/completion.test.ts
@@ -67,42 +67,46 @@ describe('completion.complete', () => {
 		streamTextMock.mockReset();
 	});
 
-	it('surfaces provider billing errors instead of masking them as Server Error', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
-		streamTextMock.mockReturnValue(
-			streamTextFailure(
-				new APICallError({
-					message: 'You exceeded your current quota, please check your plan and billing details.',
-					url: 'https://api.openai.com/v1/responses',
-					requestBodyValues: {},
-					statusCode: 429,
-					responseBody: JSON.stringify({
-						error: {
-							message:
-								'You exceeded your current quota, please check your plan and billing details.',
-							type: 'insufficient_quota',
-							code: 'insufficient_quota'
-						}
+	it(
+		'surfaces provider billing errors instead of masking them as Server Error',
+		{ timeout: 15_000 },
+		async () => {
+			const t = initConvexTest();
+			const { asUser, threadId } = await seedOwnedThread(t);
+			const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+			streamTextMock.mockReturnValue(
+				streamTextFailure(
+					new APICallError({
+						message: 'You exceeded your current quota, please check your plan and billing details.',
+						url: 'https://api.openai.com/v1/responses',
+						requestBodyValues: {},
+						statusCode: 429,
+						responseBody: JSON.stringify({
+							error: {
+								message:
+									'You exceeded your current quota, please check your plan and billing details.',
+								type: 'insufficient_quota',
+								code: 'insufficient_quota'
+							}
+						})
 					})
-				})
-			)
-		);
-
-		const failure = await t
-			.action(api.completion.complete, completeArgs(runId, executionSecret))
-			.then(
-				() => {
-					throw new Error('expected the completion action to fail');
-				},
-				(error: unknown) => error
+				)
 			);
-		expect(failure).toBeInstanceOf(ConvexError);
-		expect((failure as Error).message).toContain('exceeded your current quota');
-	});
 
-	it('reports provider 5xx failures with their status code', async () => {
+			const failure = await t
+				.action(api.completion.complete, completeArgs(runId, executionSecret))
+				.then(
+					() => {
+						throw new Error('expected the completion action to fail');
+					},
+					(error: unknown) => error
+				);
+			expect(failure).toBeInstanceOf(ConvexError);
+			expect((failure as Error).message).toContain('exceeded your current quota');
+		}
+	);
+
+	it('reports provider 5xx failures with their status code', { timeout: 15_000 }, async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
@@ -130,7 +134,7 @@ describe('completion.complete', () => {
 		expect((failure as Error).message).toContain('Bad Gateway');
 	});
 
-	it('keeps control-flow errors as plain errors for the executor', async () => {
+	it('keeps control-flow errors readable for the executor', { timeout: 15_000 }, async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
@@ -146,6 +150,51 @@ describe('completion.complete', () => {
 			);
 		expect((failure as Error).message).toContain(COMPLETION_STREAM_SUPERSEDED);
 	});
+
+	it(
+		'rejects a superseded attempt registration with the sentinel text',
+		{ timeout: 15_000 },
+		async () => {
+			const t = initConvexTest();
+			const { asUser, threadId } = await seedOwnedThread(t);
+			const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+			await t.run(async (ctx) => {
+				await ctx.db.patch(runId, { completionAttemptSeq: 9 });
+			});
+
+			// registerCompletionAttempt throws before the model is called.
+			const failure = await t
+				.action(api.completion.complete, completeArgs(runId, executionSecret))
+				.then(
+					() => {
+						throw new Error('expected the completion action to fail');
+					},
+					(error: unknown) => error
+				);
+			expect(failure).toBeInstanceOf(ConvexError);
+			expect((failure as Error).message).toBe(COMPLETION_STREAM_SUPERSEDED);
+		}
+	);
+
+	it('rejects a cancelled run with the cancellation sentinel', { timeout: 15_000 }, async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+		await t.run(async (ctx) => {
+			await ctx.db.patch(runId, { status: 'cancelled' });
+		});
+
+		const failure = await t
+			.action(api.completion.complete, completeArgs(runId, executionSecret))
+			.then(
+				() => {
+					throw new Error('expected the completion action to fail');
+				},
+				(error: unknown) => error
+			);
+		expect(failure).toBeInstanceOf(ConvexError);
+		expect((failure as Error).message).toBe('Run is cancelled.');
+	});
 });
 
 describe('completion.summarize', () => {
@@ -153,7 +202,7 @@ describe('completion.summarize', () => {
 		generateTextMock.mockReset();
 	});
 
-	it('surfaces provider billing errors from context compaction', async () => {
+	it('surfaces provider billing errors from context compaction', { timeout: 15_000 }, async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
@@ -193,22 +242,20 @@ describe('completion.summarize', () => {
 });
 
 describe('toModelCompletionConvexError', () => {
-	const context = { modelId: 'gpt-5.6-sol', serviceTier: 'standard' };
-
 	it('passes through cancellation and lease-loss control flow unchanged', () => {
 		const cancelled = new Error('Run is cancelled.');
-		expect(toModelCompletionConvexError(cancelled, context)).toBe(cancelled);
+		expect(toModelCompletionConvexError(cancelled, 'gpt-5.6-sol')).toBe(cancelled);
 		const inactive = new Error('Run is no longer active.');
-		expect(toModelCompletionConvexError(inactive, context)).toBe(inactive);
+		expect(toModelCompletionConvexError(inactive, 'gpt-5.6-sol')).toBe(inactive);
 		const superseded = new Error(COMPLETION_STREAM_SUPERSEDED);
-		expect(toModelCompletionConvexError(superseded, context)).toBe(superseded);
+		expect(toModelCompletionConvexError(superseded, 'gpt-5.6-sol')).toBe(superseded);
 	});
 
-	it('strips the Convex uncaught-error prefix before classifying', () => {
-		const error = new Error(
-			`Uncaught Error: ${COMPLETION_STREAM_SUPERSEDED}\n\tat handler (../convex/completion.ts:1:1)`
+	it('strips the Convex uncaught-error prefix from the stored message', () => {
+		const error = new Error('Uncaught Error: kaboom\n\tat handler (../convex/completion.ts:1:1)');
+		expect(toModelCompletionConvexError(error, 'gpt-5.6-sol').message).toBe(
+			'The model provider failed: kaboom'
 		);
-		expect(toModelCompletionConvexError(error, context)).toBe(error);
 	});
 
 	it('detects billing failures from the AI SDK retry chain', () => {
@@ -220,8 +267,42 @@ describe('toModelCompletionConvexError', () => {
 			data: { error: { code: 'insufficient_quota' } }
 		});
 		const wrapped = new Error('RetryError: failed after retries', { cause: quota });
-		const converted = toModelCompletionConvexError(wrapped, context);
+		const converted = toModelCompletionConvexError(wrapped, 'gpt-5.6-sol');
 		expect(converted).toBeInstanceOf(ConvexError);
-		expect(converted.message).toContain('billing');
+		expect(converted.message).toBe(
+			'The model provider rejected the request: You exceeded your current quota, please check your plan and billing details.'
+		);
+	});
+
+	it('keeps provider key material out of auth failures', () => {
+		const rejected = new APICallError({
+			message: 'Incorrect API key provided: sk-live-...redacted',
+			url: 'https://api.openai.com/v1/responses',
+			requestBodyValues: {},
+			statusCode: 401,
+			responseBody: JSON.stringify({
+				error: {
+					message: 'Incorrect API key provided: sk-live-...redacted',
+					code: 'invalid_api_key'
+				}
+			})
+		});
+		const converted = toModelCompletionConvexError(rejected, 'gpt-5.6-sol');
+		expect(converted.message).toBe(
+			'The model provider rejected the API key. Check the provider API key configuration.'
+		);
+	});
+
+	it('prefers the innermost provider message over retry wrapper text', () => {
+		const badGateway = new APICallError({
+			message: 'Bad Gateway',
+			url: 'https://api.openai.com/v1/responses',
+			requestBodyValues: {},
+			statusCode: 502
+		});
+		const wrapped = new Error('RetryError: failed after 5 retries', { cause: badGateway });
+		expect(toModelCompletionConvexError(wrapped, 'gpt-5.6-sol').message).toBe(
+			'The model provider returned a server error (HTTP 502) while running gpt-5.6-sol: Bad Gateway'
+		);
 	});
 });

--- a/apps/web/src/convex/completion.test.ts
+++ b/apps/web/src/convex/completion.test.ts
@@ -8,10 +8,11 @@ import { toModelCompletionConvexError } from '@convex/lib/agentErrors';
 import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
 
 const streamTextMock = vi.hoisted(() => vi.fn());
+const generateTextMock = vi.hoisted(() => vi.fn());
 
 vi.mock('ai', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('ai')>();
-	return { ...actual, streamText: streamTextMock };
+	return { ...actual, streamText: streamTextMock, generateText: generateTextMock };
 });
 
 function emptyCompletionStream() {
@@ -146,6 +147,50 @@ describe('completion.complete', () => {
 				(error: unknown) => error
 			);
 		expect((failure as Error).message).toContain(COMPLETION_STREAM_SUPERSEDED);
+	});
+});
+
+describe('completion.summarize', () => {
+	beforeEach(() => {
+		generateTextMock.mockReset();
+	});
+
+	it('surfaces provider billing errors from context compaction', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId, executionSecret } = await startClaimedRun(t, asUser, threadId);
+		generateTextMock.mockRejectedValue(
+			new APICallError({
+				message: 'You exceeded your current quota, please check your plan and billing details.',
+				url: 'https://api.openai.com/v1/responses',
+				requestBodyValues: {},
+				statusCode: 429,
+				responseBody: JSON.stringify({
+					error: {
+						message: 'You exceeded your current quota, please check your plan and billing details.',
+						type: 'insufficient_quota',
+						code: 'insufficient_quota'
+					}
+				})
+			})
+		);
+
+		const failure = await t
+			.action(api.completion.summarize, {
+				modelId: 'gpt-5.6-sol',
+				messagesJson: JSON.stringify([{ role: 'user', content: 'Summarize this.' }]),
+				runId,
+				claimId: 'claim-completion',
+				executionSecret
+			})
+			.then(
+				() => {
+					throw new Error('expected the summarize action to fail');
+				},
+				(error: unknown) => error
+			);
+		expect(failure).toBeInstanceOf(ConvexError);
+		expect((failure as Error).message).toContain('exceeded your current quota');
 	});
 });
 

--- a/apps/web/src/convex/completion.test.ts
+++ b/apps/web/src/convex/completion.test.ts
@@ -25,14 +25,13 @@ function rejected<T>(promise: Promise<T>): Promise<T> {
 }
 
 function streamTextFailure(error: unknown) {
-	const rejection = Promise.reject(error);
-	rejection.catch(() => {});
+	const rejection = rejected(Promise.reject(error));
 	return {
 		stream: emptyCompletionStream(),
-		text: rejected(Promise.reject(error)),
-		usage: rejected(Promise.reject(error)),
-		finalStep: rejected(Promise.reject(error)),
-		toolCalls: rejected(Promise.reject(error))
+		text: rejection,
+		usage: rejection,
+		finalStep: rejection,
+		toolCalls: rejection
 	};
 }
 
@@ -101,7 +100,6 @@ describe('completion.complete', () => {
 			);
 		expect(failure).toBeInstanceOf(ConvexError);
 		expect((failure as Error).message).toContain('exceeded your current quota');
-		expect((failure as Error).message).not.toContain('Request ID');
 	});
 
 	it('reports provider 5xx failures with their status code', async () => {

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -246,17 +246,22 @@ export const summarize = action({
 			completionContext.promptCacheKey
 		);
 		const abortController = new AbortController();
-		const result = await waitForCompletionWithAcceptance(
-			ctx,
-			generateText({
-				...sharedArgs,
-				messages,
-				maxOutputTokens: COMPACTION_MAX_OUTPUT_TOKENS,
-				abortSignal: abortController.signal
-			}),
-			claim,
-			abortController
-		);
+		let result: GenerateTextResult;
+		try {
+			result = await waitForCompletionWithAcceptance(
+				ctx,
+				generateText({
+					...sharedArgs,
+					messages,
+					maxOutputTokens: COMPACTION_MAX_OUTPUT_TOKENS,
+					abortSignal: abortController.signal
+				}),
+				claim,
+				abortController
+			);
+		} catch (error) {
+			throw toModelCompletionConvexError(error, { modelId, serviceTier });
+		}
 		const summary = result.text.trim();
 		if (!summary) throw new Error('The model returned an empty context summary.');
 		await assertSummarizeStillAccepted(ctx, claim);

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -7,7 +7,11 @@ import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
 import type { JsonValue } from '@convex/lib/json';
 import { resolveLanguageModel, resolveProviderOptions } from '@convex/lib/modelRegistry';
-import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import {
+	RUN_NO_LONGER_ACTIVE,
+	assertRunAcceptsModelCompletion,
+	toModelCompletionConvexError
+} from '@convex/lib/agentErrors';
 import {
 	isCurrentCompletionAttempt,
 	isRunClaimLeaseActive,
@@ -167,7 +171,7 @@ export const complete = action({
 			);
 		} catch (error) {
 			abortController.abort(error);
-			throw error;
+			throw toModelCompletionConvexError(error, { modelId, serviceTier });
 		}
 		await chargeModelUsage(ctx, {
 			userId: completionContext.userId,

--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -1,7 +1,7 @@
 'use node';
 
 import { generateText, jsonSchema, streamText, tool, type ModelMessage } from 'ai';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { action, type ActionCtx } from '@convex/_generated/server';
 import { api } from '@convex/_generated/api';
 import type { Id } from '@convex/_generated/dataModel';
@@ -171,7 +171,7 @@ export const complete = action({
 			);
 		} catch (error) {
 			abortController.abort(error);
-			throw toModelCompletionConvexError(error, { modelId, serviceTier });
+			throw toModelCompletionConvexError(error, modelId);
 		}
 		await chargeModelUsage(ctx, {
 			userId: completionContext.userId,
@@ -260,7 +260,7 @@ export const summarize = action({
 				abortController
 			);
 		} catch (error) {
-			throw toModelCompletionConvexError(error, { modelId, serviceTier });
+			throw toModelCompletionConvexError(error, modelId);
 		}
 		const summary = result.text.trim();
 		if (!summary) throw new Error('The model returned an empty context summary.');
@@ -320,7 +320,7 @@ async function collectStreamingCompletion(
 					events
 				});
 				if (outcome === 'superseded') {
-					throw new Error(COMPLETION_STREAM_SUPERSEDED);
+					throw new ConvexError(COMPLETION_STREAM_SUPERSEDED);
 				}
 				pendingEvents.splice(0, events.length);
 				nextFlushAt = pendingEvents.length
@@ -625,10 +625,10 @@ async function assertCompletionStillAccepted(
 	});
 	assertRunAcceptsModelCompletion(actor.status);
 	if (!isRunClaimLeaseActive(actor, Date.now())) {
-		throw new Error(RUN_NO_LONGER_ACTIVE);
+		throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 	}
 	if (!isCurrentCompletionAttempt(actor, attempt.claimId, attempt.attemptSeq)) {
-		throw new Error(COMPLETION_STREAM_SUPERSEDED);
+		throw new ConvexError(COMPLETION_STREAM_SUPERSEDED);
 	}
 	if (
 		isCompletionStreamAttemptSuperseded({
@@ -638,7 +638,7 @@ async function assertCompletionStillAccepted(
 			streamId: attempt.streamId
 		})
 	) {
-		throw new Error(COMPLETION_STREAM_SUPERSEDED);
+		throw new ConvexError(COMPLETION_STREAM_SUPERSEDED);
 	}
 }
 
@@ -649,7 +649,7 @@ async function assertSummarizeStillAccepted(ctx: ActionCtx, claim: SummarizeClai
 	});
 	assertRunAcceptsModelCompletion(actor.status);
 	if (!ownsActiveRunClaim(actor, claim.claimId, Date.now())) {
-		throw new Error(RUN_NO_LONGER_ACTIVE);
+		throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 	}
 }
 

--- a/apps/web/src/convex/lib/agentErrors.ts
+++ b/apps/web/src/convex/lib/agentErrors.ts
@@ -1,10 +1,15 @@
 import { isRunFinalStatus, type vRunStatus } from '@convex/lib/validators';
+import { COMPLETION_STREAM_SUPERSEDED } from '@convex/lib/completionStream';
+import { ConvexError } from 'convex/values';
 import type { Infer } from 'convex/values';
 
 /** Recognized by sprocket-agent (`provider.rs`) for clean run cancellation. */
 export const RUN_CANCELLED_BY_USER = 'Run is cancelled.';
 
 export const RUN_NO_LONGER_ACTIVE = 'Run is no longer active.';
+
+/** Convex prefixes thrown Error messages with "Uncaught Error:" in production builds. */
+const UNCAUGHT_ERROR_PREFIX = 'Uncaught Error: ';
 
 export function assertRunAcceptsModelCompletion(status: Infer<typeof vRunStatus>): void {
 	if (status === 'cancelled') {
@@ -13,4 +18,98 @@ export function assertRunAcceptsModelCompletion(status: Infer<typeof vRunStatus>
 	if (isRunFinalStatus(status)) {
 		throw new Error(RUN_NO_LONGER_ACTIVE);
 	}
+}
+
+function stripUncaughtPrefix(message: string): string {
+	return message.startsWith(UNCAUGHT_ERROR_PREFIX)
+		? message.slice(UNCAUGHT_ERROR_PREFIX.length)
+		: message;
+}
+
+function statusCodeFromError(error: unknown): number | undefined {
+	if (!error || typeof error !== 'object') return undefined;
+	const value = error as Record<string, unknown>;
+	if (typeof value.statusCode === 'number') return value.statusCode;
+	if (typeof value.status === 'number') return value.status;
+	return statusCodeFromError(value.cause);
+}
+
+function quotaMessageFromError(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object') return undefined;
+	const value = error as Record<string, unknown>;
+	if (typeof value.responseBody === 'string') {
+		try {
+			const body: unknown = JSON.parse(value.responseBody);
+			if (body && typeof body === 'object' && !Array.isArray(body)) {
+				const providerError = (body as Record<string, unknown>).error;
+				if (providerError && typeof providerError === 'object' && !Array.isArray(providerError)) {
+					const message = (providerError as Record<string, unknown>).message;
+					if (typeof message === 'string') return message;
+				}
+			}
+		} catch {
+			// The provider body is only parsed for a friendlier message.
+		}
+	}
+	return quotaMessageFromError(value.cause);
+}
+
+function looksLikeProviderBillingError(error: unknown): boolean {
+	if (!error || typeof error !== 'object') return false;
+	const value = error as Record<string, unknown>;
+	if (typeof value.message === 'string') {
+		const message = value.message.toLowerCase();
+		if (
+			message.includes('insufficient_quota') ||
+			message.includes('insufficient quota') ||
+			message.includes('billing') ||
+			message.includes('credit balance') ||
+			message.includes('exceeded your current quota')
+		) {
+			return true;
+		}
+	}
+	return looksLikeProviderBillingError(value.cause);
+}
+
+/**
+ * Turns failures thrown by the model layer into ConvexErrors whose messages stay
+ * readable in production; uncaught Errors are masked to "[Request ID] Server
+ * Error" for both the executor client and `run.lastError` in the UI.
+ *
+ * Control-flow errors (cancellation, lease loss, stream supersede) pass through
+ * unchanged. They must stay plain Errors so callers can detect them by message.
+ */
+export function toModelCompletionConvexError(
+	error: unknown,
+	context: { modelId: string; serviceTier: string }
+): Error {
+	if (!(error instanceof Error)) {
+		return new ConvexError(`The model provider failed: ${String(error)}`);
+	}
+	if (error instanceof ConvexError) return error;
+	const message = stripUncaughtPrefix(error.message);
+	if (
+		message.includes(RUN_CANCELLED_BY_USER) ||
+		message.includes(RUN_NO_LONGER_ACTIVE) ||
+		message.includes(COMPLETION_STREAM_SUPERSEDED)
+	) {
+		return error;
+	}
+	const statusCode = statusCodeFromError(error);
+	if (statusCode === 401 || statusCode === 403 || looksLikeProviderBillingError(error)) {
+		const providerMessage = quotaMessageFromError(error);
+		return new ConvexError(
+			providerMessage
+				? `The model provider rejected the request: ${providerMessage}`
+				: 'The model provider rejected the request. Check the provider billing, credits, and API key configuration.'
+		);
+	}
+	if (statusCode !== undefined) {
+		const qualifier = statusCode >= 500 ? 'a server error' : 'an error';
+		return new ConvexError(
+			`The model provider returned ${qualifier} (HTTP ${statusCode}) while running ${context.modelId} on the ${context.serviceTier} tier: ${message}`
+		);
+	}
+	return new ConvexError(`The model provider failed: ${message}`);
 }

--- a/apps/web/src/convex/lib/agentErrors.ts
+++ b/apps/web/src/convex/lib/agentErrors.ts
@@ -11,54 +11,101 @@ export const RUN_NO_LONGER_ACTIVE = 'Run is no longer active.';
 /** Convex prefixes thrown Error messages with "Uncaught Error:" in production builds. */
 const UNCAUGHT_ERROR_PREFIX = 'Uncaught Error: ';
 
+// Sentinels are ConvexErrors so production keeps their text: the executor
+// classifies runs by these exact messages.
 export function assertRunAcceptsModelCompletion(status: Infer<typeof vRunStatus>): void {
 	if (status === 'cancelled') {
-		throw new Error(RUN_CANCELLED_BY_USER);
+		throw new ConvexError(RUN_CANCELLED_BY_USER);
 	}
 	if (isRunFinalStatus(status)) {
-		throw new Error(RUN_NO_LONGER_ACTIVE);
+		throw new ConvexError(RUN_NO_LONGER_ACTIVE);
 	}
+}
+
+/** Follows `cause`, then the AI SDK RetryError's `lastError`. */
+function errorChain(error: unknown): Record<string, unknown>[] {
+	const chain: Record<string, unknown>[] = [];
+	let current: unknown = error;
+	while (current && typeof current === 'object') {
+		const value = current as Record<string, unknown>;
+		if (chain.includes(value)) break;
+		chain.push(value);
+		current = value.cause ?? value.lastError;
+	}
+	return chain;
 }
 
 function stripUncaughtPrefix(message: string): string {
-	return message.startsWith(UNCAUGHT_ERROR_PREFIX)
-		? message.slice(UNCAUGHT_ERROR_PREFIX.length)
-		: message;
+	if (!message.startsWith(UNCAUGHT_ERROR_PREFIX)) return message;
+	const stripped = message.slice(UNCAUGHT_ERROR_PREFIX.length);
+	const newline = stripped.indexOf('\n');
+	return newline === -1 ? stripped : stripped.slice(0, newline);
+}
+
+function providerErrorFromBody(body: unknown): { code?: string; message?: string } | undefined {
+	if (typeof body !== 'string') return undefined;
+	try {
+		const parsed: unknown = JSON.parse(body);
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+		const providerError = (parsed as Record<string, unknown>).error;
+		if (!providerError || typeof providerError !== 'object' || Array.isArray(providerError)) {
+			return undefined;
+		}
+		const record = providerError as Record<string, unknown>;
+		const code = record.code ?? record.type;
+		return {
+			...(typeof code === 'string' ? { code } : {}),
+			...(typeof record.message === 'string' ? { message: record.message } : {})
+		};
+	} catch {
+		// The provider body is only parsed for a friendlier message.
+		return undefined;
+	}
 }
 
 function statusCodeFromError(error: unknown): number | undefined {
-	if (!error || typeof error !== 'object') return undefined;
-	const value = error as Record<string, unknown>;
-	if (typeof value.statusCode === 'number') return value.statusCode;
-	if (typeof value.status === 'number') return value.status;
-	return statusCodeFromError(value.cause);
+	for (const candidate of errorChain(error)) {
+		if (typeof candidate.statusCode === 'number') return candidate.statusCode;
+		if (typeof candidate.status === 'number') return candidate.status;
+	}
+	return undefined;
 }
 
-function quotaMessageFromError(error: unknown): string | undefined {
-	if (!error || typeof error !== 'object') return undefined;
-	const value = error as Record<string, unknown>;
-	if (typeof value.responseBody === 'string') {
-		try {
-			const body: unknown = JSON.parse(value.responseBody);
-			if (body && typeof body === 'object' && !Array.isArray(body)) {
-				const providerError = (body as Record<string, unknown>).error;
-				if (providerError && typeof providerError === 'object' && !Array.isArray(providerError)) {
-					const message = (providerError as Record<string, unknown>).message;
-					if (typeof message === 'string') return message;
-				}
+function providerMessageFromError(error: unknown): string | undefined {
+	for (const candidate of errorChain(error)) {
+		const message = providerErrorFromBody(candidate.responseBody)?.message;
+		if (message) return message;
+		const data = candidate.data;
+		if (data && typeof data === 'object' && !Array.isArray(data)) {
+			const providerError = (data as Record<string, unknown>).error;
+			if (providerError && typeof providerError === 'object' && !Array.isArray(providerError)) {
+				const dataMessage = (providerError as Record<string, unknown>).message;
+				if (typeof dataMessage === 'string') return dataMessage;
 			}
-		} catch {
-			// The provider body is only parsed for a friendlier message.
 		}
 	}
-	return quotaMessageFromError(value.cause);
+	return undefined;
 }
 
 function looksLikeProviderBillingError(error: unknown): boolean {
-	if (!error || typeof error !== 'object') return false;
-	const value = error as Record<string, unknown>;
-	if (typeof value.message === 'string') {
-		const message = value.message.toLowerCase();
+	for (const candidate of errorChain(error)) {
+		if (providerErrorFromBody(candidate.responseBody)?.code === 'insufficient_quota') {
+			return true;
+		}
+		const data = candidate.data;
+		if (data && typeof data === 'object' && !Array.isArray(data)) {
+			const providerError = (data as Record<string, unknown>).error;
+			if (
+				providerError &&
+				typeof providerError === 'object' &&
+				!Array.isArray(providerError) &&
+				(providerError as Record<string, unknown>).code === 'insufficient_quota'
+			) {
+				return true;
+			}
+		}
+		if (typeof candidate.message !== 'string') continue;
+		const message = candidate.message.toLowerCase();
 		if (
 			message.includes('insufficient_quota') ||
 			message.includes('insufficient quota') ||
@@ -69,7 +116,16 @@ function looksLikeProviderBillingError(error: unknown): boolean {
 			return true;
 		}
 	}
-	return looksLikeProviderBillingError(value.cause);
+	return false;
+}
+
+function innermostMessage(error: unknown): string | undefined {
+	const chain = errorChain(error);
+	for (let index = chain.length - 1; index >= 0; index -= 1) {
+		const candidate = chain[index];
+		if (candidate instanceof Error && candidate.message) return candidate.message;
+	}
+	return undefined;
 }
 
 /**
@@ -80,10 +136,7 @@ function looksLikeProviderBillingError(error: unknown): boolean {
  * Control-flow errors (cancellation, lease loss, stream supersede) pass through
  * unchanged. They must stay plain Errors so callers can detect them by message.
  */
-export function toModelCompletionConvexError(
-	error: unknown,
-	context: { modelId: string; serviceTier: string }
-): Error {
+export function toModelCompletionConvexError(error: unknown, modelId: string): Error {
 	if (!(error instanceof Error)) {
 		return new ConvexError(`The model provider failed: ${String(error)}`);
 	}
@@ -96,20 +149,23 @@ export function toModelCompletionConvexError(
 	) {
 		return error;
 	}
+	const detail =
+		providerMessageFromError(error) ?? stripUncaughtPrefix(innermostMessage(error) ?? message);
 	const statusCode = statusCodeFromError(error);
-	if (statusCode === 401 || statusCode === 403 || looksLikeProviderBillingError(error)) {
-		const providerMessage = quotaMessageFromError(error);
+	if (looksLikeProviderBillingError(error)) {
+		return new ConvexError(`The model provider rejected the request: ${detail}`);
+	}
+	// Provider bodies for auth failures can echo the API key; keep them server-side.
+	if (statusCode === 401 || statusCode === 403) {
 		return new ConvexError(
-			providerMessage
-				? `The model provider rejected the request: ${providerMessage}`
-				: 'The model provider rejected the request. Check the provider billing, credits, and API key configuration.'
+			'The model provider rejected the API key. Check the provider API key configuration.'
 		);
 	}
 	if (statusCode !== undefined) {
 		const qualifier = statusCode >= 500 ? 'a server error' : 'an error';
 		return new ConvexError(
-			`The model provider returned ${qualifier} (HTTP ${statusCode}) while running ${context.modelId} on the ${context.serviceTier} tier: ${message}`
+			`The model provider returned ${qualifier} (HTTP ${statusCode}) while running ${modelId}: ${detail}`
 		);
 	}
-	return new ConvexError(`The model provider failed: ${message}`);
+	return new ConvexError(`The model provider failed: ${detail}`);
 }

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -13,6 +13,14 @@ use crate::types::{
 const CREATE_RUN_MAX_ATTEMPTS: usize = 3;
 const CREATE_RUN_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum FailedStartCleanup {
+    Finalized,
+    Pending,
+    Observed,
+}
+
 #[derive(Clone)]
 pub(crate) struct RuntimeClient {
     pub(crate) client: ConvexProviderClient,
@@ -170,7 +178,7 @@ impl RuntimeClient {
         request: &RunAgentRequest,
         text: &str,
         last_error: &str,
-    ) -> anyhow::Result<bool> {
+    ) -> anyhow::Result<FailedStartCleanup> {
         let mut args = BTreeMap::new();
         args.insert(
             "submissionId".to_string(),

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -18,7 +18,7 @@ const CREATE_RUN_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
 pub(crate) enum FailedStartCleanup {
     Finalized,
     Pending,
-    Observed,
+    StandDown,
 }
 
 #[derive(Clone)]

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -12,7 +12,7 @@ use tokio::time::{Instant, sleep, sleep_until, timeout};
 use uuid::Uuid;
 
 use crate::RunContextResponse;
-use crate::convex::RuntimeClient;
+use crate::convex::{FailedStartCleanup, RuntimeClient};
 use crate::provider::{AgentProvider, AgentProviderRequest, AgentProviderResult};
 use crate::types::{RunAgentRequest, deserialize_agent_history};
 
@@ -28,6 +28,14 @@ const FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
 const START_FAILURE_CLEANUP_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2_500);
 const START_FAILURE_RECONCILE_TIMEOUT: Duration = Duration::from_secs(10);
 const FAILURE_CLEANUP_RETRY_DELAY: Duration = Duration::from_millis(250);
+
+/// Must match the createRun conflict ConvexErrors in
+/// apps/web/src/convex/agentRuntime.ts ("Submission belongs to a different ...").
+const SUBMISSION_OWNED_BY_ANOTHER_EXECUTOR: &str = "Submission belongs to a different";
+
+fn submission_owned_by_another_executor(error: &str) -> bool {
+    error.contains(SUBMISSION_OWNED_BY_ANOTHER_EXECUTOR)
+}
 
 pub struct AgentRun {
     request: RunAgentRequest,
@@ -594,6 +602,15 @@ pub async fn finalize_failed_start(
     request: RunAgentRequest,
     startup_error: String,
 ) -> anyhow::Result<()> {
+    // createRun rejected the duplicate submission: a racing launch owns the
+    // run, so this executor's cleanup has nothing to terminalize.
+    if submission_owned_by_another_executor(&startup_error) {
+        eprintln!(
+            "sprocket-agent: submission {} already belongs to an active run; standing down",
+            request.submission_id
+        );
+        return Ok(());
+    }
     let runtime = RuntimeClient::from_request(&request).await?;
     runtime.completion_client().clear_auth().await;
     let text = format!("Run failed before the model started: {startup_error}");
@@ -605,14 +622,14 @@ pub async fn finalize_failed_start(
         )
         .await;
         match result {
-            Ok(Ok(crate::convex::FailedStartCleanup::Finalized)) => return Ok(()),
-            Ok(Ok(crate::convex::FailedStartCleanup::Pending)) => {
+            Ok(Ok(FailedStartCleanup::Finalized)) => return Ok(()),
+            Ok(Ok(FailedStartCleanup::Pending)) => {
                 eprintln!(
                     "sprocket-agent: startup failure cleanup has not observed submission {}; retrying",
                     request.submission_id
                 );
             }
-            Ok(Ok(crate::convex::FailedStartCleanup::Observed)) => {
+            Ok(Ok(FailedStartCleanup::StandDown)) => {
                 eprintln!(
                     "sprocket-agent: submission {} already belongs to an active run; standing down",
                     request.submission_id
@@ -784,7 +801,23 @@ fn image_media_type(media_type: &str) -> anyhow::Result<ImageMediaType> {
 mod tests {
     use sprocket_workspace::{SkillSource, WorkspaceSkill};
 
-    use super::build_workspace_preamble;
+    use super::{build_workspace_preamble, submission_owned_by_another_executor};
+
+    #[test]
+    fn submission_conflict_errors_match_the_convex_sentinel() {
+        assert!(submission_owned_by_another_executor(
+            "agentRuntime:createRun failed: Submission belongs to a different active executor."
+        ));
+        assert!(submission_owned_by_another_executor(
+            "Submission belongs to a different or incomplete run."
+        ));
+        assert!(!submission_owned_by_another_executor(
+            "timed out starting agent run"
+        ));
+        assert!(!submission_owned_by_another_executor(
+            "Submission prompt does not match the existing run."
+        ));
+    }
 
     #[test]
     fn preamble_renders_skills_block() {

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -605,12 +605,19 @@ pub async fn finalize_failed_start(
         )
         .await;
         match result {
-            Ok(Ok(true)) => return Ok(()),
-            Ok(Ok(false)) => {
+            Ok(Ok(crate::convex::FailedStartCleanup::Finalized)) => return Ok(()),
+            Ok(Ok(crate::convex::FailedStartCleanup::Pending)) => {
                 eprintln!(
                     "sprocket-agent: startup failure cleanup has not observed submission {}; retrying",
                     request.submission_id
                 );
+            }
+            Ok(Ok(crate::convex::FailedStartCleanup::Observed)) => {
+                eprintln!(
+                    "sprocket-agent: submission {} already belongs to an active run; standing down",
+                    request.submission_id
+                );
+                return Ok(());
             }
             Ok(Err(error)) => {
                 eprintln!(

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -687,18 +687,16 @@ fn should_retry_superseded_completion(message: &str, attempt: u32) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS && is_completion_stream_superseded(message)
 }
 
-/// Only Convex-side 5xx failures qualify. Client-visible 4xx errors (billing,
-/// auth, validation) reach the executor as ConvexErrors with their real
-/// messages and must fail fast instead of burning more provider quota.
+/// Retries only the masked Convex internal error ("[Request ID ...] Server
+/// Error" in production builds, InternalServerError from the sync layer).
+/// Provider 5xx reach the executor as ConvexErrors with real messages and fail
+/// fast on purpose: the AI SDK already retried them, and another full action
+/// attempt would double provider spend for marginal recovery.
 fn should_retry_server_failure(message: &str, attempt: u32) -> bool {
     if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
         return false;
     }
-    message.contains("InternalServerError")
-        || message.contains("Server Error")
-        || message.contains("HTTP 5")
-        || message.contains("status code: 5")
-        || message.contains("status code 5")
+    message.contains("] Server Error") || message.contains("InternalServerError")
 }
 
 async fn backoff_completion_retry(
@@ -931,14 +929,16 @@ mod tests {
             "Convex action failed: InternalServerError",
             1
         ));
-        assert!(should_retry_server_failure(
-            "The model provider returned a server error (HTTP 502) while running gpt-5.6-sol on the standard tier: Bad Gateway",
-            1
-        ));
         // Out of attempts: the final error is returned to the run.
         assert!(!should_retry_server_failure(
             "[Request ID: de575a03dfa7bbac] Server Error",
             COMPLETION_TRANSPORT_ATTEMPTS
+        ));
+        // Provider 5xx already exhausted the AI SDK's retries inside the
+        // action; another full attempt would double provider spend.
+        assert!(!should_retry_server_failure(
+            "The model provider returned a server error (HTTP 502) while running gpt-5.6-sol: Bad Gateway",
+            1
         ));
         // Billing/auth failures must fail fast instead of burning more quota.
         assert!(!should_retry_server_failure(

--- a/crates/sprocket-convex-provider/src/client.rs
+++ b/crates/sprocket-convex-provider/src/client.rs
@@ -667,12 +667,38 @@ async fn call_completion_action(
             backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
             continue;
         }
+        if should_retry_server_failure(&provider_error, attempt) {
+            // The action raised a 5xx before or during the model call (Convex
+            // masks it as "[Request ID] Server Error" in production). A fresh
+            // attempt re-registers with a new seq; the backend drops the
+            // partial output of the superseded streams.
+            eprintln!(
+                "sprocket-convex-provider: action {} failed transiently (attempt {attempt}); retrying: {provider_error}",
+                client.completion_action,
+            );
+            backoff_completion_retry(&mut superseded_stream_ids, stream_id, &mut retry_delay).await;
+            continue;
+        }
         return Err(CompletionError::ProviderError(provider_error));
     }
 }
 
 fn should_retry_superseded_completion(message: &str, attempt: u32) -> bool {
     attempt < COMPLETION_TRANSPORT_ATTEMPTS && is_completion_stream_superseded(message)
+}
+
+/// Only Convex-side 5xx failures qualify. Client-visible 4xx errors (billing,
+/// auth, validation) reach the executor as ConvexErrors with their real
+/// messages and must fail fast instead of burning more provider quota.
+fn should_retry_server_failure(message: &str, attempt: u32) -> bool {
+    if attempt >= COMPLETION_TRANSPORT_ATTEMPTS {
+        return false;
+    }
+    message.contains("InternalServerError")
+        || message.contains("Server Error")
+        || message.contains("HTTP 5")
+        || message.contains("status code: 5")
+        || message.contains("status code 5")
 }
 
 async fn backoff_completion_retry(
@@ -855,7 +881,7 @@ mod tests {
     use super::{
         COMPLETION_STREAM_SUPERSEDED, COMPLETION_TRANSPORT_ATTEMPTS, CompletionOutput,
         CompletionStreamEvent, InputTokenDetails, ToolCall, Usage, clone_locked, completion_choice,
-        is_completion_stream_superseded, reasoning_stream_choices,
+        is_completion_stream_superseded, reasoning_stream_choices, should_retry_server_failure,
         should_retry_superseded_completion, text_stream_choices,
     };
     use rig::completion::CompletionError;
@@ -893,6 +919,35 @@ mod tests {
         }
 
         assert_eq!(*inner.lock().await, 1);
+    }
+
+    #[test]
+    fn retries_masked_convex_server_errors_but_not_billing_failures() {
+        assert!(should_retry_server_failure(
+            "[Request ID: de575a03dfa7bbac] Server Error",
+            1
+        ));
+        assert!(should_retry_server_failure(
+            "Convex action failed: InternalServerError",
+            1
+        ));
+        assert!(should_retry_server_failure(
+            "The model provider returned a server error (HTTP 502) while running gpt-5.6-sol on the standard tier: Bad Gateway",
+            1
+        ));
+        // Out of attempts: the final error is returned to the run.
+        assert!(!should_retry_server_failure(
+            "[Request ID: de575a03dfa7bbac] Server Error",
+            COMPLETION_TRANSPORT_ATTEMPTS
+        ));
+        // Billing/auth failures must fail fast instead of burning more quota.
+        assert!(!should_retry_server_failure(
+            "The model provider rejected the request: You exceeded your current quota, please check your plan and billing details.",
+            1
+        ));
+        // Control-flow outcomes are never retried here.
+        assert!(!should_retry_server_failure("Run is cancelled.", 1));
+        assert!(!should_retry_server_failure("Run is no longer active.", 1));
     }
 
     #[test]


### PR DESCRIPTION
## What

Hard follow-ups from a production incident where two agent runs died with `CompletionError: ProviderError: [Request ID: ...] Server Error` (Convex masks uncaught action errors in production; in this case the underlying cause was an exhausted OpenAI credit balance) and a duplicate-submission cleanup looped `startup failure cleanup has not observed submission ...; retrying` until its deadline.

- **Real provider errors reach the thread.** `completion:complete` and `completion:summarize` convert model-layer failures into `ConvexError` via `toModelCompletionConvexError`, so production no longer masks them. Billing/quota rejections keep the provider's message; 401/403s get canned text (provider bodies can echo API key material); AI SDK RetryError wrappers are unwrapped so the banner shows the actual provider message.
- **Transient Convex 5xx action failures are retried** in the executor's completion transport (bounded, with the existing attemptSeq/supersededStreamIds fencing). Billing, auth, cancellation, and provider 5xx (already retried 5x by the AI SDK inside the action) still fail fast.
- **Control-flow sentinels** (`Run is cancelled.`, `Run is no longer active.`, `SPROCKET_COMPLETION_STREAM_SUPERSEDED`) now throw as `ConvexError` at their sources, so masking never turns them into fake 5xxs that the retry loop would pick up.
- **`finalizeFailedStart` returns `finalized` | `pending` | `standDown`** instead of an overloaded boolean. It resolves by execution-secret capability first (works after browser auth is gone) with a submission-identity fallback, and the executor additionally stands down directly on the createRun submission-conflict `ConvexError`, which covers the unauthenticated racing-launch case.

## Notes

- The Bedrock fallback path (`ai-fallback` wrapper in `modelRegistry.ts`) sits upstream of the new converter and is unaffected: it sees raw provider errors and still fails over on quota/5xx; only the last provider's error reaches classification.
- Pre-existing, not fixed here: a successful Bedrock failover still charges usage under the original model id, and Sprocket usage-limit errors thrown in actions also get masked to "Server Error" in production.

## Test plan

- `cargo test` (sprocket-agent, sprocket-convex-provider, sprocket-server): pass
- `bun run test`: 264 web tests pass, including new convex-test coverage for the tri-state cleanup (capability match, racing launch, unauthenticated rebound, claimed run) and action-level error surfacing (billing, provider 5xx, cancellation, supersede) for both completion actions
- `bun run build`, `prek run -a`: pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes model-provider and control-flow failures readable across the Convex boundary, adds bounded retries for masked transient completion-action failures, and makes failed-start reconciliation return explicit outcomes.

- Converts completion and summarization failures into classified `ConvexError` messages while redacting authentication failures.
- Retries masked Convex server failures with fresh attempt and stream fencing.
- Reconciles duplicate startup cleanup through `finalized`, `pending`, and `standDown` states.
- Adds focused TypeScript and Rust coverage for error propagation, retry classification, and racing launches.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code defect remains after tracing the retry, error-conversion, and startup-reconciliation paths.

The new wire shapes remain synchronized across TypeScript and Rust, completion retries retain attempt fencing and exclude classified provider failures, and failed-start cleanup preserves capability ownership without introducing a new terminalization path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Makes duplicate-submission conflicts readable, preserves completion sentinels, and introduces explicit failed-start reconciliation outcomes. |
| apps/web/src/convex/completion.ts | Converts completion and summarization failures at the action boundary while preserving cancellation and supersession control flow. |
| apps/web/src/convex/lib/agentErrors.ts | Adds provider-error chain parsing, billing/auth/server classification, and production-safe Convex error messages. |
| crates/sprocket-agent/src/convex.rs | Updates the failed-start wire response from a boolean to a strictly deserialized tri-state enum. |
| crates/sprocket-agent/src/run.rs | Handles explicit cleanup outcomes and directly stands down when createRun reports a duplicate-submission ownership conflict. |
| crates/sprocket-convex-provider/src/client.rs | Adds bounded retries for masked Convex server failures while excluding readable provider, billing, auth, and control-flow errors. |
| apps/web/src/convex/agentRuntime.createRun.test.ts | Adds coverage for capability reconciliation, racing launches, claimed runs, and readable submission conflicts. |
| apps/web/src/convex/completion.test.ts | Adds action-level and converter-level coverage for provider failures, authentication redaction, cancellation, and supersession. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as Local agent
    participant Adapter as Convex provider adapter
    participant Convex as Completion action
    participant Model as Model provider
    Agent->>Adapter: Request completion
    Adapter->>Convex: attemptSeq + streamId
    Convex->>Model: Generate completion
    alt Provider or control-flow failure
        Model-->>Convex: Error
        Convex-->>Adapter: Readable ConvexError
        Adapter-->>Agent: Fail fast
    else Masked transient Convex failure
        Convex-->>Adapter: [Request ID] Server Error
        Adapter->>Convex: Retry with fresh attemptSeq + streamId
    else Success
        Model-->>Convex: Completion
        Convex-->>Adapter: Persisted output
        Adapter-->>Agent: Completion result
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Keep control-flow sentinels ..."](https://github.com/spikonado/sprocket/commit/de16e5f2d2fed9b45aa1f7f386e96bd8607b9147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55379049)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [sprocket-agent](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/sprocket-agent.md)
- Knowledge Base — [sprocket-convex-provider](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/sprocket-convex-provider.md)
- Knowledge Base — [Convex Backend](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-backend.md)
</details>

<!-- /greptile_comment -->