### PR TITLE
fix(agent): Surface real failure text for failed tool calls

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -100,6 +100,7 @@ So nobody goes hunting for shims that do not exist:
 - Accepting Begin Patch envelopes alongside unified diffs (#66) is a permanent feature, not compat.
 - Dropping orphaned OpenAI item references (#188) must stay forever. Compaction can drop reasoning items from any history, not just pre-fix ones.
 - Usage-limit run errors (#200) now throw ConvexErrors, so `runs.lastError` carries a readable sentence where production used to mask them to `[Request ID] Server Error` strings. Clients released before #200 render that sentence in their transcript banner. It is display-only text that clears on the next run, so no compat layer ships.
+- Tool-call failures (#206) now throw ConvexErrors through the executor-facing functions and surface authored messages to the model via rig's `map_error`, so `executorJobs.error` and the model's tool result carry the real failure text where production used to mask it to `[Request ID] Server Error` strings (and rig used to redact it to "the tool failed"). Both audiences render plain display text, so no compat layer ships.
 
 ## Removal checklist
 

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -15,7 +15,7 @@ import {
 	validateQuestionText
 } from '@convex/lib/agentQuestions';
 import { getExecutionRun, getUserId } from '@convex/lib/auth';
-import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { assertRunAcceptsModelCompletion, toAgentToolConvexError } from '@convex/lib/agentErrors';
 import { vAgentQuestionSnapshot } from '@convex/lib/docs';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import { vAskQuestionOption } from '@convex/lib/validators';
@@ -120,46 +120,50 @@ export const create = mutation({
 		sequence: v.number()
 	}),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		assertRunAcceptsModelCompletion(run.status);
-		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
-			throw new Error('Run is no longer active.');
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			assertRunAcceptsModelCompletion(run.status);
+			if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			if (!run.activeJobId) {
+				throw new Error('Ask question requires an active tool job.');
+			}
+
+			const question = validateQuestionText(args.question);
+			const options = finalizeQuestionOptions(args.options);
+			const timeoutMs = Math.min(
+				MAX_QUESTION_TIMEOUT_MS,
+				Math.max(MIN_QUESTION_TIMEOUT_MS, Math.floor(args.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS))
+			);
+			const createdAt = Date.now();
+			const timeoutAt = createdAt + timeoutMs;
+			const sequence = await nextThreadSequence(ctx, run.threadId);
+
+			const questionId = await ctx.db.insert('agentQuestions', {
+				threadId: run.threadId,
+				runId: run._id,
+				jobId: run.activeJobId,
+				question,
+				options,
+				status: 'pending',
+				createdAt,
+				timeoutAt,
+				sequence
+			});
+
+			await ctx.scheduler.runAfter(timeoutMs, internal.agentQuestions.timeout, { questionId });
+
+			return {
+				questionId,
+				question,
+				options,
+				timeoutAt,
+				sequence
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		if (!run.activeJobId) {
-			throw new Error('Ask question requires an active tool job.');
-		}
-
-		const question = validateQuestionText(args.question);
-		const options = finalizeQuestionOptions(args.options);
-		const timeoutMs = Math.min(
-			MAX_QUESTION_TIMEOUT_MS,
-			Math.max(MIN_QUESTION_TIMEOUT_MS, Math.floor(args.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS))
-		);
-		const createdAt = Date.now();
-		const timeoutAt = createdAt + timeoutMs;
-		const sequence = await nextThreadSequence(ctx, run.threadId);
-
-		const questionId = await ctx.db.insert('agentQuestions', {
-			threadId: run.threadId,
-			runId: run._id,
-			jobId: run.activeJobId,
-			question,
-			options,
-			status: 'pending',
-			createdAt,
-			timeoutAt,
-			sequence
-		});
-
-		await ctx.scheduler.runAfter(timeoutMs, internal.agentQuestions.timeout, { questionId });
-
-		return {
-			questionId,
-			question,
-			options,
-			timeoutAt,
-			sequence
-		};
 	}
 });
 
@@ -237,12 +241,16 @@ export const getForExecutor = query({
 	},
 	returns: v.union(vAgentQuestionSnapshot, v.null()),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const question = await ctx.db.get('agentQuestions', args.questionId);
-		if (!question || question.runId !== run._id) {
-			return null;
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			const question = await ctx.db.get('agentQuestions', args.questionId);
+			if (!question || question.runId !== run._id) {
+				return null;
+			}
+			return toSnapshot(question);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return toSnapshot(question);
 	}
 });
 

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -20,7 +20,11 @@ import {
 	getOwnedImageUploads
 } from '@convex/lib/imageUploads';
 import { buildThreadTranscript } from '@convex/lib/threadTranscript';
-import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import {
+	RUN_NO_LONGER_ACTIVE,
+	assertRunAcceptsModelCompletion,
+	toAgentToolConvexError
+} from '@convex/lib/agentErrors';
 import {
 	assertThreadCanStartRun,
 	cancelExecutorJobsForTerminalRun,
@@ -998,42 +1002,46 @@ export const beginToolJob = mutation({
 		sequence: v.number()
 	}),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const userId = run.userId;
-		assertRunAcceptsModelCompletion(run.status);
-		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
-			throw new ConvexError(RUN_NO_LONGER_ACTIVE);
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			const userId = run.userId;
+			assertRunAcceptsModelCompletion(run.status);
+			if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+				throw new ConvexError(RUN_NO_LONGER_ACTIVE);
+			}
+			const project = await getOwnedProject(ctx.db, userId, run.projectId);
+
+			const nextSequence = project.nextExecutorSequence;
+			await ctx.db.patch('projects', project._id, {
+				nextExecutorSequence: nextSequence + 1
+			});
+
+			const job: EnqueuedExecutorJob = {
+				projectId: run.projectId,
+				threadId: run.threadId,
+				runId: args.runId,
+				kind: args.kind,
+				payload: args.payload,
+				hidden: args.hidden ?? false,
+				status: 'claimed',
+				enqueuedAt: Date.now(),
+				claimedAt: Date.now(),
+				sequence: nextSequence
+			};
+			if (args.callId) job.callId = args.callId;
+			const jobId = await ctx.db.insert('executorJobs', job);
+
+			await ctx.db.patch('runs', args.runId, {
+				status: 'awaiting_executor',
+				activeJobId: jobId
+			});
+
+			return {
+				jobId,
+				sequence: nextSequence
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const project = await getOwnedProject(ctx.db, userId, run.projectId);
-
-		const nextSequence = project.nextExecutorSequence;
-		await ctx.db.patch('projects', project._id, {
-			nextExecutorSequence: nextSequence + 1
-		});
-
-		const job: EnqueuedExecutorJob = {
-			projectId: run.projectId,
-			threadId: run.threadId,
-			runId: args.runId,
-			kind: args.kind,
-			payload: args.payload,
-			hidden: args.hidden ?? false,
-			status: 'claimed',
-			enqueuedAt: Date.now(),
-			claimedAt: Date.now(),
-			sequence: nextSequence
-		};
-		if (args.callId) job.callId = args.callId;
-		const jobId = await ctx.db.insert('executorJobs', job);
-
-		await ctx.db.patch('runs', args.runId, {
-			status: 'awaiting_executor',
-			activeJobId: jobId
-		});
-
-		return {
-			jobId,
-			sequence: nextSequence
-		};
 	}
 });

--- a/apps/web/src/convex/artifacts.ts
+++ b/apps/web/src/convex/artifacts.ts
@@ -6,7 +6,7 @@ import { getExecutionRun, getUserId } from '@convex/lib/auth';
 import { vArtifactType } from '@convex/lib/validators';
 import schema from '@convex/schema';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
