### PR TITLE
fix(models): Block image input for DeepSeek

### DIFF
--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -22,6 +22,36 @@ describe('agentRuntime.createRun', () => {
 		).rejects.toThrow('Message cannot be empty.');
 	});
 
+	it('rejects image attachments for models without image support', async () => {
+		const t = initConvexTest();
+		const { asUser, subject, threadId } = await seedOwnedThread(t);
+		const imageUploadId = await t.run(async (ctx) => {
+			const storageId = await ctx.storage.store(new Blob(['image'], { type: 'image/png' }));
+			return await ctx.db.insert('imageUploads', {
+				userId: subject,
+				storageId,
+				name: 'diagram.png',
+				mediaType: 'image/png',
+				size: 5,
+				messageIds: [],
+				attached: false
+			});
+		});
+
+		await expect(
+			asUser.mutation(api.agentRuntime.createRun, {
+				submissionId: 'sub-deepseek-image',
+				threadId,
+				prompt: 'Describe this image',
+				imageUploadIds: [imageUploadId],
+				selectedModel: 'deepseek-v4-pro-0813',
+				reasoningEffort: 'max',
+				serviceTier: 'standard',
+				executionSecret: 'deepseek-image-secret'
+			})
+		).rejects.toThrow('DeepSeek V4 Pro does not support image attachments.');
+	});
+
 	it('creates a queued run and is idempotent for the same submission', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -202,6 +202,10 @@ export const createRun = mutation({
 			reasoningEffort: args.reasoningEffort,
 			serviceTier: args.serviceTier
 		});
+		const model = getModelDefinition(args.selectedModel);
+		if (args.imageUploadIds.length > 0 && !model.supportsImages) {
+			throw new Error(`${model.label} does not support image attachments.`);
+		}
 		const secretHash = await executionSecretHash(args.executionSecret);
 		const threadRecord = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
 		const prompt = args.prompt.trim();

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -395,6 +395,7 @@ export const vCatalogModel = v.object({
 	id: vModelId,
 	label: v.string(),
 	provider: vModelProvider,
+	supportsImages: v.boolean(),
 	contextWindowTokens: v.number(),
 	autoCompactTokenLimit: v.number(),
 	reasoningEfforts: v.array(vReasoningEffort),

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -65,6 +65,12 @@ describe('model configuration', () => {
 		expect(getModelDefinition('glm-5.3').provider).toBe('zai');
 	});
 
+	it('does not advertise image support for DeepSeek models', () => {
+		expect(getModelDefinition('deepseek-v4-pro-0813').supportsImages).toBe(false);
+		expect(getModelDefinition('deepseek-v4-flash-0731').supportsImages).toBe(false);
+		expect(getModelDefinition('gpt-5.6-sol').supportsImages).toBe(true);
+	});
+
 	it('does not advertise Fast for models without a faster route', () => {
 		expect(getModelDefinition('gpt-5.6-sol').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('claude-fable-5').serviceTiers).toEqual(['standard']);

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -41,6 +41,7 @@ type ModelDefinition = {
 	id: SupportedModelId;
 	label: string;
 	provider: ModelProvider;
+	supportsImages: boolean;
 	/** Context budget exposed by the provider's coding-agent harness. */
 	contextWindowTokens: number;
 	/** Input-token count at which the harness automatically compacts. */
@@ -66,6 +67,7 @@ export const modelDefinitions = [
 		id: 'gpt-5.6-sol',
 		label: 'GPT-5.6 Sol',
 		provider: 'openai',
+		supportsImages: true,
 		// OpenAI bills the whole request at 1M rates once input exceeds 272k.
 		contextWindowTokens: 272_000,
 		autoCompactTokenLimit: 258_000,
@@ -84,6 +86,7 @@ export const modelDefinitions = [
 		id: 'claude-opus-5',
 		label: 'Claude Opus 5',
 		provider: 'anthropic',
+		supportsImages: true,
 		...millionTokenContext,
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
@@ -100,6 +103,7 @@ export const modelDefinitions = [
 		id: 'claude-fable-5',
 		label: 'Claude Fable 5',
 		provider: 'anthropic',
+		supportsImages: true,
 		...millionTokenContext,
 		reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
 		defaultReasoningEffort: 'high',
@@ -116,6 +120,7 @@ export const modelDefinitions = [
 		id: 'glm-5.3',
 		label: 'GLM 5.3',
 		provider: 'zai',
+		supportsImages: true,
 		...millionTokenContext,
 		reasoningEfforts: lowHighMaxReasoningEfforts,
 		defaultReasoningEffort: 'max',
@@ -132,6 +137,7 @@ export const modelDefinitions = [
 		id: 'kimi-k3',
 		label: 'Kimi K3',
 		provider: 'kimi',
+		supportsImages: true,
 		...millionTokenContext,
 		reasoningEfforts: lowHighMaxReasoningEfforts,
 		defaultReasoningEffort: 'max',
@@ -148,6 +154,7 @@ export const modelDefinitions = [
 		id: 'deepseek-v4-pro-0813',
 		label: 'DeepSeek V4 Pro',
 		provider: 'deepseek',
+		supportsImages: false,
 		...millionTokenContext,
 		reasoningEfforts: lowHighMaxReasoningEfforts,
 		defaultReasoningEffort: 'max',
@@ -164,6 +171,7 @@ export const modelDefinitions = [
 		id: 'deepseek-v4-flash-0731',
 		label: 'DeepSeek V4 Flash',
 		provider: 'deepseek',
+		supportsImages: false,
 		...millionTokenContext,
 		reasoningEfforts: lowHighMaxReasoningEfforts,
 		defaultReasoningEffort: 'high',

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -143,6 +143,10 @@
 	const answeringQuestion = $derived(pendingQuestion != null);
 	const composerLocked = $derived((isRunning && !answeringQuestion) || isSubmitting);
 	const hasMessageContent = $derived(Boolean(prompt.trim()) || attachments.length > 0);
+	const selectedModelSupportsImages = $derived(selectedCatalogModel?.supportsImages === true);
+	const hasUnsupportedAttachments = $derived(
+		attachments.length > 0 && selectedCatalogModel?.supportsImages === false
+	);
 	const canAnswerQuestion = $derived(
 		canSubmitQuestionAnswer({
 			selectedOptionId: selectedQuestionOptionId,
@@ -154,7 +158,10 @@
 		attachments.some((attachment) => attachment.status !== 'ready')
 	);
 	const canAttachMore = $derived(
-		attachments.length < MAX_IMAGE_ATTACHMENTS && !composerLocked && !answeringQuestion
+		selectedModelSupportsImages &&
+			attachments.length < MAX_IMAGE_ATTACHMENTS &&
+			!composerLocked &&
+			!answeringQuestion
 	);
 
 	let trackedPendingQuestionId = $state<string | null>(null);
@@ -170,7 +177,11 @@
 			}
 		}
 	});
-	const attachTooltipLabel = `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`;
+	const attachTooltipLabel = $derived(
+		selectedCatalogModel?.supportsImages === false
+			? `${selectedCatalogModel.label} does not support image input`
+			: `Attach images (up to ${MAX_IMAGE_ATTACHMENTS})`
+	);
 	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
 	const contextPercent = $derived(
 		contextUsage.contextWindowTokens > 0
@@ -272,7 +283,13 @@
 		const files = Array.from(event.clipboardData?.files ?? []).filter((file) =>
 			file.type.startsWith('image/')
 		);
-		if (files.length === 0 || isRunning || isSubmitting || answeringQuestion) {
+		if (
+			files.length === 0 ||
+			isRunning ||
+			isSubmitting ||
+			answeringQuestion ||
+			!selectedModelSupportsImages
+		) {
 			return;
 		}
 		event.preventDefault();
@@ -281,7 +298,11 @@
 
 	function showAttachTooltip(event: MouseEvent | FocusEvent) {
 		const target = event.currentTarget;
-		if (!(target instanceof HTMLButtonElement) || target.disabled) {
+		if (!(target instanceof HTMLButtonElement)) {
+			return;
+		}
+		// Disabled attach still explains no-image models; skip other disabled reasons.
+		if (target.disabled && selectedCatalogModel?.supportsImages !== false) {
 			return;
 		}
 		const rect = target.getBoundingClientRect();
@@ -343,7 +364,7 @@
 			isSubmitting ||
 			composerLocked ||
 			!canSubmitContent ||
-			(!answeringQuestion && attachmentsPending)
+			(!answeringQuestion && (attachmentsPending || hasUnsupportedAttachments))
 		) {
 			return;
 		}
@@ -553,6 +574,12 @@
 								</li>
 							{/each}
 						</ul>
+						{#if hasUnsupportedAttachments && selectedCatalogModel}
+							<p class="text-destructive mb-3 text-xs" role="alert">
+								{selectedCatalogModel.label} does not support image input. Remove the images or choose
+								another model.
+							</p>
+						{/if}
 					{/if}
 					<div class="relative min-h-0 flex-1">
 						{#if skillsPopupOpen}
@@ -764,7 +791,7 @@
 										(!answeringQuestion && !canSubmitWithModel) ||
 										isSubmitting ||
 										!canSubmitContent ||
-										(!answeringQuestion && attachmentsPending)}
+										(!answeringQuestion && (attachmentsPending || hasUnsupportedAttachments))}
 									aria-label={answeringQuestion ? 'Submit answer' : 'Send message'}
 								>
 									<ArrowUp class="size-4" />


### PR DESCRIPTION
## Summary

- declare image-input support in the model catalog and mark DeepSeek models unsupported
- disable attaching, pasting, and sending images with DeepSeek in the composer
- reject DeepSeek image attachments in `agentRuntime.createRun` as a server-side safeguard
- cover model capabilities and runtime rejection with regression tests

## Testing

- `cd apps/web && bun run test`
- `cd apps/web && bun run check`
- `cd apps/web && bunx convex typecheck`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an explicit image-input capability to model definitions and prevents DeepSeek models from receiving image attachments.
- Marks both DeepSeek variants as not supporting images while retaining image support for the remaining catalog models.
- Disables attachment, paste, and submission paths when the selected model cannot accept images.
- Adds a server-side `createRun` safeguard and regression coverage for model capabilities and rejection behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with consistent client-side guidance and server-side enforcement for unsupported DeepSeek image attachments.

The model capability is propagated through the validated catalog, the composer blocks unsupported attachment paths while preserving a clear recovery route, and createRun independently rejects bypass attempts.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Adds a server-side model-capability check before creating a run with image attachments. |
| apps/web/src/convex/lib/models.ts | Extends model definitions with image-input capability metadata and marks DeepSeek variants unsupported. |
| apps/web/src/convex/lib/docs.ts | Updates the model-catalog validator to require the new capability field. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Gates attachment, paste, and send behavior on the selected model's image capability and provides recovery guidance. |
| apps/web/src/convex/agentRuntime.createRun.test.ts | Covers server-side rejection of DeepSeek image attachments. |
| apps/web/src/convex/lib/models.test.ts | Verifies the advertised image capabilities for DeepSeek and a supported model. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  U[User selects model and composes prompt] --> C{Model supports images?}
  C -->|Yes| A[Allow attach and paste]
  A --> S[Submit createRun]
  C -->|No| D[Disable image attachment input]
  D --> E{Existing attachments?}
  E -->|Yes| B[Block send and show removal guidance]
  E -->|No| T[Allow text-only submission]
  B --> R[Remove images or select another model]
  R --> C
  T --> S
  S --> G{Server capability guard}
  G -->|Supported or no images| Q[Create queued run]
  G -->|Unsupported images| X[Reject submission]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): Block image input for DeepS..."](https://github.com/spikonado/sprocket/commit/382a6cfb611516598aa0f4a5bd42f2b3e0bbdef0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55496136)</sub>

**Context used:**

- Knowledge Base — [Web App (SvelteKit Frontend)](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-app.md)
- Knowledge Base — [Convex Backend](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-backend.md)

<!-- /greptile_comment -->