### PR TITLE
fix(payments): Align with latest Prava APIs

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -12,7 +12,7 @@ Three client populations talk to the cloud backend:
 - Installed desktop apps (AppImage/DMG/NSIS, shipped since v0.2.2) bundle their own web assets.
 - The `@spikonado/sprocket` npm CLI and the Rust agent binaries it launches.
 
-Compat shims only exist for the second and third groups. Every shim listed here protects clients older than v0.3.2 (2026-08-22), the first release carrying the client halves of #187, #191, and #192. There is no client telemetry, so age-out signals are npm download counts per version plus the per-entry database checks below.
+Compat shims only exist for the second and third groups. Every shim in sections 1–3 protects clients older than v0.3.2 (2026-08-22), the first release carrying the client halves of #187, #191, and #192; section 4 landed after v0.3.2 and protects clients up to and including v0.3.2. There is no client telemetry, so age-out signals are npm download counts per version plus the per-entry database checks below.
 
 ## 1. Executor liveness split out of `projects`
 
@@ -73,6 +73,16 @@ Source: #200. `modelCatalog.get` gained an optional `includeUsagePolicy` argumen
 Remove by dropping the argument and attaching `usagePolicy` unconditionally in `convex/modelCatalog.ts`, folding `CatalogModelWithUsagePolicy` back into `CatalogModel` (remove `usagePolicy` from the `Omit` in `convex/lib/models.ts`) and out of `convex/lib/uiModelCatalog.ts`, simplifying the `{ includeUsagePolicy: true }` call in `+page.svelte`, and collapsing `convex/modelCatalog.test.ts` to pin unconditional inclusion instead of the opt-in contract.
 
 Safe when npm downloads for versions predating the release carrying #200 have flattened.