-import { RUN_NO_LONGER_ACTIVE } from '@convex/lib/agentErrors';
+import { RUN_NO_LONGER_ACTIVE, toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 const MAX_TITLE_LENGTH = 200;
 // Content also lives in the executor job payload; stay well under Convex's 1 MiB document cap.
@@ -105,53 +105,57 @@ export const createArtifact = mutation({
 	},
 	returns: vArtifactMutationResult,
 	handler: async (ctx, args) => {
-		const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
-		const userId = run.userId;
-		const threadId = run.threadId;
-		await getOwnedThreadRecord(ctx.db, userId, threadId);
+		try {
+			const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
+			const userId = run.userId;
+			const threadId = run.threadId;
+			await getOwnedThreadRecord(ctx.db, userId, threadId);
 
-		const title = args.title.trim();
-		validateArtifactTitle(title);
-		validateArtifactContent(args.content);
+			const title = args.title.trim();
+			validateArtifactTitle(title);
+			validateArtifactContent(args.content);
 
-		// A repeated title in the same thread updates the existing artifact
-		// instead of silently dropping the new content.
-		const existing = await ctx.db
-			.query('artifacts')
-			.withIndex('by_threadId_title', (q) => q.eq('threadId', threadId).eq('title', title))
-			.first();
+			// A repeated title in the same thread updates the existing artifact
+			// instead of silently dropping the new content.
+			const existing = await ctx.db
+				.query('artifacts')
+				.withIndex('by_threadId_title', (q) => q.eq('threadId', threadId).eq('title', title))
+				.first();
 
-		if (existing) {
-			const latest = await latestArtifactVersion(ctx, existing._id);
-			const version =
-				latest?.content === args.content
-					? existing.currentVersion
-					: await insertNextVersion(ctx, existing, userId, latest, args.content);
+			if (existing) {
+				const latest = await latestArtifactVersion(ctx, existing._id);
+				const version =
+					latest?.content === args.content
+						? existing.currentVersion
+						: await insertNextVersion(ctx, existing, userId, latest, args.content);
 
-			return mutationResult(existing, version);
+				return mutationResult(existing, version);
+			}
+
+			const now = Date.now();
+			const artifactId = await ctx.db.insert('artifacts', {
+				threadId,
+				userId,
+				title,
+				type: args.contentType,
+				currentVersion: 1,
+				createdById: run._id,
+				createdAt: now,
+				updatedAt: now
+			});
+
+			await ctx.db.insert('artifactVersions', {
+				artifactId,
+				userId,
+				version: 1,
+				content: args.content,
+				createdAt: now
+			});
+
+			return { artifactId, version: 1, title, contentType: args.contentType };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-
-		const now = Date.now();
-		const artifactId = await ctx.db.insert('artifacts', {
-			threadId,
-			userId,
-			title,
-			type: args.contentType,
-			currentVersion: 1,
-			createdById: run._id,
-			createdAt: now,
-			updatedAt: now
-		});
-
-		await ctx.db.insert('artifactVersions', {
-			artifactId,
-			userId,
-			version: 1,
-			content: args.content,
-			createdAt: now
-		});
-
-		return { artifactId, version: 1, title, contentType: args.contentType };
 	}
 });
 
@@ -165,21 +169,25 @@ export const appendArtifactVersion = mutation({
 	},
 	returns: vArtifactMutationResult,
 	handler: async (ctx, args) => {
-		const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
-		const userId = run.userId;
+		try {
+			const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
+			const userId = run.userId;
 
-		const artifact: Doc<'artifacts'> | null = await ctx.db.get('artifacts', args.artifactId);
-		if (!artifact || artifact.userId !== userId || artifact.threadId !== run.threadId) {
-			throw new Error('Artifact not found.');
+			const artifact: Doc<'artifacts'> | null = await ctx.db.get('artifacts', args.artifactId);
+			if (!artifact || artifact.userId !== userId || artifact.threadId !== run.threadId) {
+				throw new Error('Artifact not found.');
+			}
+			await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
+
+			validateArtifactContent(args.content);
+
+			const latest = await latestArtifactVersion(ctx, args.artifactId);
+			const version = await insertNextVersion(ctx, artifact, userId, latest, args.content);
+
+			return mutationResult(artifact, version);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
-
-		validateArtifactContent(args.content);
-
-		const latest = await latestArtifactVersion(ctx, args.artifactId);
-		const version = await insertNextVersion(ctx, artifact, userId, latest, args.content);
-
-		return mutationResult(artifact, version);
 	}
 });
 

--- a/apps/web/src/convex/browserAgent.ts
+++ b/apps/web/src/convex/browserAgent.ts
@@ -12,6 +12,7 @@ import {
 	vBrowserObserveResult,
 	vBrowserTaskResult
 } from '@convex/lib/validators';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 // The browsing sub-agent's model. Uses the same OpenAI key as the main agent.
 const DEFAULT_MODEL = 'openai/gpt-5.6-sol';
@@ -255,19 +256,23 @@ export const act = action({
 	},
 	returns: vBrowserTaskResult,
 	handler: async (ctx, args): Promise<Infer<typeof vBrowserTaskResult>> => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			if (!args.instruction && !args.action) {
-				throw new Error('browser_act needs an instruction or an action.');
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				if (!args.instruction && !args.action) {
+					throw new Error('browser_act needs an instruction or an action.');
+				}
+				const result = args.action
+					? await stagehand.act(args.action)
+					: await stagehand.act(args.instruction!);
+				return clip(`success: ${result.success}\n${result.message}`.trim());
+			} finally {
+				await stagehand.close().catch(() => {});
 			}
-			const result = args.action
-				? await stagehand.act(args.action)
-				: await stagehand.act(args.instruction!);
-			return clip(`success: ${result.success}\n${result.message}`.trim());
-		} finally {
-			await stagehand.close().catch(() => {});
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });
@@ -282,20 +287,24 @@ export const observe = action({
 	},
 	returns: vBrowserObserveResult,
 	handler: async (ctx, args) => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			const actions = await stagehand.observe(args.instruction);
-			const bounded = boundActions(actions);
-			const clipped = clip(JSON.stringify(bounded.actions));
-			return {
-				actions: bounded.actions,
-				text: clipped.text,
-				truncated: bounded.truncated || clipped.truncated
-			};
-		} finally {
-			await stagehand.close().catch(() => {});
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				const actions = await stagehand.observe(args.instruction);
+				const bounded = boundActions(actions);
+				const clipped = clip(JSON.stringify(bounded.actions));
+				return {
+					actions: bounded.actions,
+					text: clipped.text,
+					truncated: bounded.truncated || clipped.truncated
+				};
+			} finally {
+				await stagehand.close().catch(() => {});
+			}
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });
@@ -310,14 +319,18 @@ export const extract = action({
 	},
 	returns: vBrowserTaskResult,
 	handler: async (ctx, args): Promise<Infer<typeof vBrowserTaskResult>> => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			const result = await stagehand.extract(args.instruction);
-			return clip(JSON.stringify(result));
-		} finally {
-			await stagehand.close().catch(() => {});
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				const result = await stagehand.extract(args.instruction);
+				return clip(JSON.stringify(result));
+			} finally {
+				await stagehand.close().catch(() => {});
+			}
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });

--- a/apps/web/src/convex/executor.ts
+++ b/apps/web/src/convex/executor.ts
@@ -4,6 +4,7 @@ import { getExecutionRun } from '@convex/lib/auth';
 import { executorFailureRunPatch } from '@convex/lib/runs';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
 import { isRunFinalStatus, vExecutorJobResult } from '@convex/lib/validators';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 export const complete = mutation({
 	args: {
@@ -15,34 +16,38 @@ export const complete = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const job = await ctx.db.get('executorJobs', args.jobId);
-		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (job.status === 'cancelled' || job.status === 'failed') {
-			return false;
-		}
-		if (job.status === 'completed') {
-			return true;
-		}
-		if (isRunFinalStatus(run.status)) {
-			return false;
-		}
-		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
-			return false;
-		}
+		try {
+			const job = await ctx.db.get('executorJobs', args.jobId);
+			if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			if (job.status === 'cancelled' || job.status === 'failed') {
+				return false;
+			}
+			if (job.status === 'completed') {
+				return true;
+			}
+			if (isRunFinalStatus(run.status)) {
+				return false;
+			}
+			if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
+				return false;
+			}
 
-		await ctx.db.patch('executorJobs', args.jobId, {
-			status: 'completed',
-			result: args.result,
-			completedAt: Date.now()
-		});
-		if (run.activeJobId === args.jobId) {
-			await ctx.db.patch('runs', run._id, {
-				status: 'running',
-				activeJobId: undefined
+			await ctx.db.patch('executorJobs', args.jobId, {
+				status: 'completed',
+				result: args.result,
+				completedAt: Date.now()
 			});
+			if (run.activeJobId === args.jobId) {
+				await ctx.db.patch('runs', run._id, {
+					status: 'running',
+					activeJobId: undefined
+				});
+			}
+			return true;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return true;
 	}
 });
 
@@ -56,30 +61,34 @@ export const fail = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const job = await ctx.db.get('executorJobs', args.jobId);
-		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
-			return false;
-		}
-		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
-			return false;
-		}
+		try {
+			const job = await ctx.db.get('executorJobs', args.jobId);
+			if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
+				return false;
+			}
+			if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
+				return false;
+			}
 
-		const completedAt = Date.now();
-		await ctx.db.patch('executorJobs', args.jobId, {
-			status: 'failed',
-			error: args.error,
-			completedAt
-		});
-		const runPatch = executorFailureRunPatch({
-			runStatus: run.status,
-			activeJobId: run.activeJobId,
-			failedJobId: args.jobId
-		});
-		if (runPatch) {
-			await ctx.db.patch('runs', job.runId, runPatch);
+			const completedAt = Date.now();
+			await ctx.db.patch('executorJobs', args.jobId, {
+				status: 'failed',
+				error: args.error,
+				completedAt
+			});
+			const runPatch = executorFailureRunPatch({
+				runStatus: run.status,
+				activeJobId: run.activeJobId,
+				failedJobId: args.jobId
+			});
+			if (runPatch) {
+				await ctx.db.patch('runs', job.runId, runPatch);
+			}
+			return true;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return true;
 	}
 });

--- a/apps/web/src/convex/lib/agentErrors.test.ts
+++ b/apps/web/src/convex/lib/agentErrors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ConvexError } from 'convex/values';
+import { RUN_NO_LONGER_ACTIVE, toAgentToolConvexError } from '@convex/lib/agentErrors';
+
+describe('agent tool error surfacing', () => {
+	it('passes ConvexErrors through untouched', () => {
+		const error = new ConvexError('Mandate not found.');
+		expect(toAgentToolConvexError(error)).toBe(error);
+	});
+
+	it('strips the production uncaught-error prefix', () => {
+		const error = toAgentToolConvexError(new Error('Uncaught Error: Exa search failed.'));
+		expect(error).toBeInstanceOf(ConvexError);
+		expect(error.message).toBe('Exa search failed.');
+	});
+
+	it('keeps control-flow sentinel wording', () => {
+		const error = toAgentToolConvexError(new Error(RUN_NO_LONGER_ACTIVE));
+		expect(error.message).toBe(RUN_NO_LONGER_ACTIVE);
+	});
+});

--- a/apps/web/src/convex/lib/agentErrors.ts
+++ b/apps/web/src/convex/lib/agentErrors.ts
@@ -209,3 +209,14 @@ export function toModelCompletionConvexError(error: Error, modelId: string): Err
 	}
 	return new ConvexError(`The model provider failed: ${detail}`);
 }
