### PR TITLE
feat(models): Add unlimited Ox Alpha model

### DIFF
--- a/apps/web/src/convex/completion.ts
+++ b/apps/web/src/convex/completion.ts
@@ -136,7 +136,8 @@ export const complete = action({
 		const completionContext = await prepareCompletionContext(
 			ctx,
 			args.streamRunId,
-			args.executionSecret
+			args.executionSecret,
+			modelId
 		);
 		const sharedArgs = buildSharedCompletionRequest(
 			{ ...args, modelId, serviceTier },
@@ -229,7 +230,12 @@ export const summarize = action({
 			claimId: args.claimId,
 			executionSecret: args.executionSecret
 		};
-		const completionContext = await prepareCompletionContext(ctx, args.runId, args.executionSecret);
+		const completionContext = await prepareCompletionContext(
+			ctx,
+			args.runId,
+			args.executionSecret,
+			modelId
+		);
 		await assertSummarizeStillAccepted(ctx, claim);
 		const messages = reviveImageUrls(
 			parseJson<SerializedModelMessage[]>(args.messagesJson, 'messagesJson')
@@ -271,7 +277,7 @@ export const summarize = action({
 			serviceTier,
 			tokens: normalizeCompletionUsage(result.usage)
 		});
-		await checkModelUsageLimit(ctx, completionContext.userId);
+		await checkModelUsageLimit(ctx, completionContext.userId, modelId);
 		return { summary, usage: result.usage };
 	}
 });
@@ -692,14 +698,15 @@ function delay(milliseconds: number): Promise<void> {
 async function prepareCompletionContext(
 	ctx: ActionCtx,
 	runId: Id<'runs'>,
-	executionSecret: string
+	executionSecret: string,
+	modelId: SupportedModelId
 ): Promise<{ promptCacheKey: string; streamSequence: number; userId: string }> {
 	const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
 		runId,
 		executionSecret
 	});
 	assertRunAcceptsModelCompletion(actor.status);
-	await checkModelUsageLimit(ctx, actor.userId);
+	await checkModelUsageLimit(ctx, actor.userId, modelId);
 	return {
 		promptCacheKey: `thread:${actor.threadId}`,
 		streamSequence: actor.streamSequence,

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -384,6 +384,7 @@ export const vCompletionStreamMergeResult = v.union(
 );
 
 export const vModelProvider = v.union(
+	v.literal('stealth'),
 	v.literal('openai'),
 	v.literal('anthropic'),
 	v.literal('zai'),

--- a/apps/web/src/convex/lib/modelRegistry.test.ts
+++ b/apps/web/src/convex/lib/modelRegistry.test.ts
@@ -39,6 +39,9 @@ describe('model provider request configuration', () => {
 		expect(resolveProviderOptions('glm-5.3', 'max', 'standard', 'thread:abc')).toEqual({
 			zai: { reasoningEffort: 'max' }
 		});
+		expect(resolveProviderOptions('stealth/ox-alpha', 'max', 'standard', 'thread:abc')).toEqual({
+			openrouter: { reasoningEffort: 'max' }
+		});
 	});
 
 	it('adds Anthropic service_tier only to completion request bodies', async () => {
@@ -117,6 +120,11 @@ describe('Amazon Bedrock fallback routing', () => {
 		expect(resolveLanguageModel('deepseek-v4-pro-0813', 'standard')).not.toBeInstanceOf(
 			FallbackModel
 		);
+		expect(resolveLanguageModel('stealth/ox-alpha', 'standard')).not.toBeInstanceOf(FallbackModel);
+		expect(resolveLanguageModel('stealth/ox-alpha', 'standard')).toMatchObject({
+			modelId: 'stealth/ox-alpha',
+			provider: 'openrouter.chat'
+		});
 		expect(resolveLanguageModel('kimi-k3', 'standard')).toMatchObject({
 			modelId: 'accounts/fireworks/models/kimi-k3'
 		});

--- a/apps/web/src/convex/lib/modelRegistry.ts
+++ b/apps/web/src/convex/lib/modelRegistry.ts
@@ -73,6 +73,12 @@ const zai = createOpenAICompatible({
 	// GLM 5.3 rejects thinking.type=disabled; thinking is always on.
 	transformRequestBody: (args) => ({ ...args, thinking: { type: 'enabled' } })
 });
+const openrouter = createOpenAICompatible({
+	name: 'openrouter',
+	baseURL: 'https://openrouter.ai/api/v1',
+	apiKey: process.env.OPENROUTER_API_KEY,
+	includeUsage: true
+});
 
 export function hasBedrockCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
 	if (env.AWS_BEARER_TOKEN_BEDROCK?.trim()) return true;
@@ -152,12 +158,16 @@ export function resolveLanguageModel(
 	modelId: SupportedModelId,
 	serviceTier: SupportedServiceTier
 ): LanguageModel {
-	const provider = getModelDefinition(modelId).provider;
+	const model = getModelDefinition(modelId);
+	const provider = model.inferenceProvider ?? model.provider;
 	if (provider === 'anthropic') {
 		const primary = serviceTier === 'fast' ? anthropicFast(modelId) : anthropic(modelId);
 		// Bedrock has no priority/fast routes; fail over only on standard.
 		if (serviceTier === 'fast') return primary;
 		return withBedrockFallback(primary, () => resolveBedrockFallbackModel('anthropic', modelId));
+	}
+	if (provider === 'openrouter') {
+		return openrouter.chatModel(modelId);
 	}
 	if (provider === 'zai') {
 		return zai.chatModel(modelId);
@@ -176,7 +186,8 @@ export function resolveProviderOptions(
 	serviceTier: SupportedServiceTier,
 	promptCacheKey: string
 ): Record<string, Record<string, JSONValue>> {
-	const provider = getModelDefinition(modelId).provider;
+	const model = getModelDefinition(modelId);
+	const provider = model.inferenceProvider ?? model.provider;
 	if (provider === 'anthropic') {
 		return {
 			anthropic: {
@@ -185,9 +196,9 @@ export function resolveProviderOptions(
 			}
 		};
 	}
-	if (provider === 'zai') {
+	if (provider === 'openrouter' || provider === 'zai') {
 		return {
-			zai: {
+			[provider]: {
 				...(reasoningEffort !== undefined ? { reasoningEffort } : {})
 			}
 		};

--- a/apps/web/src/convex/lib/models.test.ts
+++ b/apps/web/src/convex/lib/models.test.ts
@@ -4,10 +4,12 @@ import {
 	coercePersistedModelId,
 	coercePersistedSelection,
 	getModelDefinition,
+	isModelUsageMetered,
 	modelDefinitions,
 	modelIds,
 	persistedModelIds
 } from '@convex/lib/models';
+import { subscriptionTierIds, tierAllowedModels } from '@convex/lib/tiers';
 
 describe('model configuration', () => {
 	it('rejects reasoning efforts unsupported by a model', () => {
@@ -65,6 +67,22 @@ describe('model configuration', () => {
 		expect(getModelDefinition('glm-5.3').provider).toBe('zai');
 	});
 
+	it('marks Ox Alpha as an unmetered OpenRouter model', () => {
+		expect(getModelDefinition('stealth/ox-alpha')).toMatchObject({
+			provider: 'stealth',
+			inferenceProvider: 'openrouter',
+			supportsImages: true
+		});
+		expect(isModelUsageMetered('stealth/ox-alpha')).toBe(false);
+		expect(isModelUsageMetered('gpt-5.6-sol')).toBe(true);
+	});
+
+	it('offers Ox Alpha on every subscription tier', () => {
+		for (const tier of subscriptionTierIds) {
+			expect(tierAllowedModels[tier]).toContain('stealth/ox-alpha');
+		}
+	});
+
 	it('does not advertise image support for DeepSeek models', () => {
 		expect(getModelDefinition('deepseek-v4-pro-0813').supportsImages).toBe(false);
 		expect(getModelDefinition('deepseek-v4-flash-0731').supportsImages).toBe(false);
@@ -72,6 +90,7 @@ describe('model configuration', () => {
 	});
 
 	it('does not advertise Fast for models without a faster route', () => {
+		expect(getModelDefinition('stealth/ox-alpha').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('gpt-5.6-sol').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('claude-fable-5').serviceTiers).toEqual(['standard']);
 		expect(getModelDefinition('kimi-k3').serviceTiers).toEqual(['standard']);

--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -3,6 +3,7 @@ import type { LanguageModelUsage } from 'ai';
 export const reasoningEffortIds = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 export const serviceTierIds = ['standard', 'fast'] as const;
 export const modelIds = [
+	'stealth/ox-alpha',
 	'gpt-5.6-sol',
 	'claude-opus-5',
 	'claude-fable-5',
@@ -15,7 +16,7 @@ export const modelIds = [
 export type SupportedModelId = (typeof modelIds)[number];
 export type SupportedReasoningEffort = (typeof reasoningEffortIds)[number];
 export type SupportedServiceTier = (typeof serviceTierIds)[number];
-export type ModelProvider = 'openai' | 'anthropic' | 'zai' | 'kimi' | 'deepseek';
+export type ModelProvider = 'stealth' | 'openai' | 'anthropic' | 'zai' | 'kimi' | 'deepseek';
 
 /** Removed from the catalog; kept so existing thread/run rows still validate. */
 export const retiredModelIds = [
@@ -37,10 +38,12 @@ const retiredModelReplacements = {
 
 type TokenUsageWeights = { input: number; cacheRead: number; cacheWrite: number; output: number };
 
-type ModelDefinition = {
+export type ModelDefinition = {
 	id: SupportedModelId;
 	label: string;
 	provider: ModelProvider;
+	/** Inference host when it differs from the model provider shown in the catalog. */
+	inferenceProvider?: 'openrouter';
 	supportsImages: boolean;
 	/** Context budget exposed by the provider's coding-agent harness. */
 	contextWindowTokens: number;
@@ -49,11 +52,16 @@ type ModelDefinition = {
 	reasoningEfforts: readonly SupportedReasoningEffort[];
 	defaultReasoningEffort: SupportedReasoningEffort;
 	serviceTiers: readonly SupportedServiceTier[];
+	/** Unset means usage is metered. */
+	usagePolicy?: 'unlimited';
 	usageWeights: TokenUsageWeights & { fastMultiplier: number };
 };
 
-/** UI-facing model entry (server pricing weights omitted). */
-export type CatalogModel = Omit<ModelDefinition, 'usageWeights'>;
+/** UI-facing model entry (server-only routing and usage fields omitted). */
+export type CatalogModel = Omit<
+	ModelDefinition,
+	'inferenceProvider' | 'usagePolicy' | 'usageWeights'
+>;
 
 const millionTokenContext = {
 	contextWindowTokens: 1_000_000,
@@ -63,6 +71,26 @@ const millionTokenContext = {
 const lowHighMaxReasoningEfforts = ['low', 'high', 'max'] as const;
 
 export const modelDefinitions = [
+	{
+		id: 'stealth/ox-alpha',
+		label: 'Ox Alpha',
+		provider: 'stealth',
+		inferenceProvider: 'openrouter',
+		supportsImages: true,
+		contextWindowTokens: 1_048_576,
+		autoCompactTokenLimit: 1_015_576,
+		reasoningEfforts: lowHighMaxReasoningEfforts,
+		defaultReasoningEffort: 'max',
+		serviceTiers: ['standard'],
+		usagePolicy: 'unlimited',
+		usageWeights: {
+			input: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			output: 0,
+			fastMultiplier: 1
+		}
+	},
 	{
 		id: 'gpt-5.6-sol',
 		label: 'GPT-5.6 Sol',
@@ -195,6 +223,10 @@ export function getModelDefinition(modelId: SupportedModelId): ModelDefinition {
 	const definition = modelDefinitions.find((model) => model.id === modelId);
 	if (!definition) throw new Error(`Unsupported model: ${modelId}`);
 	return definition;
+}
+
+export function isModelUsageMetered(modelId: SupportedModelId): boolean {
+	return getModelDefinition(modelId).usagePolicy !== 'unlimited';
 }
 
 /** Map a stored (possibly retired) model id onto the current catalog. */

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -16,6 +16,7 @@ import { getFunctionName, type FunctionArgs, type FunctionReference } from 'conv
 import { v } from 'convex/values';
 import {
 	completionUsageUnits,
+	isModelUsageMetered,
 	type SupportedModelId,
 	type SupportedServiceTier
 } from '@convex/lib/models';
@@ -137,8 +138,9 @@ export async function getMeterWindow(
 }
 
 export const checkModelUsageLimits = internalMutation({
-	args: { userId: v.string() },
-	handler: async (ctx, { userId }) => {
+	args: { userId: v.string(), modelId: vModelId },
+	handler: async (ctx, { userId, modelId }) => {
+		if (!isModelUsageMetered(modelId)) return;
 		const tier = await ensureSubscription(ctx, userId);
 		if (tier === 'admin') return;
 		await checkMeterLimits(ctx, 'modelUsage', userId, tierLimits[tier]);
@@ -158,6 +160,7 @@ export const chargeModelUsageLimits = internalMutation({
 		})
 	},
 	handler: async (ctx, args) => {
+		if (!isModelUsageMetered(args.modelId)) return;
 		const tier = await ensureSubscription(ctx, args.userId);
 		if (tier === 'admin') return;
 		const count = completionUsageUnits(args.modelId, args.serviceTier, args.tokens);
@@ -188,8 +191,12 @@ async function chargeUsageDurably<Mutation extends FunctionReference<'mutation',
 	}
 }
 
-export async function checkModelUsageLimit(ctx: ActionCtx, userId: string): Promise<void> {
-	await ctx.runMutation(internal.lib.rateLimits.checkModelUsageLimits, { userId });
+export async function checkModelUsageLimit(
+	ctx: ActionCtx,
+	userId: string,
+	modelId: SupportedModelId
+): Promise<void> {
+	await ctx.runMutation(internal.lib.rateLimits.checkModelUsageLimits, { userId, modelId });
 }
 
 export async function chargeModelUsage(

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -45,7 +45,7 @@ export const tierLimits: Record<SubscriptionTier, TierLimits> = {
 };
 
 export const tierAllowedModels: Record<SubscriptionTier, readonly SupportedModelId[]> = {
-	free: ['deepseek-v4-pro-0813', 'deepseek-v4-flash-0731'],
+	free: ['stealth/ox-alpha', 'deepseek-v4-pro-0813', 'deepseek-v4-flash-0731'],
 	pro: modelIds,
 	admin: modelIds
 };

--- a/apps/web/src/convex/modelCatalog.ts
+++ b/apps/web/src/convex/modelCatalog.ts
@@ -2,7 +2,8 @@ import {
 	defaultModelId,
 	defaultReasoningEffort,
 	defaultServiceTier,
-	modelDefinitions
+	modelDefinitions,
+	type ModelDefinition
 } from '@convex/lib/models';
 import {
 	modelLockUpgradeMessage,
@@ -27,9 +28,11 @@ export const get = query({
 			defaultModelId,
 			defaultReasoningEffort,
 			defaultServiceTier,
-			// Omit server-only pricing weights from the UI catalog.
-			models: modelDefinitions.map((definition) => {
-				const { usageWeights, ...model } = definition;
+			// Omit server-only routing and usage fields from the UI catalog.
+			models: modelDefinitions.map((definition: ModelDefinition) => {
+				const { inferenceProvider, usagePolicy, usageWeights, ...model } = definition;
+				void inferenceProvider;
+				void usagePolicy;
 				void usageWeights;
 				return {
 					...model,

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -20,7 +20,10 @@ describe('subscription and usage backend', () => {
 		const weekly = model?.windows.find((window) => window.period === 'weekly');
 		expect(weekly && weekly.used > weekly.limit).toBe(true);
 		await expect(
-			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
+			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, {
+				userId,
+				modelId: 'gpt-5.6-sol'
+			})
 		).rejects.toThrow('Monthly model usage limit reached');
 	});
 
@@ -196,7 +199,10 @@ describe('subscription and usage backend', () => {
 			tokens: { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 }
 		});
 		await expect(
-			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId })
+			t.mutation(internal.lib.rateLimits.checkModelUsageLimits, {
+				userId,
+				modelId: 'gpt-5.6-sol'
+			})
 		).rejects.toThrow('Monthly model usage limit reached');
 
 		await t.run(async (ctx) => {
@@ -208,7 +214,10 @@ describe('subscription and usage backend', () => {
 			await ctx.db.patch(existing._id, { tier: 'admin' });
 		});
 
-		await t.mutation(internal.lib.rateLimits.checkModelUsageLimits, { userId });
+		await t.mutation(internal.lib.rateLimits.checkModelUsageLimits, {
+			userId,
+			modelId: 'gpt-5.6-sol'
+		});
 		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
 			userId,
 			modelId: 'gpt-5.6-sol',
@@ -221,5 +230,37 @@ describe('subscription and usage backend', () => {
 			.find((meter) => meter.id === 'modelUsage')
 			?.windows.find((window) => window.period === 'weekly');
 		expect(weekly).toMatchObject({ used: 0 });
+	});
+
+	it('does not meter unlimited model usage or block it after overdraft', async () => {
+		const t = initConvexTest();
+		const userId = 'user_unlimited_model';
+		const asUser = t.withIdentity({ subject: userId });
+		const tokens = { input: 1_000_000, cacheRead: 0, cacheWrite: 0, output: 2_000_000 };
+
+		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
+			userId,
+			modelId: 'gpt-5.6-sol',
+			serviceTier: 'standard',
+			tokens
+		});
+		await t.mutation(internal.lib.rateLimits.checkModelUsageLimits, {
+			userId,
+			modelId: 'stealth/ox-alpha'
+		});
+		const usageBeforeUnlimitedCharge = await asUser.query(api.usage.getMyUsage, {});
+		await t.mutation(internal.lib.rateLimits.chargeModelUsageLimits, {
+			userId,
+			modelId: 'stealth/ox-alpha',
+			serviceTier: 'standard',
+			tokens
+		});
+
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		const weekly = usage.meters
+			.find((meter) => meter.id === 'modelUsage')
+			?.windows.find((window) => window.period === 'weekly');
+		expect(weekly && weekly.used > weekly.limit).toBe(true);
+		expect(usage).toEqual(usageBeforeUnlimitedCharge);
 	});
 });


### PR DESCRIPTION
## Summary
- add `stealth/ox-alpha` through OpenRouter with its current context and reasoning capabilities
- make Ox Alpha available on free, pro, and admin tiers
- bypass model usage checks and charges for unlimited Ox Alpha usage

## Testing
- `nix develop -c bun run test`
- `nix develop -c bun run --cwd apps/web check`
- `nix develop -c prek run -a`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Ox Alpha through OpenRouter, exposes it to every subscription tier, and exempts its completions and summaries from model-usage quota checks and charging.
- Adds the Ox Alpha model definition, provider routing, reasoning configuration, and catalog metadata.
- Passes the selected model through completion usage checks so unlimited models can bypass metering.
- Adds coverage for routing, tier availability, model metadata, and unmetered usage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the reviewed model-routing, catalog, tier, and usage-metering paths.

The new model is accepted across the relevant validators and consumers, routes consistently through OpenRouter, and its quota and charging exemptions are applied on both completion and summarization paths as intended.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/models.ts | Adds the Ox Alpha definition, OpenRouter routing metadata, and an explicit unlimited-usage policy. |
| apps/web/src/convex/lib/modelRegistry.ts | Configures the OpenRouter-compatible client and resolves Ox Alpha models and reasoning options through it. |
| apps/web/src/convex/lib/rateLimits.ts | Makes usage checks and durable charging model-aware and bypasses both for models marked unlimited. |
| apps/web/src/convex/completion.ts | Propagates the requested model into preflight usage checks for completion and summarization paths. |
| apps/web/src/convex/lib/tiers.ts | Makes Ox Alpha selectable by free, pro, and admin users. |
| apps/web/src/convex/modelCatalog.ts | Keeps routing and usage-policy metadata server-side while exposing the remaining model catalog fields. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    U[Free, Pro, or Admin user] --> R[Create run with Ox Alpha]
    R --> C[Convex completion or summarization]
    C --> P[Resolve stealth/ox-alpha]
    P --> O[OpenRouter]
    C --> M{Usage metered?}
    M -->|No| B[Skip quota check and durable charge]
    O --> S[Return and persist model response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(models): Add unlimited Ox Alpha mod..."](https://github.com/spikonado/sprocket/commit/65a9b11d85fb964e30f4596c53ac47a88311272e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55550459)</sub>

**Context used:**

- Knowledge Base — [Convex Backend](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-backend.md)
- Knowledge Base — [sprocket-convex-provider](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/sprocket-convex-provider.md)

<!-- /greptile_comment -->