### PR TITLE
fix(agent): Report unreadable pages as a friendly scrape failure

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -100,6 +100,7 @@ So nobody goes hunting for shims that do not exist:
 - Accepting Begin Patch envelopes alongside unified diffs (#66) is a permanent feature, not compat.
 - Dropping orphaned OpenAI item references (#188) must stay forever. Compaction can drop reasoning items from any history, not just pre-fix ones.
 - Usage-limit run errors (#200) now throw ConvexErrors, so `runs.lastError` carries a readable sentence where production used to mask them to `[Request ID] Server Error` strings. Clients released before #200 render that sentence in their transcript banner. It is display-only text that clears on the next run, so no compat layer ships.
+- Tool-call failures (#206) now throw ConvexErrors through the executor-facing functions and surface authored messages to the model via rig's `map_error`, so `executorJobs.error` and the model's tool result carry the real failure text where production used to mask it to `[Request ID] Server Error` strings (and rig used to redact it to "the tool failed"). Both audiences render plain display text, so no compat layer ships.
 
 ## Removal checklist
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -12,7 +12,7 @@ Three client populations talk to the cloud backend:
 - Installed desktop apps (AppImage/DMG/NSIS, shipped since v0.2.2) bundle their own web assets.
 - The `@spikonado/sprocket` npm CLI and the Rust agent binaries it launches.
 
-Compat shims only exist for the second and third groups. Every shim listed here protects clients older than v0.3.2 (2026-08-22), the first release carrying the client halves of #187, #191, and #192. There is no client telemetry, so age-out signals are npm download counts per version plus the per-entry database checks below.
+Compat shims only exist for the second and third groups. Every shim in sections 1–3 protects clients older than v0.3.2 (2026-08-22), the first release carrying the client halves of #187, #191, and #192; section 4 landed after v0.3.2 and protects clients up to and including v0.3.2. There is no client telemetry, so age-out signals are npm download counts per version plus the per-entry database checks below.
 
 ## 1. Executor liveness split out of `projects`
 
@@ -73,6 +73,16 @@ Source: #200. `modelCatalog.get` gained an optional `includeUsagePolicy` argumen
 Remove by dropping the argument and attaching `usagePolicy` unconditionally in `convex/modelCatalog.ts`, folding `CatalogModelWithUsagePolicy` back into `CatalogModel` (remove `usagePolicy` from the `Omit` in `convex/lib/models.ts`) and out of `convex/lib/uiModelCatalog.ts`, simplifying the `{ includeUsagePolicy: true }` call in `+page.svelte`, and collapsing `convex/modelCatalog.test.ts` to pin unconditional inclusion instead of the opt-in contract.
 
 Safe when npm downloads for versions predating the release carrying #200 have flattened.
+
+## 4. Mandate setup ignores the stored payments email
+
+Up to v0.3.2, mandate setup resolved the customer email from the caller (`userEmail` tool argument or settings-screen input) with a fallback to `uiPreferences.paymentsEmail`, and the settings screen saved that email via `uiPreferences.setPaymentsEmail`. Setup now always uses the email on the caller's WorkOS identity instead.
+
+Today's compat: `mandateSetupArgs` (`convex/payments.ts`) still accepts an optional `userEmail` and ignores it, so pre-#204-era agents and settings screens keep passing theirs. `vMandateSetupPayload.userEmail` (`convex/lib/validators.ts`) stays accepted because stored `executorJobs.payload` rows written by those agents carry it. `uiPreferences.setPaymentsEmail` still writes the field for old settings screens, and `uiPreferences.paymentsEmail` stays optional in the schema so their rows keep validating.
+
+Remove by dropping `userEmail` from `mandateSetupArgs` and `vMandateSetupPayload` (sweep stored `executorJobs.payload` rows first if any still carry it), deleting `uiPreferences.setPaymentsEmail`, unsetting `paymentsEmail` on existing `uiPreferences` rows, and dropping the field from the schema — all in one PR.
+
+Safe when npm downloads for versions at or below v0.3.2 have flattened and a prod check shows no recent `paymentsEmail` writes (the way #174 verified).
 
 ## Completed removals, kept as precedent
 

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -15,7 +15,7 @@ import {
 	validateQuestionText
 } from '@convex/lib/agentQuestions';
 import { getExecutionRun, getUserId } from '@convex/lib/auth';
-import { assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import { assertRunAcceptsModelCompletion, toAgentToolConvexError } from '@convex/lib/agentErrors';
 import { vAgentQuestionSnapshot } from '@convex/lib/docs';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import { vAskQuestionOption } from '@convex/lib/validators';
@@ -120,46 +120,50 @@ export const create = mutation({
 		sequence: v.number()
 	}),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		assertRunAcceptsModelCompletion(run.status);
-		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
-			throw new Error('Run is no longer active.');
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			assertRunAcceptsModelCompletion(run.status);
+			if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			if (!run.activeJobId) {
+				throw new Error('Ask question requires an active tool job.');
+			}
+
+			const question = validateQuestionText(args.question);
+			const options = finalizeQuestionOptions(args.options);
+			const timeoutMs = Math.min(
+				MAX_QUESTION_TIMEOUT_MS,
+				Math.max(MIN_QUESTION_TIMEOUT_MS, Math.floor(args.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS))
+			);
+			const createdAt = Date.now();
+			const timeoutAt = createdAt + timeoutMs;
+			const sequence = await nextThreadSequence(ctx, run.threadId);
+
+			const questionId = await ctx.db.insert('agentQuestions', {
+				threadId: run.threadId,
+				runId: run._id,
+				jobId: run.activeJobId,
+				question,
+				options,
+				status: 'pending',
+				createdAt,
+				timeoutAt,
+				sequence
+			});
+
+			await ctx.scheduler.runAfter(timeoutMs, internal.agentQuestions.timeout, { questionId });
+
+			return {
+				questionId,
+				question,
+				options,
+				timeoutAt,
+				sequence
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		if (!run.activeJobId) {
-			throw new Error('Ask question requires an active tool job.');
-		}
-
-		const question = validateQuestionText(args.question);
-		const options = finalizeQuestionOptions(args.options);
-		const timeoutMs = Math.min(
-			MAX_QUESTION_TIMEOUT_MS,
-			Math.max(MIN_QUESTION_TIMEOUT_MS, Math.floor(args.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS))
-		);
-		const createdAt = Date.now();
-		const timeoutAt = createdAt + timeoutMs;
-		const sequence = await nextThreadSequence(ctx, run.threadId);
-
-		const questionId = await ctx.db.insert('agentQuestions', {
-			threadId: run.threadId,
-			runId: run._id,
-			jobId: run.activeJobId,
-			question,
-			options,
-			status: 'pending',
-			createdAt,
-			timeoutAt,
-			sequence
-		});
-
-		await ctx.scheduler.runAfter(timeoutMs, internal.agentQuestions.timeout, { questionId });
-
-		return {
-			questionId,
-			question,
-			options,
-			timeoutAt,
-			sequence
-		};
 	}
 });
 
@@ -237,12 +241,16 @@ export const getForExecutor = query({
 	},
 	returns: v.union(vAgentQuestionSnapshot, v.null()),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const question = await ctx.db.get('agentQuestions', args.questionId);
-		if (!question || question.runId !== run._id) {
-			return null;
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			const question = await ctx.db.get('agentQuestions', args.questionId);
+			if (!question || question.runId !== run._id) {
+				return null;
+			}
+			return toSnapshot(question);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return toSnapshot(question);
 	}
 });
 

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -20,7 +20,11 @@ import {
 	getOwnedImageUploads
 } from '@convex/lib/imageUploads';
 import { buildThreadTranscript } from '@convex/lib/threadTranscript';
-import { RUN_NO_LONGER_ACTIVE, assertRunAcceptsModelCompletion } from '@convex/lib/agentErrors';
+import {
+	RUN_NO_LONGER_ACTIVE,
+	assertRunAcceptsModelCompletion,
+	toAgentToolConvexError
+} from '@convex/lib/agentErrors';
 import {
 	assertThreadCanStartRun,
 	cancelExecutorJobsForTerminalRun,
@@ -998,42 +1002,46 @@ export const beginToolJob = mutation({
 		sequence: v.number()
 	}),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const userId = run.userId;
-		assertRunAcceptsModelCompletion(run.status);
-		if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
-			throw new ConvexError(RUN_NO_LONGER_ACTIVE);
+		try {
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			const userId = run.userId;
+			assertRunAcceptsModelCompletion(run.status);
+			if (run.claimId !== args.claimId || !isRunClaimLeaseActive(run, Date.now())) {
+				throw new ConvexError(RUN_NO_LONGER_ACTIVE);
+			}
+			const project = await getOwnedProject(ctx.db, userId, run.projectId);
+
+			const nextSequence = project.nextExecutorSequence;
+			await ctx.db.patch('projects', project._id, {
+				nextExecutorSequence: nextSequence + 1
+			});
+
+			const job: EnqueuedExecutorJob = {
+				projectId: run.projectId,
+				threadId: run.threadId,
+				runId: args.runId,
+				kind: args.kind,
+				payload: args.payload,
+				hidden: args.hidden ?? false,
+				status: 'claimed',
+				enqueuedAt: Date.now(),
+				claimedAt: Date.now(),
+				sequence: nextSequence
+			};
+			if (args.callId) job.callId = args.callId;
+			const jobId = await ctx.db.insert('executorJobs', job);
+
+			await ctx.db.patch('runs', args.runId, {
+				status: 'awaiting_executor',
+				activeJobId: jobId
+			});
+
+			return {
+				jobId,
+				sequence: nextSequence
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const project = await getOwnedProject(ctx.db, userId, run.projectId);
-
-		const nextSequence = project.nextExecutorSequence;
-		await ctx.db.patch('projects', project._id, {
-			nextExecutorSequence: nextSequence + 1
-		});
-
-		const job: EnqueuedExecutorJob = {
-			projectId: run.projectId,
-			threadId: run.threadId,
-			runId: args.runId,
-			kind: args.kind,
-			payload: args.payload,
-			hidden: args.hidden ?? false,
-			status: 'claimed',
-			enqueuedAt: Date.now(),
-			claimedAt: Date.now(),
-			sequence: nextSequence
-		};
-		if (args.callId) job.callId = args.callId;
-		const jobId = await ctx.db.insert('executorJobs', job);
-
-		await ctx.db.patch('runs', args.runId, {
-			status: 'awaiting_executor',
-			activeJobId: jobId
-		});
-
-		return {
-			jobId,
-			sequence: nextSequence
-		};
 	}
 });

--- a/apps/web/src/convex/artifacts.ts
+++ b/apps/web/src/convex/artifacts.ts
@@ -6,7 +6,7 @@ import { getExecutionRun, getUserId } from '@convex/lib/auth';
 import { vArtifactType } from '@convex/lib/validators';
 import schema from '@convex/schema';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
-import { RUN_NO_LONGER_ACTIVE } from '@convex/lib/agentErrors';
+import { RUN_NO_LONGER_ACTIVE, toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 const MAX_TITLE_LENGTH = 200;
 // Content also lives in the executor job payload; stay well under Convex's 1 MiB document cap.
@@ -105,53 +105,57 @@ export const createArtifact = mutation({
 	},
 	returns: vArtifactMutationResult,
 	handler: async (ctx, args) => {
-		const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
-		const userId = run.userId;
-		const threadId = run.threadId;
-		await getOwnedThreadRecord(ctx.db, userId, threadId);
+		try {
+			const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
+			const userId = run.userId;
+			const threadId = run.threadId;
+			await getOwnedThreadRecord(ctx.db, userId, threadId);
 
-		const title = args.title.trim();
-		validateArtifactTitle(title);
-		validateArtifactContent(args.content);
+			const title = args.title.trim();
+			validateArtifactTitle(title);
+			validateArtifactContent(args.content);
 
-		// A repeated title in the same thread updates the existing artifact
-		// instead of silently dropping the new content.
-		const existing = await ctx.db
-			.query('artifacts')
-			.withIndex('by_threadId_title', (q) => q.eq('threadId', threadId).eq('title', title))
-			.first();
+			// A repeated title in the same thread updates the existing artifact
+			// instead of silently dropping the new content.
+			const existing = await ctx.db
+				.query('artifacts')
+				.withIndex('by_threadId_title', (q) => q.eq('threadId', threadId).eq('title', title))
+				.first();
 
-		if (existing) {
-			const latest = await latestArtifactVersion(ctx, existing._id);
-			const version =
-				latest?.content === args.content
-					? existing.currentVersion
-					: await insertNextVersion(ctx, existing, userId, latest, args.content);
+			if (existing) {
+				const latest = await latestArtifactVersion(ctx, existing._id);
+				const version =
+					latest?.content === args.content
+						? existing.currentVersion
+						: await insertNextVersion(ctx, existing, userId, latest, args.content);
 
-			return mutationResult(existing, version);
+				return mutationResult(existing, version);
+			}
+
+			const now = Date.now();
+			const artifactId = await ctx.db.insert('artifacts', {
+				threadId,
+				userId,
+				title,
+				type: args.contentType,
+				currentVersion: 1,
+				createdById: run._id,
+				createdAt: now,
+				updatedAt: now
+			});
+
+			await ctx.db.insert('artifactVersions', {
+				artifactId,
+				userId,
+				version: 1,
+				content: args.content,
+				createdAt: now
+			});
+
+			return { artifactId, version: 1, title, contentType: args.contentType };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-
-		const now = Date.now();
-		const artifactId = await ctx.db.insert('artifacts', {
-			threadId,
-			userId,
-			title,
-			type: args.contentType,
-			currentVersion: 1,
-			createdById: run._id,
-			createdAt: now,
-			updatedAt: now
-		});
-
-		await ctx.db.insert('artifactVersions', {
-			artifactId,
-			userId,
-			version: 1,
-			content: args.content,
-			createdAt: now
-		});
-
-		return { artifactId, version: 1, title, contentType: args.contentType };
 	}
 });
 
@@ -165,21 +169,25 @@ export const appendArtifactVersion = mutation({
 	},
 	returns: vArtifactMutationResult,
 	handler: async (ctx, args) => {
-		const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
-		const userId = run.userId;
+		try {
+			const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
+			const userId = run.userId;
 
-		const artifact: Doc<'artifacts'> | null = await ctx.db.get('artifacts', args.artifactId);
-		if (!artifact || artifact.userId !== userId || artifact.threadId !== run.threadId) {
-			throw new Error('Artifact not found.');
+			const artifact: Doc<'artifacts'> | null = await ctx.db.get('artifacts', args.artifactId);
+			if (!artifact || artifact.userId !== userId || artifact.threadId !== run.threadId) {
+				throw new Error('Artifact not found.');
+			}
+			await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
+
+			validateArtifactContent(args.content);
+
+			const latest = await latestArtifactVersion(ctx, args.artifactId);
+			const version = await insertNextVersion(ctx, artifact, userId, latest, args.content);
+
+			return mutationResult(artifact, version);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
-
-		validateArtifactContent(args.content);
-
-		const latest = await latestArtifactVersion(ctx, args.artifactId);
-		const version = await insertNextVersion(ctx, artifact, userId, latest, args.content);
-
-		return mutationResult(artifact, version);
 	}
 });
 

--- a/apps/web/src/convex/browserAgent.ts
+++ b/apps/web/src/convex/browserAgent.ts
@@ -12,6 +12,7 @@ import {
 	vBrowserObserveResult,
 	vBrowserTaskResult
 } from '@convex/lib/validators';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 // The browsing sub-agent's model. Uses the same OpenAI key as the main agent.
 const DEFAULT_MODEL = 'openai/gpt-5.6-sol';
@@ -255,19 +256,23 @@ export const act = action({
 	},
 	returns: vBrowserTaskResult,
 	handler: async (ctx, args): Promise<Infer<typeof vBrowserTaskResult>> => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			if (!args.instruction && !args.action) {
-				throw new Error('browser_act needs an instruction or an action.');
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				if (!args.instruction && !args.action) {
+					throw new Error('browser_act needs an instruction or an action.');
+				}
+				const result = args.action
+					? await stagehand.act(args.action)
+					: await stagehand.act(args.instruction!);
+				return clip(`success: ${result.success}\n${result.message}`.trim());
+			} finally {
+				await stagehand.close().catch(() => {});
 			}
-			const result = args.action
-				? await stagehand.act(args.action)
-				: await stagehand.act(args.instruction!);
-			return clip(`success: ${result.success}\n${result.message}`.trim());
-		} finally {
-			await stagehand.close().catch(() => {});
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });
@@ -282,20 +287,24 @@ export const observe = action({
 	},
 	returns: vBrowserObserveResult,
 	handler: async (ctx, args) => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			const actions = await stagehand.observe(args.instruction);
-			const bounded = boundActions(actions);
-			const clipped = clip(JSON.stringify(bounded.actions));
-			return {
-				actions: bounded.actions,
-				text: clipped.text,
-				truncated: bounded.truncated || clipped.truncated
-			};
-		} finally {
-			await stagehand.close().catch(() => {});
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				const actions = await stagehand.observe(args.instruction);
+				const bounded = boundActions(actions);
+				const clipped = clip(JSON.stringify(bounded.actions));
+				return {
+					actions: bounded.actions,
+					text: clipped.text,
+					truncated: bounded.truncated || clipped.truncated
+				};
+			} finally {
+				await stagehand.close().catch(() => {});
+			}
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });
@@ -310,14 +319,18 @@ export const extract = action({
 	},
 	returns: vBrowserTaskResult,
 	handler: async (ctx, args): Promise<Infer<typeof vBrowserTaskResult>> => {
-		const actor = await activeActor(ctx, args);
-		const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
 		try {
-			await gotoIfProvided(stagehand, args.startUrl);
-			const result = await stagehand.extract(args.instruction);
-			return clip(JSON.stringify(result));
-		} finally {
-			await stagehand.close().catch(() => {});
+			const actor = await activeActor(ctx, args);
+			const stagehand = await attachStagehand(ctx, actor.userId, args.runId, actor.threadId);
+			try {
+				await gotoIfProvided(stagehand, args.startUrl);
+				const result = await stagehand.extract(args.instruction);
+				return clip(JSON.stringify(result));
+			} finally {
+				await stagehand.close().catch(() => {});
+			}
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
 });

--- a/apps/web/src/convex/executor.ts
+++ b/apps/web/src/convex/executor.ts
@@ -4,6 +4,7 @@ import { getExecutionRun } from '@convex/lib/auth';
 import { executorFailureRunPatch } from '@convex/lib/runs';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
 import { isRunFinalStatus, vExecutorJobResult } from '@convex/lib/validators';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 export const complete = mutation({
 	args: {
@@ -15,34 +16,38 @@ export const complete = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const job = await ctx.db.get('executorJobs', args.jobId);
-		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (job.status === 'cancelled' || job.status === 'failed') {
-			return false;
-		}
-		if (job.status === 'completed') {
-			return true;
-		}
-		if (isRunFinalStatus(run.status)) {
-			return false;
-		}
-		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
-			return false;
-		}
+		try {
+			const job = await ctx.db.get('executorJobs', args.jobId);
+			if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			if (job.status === 'cancelled' || job.status === 'failed') {
+				return false;
+			}
+			if (job.status === 'completed') {
+				return true;
+			}
+			if (isRunFinalStatus(run.status)) {
+				return false;
+			}
+			if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
+				return false;
+			}
 
-		await ctx.db.patch('executorJobs', args.jobId, {
-			status: 'completed',
-			result: args.result,
-			completedAt: Date.now()
-		});
-		if (run.activeJobId === args.jobId) {
-			await ctx.db.patch('runs', run._id, {
-				status: 'running',
-				activeJobId: undefined
+			await ctx.db.patch('executorJobs', args.jobId, {
+				status: 'completed',
+				result: args.result,
+				completedAt: Date.now()
 			});
+			if (run.activeJobId === args.jobId) {
+				await ctx.db.patch('runs', run._id, {
+					status: 'running',
+					activeJobId: undefined
+				});
+			}
+			return true;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return true;
 	}
 });
 
@@ -56,30 +61,34 @@ export const fail = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const job = await ctx.db.get('executorJobs', args.jobId);
-		if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
-			return false;
-		}
-		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
-			return false;
-		}
+		try {
+			const job = await ctx.db.get('executorJobs', args.jobId);
+			if (!job || job.runId !== args.runId) throw new Error('Executor job not found.');
+			const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
+			if (job.status === 'cancelled' || job.status === 'completed' || job.status === 'failed') {
+				return false;
+			}
+			if (!ownsActiveRunClaim(run, args.claimId, Date.now())) {
+				return false;
+			}
 
-		const completedAt = Date.now();
-		await ctx.db.patch('executorJobs', args.jobId, {
-			status: 'failed',
-			error: args.error,
-			completedAt
-		});
-		const runPatch = executorFailureRunPatch({
-			runStatus: run.status,
-			activeJobId: run.activeJobId,
-			failedJobId: args.jobId
-		});
-		if (runPatch) {
-			await ctx.db.patch('runs', job.runId, runPatch);
+			const completedAt = Date.now();
+			await ctx.db.patch('executorJobs', args.jobId, {
+				status: 'failed',
+				error: args.error,
+				completedAt
+			});
+			const runPatch = executorFailureRunPatch({
+				runStatus: run.status,
+				activeJobId: run.activeJobId,
+				failedJobId: args.jobId
+			});
+			if (runPatch) {
+				await ctx.db.patch('runs', job.runId, runPatch);
+			}
+			return true;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return true;
 	}
 });

--- a/apps/web/src/convex/lib/agentErrors.test.ts
+++ b/apps/web/src/convex/lib/agentErrors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ConvexError } from 'convex/values';
+import { RUN_NO_LONGER_ACTIVE, toAgentToolConvexError } from '@convex/lib/agentErrors';
+
+describe('agent tool error surfacing', () => {
+	it('passes ConvexErrors through untouched', () => {
+		const error = new ConvexError('Mandate not found.');
+		expect(toAgentToolConvexError(error)).toBe(error);
+	});
+
+	it('strips the production uncaught-error prefix', () => {
+		const error = toAgentToolConvexError(new Error('Uncaught Error: Exa search failed.'));
+		expect(error).toBeInstanceOf(ConvexError);
+		expect(error.message).toBe('Exa search failed.');
+	});
+
+	it('keeps control-flow sentinel wording', () => {
+		const error = toAgentToolConvexError(new Error(RUN_NO_LONGER_ACTIVE));
+		expect(error.message).toBe(RUN_NO_LONGER_ACTIVE);
+	});
+});

--- a/apps/web/src/convex/lib/agentErrors.ts
+++ b/apps/web/src/convex/lib/agentErrors.ts
@@ -209,3 +209,14 @@ export function toModelCompletionConvexError(error: Error, modelId: string): Err
 	}
 	return new ConvexError(`The model provider failed: ${detail}`);
 }
