### PR TITLE
fix(models): Update DeepSeek model IDs

### DIFF
--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -117,7 +117,7 @@ describe('Amazon Bedrock fallback routing', () => {
 			modelId: 'accounts/fireworks/models/kimi-k3'
 		});
 		expect(resolveLanguageModel('deepseek-v4-flash', 'standard')).toMatchObject({
-			modelId: 'accounts/fireworks/models/deepseek-v4-flash'
+			modelId: 'accounts/fireworks/models/deepseek-v4-flash-0731'
 		});
 		expect(resolveLanguageModel('glm-5.3', 'standard')).toMatchObject({
 			modelId: 'glm-5.3'

--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -27,13 +27,15 @@ describe('model provider request configuration', () => {
 				reasoningHistory: 'interleaved'
 			}
 		});
-		expect(resolveProviderOptions('deepseek-v4-pro', 'max', 'standard', 'thread:abc')).toEqual({
-			fireworks: {
-				reasoningEffort: 'max',
-				promptCacheKey: 'thread:abc',
-				reasoningHistory: 'interleaved'
+		expect(resolveProviderOptions('deepseek-v4-pro-0813', 'max', 'standard', 'thread:abc')).toEqual(
+			{
+				fireworks: {
+					reasoningEffort: 'max',
+					promptCacheKey: 'thread:abc',
+					reasoningHistory: 'interleaved'
+				}
 			}
-		});
+		);
 		expect(resolveProviderOptions('glm-5.3', 'max', 'standard', 'thread:abc')).toEqual({
 			zai: { reasoningEffort: 'max' }
 		});
@@ -112,11 +114,16 @@ describe('Amazon Bedrock fallback routing', () => {
 		expect(resolveLanguageModel('gpt-5.6-sol', 'fast')).not.toBeInstanceOf(FallbackModel);
 		expect(resolveLanguageModel('glm-5.3', 'standard')).not.toBeInstanceOf(FallbackModel);
 		expect(resolveLanguageModel('kimi-k3', 'standard')).not.toBeInstanceOf(FallbackModel);
-		expect(resolveLanguageModel('deepseek-v4-pro', 'standard')).not.toBeInstanceOf(FallbackModel);
+		expect(resolveLanguageModel('deepseek-v4-pro-0813', 'standard')).not.toBeInstanceOf(
+			FallbackModel
+		);
 		expect(resolveLanguageModel('kimi-k3', 'standard')).toMatchObject({
 			modelId: 'accounts/fireworks/models/kimi-k3'
 		});
-		expect(resolveLanguageModel('deepseek-v4-flash', 'standard')).toMatchObject({
+		expect(resolveLanguageModel('deepseek-v4-pro-0813', 'standard')).toMatchObject({
+			modelId: 'accounts/fireworks/models/deepseek-v4-pro-0813'
+		});
+		expect(resolveLanguageModel('deepseek-v4-flash-0731', 'standard')).toMatchObject({
 			modelId: 'accounts/fireworks/models/deepseek-v4-flash-0731'
 		});
 		expect(resolveLanguageModel('glm-5.3', 'standard')).toMatchObject({

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -147,7 +147,7 @@ function fireworksModelPath(modelId: SupportedModelId): string {
 		case 'deepseek-v4-pro':
 			return 'accounts/fireworks/models/deepseek-v4-pro';
 		case 'deepseek-v4-flash':
-			return 'accounts/fireworks/models/deepseek-v4-flash';
+			return 'accounts/fireworks/models/deepseek-v4-flash-0731';
 		default:
 			throw new Error(`Unsupported Fireworks model: ${modelId}`);
 	}

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -141,16 +141,11 @@ function resolveBedrockFallbackModel(
 }
 
 function fireworksModelPath(modelId: SupportedModelId): string {
-	switch (modelId) {
-		case 'kimi-k3':
-			return 'accounts/fireworks/models/kimi-k3';
-		case 'deepseek-v4-pro':
-			return 'accounts/fireworks/models/deepseek-v4-pro';
-		case 'deepseek-v4-flash':
-			return 'accounts/fireworks/models/deepseek-v4-flash-0731';
-		default:
-			throw new Error(`Unsupported Fireworks model: ${modelId}`);
+	const provider = getModelDefinition(modelId).provider;
+	if (provider !== 'kimi' && provider !== 'deepseek') {
+		throw new Error(`Unsupported Fireworks model: ${modelId}`);
 	}
+	return `accounts/fireworks/models/${modelId}`;
 }
 
 export function resolveLanguageModel(

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -32,11 +32,21 @@ describe('model configuration', () => {
 		expect(offered).not.toContain('gpt-5.6-luna');
 		expect(offered).not.toContain('gpt-5.6-terra');
 		expect(offered).not.toContain('grok-4.5');
+		expect(offered).not.toContain('deepseek-v4-pro');
+		expect(offered).not.toContain('deepseek-v4-flash');
 		expect(modelDefinitions.map((model) => model.id)).toEqual([...modelIds]);
 		expect(persistedModelIds as readonly string[]).toEqual(
-			expect.arrayContaining(['gpt-5.6-terra', 'gpt-5.6-luna', 'grok-4.5'])
+			expect.arrayContaining([
+				'gpt-5.6-terra',
+				'gpt-5.6-luna',
+				'grok-4.5',
+				'deepseek-v4-pro',
+				'deepseek-v4-flash'
+			])
 		);
 		expect(coercePersistedModelId('gpt-5.6-luna')).toBe('gpt-5.6-sol');
+		expect(coercePersistedModelId('deepseek-v4-pro')).toBe('deepseek-v4-pro-0813');
+		expect(coercePersistedModelId('deepseek-v4-flash')).toBe('deepseek-v4-flash-0731');
 		expect(coercePersistedModelId('kimi-k3')).toBe('kimi-k3');
 		expect(coercePersistedSelection('grok-4.5', 'fast')).toEqual({
 			modelId: 'gpt-5.6-sol',
@@ -49,8 +59,8 @@ describe('model configuration', () => {
 	});
 
 	it('labels models by lab, not inference host', () => {
-		expect(getModelDefinition('deepseek-v4-pro').provider).toBe('deepseek');
-		expect(getModelDefinition('deepseek-v4-flash').provider).toBe('deepseek');
+		expect(getModelDefinition('deepseek-v4-pro-0813').provider).toBe('deepseek');
+		expect(getModelDefinition('deepseek-v4-flash-0731').provider).toBe('deepseek');
 		expect(getModelDefinition('kimi-k3').provider).toBe('kimi');
 		expect(getModelDefinition('glm-5.3').provider).toBe('zai');
 	});
@@ -60,8 +70,8 @@ describe('model configuration', () => {
 		expect(getModelDefinition('claude-fable-5').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('kimi-k3').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('glm-5.3').serviceTiers).toEqual(['standard']);
-		expect(getModelDefinition('deepseek-v4-pro').serviceTiers).toEqual(['standard']);
-		expect(getModelDefinition('deepseek-v4-flash').serviceTiers).toEqual(['standard']);
+		expect(getModelDefinition('deepseek-v4-pro-0813').serviceTiers).toEqual(['standard']);
+		expect(getModelDefinition('deepseek-v4-flash-0731').serviceTiers).toEqual(['standard']);
 		expect(() =>
 			assertSupportedModelConfiguration({
 				modelId: 'kimi-k3',
@@ -70,7 +80,7 @@ describe('model configuration', () => {
 		).toThrow('Kimi K3 does not support the fast service tier.');
 		expect(() =>
 			assertSupportedModelConfiguration({
-				modelId: 'deepseek-v4-flash',
+				modelId: 'deepseek-v4-flash-0731',
 				serviceTier: 'fast'
 			})
 		).toThrow('DeepSeek V4 Flash does not support the fast service tier.');

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -8,8 +8,8 @@ export const modelIds = [
 	'claude-fable-5',
 	'glm-5.3',
 	'kimi-k3',
-	'deepseek-v4-pro',
-	'deepseek-v4-flash'
+	'deepseek-v4-pro-0813',
+	'deepseek-v4-flash-0731'
 ] as const;
 
 export type SupportedModelId = (typeof modelIds)[number];
@@ -18,8 +18,22 @@ export type SupportedServiceTier = (typeof serviceTierIds)[number];
 export type ModelProvider = 'openai' | 'anthropic' | 'zai' | 'kimi' | 'deepseek';
 
 /** Removed from the catalog; kept so existing thread/run rows still validate. */
-export const retiredModelIds = ['gpt-5.6-terra', 'gpt-5.6-luna', 'grok-4.5'] as const;
+export const retiredModelIds = [
+	'gpt-5.6-terra',
+	'gpt-5.6-luna',
+	'grok-4.5',
+	'deepseek-v4-pro',
+	'deepseek-v4-flash'
+] as const;
 export const persistedModelIds = [...modelIds, ...retiredModelIds] as const;
+
+const retiredModelReplacements = {
+	'gpt-5.6-terra': 'gpt-5.6-sol',
+	'gpt-5.6-luna': 'gpt-5.6-sol',
+	'grok-4.5': 'gpt-5.6-sol',
+	'deepseek-v4-pro': 'deepseek-v4-pro-0813',
+	'deepseek-v4-flash': 'deepseek-v4-flash-0731'
+} as const satisfies Record<(typeof retiredModelIds)[number], SupportedModelId>;
 
 type TokenUsageWeights = { input: number; cacheRead: number; cacheWrite: number; output: number };
 
@@ -131,7 +145,7 @@ export const modelDefinitions = [
 		}
 	},
 	{
-		id: 'deepseek-v4-pro',
+		id: 'deepseek-v4-pro-0813',
 		label: 'DeepSeek V4 Pro',
 		provider: 'deepseek',
 		...millionTokenContext,
@@ -147,7 +161,7 @@ export const modelDefinitions = [
 		}
 	},
 	{
-		id: 'deepseek-v4-flash',
+		id: 'deepseek-v4-flash-0731',
 		label: 'DeepSeek V4 Flash',
 		provider: 'deepseek',
 		...millionTokenContext,
@@ -177,9 +191,12 @@ export function getModelDefinition(modelId: SupportedModelId): ModelDefinition {
 
 /** Map a stored (possibly retired) model id onto the current catalog. */
 export function coercePersistedModelId(modelId: string): SupportedModelId {
-	return (modelIds as readonly string[]).includes(modelId)
-		? (modelId as SupportedModelId)
-		: defaultModelId;
+	if ((modelIds as readonly string[]).includes(modelId)) {
+		return modelId as SupportedModelId;
+	}
+	return (
+		retiredModelReplacements[modelId as keyof typeof retiredModelReplacements] ?? defaultModelId
+	);
 }
 
 /** Retired ids and dropped Fast offerings still stored on old runs. */

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -45,7 +45,7 @@ export const tierLimits: Record<SubscriptionTier, TierLimits> = {
 };
 
 export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModelId[]> = {
-	free: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+	free: ['deepseek-v4-pro-0813', 'deepseek-v4-flash-0731'],
 	pro: modelIds,
 	admin: modelIds
 };


### PR DESCRIPTION
## Summary
- Catalog ids are now `deepseek-v4-pro-0813` and `deepseek-v4-flash-0731`, matching the current Fireworks serverless snapshots.
- Undated `deepseek-v4-pro` / `deepseek-v4-flash` stay valid on existing threads and coerce onto those snapshots.

## Test plan
- [ ] A Free or Pro run using DeepSeek V4 Flash completes.
- [ ] A run using DeepSeek V4 Pro completes on the 0813 snapshot.
- [ ] Opening a thread that still stores `deepseek-v4-pro` or `deepseek-v4-flash` keeps using Pro / Flash instead of falling back to Sol.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR pins the DeepSeek V4 Pro and Flash catalog entries to dated Fireworks serverless model identifiers while preserving compatibility for persisted legacy identifiers.
- Replaces the active DeepSeek model IDs with versioned Fireworks snapshot IDs.
- Maps retired DeepSeek IDs to their current replacements when loading persisted selections.
- Updates free-tier availability, provider routing, and model-registry tests for the new IDs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/models.ts | Versions the active DeepSeek model IDs and maps legacy persisted IDs to their current replacements. |
| apps/web/src/convex/lib/modelRegistry.ts | Builds Fireworks model paths from validated Kimi and DeepSeek catalog identifiers. |
| apps/web/src/convex/lib/tiers.ts | Updates free-tier model availability to use the versioned DeepSeek identifiers. |
| apps/web/src/convex/lib/modelRegistry.test.ts | Verifies that both versioned DeepSeek models resolve to their expected Fireworks paths. |
| apps/web/src/convex/lib/models.test.ts | Verifies catalog retirement and coercion of legacy DeepSeek identifiers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(models): Pin DeepSeek catalog ids to..."](https://github.com/spikonado/sprocket/commit/ffbdb1a4141684945b0e284a5aebf258f42d162f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55406802)</sub>

**Context used:**

- Knowledge Base — [Convex Backend](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-backend.md)

<!-- /greptile_comment -->