+
+## 4. Mandate setup ignores the stored payments email
+
+Up to v0.3.2, mandate setup resolved the customer email from the caller (`userEmail` tool argument or settings-screen input) with a fallback to `uiPreferences.paymentsEmail`, and the settings screen saved that email via `uiPreferences.setPaymentsEmail`. Setup now always uses the email on the caller's WorkOS identity instead.
+
+Today's compat: `mandateSetupArgs` (`convex/payments.ts`) still accepts an optional `userEmail` and ignores it, so pre-#204-era agents and settings screens keep passing theirs. `vMandateSetupPayload.userEmail` (`convex/lib/validators.ts`) stays accepted because stored `executorJobs.payload` rows written by those agents carry it. `uiPreferences.setPaymentsEmail` still writes the field for old settings screens, and `uiPreferences.paymentsEmail` stays optional in the schema so their rows keep validating.
+
+Remove by dropping `userEmail` from `mandateSetupArgs` and `vMandateSetupPayload` (sweep stored `executorJobs.payload` rows first if any still carry it), deleting `uiPreferences.setPaymentsEmail`, unsetting `paymentsEmail` on existing `uiPreferences` rows, and dropping the field from the schema — all in one PR.
+
+Safe when npm downloads for versions at or below v0.3.2 have flattened and a prod check shows no recent `paymentsEmail` writes (the way #174 verified).
 
 ## Completed removals, kept as precedent
 

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -131,6 +131,8 @@ export const vMandateChargeStatus = v.union(
 export const vMandateReportOutcome = v.union(v.literal('approved'), v.literal('declined'));
 
 export const vMandateSetupPayload = v.object({
+	// Accepted-and-ignored: stored executorJobs payloads from released agents
+	// may still carry it. Mandate setup now reads the WorkOS identity email.
 	userEmail: v.optional(v.string()),
 	merchantName: v.optional(v.string()),
 	merchantUrl: v.optional(v.string()),

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -60,6 +60,8 @@ function setupArgs(run: Awaited<ReturnType<typeof startRun>>) {
 type PravaMandateFixture = {
 	id?: string;
 	status?: string;
+	merchantScope?: string;
+	recurringFrequency?: string;
 	merchantName?: string | null;
 	merchantUrl?: string;
 	countryCode?: string;
@@ -74,6 +76,10 @@ function liveListedMandate(overrides: PravaMandateFixture = {}): JsonObject {
 	const mandate: JsonObject = {
 		id: 'mdt_1',
 		status: 'active',
+		// Populated per Prava's current List Mandates response so the
+		// scope/cadence comparisons in resolution are exercised.
+		merchantScope: 'listed',
+		recurringFrequency: 'monthly',
 		merchantName: 'Example Shop',
 		merchantUrl: 'https://shop.example',
 		countryCode: 'US',
@@ -439,6 +445,41 @@ describe('payments mandates', () => {
 		await expect(
 			run.asUser.action(api.payments.mandateCharge, {
 				mandateId: setup.mandateId,
+				amount: '40.00',
+				currency: 'USD',
+				description: 'Order 8842',
+				...auth(run)
+			})
+		).rejects.toThrow(/not yet approved/);
+	});
+
+	it('does not resolve an approval whose scope or cadence differs', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+		// Same merchant + cap + currency, but approved as any-merchant.
+		const { setup } = await createApprovedMandate(t, run, [
+			liveListedMandate({ id: 'mdt_any', merchantScope: 'any' })
+		]);
+
+		await expect(
+			run.asUser.action(api.payments.mandateCharge, {
+				mandateId: setup.mandateId,
+				amount: '40.00',
+				currency: 'USD',
+				description: 'Order 8842',
+				...auth(run)
+			})
+		).rejects.toThrow(/not yet approved/);
+
+		// Same again, but approved with a weekly cadence instead of monthly.
+		const { setup: weeklySetup } = await createApprovedMandate(t, run, [
+			liveListedMandate({ id: 'mdt_weekly', recurringFrequency: 'weekly' })
+		]);
+
+		await expect(
+			run.asUser.action(api.payments.mandateCharge, {
+				mandateId: weeklySetup.mandateId,
 				amount: '40.00',
 				currency: 'USD',
 				description: 'Order 8842',

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -26,7 +26,6 @@ async function startRun(t: ConvexTestInstance, subject: string) {
 	});
 	return {
 		asUser: t.withIdentity({ subject, email: `${subject}@example.com` }),
-		userEmail: `${subject}@example.com`,
 		runId: created.runId,
 		claimId,
 		executionSecret
@@ -54,7 +53,6 @@ function setupArgs(run: Awaited<ReturnType<typeof startRun>>) {
 		frequency: 'monthly' as const,
 		scope: 'listed' as const,
 		description: 'Monthly budget',
-		userEmail: run.userEmail,
 		...auth(run)
 	};
 }
@@ -156,8 +154,21 @@ describe('payments mandates', () => {
 		const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
 		expect(body).toMatchObject({
 			user_id: 'user_alice',
+			// The email comes from the caller's WorkOS identity, not tool args.
 			user_email: 'user_alice@example.com',
 			total_amount: '120.00',
+			purchase_context: {
+				custom: [
+					{
+						merchant_details: {
+							name: 'Example Shop',
+							url: 'https://shop.example',
+							country_code_iso2: 'US'
+						},
+						product_details: [{ description: 'Monthly budget', unit_price: '120.00', quantity: 1 }]
+					}
+				]
+			},
 			mandate_setup: {
 				intent: 'mandate_setup',
 				recurring_frequency: 'monthly',
@@ -173,6 +184,19 @@ describe('payments mandates', () => {
 			approvalUrl: 'https://pay.prava.space/approve/1'
 		});
 		expect(stored).not.toHaveProperty('session_token');
+	});
+
+	it('rejects mandate setup when the WorkOS identity has no email', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+
+		await expect(
+			t.withIdentity({ subject: 'user_alice' }).action(api.payments.mandateSetup, setupArgs(run))
+		).rejects.toThrow(/no email address/);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
 	it('syncs a pending mandate to active once the owner approves', async () => {
@@ -696,7 +720,6 @@ describe('payments mandates', () => {
 				amountCap: '200.00',
 				currency: 'USD',
 				description: 'Weekly groceries',
-				userEmail: run.userEmail,
 				...auth(run)
 			})
 		).rejects.toThrow(/one-time/);
@@ -803,8 +826,7 @@ describe('payments mandates', () => {
 			amountCap: '120.00',
 			currency: 'USD',
 			frequency: 'monthly' as const,
-			scope: 'listed' as const,
-			userEmail: alice.userEmail
+			scope: 'listed' as const
 		};
 		const first = await alice.asUser.action(api.payments.setupMyMandate, {
 			...setupArgs,
@@ -856,8 +878,7 @@ describe('payments mandates', () => {
 			currency: 'USD',
 			frequency: 'monthly' as const,
 			scope: 'listed' as const,
-			description: 'Monthly budget',
-			userEmail: alice.userEmail
+			description: 'Monthly budget'
 		});
 
 		const result = await alice.asUser.action(api.payments.listMyMandates, {});

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -9,7 +9,7 @@ import {
 } from '@convex/_generated/server';
 import { api, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { getUserId } from '@convex/lib/auth';
+import { getUserId, requireIdentity } from '@convex/lib/auth';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import {
 	isMandateStatus,
@@ -55,7 +55,19 @@ async function pravaRequest<T>(path: string, init?: RequestInit): Promise<T> {
 	});
 	if (!response.ok) {
 		const details = await response.text();
-		throw new Error(`Prava request failed (${response.status})${details ? `: ${details}` : '.'}`);
+		let message = details;
+		try {
+			// SAFETY: Prava errors share one documented envelope
+			// ({error:{code,message,details}}); both fields are optional-checked
+			// before use and anything else keeps the raw body as the message.
+			const parsed = JSON.parse(details) as { error?: { code?: string; message?: string } };
+			if (parsed.error?.code || parsed.error?.message) {
+				message = [parsed.error.code, parsed.error.message].filter(Boolean).join(' - ');
+			}
+		} catch {
+			// Not JSON; surface the raw body.
+		}
+		throw new Error(`Prava request failed (${response.status})${message ? `: ${message}` : '.'}`);
 	}
 	const body = await response.text();
 	// SAFETY: unchecked decode of the trusted Prava API response into its documented contract T.
@@ -103,14 +115,6 @@ async function activeActor(
 		throw new Error('Run is no longer active.');
 	}
 	return actor;
-}
-
-function requiredUserEmail(userEmail: string): string {
-	const email = userEmail.trim();
-	if (!email) {
-		throw new Error('EMAIL_REQUIRED');
-	}
-	return email;
 }
 
 /** Any-scope (generic) mandates are one-time only. Prava rejects a recurring
@@ -213,6 +217,8 @@ type MandateReportRequest = {
 type PravaMandate = {
 	id?: string;
 	status?: string;
+	recurringFrequency?: string;
+	merchantScope?: string;
 	remaining?: string | null;
 	approvedAmount?: string;
 	currency?: string;
@@ -345,18 +351,6 @@ function mandateStatusResult(mandate: Doc<'mandates'>): Infer<typeof vMandateSta
 // ---------------------------------------------------------------------------
 // Internal queries / mutations
 // ---------------------------------------------------------------------------
-
-export const getPaymentsEmail = internalQuery({
-	args: { userId: v.string() },
-	returns: v.union(v.string(), v.null()),
-	handler: async (ctx, args) => {
-		const prefs = await ctx.db
-			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', args.userId))
-			.unique();
-		return prefs?.paymentsEmail ?? null;
-	}
-});
 
 export const insertMandate = internalMutation({
 	args: {
@@ -740,6 +734,8 @@ export const finishChargeReport = internalMutation({
 // ---------------------------------------------------------------------------
 
 const mandateSetupArgs = {
+	// Accepted-and-ignored for released clients that still send it; the email
+	// always comes from the caller's WorkOS identity.
 	userEmail: v.optional(v.string()),
 	merchantName: v.optional(v.string()),
 	merchantUrl: v.optional(v.string()),
@@ -760,10 +756,12 @@ async function createMandateSetup(
 	userId: string,
 	args: ObjectType<typeof mandateSetupArgs>
 ): Promise<Infer<typeof vMandateSetupResult>> {
-	const storedEmail: string | null = await ctx.runQuery(internal.payments.getPaymentsEmail, {
-		userId
-	});
-	const userEmail = requiredUserEmail(args.userEmail ?? storedEmail ?? '');
+	// Prava requires a customer email on merchant sessions; the signed-in
+	// WorkOS identity is the single source of truth for it.
+	const userEmail = (await requireIdentity(ctx)).email?.trim();
+	if (!userEmail) {
+		throw new Error('Your account has no email address to use for payment mandates.');
+	}
 	assertMandateFrequencyAllowed(args);
 
 	// Generic (any-scope) mandates are one-time only; Prava still needs a
@@ -800,14 +798,16 @@ async function createMandateSetup(
 			total_amount: args.amountCap,
 			currency: args.currency,
 			description: args.description,
-			purchase_context: [
-				{
-					merchant_details: merchantDetails,
-					product_details: [
-						{ description: args.description, unit_price: args.amountCap, quantity: 1 }
-					]
-				}
-			],
+			purchase_context: {
+				custom: [
+					{
+						merchant_details: merchantDetails,
+						product_details: [
+							{ description: args.description, unit_price: args.amountCap, quantity: 1 }
+						]
+					}
+				]
+			},
 			mandate_setup: (() => {
 				const setup: MandateSetupRequest = {
 					intent: 'mandate_setup',
@@ -861,6 +861,12 @@ export const mandateSetup = action({
 function isMatchingLivePravaMandate(mandate: Doc<'mandates'>, prava: PravaMandate): boolean {
 	if (!prava.id) return false;
 	if (!LIVE_MANDATE_STATUSES.has(prava.status ?? '')) return false;
+	// A different scope or cadence is a different authorization even when the
+	// merchant name and cap coincide.
+	if (prava.merchantScope !== undefined && prava.merchantScope !== mandate.scope) return false;
+	if (prava.recurringFrequency !== undefined && prava.recurringFrequency !== mandate.frequency) {
+		return false;
+	}
 	// A mandate approved in another currency is a different authorization;
 	// never resolve (and later charge) it for this setup.
 	if ((prava.currency ?? '').toUpperCase() !== mandate.currency.toUpperCase()) return false;
@@ -1123,6 +1129,7 @@ export const mandateCharge = action({
 		let result: {
 			transactionId?: string;
 			status?: string;
+			errorCode?: string;
 			credentials?: {
 				token: string;
 				dynamicCvv: string;
@@ -1165,7 +1172,7 @@ export const mandateCharge = action({
 				userId: actor.userId,
 				status: 'failed'
 			});
-			throw new Error(result.errorMessage ?? 'Mandate charge failed.');
+			throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
 		}
 		await ctx.runMutation(internal.payments.completeCharge, {
 			chargeId: reservation.chargeId,

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -52,6 +52,9 @@ export default defineSchema({
 		// Remove once those clients age out.
 		lastThreadId: v.optional(v.id('threadRecords')),
 		theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
+		// Deprecated: mandate setup now uses the WorkOS identity email. Kept so
+		// rows written by older clients still validate; see
+		// BACKWARDS_COMPATIBILITY.md before removing.
 		paymentsEmail: v.optional(v.string())
 	}).index('by_userId', ['userId']),
 	projects: defineTable({

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -76,6 +76,10 @@ export const setTheme = mutation({
 });
 
 export const setPaymentsEmail = mutation({
+	// Deprecated: no current caller; kept because released clients still save a
+	// payments email here. Mandate setup ignores it and uses the WorkOS
+	// identity email instead. Remove with the schema field once those clients
+	// age out (see BACKWARDS_COMPATIBILITY.md).
 	args: { email: v.string() },
 	returns: v.null(),
 	handler: async (ctx, args) => {

--- a/apps/web/src/lib/components/home/settings-payments.svelte
+++ b/apps/web/src/lib/components/home/settings-payments.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { useAction, useAuth, useMutation, useQuery } from 'convex-svelte';
+	import { useAction, useAuth } from 'convex-svelte';
 	import type { Id } from '$convex/_generated/dataModel';
 	import { api } from '$convex/_generated/api';
 	import type { MandateApproval } from '$lib/chat/mandate';
@@ -25,10 +25,6 @@
 	};
 
 	const convexAuth = useAuth();
-	const prefsQuery = useQuery(api.uiPreferences.getMine, () =>
-		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
-	);
-	const setPaymentsEmail = useMutation(api.uiPreferences.setPaymentsEmail);
 	const listMyMandates = useAction(api.payments.listMyMandates);
 	const setupMyMandate = useAction(api.payments.setupMyMandate);
 	const setMyMandateLifecycle = useAction(api.payments.setMyMandateLifecycle);
@@ -49,12 +45,6 @@
 	const labelClass = 'text-muted-foreground text-[12px]';
 	const actionLinkClass =
 		'text-muted-foreground hover:text-foreground text-[12px] transition disabled:pointer-events-none disabled:opacity-40';
-
-	let paymentsEmail = $state('');
-	let emailHydrated = $state(false);
-	let emailSaving = $state(false);
-	let emailSaved = $state(false);
-	let emailError = $state<string | null>(null);
 
 	let merchantName = $state('');
 	let merchantUrl = $state('');
@@ -86,15 +76,6 @@
 		if (scope === 'any' && frequency !== 'one_time') {
 			frequency = 'one_time';
 		}
-	});
-
-	$effect(() => {
-		const data = prefsQuery.data;
-		if (data === undefined || emailHydrated) {
-			return;
-		}
-		paymentsEmail = data?.paymentsEmail ?? '';
-		emailHydrated = true;
 	});
 
 	$effect(() => {
@@ -148,26 +129,8 @@
 		}
 	}
 
-	async function savePaymentsEmail() {
-		emailSaving = true;
-		emailError = null;
-		emailSaved = false;
-		try {
-			await setPaymentsEmail({ email: paymentsEmail.trim() });
-			emailSaved = true;
-		} catch (error) {
-			emailError = catchMessage(error, 'Couldn’t save email.');
-		} finally {
-			emailSaving = false;
-		}
-	}
-
 	async function submitMandateSetup(event: Event) {
 		event.preventDefault();
-		if (!paymentsEmail.trim()) {
-			setupError = 'Save your payments email above first — it’s required to set up a mandate.';
-			return;
-		}
 		setupSubmitting = true;
 		setupError = null;
 		pendingApproval = null;
@@ -183,8 +146,7 @@
 				currency: currency.trim(),
 				frequency,
 				scope,
-				description: description.trim(),
-				userEmail: paymentsEmail.trim()
+				description: description.trim()
 			});
 			pendingApproval = {
 				mandateId: result.mandateId,
@@ -226,46 +188,6 @@
 
 	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
 		<div class="max-w-xl space-y-10">
-			<div>
-				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
-					Payments email
-				</p>
-				<p class="text-muted-foreground mt-2 text-sm leading-6">
-					Used when setting up spending mandates. Saved to your account preferences.
-				</p>
-				<form
-					class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end"
-					onsubmit={(event) => {
-						event.preventDefault();
-						void savePaymentsEmail();
-					}}
-				>
-					<label class="block min-w-0 flex-1 space-y-1.5">
-						<span class={labelClass}>Email</span>
-						<input
-							class={fieldClass}
-							type="email"
-							autocomplete="email"
-							bind:value={paymentsEmail}
-							placeholder="you@example.com"
-							disabled={emailSaving || prefsQuery.isLoading}
-							oninput={() => {
-								emailSaved = false;
-								emailError = null;
-							}}
-						/>
-					</label>
-					<Button type="submit" variant="outline" disabled={emailSaving || !paymentsEmail.trim()}>
-						{emailSaving ? 'Saving…' : 'Save'}
-					</Button>
-				</form>
-				{#if emailError}
-					<p class="text-destructive mt-2 text-sm">{emailError}</p>
-				{:else if emailSaved}
-					<p class="text-muted-foreground mt-2 text-sm" role="status">Saved.</p>
-				{/if}
-			</div>
-
 			<div>
 				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
 					Set up a spending mandate

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -462,9 +462,6 @@ pub(crate) enum MandateScope {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MandateSetupArgs {
-    /// Email the user uses for purchase approvals; optional when one is already on file.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user_email: Option<String>,
     /// Merchant to lock this mandate to (required for `listed` scope).
     #[serde(skip_serializing_if = "Option::is_none")]
     merchant_name: Option<String>,


### PR DESCRIPTION
## What

Two changes to the Prava mandate flow, per its current docs + OpenAPI spec (docs.prava.space, API v1.0.0):

**Mandate setup now uses the caller's WorkOS identity email.** The stored "Payments email" preference is gone from the setup path: `createMandateSetup` reads `requireIdentity(ctx).email`, which is available on both call paths (executor tool actions and settings-screen actions run under the user's WorkOS token). The settings screen drops its Payments-email form, and the Rust `mandate_setup` tool drops its `userEmail` argument.

**API alignment:**
- `purchase_context` on Create Session is now sent as `{ custom: [{ merchant_details, product_details }] }`. We were still sending the pre-spec bare-array shape, which the current API documents as invalid (`custom` is required inside `purchase_context`).
- Mandate resolution additionally compares `recurringFrequency` / `merchantScope` from List Mandates, so two local setups differing only in cadence can no longer resolve to each other's approval.
- Prava errors are parsed from the documented `{error:{code,message}}` envelope; failures surface e.g. `MANDATE_NOT_ACTIVE - ...` instead of raw JSON.
- Charge failures fall back to `errorCode` when `errorMessage` is absent.

## Backwards compatibility

The payments feature shipped in v0.3.0–v0.3.2, so released desktop clients still send the old fields. Per BACKWARDS_COMPATIBILITY.md conventions, shims are kept and recorded as **entry 4** with removal gates:

- `userEmail` stays accepted-and-ignored in `mandateSetupArgs` / `vMandateSetupPayload` (stored `executorJobs.payload` rows carry it).
- `uiPreferences.setPaymentsEmail` still writes for old settings screens; `uiPreferences.paymentsEmail` stays optional in the schema so their rows validate.
- Removal PR checklist included in the entry.

No compat for anything else — charge/report/list endpoints were already spec-shaped.

## Checks

- `bun run test` (apps/web): 274/274 pass (payments suite 24/24, incl. new purchase_context shape + no-email rejection tests)
- `cargo test -p sprocket-agent`: 40/40 pass
- `bun run build`, `svelte-check`: clean
- `prek run -a`: all hooks pass




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns the Prava mandate flow with the current API and authenticated WorkOS identity while preserving compatibility with released clients.
- Uses the caller’s identity email and removes the current settings/tool email input.
- Updates purchase-context and error-response handling.
- Includes scope and cadence in external mandate matching.
- Retains documented validators, schema fields, and mutations needed by older clients.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/payments.ts | Updates identity-email selection, Prava request shapes and errors, mandate matching, and charge error fallback without leaving the previously reported test gap. |
| apps/web/src/convex/payments.test.ts | Populates scope and cadence in successful fixtures and independently verifies both mismatch branches, resolving the previous review finding. |
| crates/sprocket-agent/src/tools.rs | Removes the obsolete model-facing userEmail argument while the backend retains compatibility for persisted and older-client payloads. |
| apps/web/src/lib/components/home/settings-payments.svelte | Removes the obsolete payments-email preference UI and relies on authenticated identity during mandate setup. |
| BACKWARDS_COMPATIBILITY.md | Documents the retained compatibility shims and explicit removal gates for clients through v0.3.2. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(payments): Populate Prava scope/cad..."](https://github.com/spikonado/sprocket/commit/358342be663a5c6dd8c3aaa3256bb949d5842c2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56504985)</sub>

<!-- /greptile_comment -->