+
+/**
+ * Converts failures caught in executor-facing tool functions into ConvexErrors
+ * so their text reaches the executor client and `job.error`; uncaught Errors
+ * are masked to "[Request ID] Server Error" for both audiences in production.
+ */
+export function toAgentToolConvexError(error: Error): Error {
+	if (error instanceof ConvexError) return error;
+	const message = stripUncaughtPrefix(error.message) || error.name;
+	return new ConvexError(message);
+}

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -131,6 +131,8 @@ export const vMandateChargeStatus = v.union(
 export const vMandateReportOutcome = v.union(v.literal('approved'), v.literal('declined'));
 
 export const vMandateSetupPayload = v.object({
+	// Accepted-and-ignored: stored executorJobs payloads from released agents
+	// may still carry it. Mandate setup now reads the WorkOS identity email.
 	userEmail: v.optional(v.string()),
 	merchantName: v.optional(v.string()),
 	merchantUrl: v.optional(v.string()),

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -60,6 +60,8 @@ function setupArgs(run: Awaited<ReturnType<typeof startRun>>) {
 type PravaMandateFixture = {
 	id?: string;
 	status?: string;
+	merchantScope?: string;
+	recurringFrequency?: string;
 	merchantName?: string | null;
 	merchantUrl?: string;
 	countryCode?: string;
@@ -74,6 +76,10 @@ function liveListedMandate(overrides: PravaMandateFixture = {}): JsonObject {
 	const mandate: JsonObject = {
 		id: 'mdt_1',
 		status: 'active',
+		// Populated per Prava's current List Mandates response so the
+		// scope/cadence comparisons in resolution are exercised.
+		merchantScope: 'listed',
+		recurringFrequency: 'monthly',
 		merchantName: 'Example Shop',
 		merchantUrl: 'https://shop.example',
 		countryCode: 'US',
@@ -439,6 +445,41 @@ describe('payments mandates', () => {
 		await expect(
 			run.asUser.action(api.payments.mandateCharge, {
 				mandateId: setup.mandateId,
+				amount: '40.00',
+				currency: 'USD',
+				description: 'Order 8842',
+				...auth(run)
+			})
+		).rejects.toThrow(/not yet approved/);
+	});
+
+	it('does not resolve an approval whose scope or cadence differs', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+		// Same merchant + cap + currency, but approved as any-merchant.
+		const { setup } = await createApprovedMandate(t, run, [
+			liveListedMandate({ id: 'mdt_any', merchantScope: 'any' })
+		]);
+
+		await expect(
+			run.asUser.action(api.payments.mandateCharge, {
+				mandateId: setup.mandateId,
+				amount: '40.00',
+				currency: 'USD',
+				description: 'Order 8842',
+				...auth(run)
+			})
+		).rejects.toThrow(/not yet approved/);
+
+		// Same again, but approved with a weekly cadence instead of monthly.
+		const { setup: weeklySetup } = await createApprovedMandate(t, run, [
+			liveListedMandate({ id: 'mdt_weekly', recurringFrequency: 'weekly' })
+		]);
+
+		await expect(
+			run.asUser.action(api.payments.mandateCharge, {
+				mandateId: weeklySetup.mandateId,
 				amount: '40.00',
 				currency: 'USD',
 				description: 'Order 8842',

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -26,7 +26,6 @@ async function startRun(t: ConvexTestInstance, subject: string) {
 	});
 	return {
 		asUser: t.withIdentity({ subject, email: `${subject}@example.com` }),
-		userEmail: `${subject}@example.com`,
 		runId: created.runId,
 		claimId,
 		executionSecret
@@ -54,7 +53,6 @@ function setupArgs(run: Awaited<ReturnType<typeof startRun>>) {
 		frequency: 'monthly' as const,
 		scope: 'listed' as const,
 		description: 'Monthly budget',
-		userEmail: run.userEmail,
 		...auth(run)
 	};
 }
@@ -156,8 +154,21 @@ describe('payments mandates', () => {
 		const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
 		expect(body).toMatchObject({
 			user_id: 'user_alice',
+			// The email comes from the caller's WorkOS identity, not tool args.
 			user_email: 'user_alice@example.com',
 			total_amount: '120.00',
+			purchase_context: {
+				custom: [
+					{
+						merchant_details: {
+							name: 'Example Shop',
+							url: 'https://shop.example',
+							country_code_iso2: 'US'
+						},
+						product_details: [{ description: 'Monthly budget', unit_price: '120.00', quantity: 1 }]
+					}
+				]
+			},
 			mandate_setup: {
 				intent: 'mandate_setup',
 				recurring_frequency: 'monthly',
@@ -173,6 +184,19 @@ describe('payments mandates', () => {
 			approvalUrl: 'https://pay.prava.space/approve/1'
 		});
 		expect(stored).not.toHaveProperty('session_token');
+	});
+
+	it('rejects mandate setup when the WorkOS identity has no email', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+
+		await expect(
+			t.withIdentity({ subject: 'user_alice' }).action(api.payments.mandateSetup, setupArgs(run))
+		).rejects.toThrow(/no email address/);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
 	it('syncs a pending mandate to active once the owner approves', async () => {
@@ -696,7 +720,6 @@ describe('payments mandates', () => {
 				amountCap: '200.00',
 				currency: 'USD',
 				description: 'Weekly groceries',
-				userEmail: run.userEmail,
 				...auth(run)
 			})
 		).rejects.toThrow(/one-time/);
@@ -803,8 +826,7 @@ describe('payments mandates', () => {
 			amountCap: '120.00',
 			currency: 'USD',
 			frequency: 'monthly' as const,
-			scope: 'listed' as const,
-			userEmail: alice.userEmail
+			scope: 'listed' as const
 		};
 		const first = await alice.asUser.action(api.payments.setupMyMandate, {
 			...setupArgs,
@@ -856,8 +878,7 @@ describe('payments mandates', () => {
 			currency: 'USD',
 			frequency: 'monthly' as const,
 			scope: 'listed' as const,
-			description: 'Monthly budget',
-			userEmail: alice.userEmail
+			description: 'Monthly budget'
 		});
 
 		const result = await alice.asUser.action(api.payments.listMyMandates, {});

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -11,6 +11,7 @@ import { api, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { getUserId, requireIdentity } from '@convex/lib/auth';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 import {
 	isMandateStatus,
 	vMandateChargeStatus,
@@ -368,27 +369,31 @@ export const insertMandate = internalMutation({
 	},
 	returns: v.id('mandates'),
 	handler: async (ctx, args) => {
-		const description = args.description.trim();
-		if (!description) {
-			throw new Error('Mandate description is required.');
+		try {
+			const description = args.description.trim();
+			if (!description) {
+				throw new Error('Mandate description is required.');
+			}
+			const now = Date.now();
+			return await ctx.db.insert('mandates', {
+				userId: args.userId,
+				pravaSessionId: args.pravaSessionId,
+				merchantName: args.merchantName,
+				merchantUrl: args.merchantUrl,
+				countryCode: args.countryCode,
+				amountCap: requireMoneyMinor(args.amountCap, 'Amount cap'),
+				currency: args.currency,
+				frequency: args.frequency,
+				scope: args.scope,
+				description,
+				approvalUrl: args.approvalUrl,
+				status: 'pending',
+				createdAt: now,
+				updatedAt: now
+			});
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const now = Date.now();
-		return await ctx.db.insert('mandates', {
-			userId: args.userId,
-			pravaSessionId: args.pravaSessionId,
-			merchantName: args.merchantName,
-			merchantUrl: args.merchantUrl,
-			countryCode: args.countryCode,
-			amountCap: requireMoneyMinor(args.amountCap, 'Amount cap'),
-			currency: args.currency,
-			frequency: args.frequency,
-			scope: args.scope,
-			description,
-			approvalUrl: args.approvalUrl,
-			status: 'pending',
-			createdAt: now,
-			updatedAt: now
-		});
 	}
 });
 
@@ -424,24 +429,28 @@ export const syncMandate = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const mandate = await ctx.db.get('mandates', args.mandateId);
-		if (!mandate || mandate.userId !== args.userId) {
-			throw new Error('Mandate not found.');
+		try {
+			const mandate = await ctx.db.get('mandates', args.mandateId);
+			if (!mandate || mandate.userId !== args.userId) {
+				throw new Error('Mandate not found.');
+			}
+			const patch: MandateSyncPatch = { updatedAt: Date.now() };
+			if (args.pravaMandateId !== undefined && !mandate.pravaMandateId) {
+				patch.pravaMandateId = args.pravaMandateId;
+			}
+			// Never rewind a terminal status.
+			const terminal = new Set(['consumed', 'cancelled', 'expired']);
+			if (args.status && !(terminal.has(mandate.status) && args.status !== mandate.status)) {
+				patch.status = args.status;
+			}
+			if (args.remaining !== undefined) patch.remaining = args.remaining;
+			if (args.validUntil !== undefined) patch.validUntil = args.validUntil;
+			if (args.renewsAt !== undefined) patch.renewsAt = args.renewsAt;
+			await ctx.db.patch('mandates', args.mandateId, patch);
+			return null;
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		const patch: MandateSyncPatch = { updatedAt: Date.now() };
-		if (args.pravaMandateId !== undefined && !mandate.pravaMandateId) {
-			patch.pravaMandateId = args.pravaMandateId;
-		}
-		// Never rewind a terminal status.
-		const terminal = new Set(['consumed', 'cancelled', 'expired']);
-		if (args.status && !(terminal.has(mandate.status) && args.status !== mandate.status)) {
-			patch.status = args.status;
-		}
-		if (args.remaining !== undefined) patch.remaining = args.remaining;
-		if (args.validUntil !== undefined) patch.validUntil = args.validUntil;
-		if (args.renewsAt !== undefined) patch.renewsAt = args.renewsAt;
-		await ctx.db.patch('mandates', args.mandateId, patch);
-		return null;
 	}
 });
 
@@ -475,86 +484,92 @@ export const reserveCharge = internalMutation({
 	},
 	returns: reserveChargeResult,
 	handler: async (ctx, args) => {
-		const amount = requireMoneyMinor(args.amount, 'Charge amount');
-		const reference = args.reference?.trim() || undefined;
-		const now = Date.now();
+		try {
+			const amount = requireMoneyMinor(args.amount, 'Charge amount');
+			const reference = args.reference?.trim() || undefined;
+			const now = Date.now();
 
-		if (reference !== undefined) {
-			const matches = await ctx.db
-				.query('mandateCharges')
-				.withIndex('by_mandate_reference', (query) =>
-					query.eq('mandateId', args.mandateId).eq('reference', reference)
-				)
-				.take(2);
-			if (matches.length > 1) {
-				throw new Error('Charge reference matches multiple existing charges.');
-			}
-			const existing = matches[0];
-			if (existing) {
-				if (existing.userId !== args.userId) {
-					throw new Error('Charge not found.');
+			if (reference !== undefined) {
+				const matches = await ctx.db
+					.query('mandateCharges')
+					.withIndex('by_mandate_reference', (query) =>
+						query.eq('mandateId', args.mandateId).eq('reference', reference)
+					)
+					.take(2);
+				if (matches.length > 1) {
+					throw new Error('Charge reference matches multiple existing charges.');
 				}
-				if (existing.amount !== amount || existing.currency !== args.currency) {
-					throw new Error('Charge reference was already used with a different amount or currency.');
-				}
-				if (existing.pravaTransactionId) {
-					return {
-						kind: 'existing' as const,
-						chargeId: existing._id,
-						transactionId: existing.pravaTransactionId
-					};
-				}
-				if (existing.providerRequestedAt !== undefined) {
-					// Ambiguous delivery: the provider POST may have committed.
-					// Never reclaim for another charge. That would double-bill.
-					throw new Error(
-						'A previous charge attempt for this reference may have already been submitted to Prava; refusing to charge again.'
-					);
-				}
-				if (existing.status === 'failed') {
+				const existing = matches[0];
+				if (existing) {
+					if (existing.userId !== args.userId) {
+						throw new Error('Charge not found.');
+					}
+					if (existing.amount !== amount || existing.currency !== args.currency) {
+						throw new Error(
+							'Charge reference was already used with a different amount or currency.'
+						);
+					}
+					if (existing.pravaTransactionId) {
+						return {
+							kind: 'existing' as const,
+							chargeId: existing._id,
+							transactionId: existing.pravaTransactionId
+						};
+					}
+					if (existing.providerRequestedAt !== undefined) {
+						// Ambiguous delivery: the provider POST may have committed.
+						// Never reclaim for another charge. That would double-bill.
+						throw new Error(
+							'A previous charge attempt for this reference may have already been submitted to Prava; refusing to charge again.'
+						);
+					}
+					if (existing.status === 'failed') {
+						await ctx.db.patch('mandateCharges', existing._id, {
+							runId: args.runId,
+							description: args.description,
+							status: 'awaiting_result',
+							pravaTransactionId: undefined,
+							providerRequestedAt: undefined,
+							chargingStartedAt: now,
+							updatedAt: now
+						});
+						return { kind: 'reserved' as const, chargeId: existing._id };
+					}
+					if (
+						existing.chargingStartedAt !== undefined &&
+						now - existing.chargingStartedAt <= CHARGE_CLAIM_STALE_MS
+					) {
+						return { kind: 'inFlight' as const };
+					}
+					// Abandoned reservation that never reached Prava: reclaim.
 					await ctx.db.patch('mandateCharges', existing._id, {
 						runId: args.runId,
 						description: args.description,
 						status: 'awaiting_result',
-						pravaTransactionId: undefined,
-						providerRequestedAt: undefined,
 						chargingStartedAt: now,
 						updatedAt: now
 					});
 					return { kind: 'reserved' as const, chargeId: existing._id };
 				}
-				if (
-					existing.chargingStartedAt !== undefined &&
-					now - existing.chargingStartedAt <= CHARGE_CLAIM_STALE_MS
-				) {
-					return { kind: 'inFlight' as const };
-				}
-				// Abandoned reservation that never reached Prava: reclaim.
-				await ctx.db.patch('mandateCharges', existing._id, {
-					runId: args.runId,
-					description: args.description,
-					status: 'awaiting_result',
-					chargingStartedAt: now,
-					updatedAt: now
-				});
-				return { kind: 'reserved' as const, chargeId: existing._id };
 			}
-		}
 
-		const chargeId = await ctx.db.insert('mandateCharges', {
-			mandateId: args.mandateId,
-			runId: args.runId,
-			userId: args.userId,
-			amount,
-			currency: args.currency,
-			description: args.description,
-			reference,
-			status: 'awaiting_result',
-			chargingStartedAt: now,
-			createdAt: now,
-			updatedAt: now
-		});
-		return { kind: 'reserved' as const, chargeId };
+			const chargeId = await ctx.db.insert('mandateCharges', {
+				mandateId: args.mandateId,
+				runId: args.runId,
+				userId: args.userId,
+				amount,
+				currency: args.currency,
+				description: args.description,
+				reference,
+				status: 'awaiting_result',
+				chargingStartedAt: now,
+				createdAt: now,
+				updatedAt: now
+			});
+			return { kind: 'reserved' as const, chargeId };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -651,34 +666,38 @@ export const claimChargeReport = internalMutation({
 	},
 	returns: v.union(v.literal('claimed'), v.literal('already'), v.literal('inFlight')),
 	handler: async (ctx, args) => {
-		const charge = await ownedCharge(ctx, args.chargeId, args.userId);
-		if (charge.reportedAt) {
-			return 'already';
-		}
-		// The first-claimed outcome is immutable. A conflicting report must
-		// never be sent. A crash between the provider POST and the local
-		// finalize would otherwise let a retry overwrite the outcome and POST
-		// the opposite terminal state to the card network.
-		if (charge.reportOutcome && charge.reportOutcome !== args.outcome) {
-			throw new Error(
-				`Charge already has a ${charge.reportOutcome} report in progress; the outcome cannot be changed.`
-			);
-		}
-		if (charge.reportingStartedAt) {
-			// A claim newer than the report window belongs to a live concurrent
-			// caller and has not completed, so say so rather than claim success. An
-			// older one is abandoned (its caller died), so reclaim it and re-send;
-			// the provider report is idempotent on the transaction id.
-			if (Date.now() - charge.reportingStartedAt <= REPORT_CLAIM_STALE_MS) {
-				return 'inFlight';
+		try {
+			const charge = await ownedCharge(ctx, args.chargeId, args.userId);
+			if (charge.reportedAt) {
+				return 'already';
 			}
+			// The first-claimed outcome is immutable. A conflicting report must
+			// never be sent. A crash between the provider POST and the local
+			// finalize would otherwise let a retry overwrite the outcome and POST
+			// the opposite terminal state to the card network.
+			if (charge.reportOutcome && charge.reportOutcome !== args.outcome) {
+				throw new Error(
+					`Charge already has a ${charge.reportOutcome} report in progress; the outcome cannot be changed.`
+				);
+			}
+			if (charge.reportingStartedAt) {
+				// A claim newer than the report window belongs to a live concurrent
+				// caller and has not completed, so say so rather than claim success. An
+				// older one is abandoned (its caller died), so reclaim it and re-send;
+				// the provider report is idempotent on the transaction id.
+				if (Date.now() - charge.reportingStartedAt <= REPORT_CLAIM_STALE_MS) {
+					return 'inFlight';
+				}
+			}
+			await ctx.db.patch('mandateCharges', args.chargeId, {
+				reportingStartedAt: Date.now(),
+				reportOutcome: args.outcome,
+				updatedAt: Date.now()
+			});
+			return 'claimed';
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.db.patch('mandateCharges', args.chargeId, {
-			reportingStartedAt: Date.now(),
-			reportOutcome: args.outcome,
-			updatedAt: Date.now()
-		});
-		return 'claimed';
 	}
 });
 
@@ -850,8 +869,12 @@ export const mandateSetup = action({
 	},
 	returns: vMandateSetupResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateSetupResult>> => {
-		const actor = await activeActor(ctx, args);
-		return await createMandateSetup(ctx, actor.userId, args);
+		try {
+			const actor = await activeActor(ctx, args);
+			return await createMandateSetup(ctx, actor.userId, args);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -1038,25 +1061,29 @@ export const mandateStatus = action({
 	},
 	returns: vMandateStatusResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateStatusResult>> => {
-		const actor = await activeActor(ctx, args);
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: args.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate) throw new Error('Mandate not found.');
+		try {
+			const actor = await activeActor(ctx, args);
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: args.mandateId,
+				userId: actor.userId
+			});
+			if (!mandate) throw new Error('Mandate not found.');
 
-		let synced = mandate;
-		if (LIVE_MANDATE_STATUSES.has(mandate.status)) {
-			try {
-				const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
-				const sync = mandateSyncArgs(mandate._id, actor.userId, prava);
-				await ctx.runMutation(internal.payments.syncMandate, sync);
-				synced = withMandateSync(mandate, sync);
-			} catch {
-				// Still awaiting the owner's passkey approval, so keep the stored status.
+			let synced = mandate;
+			if (LIVE_MANDATE_STATUSES.has(mandate.status)) {
+				try {
+					const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
+					const sync = mandateSyncArgs(mandate._id, actor.userId, prava);
+					await ctx.runMutation(internal.payments.syncMandate, sync);
+					synced = withMandateSync(mandate, sync);
+				} catch {
+					// Still awaiting the owner's passkey approval, so keep the stored status.
+				}
 			}
+			return mandateStatusResult(synced);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		return mandateStatusResult(synced);
 	}
 });
 
@@ -1068,8 +1095,12 @@ export const mandateList = action({
 	},
 	returns: vMandateListResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateListResult>> => {
-		const actor = await activeActor(ctx, args);
-		return await listLinkedMandates(ctx, actor.userId);
+		try {
+			const actor = await activeActor(ctx, args);
+			return await listLinkedMandates(ctx, actor.userId);
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -1086,109 +1117,113 @@ export const mandateCharge = action({
 	},
 	returns: vMandateChargeResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateChargeResult>> => {
-		const actor = await activeActor(ctx, args);
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: args.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate) throw new Error('Mandate not found.');
-		assertChargeable(mandate, args);
-		if (mandate.status === 'paused') {
-			throw new Error('Mandate is paused and cannot be charged.');
-		}
-
-		const reference = args.reference?.trim() || undefined;
-		const reservation = await ctx.runMutation(internal.payments.reserveCharge, {
-			mandateId: mandate._id,
-			runId: args.runId,
-			userId: actor.userId,
-			amount: args.amount,
-			currency: mandate.currency,
-			description: args.description,
-			reference
-		});
-		if (reservation.kind === 'existing') {
-			// Credentials are never persisted, only the non-sensitive handle.
-			return {
-				chargeId: reservation.chargeId,
-				transactionId: reservation.transactionId
-			};
-		}
-		if (reservation.kind === 'inFlight') {
-			throw new Error('A charge with this reference is already in progress. Retry shortly.');
-		}
-
-		const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
-		if ((prava.status ?? '').toLowerCase() !== 'active') {
-			await ctx.runMutation(internal.payments.releaseChargeReservation, {
-				chargeId: reservation.chargeId,
-				userId: actor.userId
-			});
-			throw new Error('Mandate is not active and cannot be charged.');
-		}
-		let result: {
-			transactionId?: string;
-			status?: string;
-			errorCode?: string;
-			credentials?: {
-				token: string;
-				dynamicCvv: string;
-				expiryMonth: string;
-				expiryYear: string;
-			};
-			errorMessage?: string;
-		};
-		// Mark before the network call so a lost response cannot be mistaken
-		// for an abandoned reservation that is safe to reclaim.
-		await ctx.runMutation(internal.payments.markChargeProviderRequested, {
-			chargeId: reservation.chargeId,
-			userId: actor.userId
-		});
 		try {
-			result = await pravaRequest(`/v1/mandates/${encodeURIComponent(prava.id)}/charge`, {
-				method: 'POST',
-				body: JSON.stringify(
-					(() => {
-						const chargeBody: MandateChargeRequest = {
-							amount: args.amount
-						};
-						if (reference !== undefined) chargeBody.reference = reference;
-						return chargeBody;
-					})()
-				)
+			const actor = await activeActor(ctx, args);
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: args.mandateId,
+				userId: actor.userId
 			});
-		} catch (error) {
-			await ctx.runMutation(internal.payments.releaseChargeReservation, {
+			if (!mandate) throw new Error('Mandate not found.');
+			assertChargeable(mandate, args);
+			if (mandate.status === 'paused') {
+				throw new Error('Mandate is paused and cannot be charged.');
+			}
+
+			const reference = args.reference?.trim() || undefined;
+			const reservation = await ctx.runMutation(internal.payments.reserveCharge, {
+				mandateId: mandate._id,
+				runId: args.runId,
+				userId: actor.userId,
+				amount: args.amount,
+				currency: mandate.currency,
+				description: args.description,
+				reference
+			});
+			if (reservation.kind === 'existing') {
+				// Credentials are never persisted, only the non-sensitive handle.
+				return {
+					chargeId: reservation.chargeId,
+					transactionId: reservation.transactionId
+				};
+			}
+			if (reservation.kind === 'inFlight') {
+				throw new Error('A charge with this reference is already in progress. Retry shortly.');
+			}
+
+			const prava = await resolvePravaMandate(ctx, actor.userId, mandate);
+			if ((prava.status ?? '').toLowerCase() !== 'active') {
+				await ctx.runMutation(internal.payments.releaseChargeReservation, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId
+				});
+				throw new Error('Mandate is not active and cannot be charged.');
+			}
+			let result: {
+				transactionId?: string;
+				status?: string;
+				errorCode?: string;
+				credentials?: {
+					token: string;
+					dynamicCvv: string;
+					expiryMonth: string;
+					expiryYear: string;
+				};
+				errorMessage?: string;
+			};
+			// Mark before the network call so a lost response cannot be mistaken
+			// for an abandoned reservation that is safe to reclaim.
+			await ctx.runMutation(internal.payments.markChargeProviderRequested, {
 				chargeId: reservation.chargeId,
 				userId: actor.userId
 			});
-			throw error;
-		}
+			try {
+				result = await pravaRequest(`/v1/mandates/${encodeURIComponent(prava.id)}/charge`, {
+					method: 'POST',
+					body: JSON.stringify(
+						(() => {
+							const chargeBody: MandateChargeRequest = {
+								amount: args.amount
+							};
+							if (reference !== undefined) chargeBody.reference = reference;
+							return chargeBody;
+						})()
+					)
+				});
+			} catch (error) {
+				await ctx.runMutation(internal.payments.releaseChargeReservation, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId
+				});
+				throw error;
+			}
 
-		const { credentials, transactionId } = result;
-		if (result.status === 'failed' || !credentials || !transactionId) {
-			await ctx.runMutation(internal.payments.updateChargeStatus, {
+			const { credentials, transactionId } = result;
+			if (result.status === 'failed' || !credentials || !transactionId) {
+				await ctx.runMutation(internal.payments.updateChargeStatus, {
+					chargeId: reservation.chargeId,
+					userId: actor.userId,
+					status: 'failed'
+				});
+				throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
+			}
+			await ctx.runMutation(internal.payments.completeCharge, {
 				chargeId: reservation.chargeId,
 				userId: actor.userId,
-				status: 'failed'
+				pravaTransactionId: transactionId
 			});
-			throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
+			// Return only validated credential fields. Prava may include extras
+			// (e.g. dynamicDataType) that must not leak into the action result.
+			return {
+				chargeId: reservation.chargeId,
+				transactionId,
+				token: credentials.token,
+				dynamicCvv: credentials.dynamicCvv,
+				expiryMonth: credentials.expiryMonth,
+				expiryYear: credentials.expiryYear
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.runMutation(internal.payments.completeCharge, {
-			chargeId: reservation.chargeId,
-			userId: actor.userId,
-			pravaTransactionId: transactionId
-		});
-		// Return only validated credential fields. Prava may include extras
-		// (e.g. dynamicDataType) that must not leak into the action result.
-		return {
-			chargeId: reservation.chargeId,
-			transactionId,
-			token: credentials.token,
-			dynamicCvv: credentials.dynamicCvv,
-			expiryMonth: credentials.expiryMonth,
-			expiryYear: credentials.expiryYear
-		};
 	}
 });
 
@@ -1203,88 +1238,92 @@ export const mandateReport = action({
 	},
 	returns: vMandateReportResult,
 	handler: async (ctx, args): Promise<Infer<typeof vMandateReportResult>> => {
-		const actor = await activeActor(ctx, args);
-		const charge = await ctx.runQuery(internal.payments.getOwnedCharge, {
-			chargeId: args.chargeId,
-			userId: actor.userId
-		});
-		if (!charge) throw new Error('Charge not found.');
-		if (charge.reportedAt) {
-			return { reported: true, alreadyReported: true };
-		}
-
-		// claimChargeReport atomically reserves this report (reclaiming an
-		// abandoned stale claim), so only one caller reaches Prava per attempt.
-		const claim = await ctx.runMutation(internal.payments.claimChargeReport, {
-			chargeId: charge._id,
-			userId: actor.userId,
-			outcome: args.outcome
-		});
-		if (claim === 'already') {
-			return { reported: true, alreadyReported: true };
-		}
-		if (claim === 'inFlight') {
-			// Another caller is mid-report. Not yet delivered, so don't claim success.
-			return { reported: false, inFlight: true };
-		}
-
-		if (!charge.pravaTransactionId) {
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
-				userId: actor.userId,
-				clearOutcome: true
-			});
-			throw new Error('Prava transaction id is unavailable.');
-		}
-		const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
-			mandateId: charge.mandateId,
-			userId: actor.userId
-		});
-		if (!mandate?.pravaMandateId) {
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
-				userId: actor.userId,
-				clearOutcome: true
-			});
-			throw new Error('Prava mandate id is unavailable.');
-		}
-		// claimChargeReport rejects a conflicting outcome, so args.outcome is
-		// the bound terminal state for this charge.
-		const outcome = args.outcome;
 		try {
-			await pravaRequest(
-				`/v1/mandates/${encodeURIComponent(mandate.pravaMandateId)}/charges/${encodeURIComponent(charge.pravaTransactionId)}/report`,
-				{
-					method: 'POST',
-					body: JSON.stringify(
-						(() => {
-							const reportBody: MandateReportRequest = {
-								txn_status: outcome === 'approved' ? 'APPROVED' : 'DECLINED',
-								txn_type: 'PURCHASE'
-							};
-							if (args.amountPaid !== undefined) reportBody.amount_paid = args.amountPaid;
-							return reportBody;
-						})()
-					)
-				}
-			);
-		} catch (error) {
-			// Ambiguous delivery: the POST may have committed remotely. Drop the
-			// in-flight claim so a same-outcome retry can re-send (idempotent on
-			// transaction id), but keep reportOutcome so the opposite result
-			// cannot be reserved later.
-			await ctx.runMutation(internal.payments.releaseChargeReport, {
-				chargeId: charge._id,
+			const actor = await activeActor(ctx, args);
+			const charge = await ctx.runQuery(internal.payments.getOwnedCharge, {
+				chargeId: args.chargeId,
 				userId: actor.userId
 			});
-			throw error;
+			if (!charge) throw new Error('Charge not found.');
+			if (charge.reportedAt) {
+				return { reported: true, alreadyReported: true };
+			}
+
+			// claimChargeReport atomically reserves this report (reclaiming an
+			// abandoned stale claim), so only one caller reaches Prava per attempt.
+			const claim = await ctx.runMutation(internal.payments.claimChargeReport, {
+				chargeId: charge._id,
+				userId: actor.userId,
+				outcome: args.outcome
+			});
+			if (claim === 'already') {
+				return { reported: true, alreadyReported: true };
+			}
+			if (claim === 'inFlight') {
+				// Another caller is mid-report. Not yet delivered, so don't claim success.
+				return { reported: false, inFlight: true };
+			}
+
+			if (!charge.pravaTransactionId) {
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId,
+					clearOutcome: true
+				});
+				throw new Error('Prava transaction id is unavailable.');
+			}
+			const mandate = await ctx.runQuery(internal.payments.getOwnedMandate, {
+				mandateId: charge.mandateId,
+				userId: actor.userId
+			});
+			if (!mandate?.pravaMandateId) {
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId,
+					clearOutcome: true
+				});
+				throw new Error('Prava mandate id is unavailable.');
+			}
+			// claimChargeReport rejects a conflicting outcome, so args.outcome is
+			// the bound terminal state for this charge.
+			const outcome = args.outcome;
+			try {
+				await pravaRequest(
+					`/v1/mandates/${encodeURIComponent(mandate.pravaMandateId)}/charges/${encodeURIComponent(charge.pravaTransactionId)}/report`,
+					{
+						method: 'POST',
+						body: JSON.stringify(
+							(() => {
+								const reportBody: MandateReportRequest = {
+									txn_status: outcome === 'approved' ? 'APPROVED' : 'DECLINED',
+									txn_type: 'PURCHASE'
+								};
+								if (args.amountPaid !== undefined) reportBody.amount_paid = args.amountPaid;
+								return reportBody;
+							})()
+						)
+					}
+				);
+			} catch (error) {
+				// Ambiguous delivery: the POST may have committed remotely. Drop the
+				// in-flight claim so a same-outcome retry can re-send (idempotent on
+				// transaction id), but keep reportOutcome so the opposite result
+				// cannot be reserved later.
+				await ctx.runMutation(internal.payments.releaseChargeReport, {
+					chargeId: charge._id,
+					userId: actor.userId
+				});
+				throw error;
+			}
+			await ctx.runMutation(internal.payments.finishChargeReport, {
+				chargeId: charge._id,
+				userId: actor.userId,
+				status: statusForOutcome(outcome)
+			});
+			return { reported: true };
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
-		await ctx.runMutation(internal.payments.finishChargeReport, {
-			chargeId: charge._id,
-			userId: actor.userId,
-			status: statusForOutcome(outcome)
-		});
-		return { reported: true };
 	}
 });
 

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -9,7 +9,7 @@ import {
 } from '@convex/_generated/server';
 import { api, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { getUserId } from '@convex/lib/auth';
+import { getUserId, requireIdentity } from '@convex/lib/auth';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import {
 	isMandateStatus,
@@ -55,7 +55,19 @@ async function pravaRequest<T>(path: string, init?: RequestInit): Promise<T> {
 	});
 	if (!response.ok) {
 		const details = await response.text();
-		throw new Error(`Prava request failed (${response.status})${details ? `: ${details}` : '.'}`);
+		let message = details;
+		try {
+			// SAFETY: Prava errors share one documented envelope
+			// ({error:{code,message,details}}); both fields are optional-checked
+			// before use and anything else keeps the raw body as the message.
+			const parsed = JSON.parse(details) as { error?: { code?: string; message?: string } };
+			if (parsed.error?.code || parsed.error?.message) {
+				message = [parsed.error.code, parsed.error.message].filter(Boolean).join(' - ');
+			}
+		} catch {
+			// Not JSON; surface the raw body.
+		}
+		throw new Error(`Prava request failed (${response.status})${message ? `: ${message}` : '.'}`);
 	}
 	const body = await response.text();
 	// SAFETY: unchecked decode of the trusted Prava API response into its documented contract T.
@@ -103,14 +115,6 @@ async function activeActor(
 		throw new Error('Run is no longer active.');
 	}
 	return actor;
-}
-
-function requiredUserEmail(userEmail: string): string {
-	const email = userEmail.trim();
-	if (!email) {
-		throw new Error('EMAIL_REQUIRED');
-	}
-	return email;
 }
 
 /** Any-scope (generic) mandates are one-time only. Prava rejects a recurring
@@ -213,6 +217,8 @@ type MandateReportRequest = {
 type PravaMandate = {
 	id?: string;
 	status?: string;
+	recurringFrequency?: string;
+	merchantScope?: string;
 	remaining?: string | null;
 	approvedAmount?: string;
 	currency?: string;
@@ -345,18 +351,6 @@ function mandateStatusResult(mandate: Doc<'mandates'>): Infer<typeof vMandateSta
 // ---------------------------------------------------------------------------
 // Internal queries / mutations
 // ---------------------------------------------------------------------------
-
-export const getPaymentsEmail = internalQuery({
-	args: { userId: v.string() },
-	returns: v.union(v.string(), v.null()),
-	handler: async (ctx, args) => {
-		const prefs = await ctx.db
-			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', args.userId))
-			.unique();
-		return prefs?.paymentsEmail ?? null;
-	}
-});
 
 export const insertMandate = internalMutation({
 	args: {
@@ -740,6 +734,8 @@ export const finishChargeReport = internalMutation({
 // ---------------------------------------------------------------------------
 
 const mandateSetupArgs = {
+	// Accepted-and-ignored for released clients that still send it; the email
+	// always comes from the caller's WorkOS identity.
 	userEmail: v.optional(v.string()),
 	merchantName: v.optional(v.string()),
 	merchantUrl: v.optional(v.string()),
@@ -760,10 +756,12 @@ async function createMandateSetup(
 	userId: string,
 	args: ObjectType<typeof mandateSetupArgs>
 ): Promise<Infer<typeof vMandateSetupResult>> {
-	const storedEmail: string | null = await ctx.runQuery(internal.payments.getPaymentsEmail, {
-		userId
-	});
-	const userEmail = requiredUserEmail(args.userEmail ?? storedEmail ?? '');
+	// Prava requires a customer email on merchant sessions; the signed-in
+	// WorkOS identity is the single source of truth for it.
+	const userEmail = (await requireIdentity(ctx)).email?.trim();
+	if (!userEmail) {
+		throw new Error('Your account has no email address to use for payment mandates.');
+	}
 	assertMandateFrequencyAllowed(args);
 
 	// Generic (any-scope) mandates are one-time only; Prava still needs a
@@ -800,14 +798,16 @@ async function createMandateSetup(
 			total_amount: args.amountCap,
 			currency: args.currency,
 			description: args.description,
-			purchase_context: [
-				{
-					merchant_details: merchantDetails,
-					product_details: [
-						{ description: args.description, unit_price: args.amountCap, quantity: 1 }
-					]
-				}
-			],
+			purchase_context: {
+				custom: [
+					{
+						merchant_details: merchantDetails,
+						product_details: [
+							{ description: args.description, unit_price: args.amountCap, quantity: 1 }
+						]
+					}
+				]
+			},
 			mandate_setup: (() => {
 				const setup: MandateSetupRequest = {
 					intent: 'mandate_setup',
@@ -861,6 +861,12 @@ export const mandateSetup = action({
 function isMatchingLivePravaMandate(mandate: Doc<'mandates'>, prava: PravaMandate): boolean {
 	if (!prava.id) return false;
 	if (!LIVE_MANDATE_STATUSES.has(prava.status ?? '')) return false;
+	// A different scope or cadence is a different authorization even when the
+	// merchant name and cap coincide.
+	if (prava.merchantScope !== undefined && prava.merchantScope !== mandate.scope) return false;
+	if (prava.recurringFrequency !== undefined && prava.recurringFrequency !== mandate.frequency) {
+		return false;
+	}
 	// A mandate approved in another currency is a different authorization;
 	// never resolve (and later charge) it for this setup.
 	if ((prava.currency ?? '').toUpperCase() !== mandate.currency.toUpperCase()) return false;
@@ -1123,6 +1129,7 @@ export const mandateCharge = action({
 		let result: {
 			transactionId?: string;
 			status?: string;
+			errorCode?: string;
 			credentials?: {
 				token: string;
 				dynamicCvv: string;
@@ -1165,7 +1172,7 @@ export const mandateCharge = action({
 				userId: actor.userId,
 				status: 'failed'
 			});
-			throw new Error(result.errorMessage ?? 'Mandate charge failed.');
+			throw new Error(result.errorMessage ?? result.errorCode ?? 'Mandate charge failed.');
 		}
 		await ctx.runMutation(internal.payments.completeCharge, {
 			chargeId: reservation.chargeId,

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -52,6 +52,9 @@ export default defineSchema({
 		// Remove once those clients age out.
 		lastThreadId: v.optional(v.id('threadRecords')),
 		theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
+		// Deprecated: mandate setup now uses the WorkOS identity email. Kept so
+		// rows written by older clients still validate; see
+		// BACKWARDS_COMPATIBILITY.md before removing.
 		paymentsEmail: v.optional(v.string())
 	}).index('by_userId', ['userId']),
 	projects: defineTable({

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -76,6 +76,10 @@ export const setTheme = mutation({
 });
 
 export const setPaymentsEmail = mutation({
+	// Deprecated: no current caller; kept because released clients still save a
+	// payments email here. Mandate setup ignores it and uses the WorkOS
+	// identity email instead. Remove with the schema field once those clients
+	// age out (see BACKWARDS_COMPATIBILITY.md).
 	args: { email: v.string() },
 	returns: v.null(),
 	handler: async (ctx, args) => {

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isUnparseablePageFailure } from '@convex/webTools';
+
+describe('unparseable page failures', () => {
+	it('recognizes component return-validation failures', () => {
+		const error = new Error(
+			'Uncaught ConvexError: ReturnsValidationError: Value does not match validator. Path: .values()'
+		);
+		expect(isUnparseablePageFailure(error)).toBe(true);
+	});
+
+	it('leaves timeouts and other failures alone', () => {
+		expect(isUnparseablePageFailure(new Error('Context.dev scrape timed out after 60000ms.'))).toBe(
+			false
+		);
+		expect(isUnparseablePageFailure(new Error('Run is no longer active.'))).toBe(false);
+	});
+});

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -7,6 +7,7 @@ import { action } from '@convex/_generated/server';
 import { api, components } from '@convex/_generated/api';
 import { vScrapeUrlResult, vWebSearchResult } from '@convex/lib/validators';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
+import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 
 const contextDev = new ContextDev(components.contextDev);
 const exa = new ExaClient(components.exa);
@@ -68,41 +69,45 @@ export const scrapeUrl = action({
 	},
 	returns: vScrapeUrlResult,
 	handler: async (ctx, args) => {
-		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-			runId: args.runId,
-			executionSecret: args.executionSecret
-		});
-		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
-			throw new Error('Run is no longer active.');
-		}
-		let url: URL;
 		try {
-			url = new URL(args.url.trim());
-		} catch {
-			throw new Error(`Invalid URL: ${args.url}`);
-		}
-		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-			throw new Error('Only http(s) URLs can be scraped.');
-		}
+			const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+				runId: args.runId,
+				executionSecret: args.executionSecret
+			});
+			if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			let url: URL;
+			try {
+				url = new URL(args.url.trim());
+			} catch {
+				throw new Error(`Invalid URL: ${args.url}`);
+			}
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+				throw new Error('Only http(s) URLs can be scraped.');
+			}
 
-		const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
-			contextDev.scrapeMarkdown(ctx, {
-				params: {
-					url: url.toString(),
-					useMainContentOnly: true,
-					timeoutMS: SCRAPE_TIMEOUT_MS
-				}
-			})
-		);
+			const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
+				contextDev.scrapeMarkdown(ctx, {
+					params: {
+						url: url.toString(),
+						useMainContentOnly: true,
+						timeoutMS: SCRAPE_TIMEOUT_MS
+					}
+				})
+			);
 
-		const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
-		return {
-			url: response.url,
-			markdown: truncated
-				? response.markdown.slice(0, SCRAPE_MARKDOWN_MAX_CHARS)
-				: response.markdown,
-			truncated
-		};
+			const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
+			return {
+				url: response.url,
+				markdown: truncated
+					? response.markdown.slice(0, SCRAPE_MARKDOWN_MAX_CHARS)
+					: response.markdown,
+				truncated
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });
 
@@ -116,46 +121,50 @@ export const webSearch = action({
 	},
 	returns: vWebSearchResult,
 	handler: async (ctx, args) => {
-		const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
-			runId: args.runId,
-			executionSecret: args.executionSecret
-		});
-		if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
-			throw new Error('Run is no longer active.');
-		}
-		const query = args.query.trim();
-		if (!query) {
-			throw new Error('Search query cannot be empty.');
-		}
-		const requested =
-			args.numResults !== undefined && Number.isFinite(args.numResults)
-				? Math.floor(args.numResults)
-				: DEFAULT_SEARCH_RESULTS;
-		const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
+		try {
+			const actor = await ctx.runQuery(api.agentRuntime.completionActor, {
+				runId: args.runId,
+				executionSecret: args.executionSecret
+			});
+			if (actor.claimId !== args.claimId || !isRunClaimLeaseActive(actor, Date.now())) {
+				throw new Error('Run is no longer active.');
+			}
+			const query = args.query.trim();
+			if (!query) {
+				throw new Error('Search query cannot be empty.');
+			}
+			const requested =
+				args.numResults !== undefined && Number.isFinite(args.numResults)
+					? Math.floor(args.numResults)
+					: DEFAULT_SEARCH_RESULTS;
+			const numResults = Math.min(Math.max(requested, 1), MAX_SEARCH_RESULTS);
 
-		const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
-			exa.search(ctx, {
-				query,
-				type: 'auto',
-				numResults,
-				contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
-			})
-		);
+			const response = await callComponent('Exa search', SEARCH_TIMEOUT_MS, () =>
+				exa.search(ctx, {
+					query,
+					type: 'auto',
+					numResults,
+					contents: { text: { maxCharacters: SEARCH_RESULT_TEXT_MAX_CHARS } }
+				})
+			);
 
-		return {
-			results: response.results.flatMap((result) => {
-				if (!result.url) {
-					return [];
-				}
-				const item: Infer<typeof vWebSearchResult>['results'][number] = {
-					url: result.url
-				};
-				if (result.title) item.title = result.title;
-				if (result.publishedDate) item.publishedDate = result.publishedDate;
-				if (result.author) item.author = result.author;
-				if (result.text) item.text = result.text;
-				return [item];
-			})
-		};
+			return {
+				results: response.results.flatMap((result) => {
+					if (!result.url) {
+						return [];
+					}
+					const item: Infer<typeof vWebSearchResult>['results'][number] = {
+						url: result.url
+					};
+					if (result.title) item.title = result.title;
+					if (result.publishedDate) item.publishedDate = result.publishedDate;
+					if (result.author) item.author = result.author;
+					if (result.text) item.text = result.text;
+					return [item];
+				})
+			};
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
 	}
 });

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -23,6 +23,15 @@ const SEARCH_TIMEOUT_MS = 30_000;
 
 class WebToolTimeout extends Error {}
 
+// Context.dev validates its scrape result against a bounded-depth JSON schema,
+// so pages whose metadata nests deeper than the bound fail inside the component
+// before any content reaches us (#208).
+export function isUnparseablePageFailure(error: Error): boolean {
+	return error.message.includes('ReturnsValidationError');
+}
+
+const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and failed to parse as markdown.';
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -53,6 +62,10 @@ async function callComponent<T>(
 		return await withTimeout(label, timeoutMs, run());
 	} catch (error) {
 		if (error instanceof WebToolTimeout) {
+			throw error;
+		}
+		if (error instanceof Error && isUnparseablePageFailure(error)) {
+			// The same page fails validation on every attempt.
 			throw error;
 		}
 		await sleep(RETRY_DELAY_MS);
@@ -87,15 +100,23 @@ export const scrapeUrl = action({
 				throw new Error('Only http(s) URLs can be scraped.');
 			}
 
-			const response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
-				contextDev.scrapeMarkdown(ctx, {
-					params: {
-						url: url.toString(),
-						useMainContentOnly: true,
-						timeoutMS: SCRAPE_TIMEOUT_MS
-					}
-				})
-			);
+			let response: Awaited<ReturnType<typeof contextDev.scrapeMarkdown>>;
+			try {
+				response = await callComponent('Context.dev scrape', SCRAPE_TIMEOUT_MS, () =>
+					contextDev.scrapeMarkdown(ctx, {
+						params: {
+							url: url.toString(),
+							useMainContentOnly: true,
+							timeoutMS: SCRAPE_TIMEOUT_MS
+						}
+					})
+				);
+			} catch (error) {
+				if (error instanceof Error && isUnparseablePageFailure(error)) {
+					throw new Error(UNPARSEABLE_PAGE_ERROR, { cause: error });
+				}
+				throw error;
+			}
 
 			const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
 			return {

--- a/apps/web/src/lib/components/home/settings-payments.svelte
+++ b/apps/web/src/lib/components/home/settings-payments.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { useAction, useAuth, useMutation, useQuery } from 'convex-svelte';
+	import { useAction, useAuth } from 'convex-svelte';
 	import type { Id } from '$convex/_generated/dataModel';
 	import { api } from '$convex/_generated/api';
 	import type { MandateApproval } from '$lib/chat/mandate';
@@ -25,10 +25,6 @@
 	};
 
 	const convexAuth = useAuth();
-	const prefsQuery = useQuery(api.uiPreferences.getMine, () =>
-		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
-	);
-	const setPaymentsEmail = useMutation(api.uiPreferences.setPaymentsEmail);
 	const listMyMandates = useAction(api.payments.listMyMandates);
 	const setupMyMandate = useAction(api.payments.setupMyMandate);
 	const setMyMandateLifecycle = useAction(api.payments.setMyMandateLifecycle);
@@ -49,12 +45,6 @@
 	const labelClass = 'text-muted-foreground text-[12px]';
 	const actionLinkClass =
 		'text-muted-foreground hover:text-foreground text-[12px] transition disabled:pointer-events-none disabled:opacity-40';
-
-	let paymentsEmail = $state('');
-	let emailHydrated = $state(false);
-	let emailSaving = $state(false);
-	let emailSaved = $state(false);
-	let emailError = $state<string | null>(null);
 
 	let merchantName = $state('');
 	let merchantUrl = $state('');
@@ -86,15 +76,6 @@
 		if (scope === 'any' && frequency !== 'one_time') {
 			frequency = 'one_time';
 		}
-	});
-
-	$effect(() => {
-		const data = prefsQuery.data;
-		if (data === undefined || emailHydrated) {
-			return;
-		}
-		paymentsEmail = data?.paymentsEmail ?? '';
-		emailHydrated = true;
 	});
 
 	$effect(() => {
@@ -148,26 +129,8 @@
 		}
 	}
 
-	async function savePaymentsEmail() {
-		emailSaving = true;
-		emailError = null;
-		emailSaved = false;
-		try {
-			await setPaymentsEmail({ email: paymentsEmail.trim() });
-			emailSaved = true;
-		} catch (error) {
-			emailError = catchMessage(error, 'Couldn’t save email.');
-		} finally {
-			emailSaving = false;
-		}
-	}
-
 	async function submitMandateSetup(event: Event) {
 		event.preventDefault();
-		if (!paymentsEmail.trim()) {
-			setupError = 'Save your payments email above first — it’s required to set up a mandate.';
-			return;
-		}
 		setupSubmitting = true;
 		setupError = null;
 		pendingApproval = null;
@@ -183,8 +146,7 @@
 				currency: currency.trim(),
 				frequency,
 				scope,
-				description: description.trim(),
-				userEmail: paymentsEmail.trim()
+				description: description.trim()
 			});
 			pendingApproval = {
 				mandateId: result.mandateId,
@@ -226,46 +188,6 @@
 
 	<div class="min-h-0 flex-1 overflow-y-auto px-6 py-8">
 		<div class="max-w-xl space-y-10">
-			<div>
-				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
-					Payments email
-				</p>
-				<p class="text-muted-foreground mt-2 text-sm leading-6">
-					Used when setting up spending mandates. Saved to your account preferences.
-				</p>
-				<form
-					class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end"
-					onsubmit={(event) => {
-						event.preventDefault();
-						void savePaymentsEmail();
-					}}
-				>
-					<label class="block min-w-0 flex-1 space-y-1.5">
-						<span class={labelClass}>Email</span>
-						<input
-							class={fieldClass}
-							type="email"
-							autocomplete="email"
-							bind:value={paymentsEmail}
-							placeholder="you@example.com"
-							disabled={emailSaving || prefsQuery.isLoading}
-							oninput={() => {
-								emailSaved = false;
-								emailError = null;
-							}}
-						/>
-					</label>
-					<Button type="submit" variant="outline" disabled={emailSaving || !paymentsEmail.trim()}>
-						{emailSaving ? 'Saving…' : 'Save'}
-					</Button>
-				</form>
-				{#if emailError}
-					<p class="text-destructive mt-2 text-sm">{emailError}</p>
-				{:else if emailSaved}
-					<p class="text-muted-foreground mt-2 text-sm" role="status">Saved.</p>
-				{/if}
-			</div>
-
 			<div>
 				<p class="text-muted-foreground font-mono text-[11px] tracking-[0.18em] uppercase">
 					Set up a spending mandate

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -462,9 +462,6 @@ pub(crate) enum MandateScope {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct MandateSetupArgs {
-    /// Email the user uses for purchase approvals; optional when one is already on file.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user_email: Option<String>,
     /// Merchant to lock this mandate to (required for `listed` scope).
     #[serde(skip_serializing_if = "Option::is_none")]
     merchant_name: Option<String>,

--- a/crates/sprocket-agent/src/tools.rs
+++ b/crates/sprocket-agent/src/tools.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use convex::Value;
 use futures::StreamExt;
+use rig::tool::ToolExecutionError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -39,6 +40,19 @@ pub(crate) enum AgentToolError {
     Cancelled,
     #[error("{0}")]
     Message(String),
+}
+
+impl From<AgentToolError> for ToolExecutionError {
+    // rig's default redaction would show models only "the tool failed"; these
+    // messages are authored for display and already land in job.error.
+    fn from(error: AgentToolError) -> Self {
+        match error {
+            AgentToolError::Cancelled => {
+                ToolExecutionError::cancelled("Tool execution was cancelled.")
+            }
+            AgentToolError::Message(message) => ToolExecutionError::other(message),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -645,6 +659,10 @@ impl rig::tool::Tool for ExecCommandTool {
         exec_command_parameters()
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -694,6 +712,10 @@ impl rig::tool::Tool for WriteStdinTool {
         write_stdin_parameters()
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -740,6 +762,10 @@ impl rig::tool::Tool for AskQuestionTool {
 
     fn parameters(&self) -> serde_json::Value {
         ask_question_parameters()
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -800,6 +826,10 @@ impl rig::tool::Tool for AwaitQuestionTool {
 
     fn parameters(&self) -> serde_json::Value {
         await_question_parameters()
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -867,6 +897,10 @@ impl rig::tool::Tool for ApplyPatchTool {
         json!(schemars::schema_for!(ApplyPatchArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -904,6 +938,10 @@ impl rig::tool::Tool for WebSearchTool {
 
     fn parameters(&self) -> serde_json::Value {
         web_search_parameters()
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -958,6 +996,10 @@ impl rig::tool::Tool for ScrapeUrlTool {
         json!(schemars::schema_for!(ScrapeUrlArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1000,6 +1042,10 @@ impl rig::tool::Tool for CreateArtifactTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(CreateArtifactArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1045,6 +1091,10 @@ impl rig::tool::Tool for UpdateArtifactTool {
         json!(schemars::schema_for!(UpdateArtifactArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1086,6 +1136,10 @@ impl rig::tool::Tool for BrowserObserveTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(BrowserObserveArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1133,6 +1187,10 @@ impl rig::tool::Tool for BrowserActTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(BrowserActToolArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1200,6 +1258,10 @@ impl rig::tool::Tool for BrowserExtractTool {
         json!(schemars::schema_for!(BrowserExtractArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1248,6 +1310,10 @@ impl rig::tool::Tool for MandateSetupTool {
         json!(schemars::schema_for!(MandateSetupArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1276,6 +1342,10 @@ impl rig::tool::Tool for MandateStatusTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(MandateIdArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1308,6 +1378,10 @@ impl rig::tool::Tool for MandateListTool {
         json!({ "type": "object", "properties": {}, "additionalProperties": false })
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1330,6 +1404,10 @@ impl rig::tool::Tool for MandateChargeTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(MandateChargeArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1362,6 +1440,10 @@ impl rig::tool::Tool for MandateReportTool {
         json!(schemars::schema_for!(MandateReportArgs))
     }
 
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
+    }
+
     async fn call(
         &self,
         _context: &mut rig::tool::ToolContext,
@@ -1390,6 +1472,10 @@ impl rig::tool::Tool for ReadSkillTool {
 
     fn parameters(&self) -> serde_json::Value {
         json!(schemars::schema_for!(ReadSkillArgs))
+    }
+
+    fn map_error(&self, error: Self::Error) -> ToolExecutionError {
+        error.into()
     }
 
     async fn call(
@@ -1921,6 +2007,20 @@ mod tests {
     use sprocket_workspace::{SkillSource, WorkspaceSkill};
 
     use super::*;
+
+    #[test]
+    fn agent_tool_errors_map_to_model_visible_execution_errors() {
+        let mapped: ToolExecutionError =
+            AgentToolError::Message("failed to parse Begin Patch input".to_string()).into();
+        assert_eq!(
+            mapped.model_feedback(),
+            Some("failed to parse Begin Patch input")
+        );
+        assert_eq!(mapped.kind(), rig::tool::ToolErrorKind::Other);
+
+        let cancelled: ToolExecutionError = AgentToolError::Cancelled.into();
+        assert_eq!(cancelled.kind(), rig::tool::ToolErrorKind::Cancelled);
+    }
 
     #[test]
     fn tool_error_includes_anyhow_context_chain() {


### PR DESCRIPTION
Stacked on #206. Tracks #208.

## What happens

`scrape_url` fails on complex pages (github.blog reproduced it). The Context.dev component returns its scrape result including an undeclared `values` payload of raw page metadata, and validates that result inside its own action against a bounded-depth JSON schema. Deeply nested pages fail that validation before our handler receives anything, and the error carries the whole page payload plus a thousands-of-characters validator dump.

I checked whether we can drop the payload ourselves (the original idea in #208): no. The component takes no parameter that skips metadata, every scrape method declares it in its return type, and validation runs server-side in the component before we see data. Only Context.dev can fix this properly; that is tracked in #208 with the package findings.

So this PR keeps the tool usable today:

- Classify that one failure mode (`ReturnsValidationError` from the scrape call) and fail with "The webpage is too complex and failed to parse as markdown." The original error stays attached as `cause` for server logs; neither the model nor `job.error` shows the dump.
- Skip the retry for this failure class in `callComponent`. It is deterministic per page, so retrying only burned a second timeout window.
- Everything else still surfaces through the readable error path from #206.

## Checks

- vitest: classifier unit tests added, full suite 280/280
- eslint + convex typecheck clean
- prek run -a clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes executor-facing tool failures readable while preserving their underlying causes, and translates Context.dev scrape return-validation failures into a concise page-complexity message without retrying the deterministic request.
- Adds centralized Convex error normalization and propagates authored tool failure text to the Rust model loop.
- Wraps web, browser, artifact, question, executor, and payment tool boundaries with readable error handling.
- Updates mandate identity sourcing and external-approval matching while retaining released-client compatibility fields.
- Adds focused tests for error extraction, scrape classification, and payment behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code failure remains after tracing scrape classification, error propagation, authentication, and payment-state behavior.

Existing Convex errors and cancellation messages remain intact, production agent actions retain authenticated user identity, and the new scrape handling converts the documented deterministic validation failure without exposing its oversized payload.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Classifies Context.dev return-validation failures, avoids their deterministic retry, and surfaces a bounded friendly scrape error. |
| apps/web/src/convex/lib/agentErrors.ts | Centralizes extraction and conversion of nested tool errors while preserving existing ConvexError values. |
| crates/sprocket-agent/src/tools.rs | Converts authored agent-tool failures into model-visible Rig tool errors while retaining cancellation classification. |
| apps/web/src/convex/payments.ts | Uses authenticated identity email for mandate setup, tightens external mandate matching, and normalizes payment-tool failures. |
| apps/web/src/convex/browserAgent.ts | Extends readable error conversion across browser actions without changing session cleanup. |
| apps/web/src/convex/agentRuntime.ts | Makes tool-job initialization failures readable while preserving run-claim checks and state transitions. |
| apps/web/src/lib/components/home/settings-payments.svelte | Removes the obsolete stored payment-email form and relies on the authenticated account identity during mandate setup. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Model
    participant Agent as Rust agent
    participant Convex
    participant Context as Context.dev
    Model->>Agent: scrape_url
    Agent->>Convex: scrapeUrl action
    Convex->>Context: scrapeMarkdown
    Context-->>Convex: ReturnsValidationError
    Convex-->>Agent: Friendly ConvexError
    Agent->>Convex: Record failed executor job
    Agent-->>Model: Readable tool failure
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Report unreadable pages as a..."](https://github.com/spikonado/sprocket/commit/34159b8e316caeab8cb4ff862a66ddb047447320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56530375)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent tool execution](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-tool-execution.md)
- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->