+
+/**
+ * Converts failures caught in executor-facing tool functions into ConvexErrors
+ * so their text reaches the executor client and `job.error`; uncaught Errors
+ * are masked to "[Request ID] Server Error" for both audiences in production.
+ */
+export function toAgentToolConvexError(error: Error): Error {
+	if (error instanceof ConvexError) return error;
+	const message = stripUncaughtPrefix(error.message) || error.name;
+	return new ConvexError(message);
+}

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -11,6 +11,7 @@ import { api, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { getUserId, pickPrimaryUser } from '@convex/lib/auth';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 import {
 	isMandateStatus,
 	vMandateChargeStatus,
@@ -368,27 +369,31 @@ export const insertMandate = internalMutation({
 	},
 	returns: v.id('mandates'),
 	handler: async (ctx, args) => {
-		const description = args.description.trim();
-		if (!description) {
-			throw new Error('Mandate description is required.');
+		try {
+			const description = args.description.trim();
+			if (!description) {
+				throw new Error('Mandate description is required.');
+			}
+			const now = Date.now();
+			return await ctx.db.insert('mandates', {
+				userId: args.userId,
+				pravaSessionId: args.pravaSessionId,
+				merchantName: args.merchantName,
+				merchantUrl: args.merchantUrl,
+				countryCode: args.countryCode,
+				amountCap: requireMoneyMinor(args.amountCap, 'Amount cap'),
+				currency: args.currency,
+				frequency: args.frequency,
+				scope: args.scope,
+				description,
+				approvalUrl: args.approvalUrl,
+				status: 'pending',
+				createdAt: now,
+				updatedAt: now
+			});
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const now = Date.now();
-		return await ctx.db.insert('mandates', {
-			userId: args.userId,
-			pravaSessionId: args.pravaSessionId,
-			merchantName: args.merchantName,
-			merchantUrl: args.merchantUrl,
-			countryCode: args.countryCode,
-			amountCap: requireMoneyMinor(args.amountCap, 'Amount cap'),
-			currency: args.currency,
-			frequency: args.frequency,
-			scope: args.scope,
-			description,
-			approvalUrl: args.approvalUrl,
-			status: 'pending',
-			createdAt: now,
-			updatedAt: now
-		});
 	}
 });
 
@@ -442,24 +447,28 @@ export const syncMandate = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const mandate = await ctx.db.get('mandates', args.mandateId);
-		if (!mandate || mandate.userId !== args.userId) {
-			throw new Error('Mandate not found.');
+		try {
+			const mandate = await ctx.db.get('mandates', args.mandateId);
+			if (!mandate || mandate.userId !== args.userId) {
+				throw new Error('Mandate not found.');
+			}
+			const patch: MandateSyncPatch = { updatedAt: Date.now() };
+			if (args.pravaMandateId !== undefined && !mandate.pravaMandateId) {
+				patch.pravaMandateId = args.pravaMandateId;
+			}
+			// Never rewind a terminal status.
+			const terminal = new Set(['consumed', 'cancelled', 'expired']);
+			if (args.status && !(terminal.has(mandate.status) && args.status !== mandate.status)) {
+				patch.status = args.status;
+			}
+			if (args.remaining !== undefined) patch.remaining = args.remaining;
+			if (args.validUntil !== undefined) patch.validUntil = args.validUntil;
+			if (args.renewsAt !== undefined) patch.renewsAt = args.renewsAt;
+			await ctx.db.patch('mandates', args.mandateId, patch);
+			return null;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const patch: MandateSyncPatch = { updatedAt: Date.now() };
-		if (args.pravaMandateId !== undefined && !mandate.pravaMandateId) {
-			patch.pravaMandateId = args.pravaMandateId;
-		}
-		// Never rewind a terminal status.
-		const terminal = new Set(['consumed', 'cancelled', 'expired']);
-		if (args.status && !(terminal.has(mandate.status) && args.status !== mandate.status)) {
-			patch.status = args.status;
-		}
-		if (args.remaining !== undefined) patch.remaining = args.remaining;
-		if (args.validUntil !== undefined) patch.validUntil = args.validUntil;
-		if (args.renewsAt !== undefined) patch.renewsAt = args.renewsAt;
-		await ctx.db.patch('mandates', args.mandateId, patch);
-		return null;
 	}
 });
 
@@ -493,86 +502,92 @@ export const reserveCharge = internalMutation({
 	},
 	returns: reserveChargeResult,
 	handler: async (ctx, args) => {
-		const amount = requireMoneyMinor(args.amount, 'Charge amount');
-		const reference = args.reference?.trim() || undefined;
-		const now = Date.now();
+		try {
+			const amount = requireMoneyMinor(args.amount, 'Charge amount');
+			const reference = args.reference?.trim() || undefined;
+			const now = Date.now();
 
-		if (reference !== undefined) {
-			const matches = await ctx.db
-				.query('mandateCharges')
-				.withIndex('by_mandate_reference', (query) =>
-					query.eq('mandateId', args.mandateId).eq('reference', reference)
-				)
-				.take(2);
-			if (matches.length > 1) {
-				throw new Error('Charge reference matches multiple existing charges.');
-			}
-			const existing = matches[0];
-			if (existing) {
-				if (existing.userId !== args.userId) {
-					throw new Error('Charge not found.');
+			if (reference !== undefined) {
+				const matches = await ctx.db
+					.query('mandateCharges')
+					.withIndex('by_mandate_reference', (query) =>
+						query.eq('mandateId', args.mandateId).eq('reference', reference)
+					)
+					.take(2);
+				if (matches.length > 1) {
+					throw new Error('Charge reference matches multiple existing charges.');
 				}
-				if (existing.amount !== amount || existing.currency !== args.currency) {
-					throw new Error('Charge reference was already used with a different amount or currency.');
-				}
-				if (existing.pravaTransactionId) {
-					return {
-						kind: 'existing' as const,
-						chargeId: existing._id,
-						transactionId: existing.pravaTransactionId
-					};
-				}
-				if (existing.providerRequestedAt !== undefined) {
-					// Ambiguous delivery: the provider POST may have committed.
-					// Never reclaim for another charge. That would double-bill.
-					throw new Error(
-						'A previous charge attempt for this reference may have already been submitted to Prava; refusing to charge again.'
-					);
-				}
-				if (existing.status === 'failed') {
+				const existing = matches[0];
+				if (existing) {
+					if (existing.userId !== args.userId) {
+						throw new Error('Charge not found.');
+					}
+					if (existing.amount !== amount || existing.currency !== args.currency) {
+						throw new Error(
+							'Charge reference was already used with a different amount or currency.'
+						);
+					}
+					if (existing.pravaTransactionId) {
+						return {
+							kind: 'existing' as const,
+							chargeId: existing._id,
+							transactionId: existing.pravaTransactionId
+						};
+					}
+					if (existing.providerRequestedAt !== undefined) {
+						// Ambiguous delivery: the provider POST may have committed.
+						// Never reclaim for another charge. That would double-bill.
+						throw new Error(
+							'A previous charge attempt for this reference may have already been submitted to Prava; refusing to charge again.'
+						);
+					}
+					if (existing.status === 'failed') {
+						await ctx.db.patch('mandateCharges', existing._id, {
+							runId: args.runId,
+							description: args.description,
+							status: 'awaiting_result',
+							pravaTransactionId: undefined,
+							providerRequestedAt: undefined,
+							chargingStartedAt: now,
+							updatedAt: now
+						});
+						return { kind: 'reserved' as const, chargeId: existing._id };
+					}
+					if (
+						existing.chargingStartedAt !== undefined &&
+						now - existing.chargingStartedAt <= CHARGE_CLAIM_STALE_MS
+					) {
+						return { kind: 'inFlight' as const };
+					}
+					// Abandoned reservation that never reached Prava: reclaim.
 					await ctx.db.patch('mandateCharges', existing._id, {
 						runId: args.runId,
 						description: args.description,
 						status: 'awaiting_result',
-						pravaTransactionId: undefined,
-						providerRequestedAt: undefined,
 						chargingStartedAt: now,
 						updatedAt: now
 					});
 					return { kind: 'reserved' as const, chargeId: existing._id };
 				}
-				if (
-					existing.chargingStartedAt !== undefined &&
-					now - existing.chargingStartedAt <= CHARGE_CLAIM_STALE_MS
-				) {
-					return { kind: 'inFlight' as const };
-				}
-				// Abandoned reservation that never reached Prava: reclaim.
-				await ctx.db.patch('mandateCharges', existing._id, {
-					runId: args.runId,
-					description: args.description,
-					status: 'awaiting_result',
-					chargingStartedAt: now,
-					updatedAt: now
-				});
-				return { kind: 'reserved' as const, chargeId: existing._id };
 			}
-		}
 
-		const chargeId = await ctx.db.insert('mandateCharges', {
-			mandateId: args.mandateId,
-			runId: args.runId,
-			userId: args.userId,
-			amount,
-			currency: args.currency,
-			description: args.description,
-			reference,
-			status: 'awaiting_result',
-			chargingStartedAt: now,
-			createdAt: now,
-			updatedAt: now
-		});
-		return { kind: 'reserved' as const, chargeId };
+			const chargeId = await ctx.db.insert('mandateCharges', {
+				mandateId: args.mandateId,
+				runId: args.runId,
+				userId: args.userId,
+				amount,
+				currency: args.currency,
+				description: args.description,
+				reference,
+				status: 'awaiting_result',
+				chargingStartedAt: now,
+				createdAt: now,
+				updatedAt: now
+			});
+			return { kind: 'reserved' as const, chargeId };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -669,34 +684,38 @@ export const claimChargeReport = internalMutation({
 	},
 	returns: v.union(v.literal('claimed'), v.literal('already'), v.literal('inFlight')),
 	handler: async (ctx, args) => {
-		const charge = await ownedCharge(ctx, args.chargeId, args.userId);
-		if (charge.reportedAt) {
-			return 'already';
-		}
-		// The first-claimed outcome is immutable. A conflicting report must
-		// never be sent. A crash between the provider POST and the local
-		// finalize would otherwise let a retry overwrite the outcome and POST
-		// the opposite terminal state to the card network.
-		if (charge.reportOutcome && charge.reportOutcome !== args.outcome) {
-			throw new Error(
-				`Charge already has a ${charge.reportOutcome} report in progress; the outcome cannot be changed.`
-			);
-		}
-		if (charge.reportingStartedAt) {
-			// A claim newer than the report window belongs to a live concurrent
-			// caller and has not completed, so say so rather than claim success. An
-			// older one is abandoned (its caller died), so reclaim it and re-send;
-			// the provider report is idempotent on the transaction id.
-			if (Date.now() - charge.reportingStartedAt <= REPORT_CLAIM_STALE_MS) {
-				return 'inFlight';
+		try {
+			const charge = await ownedCharge(ctx, args.chargeId, args.userId);
+			if (charge.reportedAt) {
+				return 'already';
 			}
+			// The first-claimed outcome is immutable. A conflicting report must
+			// never be sent. A crash between the provider POST and the local
+			// finalize would otherwise let a retry overwrite the outcome and POST
+			// the opposite terminal state to the card network.
+			if (charge.reportOutcome && charge.reportOutcome !== args.outcome) {
+				throw new Error(
+					`Charge already has a ${charge.reportOutcome} report in progress; the outcome cannot be changed.`
+				);
+			}
+			if (charge.reportingStartedAt) {
+				// A claim newer than the report window belongs to a live concurrent
+				// caller and has not completed, so say so rather than claim success. An
+				// older one is abandoned (its caller died), so reclaim it and re-send;
+				// the provider report is idempotent on the transaction id.
+				if (Date.now() - charge.reportingStartedAt <= REPORT_CLAIM_STALE_MS) {
+					return 'inFlight';
+				}
+			}
+			await ctx.db.patch('mandateCharges', args.chargeId, {
+				reportingStartedAt: Date.now(),
+				reportOutcome: args.outcome,
+				updatedAt: Date.now()
+			});
+			return 'claimed';
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.db.patch('mandateCharges', args.chargeId, {
-			reportingStartedAt: Date.now(),
-			reportOutcome: args.outcome,
-			updatedAt: Date.now()
-		});
-		return 'claimed';
 	}
 });
 
@@ -866,8 +885,12 @@ export const mandateSetup = action({
 	},
 	returns: vMandateSetupResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateSetupResult>> => {
-		const actor = await activeActor(ctx, args);
-		return await createMandateSetup(ctx, actor.userId, args);
+		try {
+			const actor = await activeActor(ctx, args);
+			return await createMandateSetup(ctx, actor.userId, args);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -1054,25 +1077,29 @@ export const mandateStatus = action({
 	},
 	returns: vMandateStatusResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateStatusResult>> => {
-		const actor = await activeActor(ctx, args);
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: args.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate) throw new Error('Mandate not found.');
+		try {
+			const actor = await activeActor(ctx, args);
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: args.mandateId,
+				userId: actor.userId
+			});
+			if (!mandate) throw new Error('Mandate not found.');
 
-		let synced = mandate;
-		if (LIVE_MANDATE_STATUSES.has(mandate.status)) {
-			try {
-				const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
-				const sync = mandateSyncArgs(mandate._id, actor.userId, prava);
-				await ctx.runMutation(internal.payments.syncMandate, sync);
-				synced = withMandateSync(mandate, sync);
-			} catch {
-				// Still awaiting the owner's passkey approval, so keep the stored status.
+			let synced = mandate;
+			if (LIVE_MANDATE_STATUSES.has(mandate.status)) {
+				try {
+					const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
+					const sync = mandateSyncArgs(mandate._id, actor.userId, prava);
+					await ctx.runMutation(internal.payments.syncMandate, sync);
+					synced = withMandateSync(mandate, sync);
+				} catch {
+					// Still awaiting the owner's passkey approval, so keep the stored status.
+				}
 			}
+			return mandateStatusResult(synced);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return mandateStatusResult(synced);
 	}
 });
 
@@ -1084,8 +1111,12 @@ export const mandateList = action({
 	},
 	returns: vMandateListResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateListResult>> => {
-		const actor = await activeActor(ctx, args);
-		return await listLinkedMandates(ctx, actor.userId);
+		try {
+			const actor = await activeActor(ctx, args);
+			return await listLinkedMandates(ctx, actor.userId);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -1102,109 +1133,113 @@ export const mandateCharge = action({
 	},
 	returns: vMandateChargeResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateChargeResult>> => {
-		const actor = await activeActor(ctx, args);
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: args.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate) throw new Error('Mandate not found.');
-		assertChargeable(mandate, args);
-		if (mandate.status === 'paused') {
-			throw new Error('Mandate is paused and cannot be charged.');
-		}
-
-		const reference = args.reference?.trim() || undefined;
-		const reservation = await ctx.runMutation(internal.payments.reserveCharge, {
-			mandateId: mandate._id,
-			runId: args.runId,
-			userId: actor.userId,
-			amount: args.amount,
-			currency: mandate.currency,
-			description: args.description,
-			reference
-		});
-		if (reservation.kind === 'existing') {
-			// Credentials are never persisted, only the non-sensitive handle.
-			return {
-				chargeId: reservation.chargeId,
-				transactionId: reservation.transactionId
-			};
-		}
-		if (reservation.kind === 'inFlight') {
-			throw new Error('A charge with this reference is already in progress. Retry shortly.');
-		}
-
-		const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
-		if ((prava.status ?? '').toLowerCase() !== 'active') {
-			await ctx.runMutation(internal.payments.releaseChargeReservation, {
-				chargeId: reservation.chargeId,
-				userId: actor.userId
-			});
-			throw new Error('Mandate is not active and cannot be charged.');
-		}
-		let result: {
-			transactionId?: string;
-			status?: string;
-			errorCode?: string;
-			credentials?: {
-				token: string;
-				dynamicCvv: string;
-				expiryMonth: string;
-				expiryYear: string;
-			};
-			errorMessage?: string;
-		};
-		// Mark before the network call so a lost response cannot be mistaken
-		// for an abandoned reservation that is safe to reclaim.
-		await ctx.runMutation(internal.payments.markChargeProviderRequested, {
-			chargeId: reservation.chargeId,
-			userId: actor.userId
-		});
 		try {
-			result = await pravaRequest(`/v1/mandates/${encodeURIComponent(prava.id)}/charge`, {
-				method: 'POST',
-				body: JSON.stringify(
-					(() => {
-						const chargeBody: MandateChargeRequest = {
-							amount: args.amount
-						};
-						if (reference !== undefined) chargeBody.reference = reference;
-						return chargeBody;
-					})()
-				)
+			const actor = await activeActor(ctx, args);
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: args.mandateId,
+				userId: actor.userId
 			});
-		} catch (error) {
-			await ctx.runMutation(internal.payments.releaseChargeReservation, {
+			if (!mandate) throw new Error('Mandate not found.');
+			assertChargeable(mandate, args);
+			if (mandate.status === 'paused') {
+				throw new Error('Mandate is paused and cannot be charged.');
+			}
+
+			const reference = args.reference?.trim() || undefined;
+			const reservation = await ctx.runMutation(internal.payments.reserveCharge, {
+				mandateId: mandate._id,
+				runId: args.runId,
+				userId: actor.userId,
+				amount: args.amount,
+				currency: mandate.currency,
+				description: args.description,
+				reference
+			});
+			if (reservation.kind === 'existing') {
+				// Credentials are never persisted, only the non-sensitive handle.
+				return {
+					chargeId: reservation.chargeId,
+					transactionId: reservation.transactionId
+				};
+			}
+			if (reservation.kind === 'inFlight') {
+				throw new Error('A charge with this reference is already in progress. Retry shortly.');
+			}
+
+			const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
+			if ((prava.status ?? '').toLowerCase() !== 'active') {
+				await ctx.runMutation(internal.payments.releaseChargeReservation, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId
+				});
+				throw new Error('Mandate is not active and cannot be charged.');
+			}
+			let result: {
+				transactionId?: string;
+				status?: string;
+				errorCode?: string;
+				credentials?: {
+					token: string;
+					dynamicCvv: string;
+					expiryMonth: string;
+					expiryYear: string;
+				};
+				errorMessage?: string;
+			};
+			// Mark before the network call so a lost response cannot be mistaken
+			// for an abandoned reservation that is safe to reclaim.
+			await ctx.runMutation(internal.payments.markChargeProviderRequested, {
 				chargeId: reservation.chargeId,
 				userId: actor.userId
 			});
-			throw error;
-		}
+			try {
+				result = await pravaRequest(`/v1/mandates/${encodeURIComponent(prava.id)}/charge`, {
+					method: 'POST',
+					body: JSON.stringify(
+						(() => {
+							const chargeBody: MandateChargeRequest = {
+								amount: args.amount
+							};
+							if (reference !== undefined) chargeBody.reference = reference;
+							return chargeBody;
+						})()
+					)
+				});
+			} catch (error) {
+				await ctx.runMutation(internal.payments.releaseChargeReservation, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId
+				});
+				throw error;
+			}
 
-		const { credentials, transactionId } = result;
-		if (result.status === 'failed' || !credentials || !transactionId) {
-			await ctx.runMutation(internal.payments.updateChargeStatus, {
+			const { credentials, transactionId } = result;
+			if (result.status === 'failed' || !credentials || !transactionId) {
+				await ctx.runMutation(internal.payments.updateChargeStatus, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId,
+					status: 'failed'
+				});
+				throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
+			}
+			await ctx.runMutation(internal.payments.completeCharge, {
 				chargeId: reservation.chargeId,
 				userId: actor.userId,
-				status: 'failed'
+				pravaTransactionId: transactionId
 			});
-			throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
+			// Return only validated credential fields. Prava may include extras
+			// (e.g. dynamicDataType) that must not leak into the action result.
+			return {
+				chargeId: reservation.chargeId,
+				transactionId,
+				token: credentials.token,
+				dynamicCvv: credentials.dynamicCvv,
+				expiryMonth: credentials.expiryMonth,
+				expiryYear: credentials.expiryYear
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.runMutation(internal.payments.completeCharge, {
-			chargeId: reservation.chargeId,
-			userId: actor.userId,
-			pravaTransactionId: transactionId
-		});
-		// Return only validated credential fields. Prava may include extras
-		// (e.g. dynamicDataType) that must not leak into the action result.
-		return {
-			chargeId: reservation.chargeId,
-			transactionId,
-			token: credentials.token,
-			dynamicCvv: credentials.dynamicCvv,
-			expiryMonth: credentials.expiryMonth,
-			expiryYear: credentials.expiryYear
-		};
 	}
 });
 
@@ -1219,88 +1254,92 @@ export const mandateReport = action({
 	},
 	returns: vMandateReportResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateReportResult>> => {
-		const actor = await activeActor(ctx, args);
-		const charge = await ctx.runQuery(internal.payments.getOwnedCharge, {
-			chargeId: args.chargeId,
-			userId: actor.userId
-		});
-		if (!charge) throw new Error('Charge not found.');
-		if (charge.reportedAt) {
-			return { reported: true, alreadyReported: true };
-		}
-
-		// claimChargeReport atomically reserves this report (reclaiming an
-		// abandoned stale claim), so only one caller reaches Prava per attempt.
-		const claim = await ctx.runMutation(internal.payments.claimChargeReport, {
-			chargeId: charge._id,
-			userId: actor.userId,
-			outcome: args.outcome
-		});
-		if (claim === 'already') {
-			return { reported: true, alreadyReported: true };
-		}
-		if (claim === 'inFlight') {
-			// Another caller is mid-report. Not yet delivered, so don't claim success.
-			return { reported: false, inFlight: true };
-		}
-
-		if (!charge.pravaTransactionId) {
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
-				userId: actor.userId,
-				clearOutcome: true
-			});
-			throw new Error('Prava transaction id is unavailable.');
-		}
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: charge.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate?.pravaMandateId) {
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
-				userId: actor.userId,
-				clearOutcome: true
-			});
-			throw new Error('Prava mandate id is unavailable.');
-		}
-		// claimChargeReport rejects a conflicting outcome, so args.outcome is
-		// the bound terminal state for this charge.
-		const outcome = args.outcome;
 		try {
-			await pravaRequest(
-				`/v1/mandates/${encodeURIComponent(mandate.pravaMandateId)}/charges/${encodeURIComponent(charge.pravaTransactionId)}/report`,
-				{
-					method: 'POST',
-					body: JSON.stringify(
-						(() => {
-							const reportBody: MandateReportRequest = {
-								txn_status: outcome === 'approved' ? 'APPROVED' : 'DECLINED',
-								txn_type: 'PURCHASE'
-							};
-							if (args.amountPaid !== undefined) reportBody.amount_paid = args.amountPaid;
-							return reportBody;
-						})()
-					)
-				}
-			);
-		} catch (error) {
-			// Ambiguous delivery: the POST may have committed remotely. Drop the
-			// in-flight claim so a same-outcome retry can re-send (idempotent on
-			// transaction id), but keep reportOutcome so the opposite result
-			// cannot be reserved later.
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
+			const actor = await activeActor(ctx, args);
+			const charge = await ctx.runQuery(internal.payments.getOwnedCharge, {
+				chargeId: args.chargeId,
 				userId: actor.userId
 			});
-			throw error;
+			if (!charge) throw new Error('Charge not found.');
+			if (charge.reportedAt) {
+				return { reported: true, alreadyReported: true };
+			}
+
+			// claimChargeReport atomically reserves this report (reclaiming an
+			// abandoned stale claim), so only one caller reaches Prava per attempt.
+			const claim = await ctx.runMutation(internal.payments.claimChargeReport, {
+				chargeId: charge._id,
+				userId: actor.userId,
+				outcome: args.outcome
+			});
+			if (claim === 'already') {
+				return { reported: true, alreadyReported: true };
+			}
+			if (claim === 'inFlight') {
+				// Another caller is mid-report. Not yet delivered, so don't claim success.
+				return { reported: false, inFlight: true };
+			}
+
+			if (!charge.pravaTransactionId) {
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId,
+					clearOutcome: true
+				});
+				throw new Error('Prava transaction id is unavailable.');
+			}
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: charge.mandateId,
+				userId: actor.userId
+			});
+			if (!mandate?.pravaMandateId) {
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId,
+					clearOutcome: true
+				});
+				throw new Error('Prava mandate id is unavailable.');
+			}
+			// claimChargeReport rejects a conflicting outcome, so args.outcome is
+			// the bound terminal state for this charge.
+			const outcome = args.outcome;
+			try {
+				await pravaRequest(
+					`/v1/mandates/${encodeURIComponent(mandate.pravaMandateId)}/charges/${encodeURIComponent(charge.pravaTransactionId)}/report`,
+					{
+						method: 'POST',
+						body: JSON.stringify(
+							(() => {
+								const reportBody: MandateReportRequest = {
+									txn_status: outcome === 'approved' ? 'APPROVED' : 'DECLINED',
+									txn_type: 'PURCHASE'
+								};
+								if (args.amountPaid !== undefined) reportBody.amount_paid = args.amountPaid;
+								return reportBody;
+							})()
+						)
+					}
+				);
+			} catch (error) {
+				// Ambiguous delivery: the POST may have committed remotely. Drop the
+				// in-flight claim so a same-outcome retry can re-send (idempotent on
+				// transaction id), but keep reportOutcome so the opposite result
+				// cannot be reserved later.
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId
+				});
+				throw error;
+			}
+			await ctx.runMutation(internal.payments.finishChargeReport, {
+				chargeId: charge._id,
+				userId: actor.userId,
+				status: statusForOutcome(outcome)
+			});
+			return { reported: true };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.runMutation(internal.payments.finishChargeReport, {
-			chargeId: charge._id,
-			userId: actor.userId,
-			status: statusForOutcome(outcome)
-		});
-		return { reported: true };
 	}
 });
 

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isUnparseablePageFailure } from '@convex/webTools';
+
+describe('unparseable page failures', () => {
+	it('recognizes component return-validation failures', () => {
+		const error = new Error(
+			'Uncaught ConvexError: ReturnsValidationError: Value does not match validator. Path: .values()'
+		);
+		expect(isUnparseablePageFailure(error)).toBe(true);
+	});
+
+	it('leaves timeouts and other failures alone', () => {
+		expect(isUnparseablePageFailure(new Error('Context.dev scrape timed out after 60000ms.'))).toBe(
+			false
+		);
+		expect(isUnparseablePageFailure(new Error('Run is no longer active.'))).toBe(false);
+	});
+});

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -7,6 +7,7 @@ import { action } from '@convex/_generated/server';
 import { api, components } from '@convex/_generated/api';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 const contextDev = new ContextDev(components.contextDev);
 const exa = new ExaClient(components.exa);
@@ -21,6 +22,15 @@ const SEARCH_RESULT_TEXT_MAX_CHARS = 2_000;
 const SEARCH_TIMEOUT_MS = 30_000;
 
 class WebToolTimeout extends Error {}
+
+// Context.dev validates its scrape result against a bounded-depth JSON schema,
+// so pages whose metadata nests deeper than the bound fail inside the component
+// before any content reaches us (#208).
+export function isUnparseablePageFailure(error: Error): boolean {
+	return error.message.includes('ReturnsValidationError');
+}
+
+const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -54,6 +64,10 @@ async function callComponent<T>(
 		if (error instanceof WebToolTimeout) {
 			throw error;
 		}
+		if (error instanceof Error && isUnparseablePageFailure(error)) {
+			// The same page fails validation on every attempt.
+			throw error;
+		}
 		await sleep(RETRY_DELAY_MS);
 		return await withTimeout(label, timeoutMs, run());
 	}
@@ -68,41 +82,53 @@ export const scrapeUrl = action({
 	},
 	returns: vScrapeUrlResult,
 	handler: async (ctx, args) => {
-		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-			runId: args.runId,
-			executionSecret: args.executionSecret
-		});
-		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
-			throw new Error('Run is no longer active.');
-		}
-		let url: URL;
 		try {
-			url = new URL(args.url.trim());
-		} catch {
-			throw new Error(`Invalid URL: ${args.url}`);
-		}
-		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-			throw new Error('Only http(s) URLs can be scraped.');
-		}
+			const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+				runId: args.runId,
+				executionSecret: args.executionSecret
+			});
+			if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			let url: URL;
+			try {
+				url = new URL(args.url.trim());
+			} catch {
+				throw new Error(`Invalid URL: ${args.url}`);
+			}
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+				throw new Error('Only http(s) URLs can be scraped.');
+			}
 
