### PR TITLE
feat(models): Change default model to stealth/ox-alpha

### DIFF
--- a/apps/web/src/convex/lib/models.ts
+++ b/apps/web/src/convex/lib/models.ts
@@ -214,7 +214,7 @@ export const modelDefinitions = [
 	}
 ] as const satisfies readonly ModelDefinition[];
 
-export const defaultModelId = 'gpt-5.6-sol' as const;
+export const defaultModelId = 'stealth/ox-alpha' as const;
 export const defaultReasoningEffort: SupportedReasoningEffort =
 	getModelDefinition(defaultModelId).defaultReasoningEffort;
 export const defaultServiceTier = 'standard' as const;


### PR DESCRIPTION
## Summary
- Flip `defaultModelId` from `gpt-5.6-sol` to `stealth/ox-alpha` so new threads, the composer, and the legacy-model-id fallback all default to Ox Alpha.

Ox Alpha is already offered on every subscription tier and is unmetered (#195), so no tier or billing changes are needed. `defaultReasoningEffort` follows the model definition ('max') automatically.

## Test plan
- [x] `bun run test` — 38 files / 272 tests pass in apps/web
- [x] `bun run check` + `bun run lint` (svelte-check, eslint, convex typecheck) clean
- [x] `prek run -a` all hooks pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the application-wide default model from GPT-5.6 Sol to Ox Alpha. The derived default reasoning effort consequently becomes Ox Alpha’s configured `max` setting, while the standard service tier remains unchanged.

- Makes `stealth/ox-alpha` the default for new selections and legacy-model fallbacks.
- Reuses the existing model definition, provider routing, tier eligibility, and unmetered usage policy.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the new default is already defined, provider-routed, and permitted on every subscription tier.

The changed constant resolves to an existing Ox Alpha model definition with a valid maximum reasoning effort and standard service tier, while current tier checks allow it for free, pro, and admin users.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/models.ts | Changes the default model identifier to an existing, registry-supported Ox Alpha definition that is allowed across all subscription tiers. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(models): Default to Ox Alpha"](https://github.com/spikonado/sprocket/commit/5a56c5aadc7f5f366791f41148bca5e2dbf11c0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55841231)</sub>

<!-- /greptile_comment -->