### PR TITLE
build(release): Bump version to v0.3.2

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             source_sha="$TESTED_SHA"
-            version="0.2.0-dev.$source_sha"
+            version="0.3.2-dev.$source_sha"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             source_sha="$GITHUB_SHA"
             version="${GITHUB_REF_NAME#v}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-agent"
-version = "0.2.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "convex",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-cli"
-version = "0.2.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-convex-provider"
-version = "0.2.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "convex",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-server"
-version = "0.2.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-workspace"
-version = "0.2.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.2"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spikonado/sprocket",
-	"version": "0.2.0",
+	"version": "0.3.2",
 	"description": "Agentic platform for streamlining hardware and software development",
 	"license": "FSL-1.1-ALv2",
 	"type": "module",


### PR DESCRIPTION
Syncs the version strings to v0.3.2, matching the existing release tag. Follows the pattern of the v0.2.0 bump (#124): workspace Cargo.toml, Cargo.lock, npm/sprocket/package.json, and the npm-release workflow dev-version prefix.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Synchronizes the Rust workspace, lockfile, npm wrapper, and development-release workflow with version 0.3.2.
- Updates the workspace package version and all five inherited workspace-crate lockfile entries.
- Updates the npm wrapper’s package version.
- Changes workflow-run development releases to use the `0.3.2-dev.<sha>` version prefix.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because all release version sources changed by this PR are consistently synchronized.

The Rust workspace and lockfile entries agree at 0.3.2, the npm wrapper uses the same version, and the development workflow retains its established SHA-qualified prerelease and dist-tag behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Updates the development-release version prefix while preserving the existing SHA-based uniqueness and `dev` dist-tag publication flow. |
| Cargo.toml | Updates the shared workspace package version to 0.3.2 for all inheriting crates. |
| Cargo.lock | Consistently updates all five workspace crate entries to the inherited 0.3.2 version. |
| npm/sprocket/package.json | Aligns the npm wrapper’s committed package version with the Rust workspace and release tag. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build(release): Bump version to v0.3.2"](https://github.com/spikonado/sprocket/commit/db8bc3091412fbc41bb8510f9cd280b6980ab0ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55844925)</sub>

<!-- /greptile_comment -->