-		const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
-			contextDev.scrapeMarkdown(ctx, {
-				params: {
-					url: url.toString(),
-					useMainContentOnly: true,
-					timeoutMS: SCRAPE_TIMEOUT_MS
+			let response: Awaited<ReturnType<typeof contextDev.scrapeMarkdown>>;
+			try {
+				response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
+					contextDev.scrapeMarkdown(ctx, {
+						params: {
+							url: url.toString(),
+							useMainContentOnly: true,
+							timeoutMS: SCRAPE_TIMEOUT_MS
+						}
+					})
+				);
+			} catch (error) {
+				if (error instanceof Error && isUnparseablePageFailure(error)) {
+					throw new Error(UNPARSEABLE_PAGE_ERROR, { cause: error });
 				}
-			})
-		);
+				throw error;
+			}
 
-		const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
-		return {
-			url: response.url,
-			markdown: truncated
-				? response.markdown.slice(0, SCRAPE_MARKDOWN_MAX_CHARS)
-				: response.markdown,
-			truncated
-		};
+			const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
+			return {
+				url: response.url,
+				markdown: truncated
+					? response.markdown.slice(0, SCRAPE_MARKDOWN_MAX_CHARS)
+					: response.markdown,
+				truncated
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -116,46 +142,50 @@ export const webSearch = action({
 	},
 	returns: vWebSearchResult,
 	handler: async (ctx, args) => {
-		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-			runId: args.runId,
-			executionSecret: args.executionSecret
-		});
-		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
-			throw new Error('Run is no longer active.');
-		}
-		const query = args.query.trim();
-		if (!query) {
-			throw new Error('Search query cannot be empty.');
-		}
-		const requested =
-			args.numResults !== undefined && Number.isFinite(args.numResults)
-				? Math.floor(args.numResults)
-				: DEFAULT_SEARCH_RESULTS;
-		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
+		try {
+			const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+				runId: args.runId,
+				executionSecret: args.executionSecret
+			});
+			if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			const query = args.query.trim();
+			if (!query) {
+				throw new Error('Search query cannot be empty.');
+			}
+			const requested =
+				args.numResults !== undefined && Number.isFinite(args.numResults)
+					? Math.floor(args.numResults)
+					: DEFAULT_SEARCH_RESULTS;
+			const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
 
-		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
-			exa.search(ctx, {
-				query,
-				type: 'auto',
-				numResults,
-				contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
-			})
-		);
+			const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
+				exa.search(ctx, {
+					query,
+					type: 'auto',
+					numResults,
+					contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
+				})
+			);
 
-		return {
-			results: response.results.flatMap((result) => {
-				if (!result.url) {
-					return [];
-				}
-				const item: Infer<typeof vWebSearchResult>['results'][number] = {
-					url: result.url
-				};
-				if (result.title) item.title = result.title;
-				if (result.publishedDate) item.publishedDate = result.publishedDate;
-				if (result.author) item.author = result.author;
-				if (result.text) item.text = result.text;
-				return [item];
-			})
-		};
+			return {
+				results: response.results.flatMap((result) => {
+					if (!result.url) {
+						return [];
+					}
+					const item: Infer<typeof vWebSearchResult>['results'][number] = {
+						url: result.url
+					};
+					if (result.title) item.title = result.title;
+					if (result.publishedDate) item.publishedDate = result.publishedDate;
+					if (result.author) item.author = result.author;
+					if (result.text) item.text = result.text;
+					return [item];
+				})
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -458,9 +458,40 @@ fn decode_function_result<T: for<'de> Deserialize<'de>>(
                 )
             })
         }
-        FunctionResult::ErrorMessage(message) => Err(anyhow!("{function} failed: {message}")),
-        FunctionResult::ConvexError(error) => Err(anyhow!("{function} failed: {}", error.message)),
+        FunctionResult::ErrorMessage(message) => {
+            Err(anyhow!(clean_function_error_message(&message)))
+        }
+        FunctionResult::ConvexError(error) => {
+            Err(anyhow!(clean_function_error_message(&error.message)))
+        }
     }
+}
+
+/// Strips the transport noise Convex wraps around failed function calls:
+/// production masking lines ("[Request ID ...] Server Error"), `Uncaught`
+/// prefixes, and stack frames. Tool results show only the readable sentence.
+fn clean_function_error_message(raw: &str) -> String {
+    let mut content: Vec<&str> = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("[Request ID") {
+            continue;
+        }
+        if line.starts_with([' ', '\t']) && trimmed.starts_with("at ") {
+            continue;
+        }
+        let message = trimmed
+            .strip_prefix("Uncaught ConvexError: ")
+            .or_else(|| trimmed.strip_prefix("Uncaught Error: "))
+            .unwrap_or(trimmed);
+        content.push(message);
+    }
+    if content.is_empty() {
+        // Production masking left nothing readable behind; the request id
+        // stays available in the Convex dashboard logs.
+        return "The server failed without a readable error.".to_string();
+    }
+    content.join(" ")
 }
 
 fn convex_value_to_plain_json(value: Value) -> serde_json::Value {
@@ -483,5 +514,43 @@ fn convex_value_to_plain_json(value: Value) -> serde_json::Value {
                 .map(|(key, value)| (key, convex_value_to_plain_json(value)))
                 .collect(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleans_masking_lines_prefixes_and_stack_frames() {
+        let raw = "[Request ID: 84f5068c0836218d] Server Error\nUncaught ConvexError: The webpage is too complex and could not be parsed as Markdown.\n    at handler (../src/convex/webTools.ts:130:2)";
+        assert_eq!(
+            clean_function_error_message(raw),
+            "The webpage is too complex and could not be parsed as Markdown."
+        );
+    }
+
+    #[test]
+    fn keeps_plain_messages_untouched() {
+        assert_eq!(
+            clean_function_error_message("Mandate not found."),
+            "Mandate not found."
+        );
+    }
+
+    #[test]
+    fn strips_uncaught_error_prefixes() {
+        assert_eq!(
+            clean_function_error_message("Uncaught Error: Prava request failed (500): boom"),
+            "Prava request failed (500): boom"
+        );
+    }
+
+    #[test]
+    fn falls_back_when_production_masks_the_whole_error() {
+        assert_eq!(
+            clean_function_error_message("[Request ID: 0d45611fde71c0f2] Server Error"),
+            "The server failed without a readable error."
+        );
     }
 }

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use convex::Value;
 use futures::StreamExt;
+use rig::tool::{ToolErrorKind, ToolExecutionError};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -33,12 +34,15 @@ const GET_QUESTION_FUNCTION: &str = "agentQuestions:getForExecutor";
 use crate::convex::RuntimeClient;
 use crate::hooks::ToolCallTracker;
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum AgentToolError {
-    #[error("Run is no longer active.")]
-    Cancelled,
-    #[error("{0}")]
-    Message(String),
+/// Builds the model-visible failure for an agent tool. Constructing rig's
+/// canonical error directly means its default `map_error` downcast preserves
+/// the message instead of redacting it to "the tool failed".
+fn tool_failure(message: impl Into<String>) -> ToolExecutionError {
+    ToolExecutionError::other(message.into())
+}
+
+fn cancelled_error() -> ToolExecutionError {
+    ToolExecutionError::cancelled("Tool execution was cancelled.")
 }
 
 #[derive(Clone)]
@@ -632,7 +636,7 @@ struct CreateQuestionResponse {
 
 impl rig::tool::Tool for ExecCommandTool {
     const NAME: &'static str = "exec_command";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = ExecCommandArgs;
     type Output = serde_json::Value;
 
@@ -681,7 +685,7 @@ impl rig::tool::Tool for ExecCommandTool {
 
 impl rig::tool::Tool for WriteStdinTool {
     const NAME: &'static str = "write_stdin";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = WriteStdinArgs;
     type Output = serde_json::Value;
 
@@ -728,7 +732,7 @@ impl rig::tool::Tool for WriteStdinTool {
 
 impl rig::tool::Tool for AskQuestionTool {
     const NAME: &'static str = "ask_question";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = AskQuestionArgs;
     type Output = serde_json::Value;
 
@@ -789,7 +793,7 @@ impl rig::tool::Tool for AskQuestionTool {
 
 impl rig::tool::Tool for AwaitQuestionTool {
     const NAME: &'static str = "await_question";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = AwaitQuestionArgs;
     type Output = serde_json::Value;
 
@@ -808,9 +812,7 @@ impl rig::tool::Tool for AwaitQuestionTool {
         args: Self::Args,
     ) -> Result<Self::Output, Self::Error> {
         if args.question_id.trim().is_empty() {
-            return Err(AgentToolError::Message(
-                "questionId cannot be empty".to_string(),
-            ));
+            return Err(tool_failure("questionId cannot be empty"));
         }
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         execute_tool_job(
@@ -827,9 +829,7 @@ impl rig::tool::Tool for AwaitQuestionTool {
                 async move {
                     let snapshot = fetch_question_snapshot(&runtime, &run_id, &question_id).await?;
                     let Some(snapshot) = snapshot else {
-                        return Err(AgentToolError::Message(format!(
-                            "Unknown questionId '{question_id}'"
-                        )));
+                        return Err(tool_failure(format!("Unknown questionId '{question_id}'")));
                     };
                     // Avoid racing the yield deadline against a slow first subscription
                     // update when the question is already terminal.
@@ -855,7 +855,7 @@ impl rig::tool::Tool for AwaitQuestionTool {
 
 impl rig::tool::Tool for ApplyPatchTool {
     const NAME: &'static str = "apply_patch";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = ApplyPatchArgs;
     type Output = serde_json::Value;
 
@@ -893,7 +893,7 @@ impl rig::tool::Tool for ApplyPatchTool {
 
 impl rig::tool::Tool for WebSearchTool {
     const NAME: &'static str = "web_search";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = WebSearchArgs;
     type Output = serde_json::Value;
 
@@ -945,7 +945,7 @@ impl rig::tool::Tool for WebSearchTool {
 
 impl rig::tool::Tool for ScrapeUrlTool {
     const NAME: &'static str = "scrape_url";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = ScrapeUrlArgs;
     type Output = serde_json::Value;
 
@@ -990,7 +990,7 @@ impl rig::tool::Tool for ScrapeUrlTool {
 
 impl rig::tool::Tool for CreateArtifactTool {
     const NAME: &'static str = "create_artifact";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = CreateArtifactArgs;
     type Output = serde_json::Value;
 
@@ -1033,7 +1033,7 @@ impl rig::tool::Tool for CreateArtifactTool {
 
 impl rig::tool::Tool for UpdateArtifactTool {
     const NAME: &'static str = "update_artifact";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = UpdateArtifactArgs;
     type Output = serde_json::Value;
 
@@ -1076,7 +1076,7 @@ impl rig::tool::Tool for UpdateArtifactTool {
 
 impl rig::tool::Tool for BrowserObserveTool {
     const NAME: &'static str = "browser_observe";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = BrowserObserveArgs;
     type Output = serde_json::Value;
 
@@ -1123,7 +1123,7 @@ impl rig::tool::Tool for BrowserObserveTool {
 
 impl rig::tool::Tool for BrowserActTool {
     const NAME: &'static str = "browser_act";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = BrowserActToolArgs;
     type Output = serde_json::Value;
 
@@ -1142,7 +1142,7 @@ impl rig::tool::Tool for BrowserActTool {
     ) -> Result<Self::Output, Self::Error> {
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         if args.instruction.is_none() && args.action.is_none() {
-            return Err(AgentToolError::Message(
+            return Err(tool_failure(
                 "browser_act needs an instruction or an action".to_string(),
             ));
         }
@@ -1187,7 +1187,7 @@ impl rig::tool::Tool for BrowserActTool {
 
 impl rig::tool::Tool for BrowserExtractTool {
     const NAME: &'static str = "browser_extract";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = BrowserExtractArgs;
     type Output = serde_json::Value;
 
@@ -1235,7 +1235,7 @@ impl rig::tool::Tool for BrowserExtractTool {
 
 impl rig::tool::Tool for MandateSetupTool {
     const NAME: &'static str = "mandate_setup";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = MandateSetupArgs;
     type Output = serde_json::Value;
 
@@ -1265,7 +1265,7 @@ impl rig::tool::Tool for MandateSetupTool {
 
 impl rig::tool::Tool for MandateStatusTool {
     const NAME: &'static str = "mandate_status";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = MandateIdArgs;
     type Output = serde_json::Value;
 
@@ -1295,7 +1295,7 @@ impl rig::tool::Tool for MandateStatusTool {
 
 impl rig::tool::Tool for MandateListTool {
     const NAME: &'static str = "mandate_list";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = serde_json::Value;
     type Output = serde_json::Value;
 
@@ -1319,7 +1319,7 @@ impl rig::tool::Tool for MandateListTool {
 
 impl rig::tool::Tool for MandateChargeTool {
     const NAME: &'static str = "mandate_charge";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = MandateChargeArgs;
     type Output = serde_json::Value;
 
@@ -1349,7 +1349,7 @@ impl rig::tool::Tool for MandateChargeTool {
 
 impl rig::tool::Tool for MandateReportTool {
     const NAME: &'static str = "mandate_report";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = MandateReportArgs;
     type Output = serde_json::Value;
 
@@ -1379,7 +1379,7 @@ impl rig::tool::Tool for MandateReportTool {
 
 impl rig::tool::Tool for ReadSkillTool {
     const NAME: &'static str = "read_skill";
-    type Error = AgentToolError;
+    type Error = ToolExecutionError;
     type Args = ReadSkillArgs;
     type Output = serde_json::Value;
 
@@ -1418,7 +1418,7 @@ impl rig::tool::Tool for ReadSkillTool {
 pub(crate) fn resolve_read_skill(
     skills: &[WorkspaceSkill],
     name: &str,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     let Some(skill) = skills.iter().find(|skill| skill.name == name) else {
         let available = if skills.is_empty() {
             "(none)".to_string()
@@ -1429,7 +1429,7 @@ pub(crate) fn resolve_read_skill(
                 .collect::<Vec<_>>()
                 .join(", ")
         };
-        return Err(AgentToolError::Message(format!(
+        return Err(tool_failure(format!(
             "Unknown skill '{name}'. Available skills: {available}"
         )));
     };
@@ -1455,20 +1455,18 @@ struct PreparedAskQuestion {
     options: Vec<AskQuestionOption>,
 }
 
-fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, AgentToolError> {
+fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, ToolExecutionError> {
     let question = args.question.trim();
     if question.is_empty() {
-        return Err(AgentToolError::Message(
-            "Question cannot be empty.".to_string(),
-        ));
+        return Err(tool_failure("Question cannot be empty."));
     }
     if question.chars().count() > MAX_QUESTION_CHARS {
-        return Err(AgentToolError::Message(format!(
+        return Err(tool_failure(format!(
             "Question cannot exceed {MAX_QUESTION_CHARS} characters."
         )));
     }
     if args.options.len() < MIN_AGENT_OPTIONS || args.options.len() > MAX_AGENT_OPTIONS {
-        return Err(AgentToolError::Message(format!(
+        return Err(tool_failure(format!(
             "Provide between {MIN_AGENT_OPTIONS} and {MAX_AGENT_OPTIONS} options (the agent-decide option is added automatically)."
         )));
     }
@@ -1479,34 +1477,28 @@ fn prepare_ask_question(args: &AskQuestionArgs) -> Result<PreparedAskQuestion, A
         let id = option.id.trim();
         let label = option.label.trim();
         if id.is_empty() {
-            return Err(AgentToolError::Message(
-                "Option id cannot be empty.".to_string(),
-            ));
+            return Err(tool_failure("Option id cannot be empty."));
         }
         if label.is_empty() {
-            return Err(AgentToolError::Message(
-                "Option label cannot be empty.".to_string(),
-            ));
+            return Err(tool_failure("Option label cannot be empty."));
         }
         if id.chars().count() > MAX_OPTION_ID_CHARS {
-            return Err(AgentToolError::Message(format!(
+            return Err(tool_failure(format!(
                 "Option id cannot exceed {MAX_OPTION_ID_CHARS} characters."
             )));
         }
         if label.chars().count() > MAX_OPTION_LABEL_CHARS {
-            return Err(AgentToolError::Message(format!(
+            return Err(tool_failure(format!(
                 "Option label cannot exceed {MAX_OPTION_LABEL_CHARS} characters."
             )));
         }
         if id == AGENT_DECIDE_OPTION_ID {
-            return Err(AgentToolError::Message(format!(
+            return Err(tool_failure(format!(
                 "Option id '{AGENT_DECIDE_OPTION_ID}' is reserved."
             )));
         }
         if !seen.insert(id.to_string()) {
-            return Err(AgentToolError::Message(format!(
-                "Duplicate option id '{id}'."
-            )));
+            return Err(tool_failure(format!("Duplicate option id '{id}'.")));
         }
         options.push(AskQuestionOption {
             id: id.to_string(),
@@ -1527,7 +1519,7 @@ async fn create_agent_question(
     question: &str,
     options: &[AskQuestionOption],
     timeout_ms: u64,
-) -> Result<CreateQuestionResponse, AgentToolError> {
+) -> Result<CreateQuestionResponse, ToolExecutionError> {
     let mut args = BTreeMap::new();
     args.insert("runId".to_string(), run_id.to_string().into());
     args.insert("claimId".to_string(), claim_id.to_string().into());
@@ -1548,7 +1540,7 @@ async fn fetch_question_snapshot(
     runtime: &RuntimeClient,
     run_id: &str,
     question_id: &str,
-) -> Result<Option<QuestionSnapshot>, AgentToolError> {
+) -> Result<Option<QuestionSnapshot>, ToolExecutionError> {
     let mut args = BTreeMap::new();
     args.insert("runId".to_string(), run_id.to_string().into());
     args.insert("questionId".to_string(), question_id.to_string().into());
@@ -1574,7 +1566,7 @@ fn pending_question_result(
 
 fn question_result_from_snapshot(
     snapshot: &QuestionSnapshot,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     match snapshot.status.as_str() {
         "pending" => Ok(pending_question_result(
             &snapshot.question_id,
@@ -1596,8 +1588,8 @@ fn question_result_from_snapshot(
             "pending": false,
             "timedOut": true,
         })),
-        "cancelled" => Err(AgentToolError::Cancelled),
-        other => Err(AgentToolError::Message(format!(
+        "cancelled" => Err(cancelled_error()),
+        other => Err(tool_failure(format!(
             "Unexpected question status '{other}'"
         ))),
     }
@@ -1608,7 +1600,7 @@ async fn mandate_action_job(
     kind: &str,
     function: &'static str,
     payload: serde_json::Value,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     execute_tool_job(
         &context.runtime,
         &context.run_id,
@@ -1633,7 +1625,7 @@ async fn observe_question(
     options: &[AskQuestionOption],
     yield_time_ms: u64,
     cancellation: WorkspaceCancellation,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     let mut args = BTreeMap::new();
     args.insert("runId".to_string(), run_id.to_string().into());
     args.insert("questionId".to_string(), question_id.to_string().into());
@@ -1650,12 +1642,12 @@ async fn observe_question(
 
     loop {
         if cancellation.is_cancelled() {
-            return Err(AgentToolError::Cancelled);
+            return Err(cancelled_error());
         }
 
         let update = tokio::select! {
             biased;
-            _ = cancellation.cancelled() => return Err(AgentToolError::Cancelled),
+            _ = cancellation.cancelled() => return Err(cancelled_error()),
             // Prefer subscription updates over the yield deadline so an answer/timeout
             // that arrives in the same tick is not reported as still pending.
             update = updates.next() => update,
@@ -1680,17 +1672,13 @@ async fn observe_question(
         };
 
         let Some(update) = update else {
-            return Err(AgentToolError::Message(
-                "question subscription closed".to_string(),
-            ));
+            return Err(tool_failure("question subscription closed"));
         };
         let snapshot: Option<QuestionSnapshot> =
             RuntimeClient::decode_subscription_update(update, GET_QUESTION_FUNCTION)
                 .map_err(tool_error)?;
         let Some(snapshot) = snapshot else {
-            return Err(AgentToolError::Message(format!(
-                "Unknown questionId '{question_id}'"
-            )));
+            return Err(tool_failure(format!("Unknown questionId '{question_id}'")));
         };
         if snapshot.status != "pending" {
             return question_result_from_snapshot(&snapshot);
@@ -1709,10 +1697,10 @@ async fn run_convex_tool_action(
     cancellation: WorkspaceCancellation,
     function: &str,
     args: BTreeMap<String, Value>,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     tokio::select! {
         biased;
-        _ = cancellation.cancelled() => Err(AgentToolError::Cancelled),
+        _ = cancellation.cancelled() => Err(cancelled_error()),
         result = runtime.action_json::<serde_json::Value>(function, args) => {
             result.map_err(tool_error)
         }
@@ -1726,10 +1714,10 @@ async fn run_convex_tool_mutation(
     cancellation: WorkspaceCancellation,
     function: &str,
     args: BTreeMap<String, Value>,
-) -> Result<serde_json::Value, AgentToolError> {
+) -> Result<serde_json::Value, ToolExecutionError> {
     tokio::select! {
         biased;
-        _ = cancellation.cancelled() => Err(AgentToolError::Cancelled),
+        _ = cancellation.cancelled() => Err(cancelled_error()),
         result = runtime.mutation_json::<serde_json::Value>(function, args) => {
             result.map_err(tool_error)
         }
@@ -1741,14 +1729,12 @@ fn mutation_args_from_payload(
     run_id: &str,
     claim_id: &str,
     payload: &serde_json::Value,
-) -> Result<BTreeMap<String, Value>, AgentToolError> {
+) -> Result<BTreeMap<String, Value>, ToolExecutionError> {
     let mut mutation_args = BTreeMap::new();
     mutation_args.insert("runId".to_string(), run_id.to_string().into());
     mutation_args.insert("claimId".to_string(), claim_id.to_string().into());
     let Some(fields) = payload.as_object() else {
-        return Err(AgentToolError::Message(
-            "artifact tool payload must be an object".to_string(),
-        ));
+        return Err(tool_failure("artifact tool payload must be an object"));
     };
     for (key, value) in fields {
         mutation_args.insert(
@@ -1763,13 +1749,13 @@ fn action_args_from_payload(
     run_id: &str,
     claim_id: &str,
     payload: &serde_json::Value,
-) -> Result<BTreeMap<String, Value>, AgentToolError> {
+) -> Result<BTreeMap<String, Value>, ToolExecutionError> {
     let mut args = BTreeMap::new();
     args.insert("runId".to_string(), run_id.to_string().into());
     args.insert("claimId".to_string(), claim_id.to_string().into());
     let fields = payload
         .as_object()
-        .ok_or_else(|| AgentToolError::Message("tool payload must be an object".to_string()))?;
+        .ok_or_else(|| tool_failure("tool payload must be an object"))?;
     for (key, value) in fields {
         args.insert(
             key.clone(),
@@ -1787,10 +1773,10 @@ async fn execute_tool_job<F, Fut>(
     tool_call_tracker: &ToolCallTracker,
     payload: serde_json::Value,
     operation: F,
-) -> Result<serde_json::Value, AgentToolError>
+) -> Result<serde_json::Value, ToolExecutionError>
 where
     F: FnOnce(WorkspaceCancellation) -> Fut,
-    Fut: std::future::Future<Output = Result<serde_json::Value, AgentToolError>>,
+    Fut: std::future::Future<Output = Result<serde_json::Value, ToolExecutionError>>,
 {
     eprintln!("sprocket-agent: starting tool {} for run {}", kind, run_id);
     let mut run_updates = runtime
@@ -1800,11 +1786,11 @@ where
     let initial_update = run_updates
         .next()
         .await
-        .ok_or_else(|| AgentToolError::Message("run status subscription closed".to_string()))?;
+        .ok_or_else(|| tool_failure("run status subscription closed"))?;
     let initial_run_finished =
         RuntimeClient::decode_run_finished_update(initial_update).map_err(tool_error)?;
     if initial_run_finished {
-        return Err(AgentToolError::Cancelled);
+        return Err(cancelled_error());
     }
 
     let mut begin_args = BTreeMap::new();
@@ -1825,7 +1811,7 @@ where
     let job_id = begin_result
         .get("jobId")
         .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| AgentToolError::Message("beginToolJob did not return a jobId".to_string()))?
+        .ok_or_else(|| tool_failure("beginToolJob did not return a jobId"))?
         .to_string();
 
     let cancellation = WorkspaceCancellation::new();
@@ -1838,7 +1824,7 @@ where
                 let Some(update) = update else {
                     cancellation.cancel();
                     let _ = operation.await;
-                    break Err(AgentToolError::Message("run status subscription closed".to_string()));
+                    break Err(tool_failure("run status subscription closed"));
                 };
                 match RuntimeClient::decode_run_finished_update(update) {
                     Ok(false) => {}
@@ -1846,7 +1832,7 @@ where
                         cancellation.cancel();
                         let _ = operation.await;
                         eprintln!("sprocket-agent: cancelled tool {} for run {}", kind, run_id);
-                        return Err(AgentToolError::Cancelled);
+                        return Err(cancelled_error());
                     }
                     Err(error) => {
                         cancellation.cancel();
@@ -1877,7 +1863,7 @@ where
             if accepted {
                 Ok(output)
             } else {
-                Err(AgentToolError::Cancelled)
+                Err(cancelled_error())
             }
         }
         Err(error) => {
@@ -1887,8 +1873,8 @@ where
             );
             // Terminal runs already cancel claimed jobs via
             // cancelExecutorJobsForTerminalRun in finalizeRunRecord.
-            if matches!(error, AgentToolError::Cancelled) {
-                return Err(AgentToolError::Cancelled);
+            if error.kind() == ToolErrorKind::Cancelled {
+                return Err(error);
             }
             let mut fail_args = BTreeMap::new();
             fail_args.insert("jobId".to_string(), job_id.into());
@@ -1902,17 +1888,17 @@ where
             if accepted {
                 Err(error)
             } else {
-                Err(AgentToolError::Cancelled)
+                Err(cancelled_error())
             }
         }
     }
 }
 
-fn tool_error(error: anyhow::Error) -> AgentToolError {
+fn tool_error(error: anyhow::Error) -> ToolExecutionError {
     if error.is::<WorkspaceOperationCancelled>() {
-        AgentToolError::Cancelled
+        cancelled_error()
     } else {
-        AgentToolError::Message(format!("{error:#}"))
+        tool_failure(format!("{error:#}"))
     }
 }
 
@@ -1926,19 +1912,22 @@ mod tests {
     fn tool_error_includes_anyhow_context_chain() {
         let error =
             anyhow::anyhow!("invalid add-file line").context("failed to parse Begin Patch input");
-        match tool_error(error) {
-            AgentToolError::Message(message) => {
-                assert!(
-                    message.contains("failed to parse Begin Patch input"),
-                    "missing outer context: {message}"
-                );
-                assert!(
-                    message.contains("invalid add-file line"),
-                    "missing root cause: {message}"
-                );
-            }
-            AgentToolError::Cancelled => panic!("expected message error"),
-        }
+        let mapped = tool_error(error);
+        let message = mapped.model_feedback().expect("model feedback");
+        assert!(
+            message.contains("failed to parse Begin Patch input"),
+            "missing outer context: {message}"
+        );
+        assert!(
+            message.contains("invalid add-file line"),
+            "missing root cause: {message}"
+        );
+    }
+
+    #[test]
+    fn tool_error_maps_workspace_cancellation_to_cancelled_kind() {
+        let mapped = tool_error(anyhow::Error::new(WorkspaceOperationCancelled));
+        assert_eq!(mapped.kind(), ToolErrorKind::Cancelled);
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #209 and #211 (collapsed). Tracks #208 for the upstream Context.dev fix.

## Problem

When a tool call failed, the model and the user saw useless text. Three layers were responsible:

1. Executor-facing Convex functions (`webTools`, `browserAgent`, `payments` mandates, `artifacts`, `agentQuestions`, `executor.complete/fail`, `agentRuntime.beginToolJob`) threw plain `Error`s, which production Convex masks to `[Request ID] Server Error` before they reach the executor client and `executorJobs.error`. (#190/#200 fixed completions and usage limits; tool calls were missed.)
2. Tools declared a custom error type, so rig's default `Tool::map_error` downcast missed and redacted model feedback to "the tool failed".
3. Our decoder prepends transport noise: `{function} failed:`, masked production lines, `Uncaught ConvexError:` prefixes, stack frames.

## Changes

- `lib/agentErrors.ts`: `toAgentToolConvexError()` converts caught failures into readable `ConvexError`s; control-flow sentinels keep their exact wording.
- All executor-facing handlers rethrow through it, including payments internals on the mandate paths.
- `sprocket-agent`: tools now fail with rig's canonical `ToolExecutionError` directly (`tool_failure`/`cancelled_error` constructors), so rig's own downcast preserves kind, retry hints, and the message. No `map_error` overrides needed anywhere.
- `decode_function_result` sanitizes messages: masking lines, `Uncaught` prefixes, and stack frames are stripped, and the `{function} failed:` prefix is gone. Fully masked errors fall back to "The server failed without a readable error."
- `scrape_url`: complex pages that fail Context.dev's bounded-depth result validation now fail with "The webpage is too complex and could not be parsed as Markdown." and skip the pointless retry (#208 has the upstream findings).

Display-only; no compat layer (noted in BACKWARDS_COMPATIBILITY.md).

## Checks

- `cargo test` all crates pass (45 in sprocket-agent incl. new sanitizer/cancellation tests)
- vitest 280/280
- eslint + convex typecheck + prek clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes executor-facing tool failures readable to both the model and transcript by preserving authored Convex errors, mapping Rust tool failures into Rig feedback, and cleaning transport noise.
- Wraps executor-facing Convex failures in readable `ConvexError` values.
- Preserves tool error messages through the Rust/Rig execution boundary.
- Sanitizes Convex transport prefixes, masked lines, and stack frames.
- Adds a non-retryable message for Context.dev pages that exceed bounded-depth validation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/agentErrors.ts | Adds the shared conversion that preserves existing Convex errors and exposes readable messages for plain executor-facing failures. |
| crates/sprocket-agent/src/convex.rs | Cleans Convex transport noise from function failures while retaining a deterministic fallback for fully masked errors. |
| crates/sprocket-agent/src/tools.rs | Maps agent tool failures into Rig's canonical execution error so authored messages reach the model across the full tool surface. |
| apps/web/src/convex/webTools.ts | Wraps web-tool failures for readable propagation and replaces futile retries for overly complex scrape results with a specific message. |
| apps/web/src/convex/payments.ts | Applies readable error propagation across mandate actions and their internal mutation boundaries without changing payment state transitions. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Model
    participant Agent as Rust agent
    participant Convex
    participant Tool as Remote tool
    participant Transcript
    Model->>Agent: Typed tool call
    Agent->>Convex: Begin executor job
    Agent->>Tool: Execute operation
    Tool-->>Convex: Authored ConvexError
    Convex-->>Agent: Readable sanitized failure
    Agent->>Convex: Fail executor job with message
    Convex-->>Transcript: Display real failure text
    Agent-->>Model: ToolExecutionError feedback
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(agent): Surface real failure text fo..."](https://github.com/spikonado/sprocket/commit/4ef14cbcf234a8f29263f940617c7db8a8b7be26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56513328)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent tool execution](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-tool-execution.md)
- Knowledge Base — [Convex provider client](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-provider.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->