### PR TITLE
fix(payments): Resolve mandate email from convex users row

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -76,7 +76,7 @@ Safe when npm downloads for versions predating the release carrying #200 have fl
 
 ## 4. Mandate setup ignores the stored payments email
 
-Up to v0.3.2, mandate setup resolved the customer email from the caller (`userEmail` tool argument or settings-screen input) with a fallback to `uiPreferences.paymentsEmail`, and the settings screen saved that email via `uiPreferences.setPaymentsEmail`. Setup now always uses the email on the caller's WorkOS identity instead.
+Up to v0.3.2, mandate setup resolved the customer email from the caller (`userEmail` tool argument or settings-screen input) with a fallback to `uiPreferences.paymentsEmail`, and the settings screen saved that email via `uiPreferences.setPaymentsEmail`. Setup now reads the WorkOS email that `ensureCurrentUser` syncs onto the caller's `users` row (executor actions have no usable caller identity — the run's auth token is a launch-time snapshot).
 
 Today's compat: `mandateSetupArgs` (`convex/payments.ts`) still accepts an optional `userEmail` and ignores it, so pre-#204-era agents and settings screens keep passing theirs. `vMandateSetupPayload.userEmail` (`convex/lib/validators.ts`) stays accepted because stored `executorJobs.payload` rows written by those agents carry it. `uiPreferences.setPaymentsEmail` still writes the field for old settings screens, and `uiPreferences.paymentsEmail` stays optional in the schema so their rows keep validating.
 

--- a/apps/web/skills-lock.json
+++ b/apps/web/skills-lock.json
@@ -59,7 +59,7 @@
 			"source": "get-convex/agent-skills",
 			"sourceType": "github",
 			"skillPath": "skills/convex-create-component/SKILL.md",
-			"computedHash": "012acb639fccc22a47e89ef69941689f9328ac9ff5b872d77af6328407ec8876"
+			"computedHash": "641d2904a3aab8edacb11ef51c7bcf8a64b304d3f4e6a2ea040c5355f9333c37"
 		},
 		"convex-crons": {
 			"source": "get-convex/agent-skills",

--- a/apps/web/src/convex/_generated/ai/ai-files.state.json
+++ b/apps/web/src/convex/_generated/ai/ai-files.state.json
@@ -2,5 +2,5 @@
   "guidelinesHash": "533ba2428f2dc572e825555e6e681d2e56e7e757c15a3fdd036a5d705413f020",
   "agentsMdSectionHash": "9ad958b9c42a2a29bf78583b89fd58c6d28c2d2411bcf3996962e42394f2a4e7",
   "claudeMdHash": "9ad958b9c42a2a29bf78583b89fd58c6d28c2d2411bcf3996962e42394f2a4e7",
-  "agentSkillsSha": "6843b65f3cbcee34bb2bc984d444f42ac7ca2a61"
+  "agentSkillsSha": "6bc4b14a2dcd73fd388eb0570afe6d1cdb185f2e"
 }

--- a/apps/web/src/convex/_generated/server.d.ts
+++ b/apps/web/src/convex/_generated/server.d.ts
@@ -45,7 +45,8 @@ type Env = {
   readonly FIREWORKS_API_KEY: string | undefined;
   readonly OPENAI_API_KEY: string | undefined;
   readonly OPENROUTER_API_KEY: string | undefined;
-  readonly PRAVA_BACKEND_URL: "https://sandbox.api.prava.space" | "https://api.prava.space";
+  readonly PRAVA_BACKEND_URL:
+    "https://sandbox.api.prava.space" | "https://api.prava.space";
   readonly PRAVA_SECRET_KEY: string | undefined;
   readonly WORKOS_CLIENT_ID: string;
   readonly ZAI_API_KEY: string | undefined;

--- a/apps/web/src/convex/lib/auth.ts
+++ b/apps/web/src/convex/lib/auth.ts
@@ -27,7 +27,8 @@ export async function requireIdentity(
 	return identity;
 }
 
-function pickPrimaryUser(rows: Array<Doc<'users'>>): Doc<'users'> | null {
+/** Earliest row wins so first-login duplicates converge deterministically. */
+export function pickPrimaryUser(rows: Array<Doc<'users'>>): Doc<'users'> | null {
 	if (rows.length === 0) return null;
 	return [...rows].sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id))[0];
 }
@@ -49,25 +50,32 @@ export async function getCurrentUser(
  * first sight. */
 export async function ensureCurrentUser(ctx: GenericMutationCtx<DataModel>): Promise<Doc<'users'>> {
 	const identity = await requireIdentity(ctx);
+	const email = identity.email?.trim() || undefined;
 	const rows = await ctx.db
 		.query('users')
 		.withIndex('by_subject', (query) => query.eq('subject', identity.subject))
 		.collect();
 	if (rows.length > 0) {
-		const primary = pickPrimaryUser(rows);
+		let primary = pickPrimaryUser(rows);
 		if (!primary) throw new Error('Failed to resolve the user record.');
 		// A first-login race can insert two rows for one subject; converge on
 		// the earliest instead of poisoning later unique reads.
 		for (const extra of rows) {
 			if (extra._id !== primary._id) await ctx.db.delete('users', extra._id);
 		}
+		if (email && email !== primary.email) {
+			await ctx.db.patch('users', primary._id, { email });
+			primary = { ...primary, email };
+		}
 		return primary;
 	}
-	const id = await ctx.db.insert('users', {
+	const newUser = {
 		subject: identity.subject,
 		tokenIdentifier: identity.tokenIdentifier,
-		createdAt: Date.now()
-	});
+		createdAt: Date.now(),
+		email
+	};
+	const id = await ctx.db.insert('users', newUser);
 	const created = await ctx.db.get('users', id);
 	if (!created) throw new Error('Failed to create the user record.');
 	return created;

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -11,6 +11,11 @@ import {
 
 async function startRun(t: ConvexTestInstance, subject: string) {
 	const { asUser, threadId } = await seedOwnedThread(t, subject);
+	// What the client's page-load bootstrap leaves behind: a users row whose
+	// email ensureCurrentUser synced from the WorkOS identity.
+	await t
+		.withIdentity({ subject, email: `${subject}@example.com` })
+		.mutation(api.billing.ensureMySubscription, {});
 	const executionSecret = `mandate-secret-${subject}`;
 	const created = await createQueuedRun(
 		asUser,
@@ -41,6 +46,17 @@ function jsonResponse(value: JsonValue, status = 200) {
 
 function auth(run: Awaited<ReturnType<typeof startRun>>) {
 	return { runId: run.runId, claimId: run.claimId, executionSecret: run.executionSecret };
+}
+
+async function clearUserEmail(t: ConvexTestInstance, subject: string) {
+	await t.run(async (ctx) => {
+		const row = await ctx.db
+			.query('users')
+			.withIndex('by_subject', (query) => query.eq('subject', subject))
+			.unique();
+		if (!row) throw new Error(`Expected a users row for ${subject}`);
+		await ctx.db.patch('users', row._id, { email: undefined });
+	});
 }
 
 function setupArgs(run: Awaited<ReturnType<typeof startRun>>) {
@@ -192,16 +208,39 @@ describe('payments mandates', () => {
 		expect(stored).not.toHaveProperty('session_token');
 	});
 
-	it('rejects mandate setup when the WorkOS identity has no email', async () => {
+	it('resolves the synced account email without a caller identity', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const fetchMock = vi.fn().mockResolvedValue(
+			jsonResponse({
+				session_id: 'prava-session-1',
+				iframe_url: 'https://pay.prava.space/approve/1',
+				session_token: 'session-token-1',
+				expires_at: '2026-08-01T10:15:00Z'
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+
+		// Executor actions run under the execution secret with no user JWT;
+		// this is exactly how the agent calls the tool action.
+		const result = await t.action(api.payments.mandateSetup, setupArgs(run));
+		expect(result.approvalUrl).toBe('https://pay.prava.space/approve/1');
+		const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+		expect(body.user_email).toBe('user_alice@example.com');
+	});
+
+	it('rejects mandate setup when no account email is available', async () => {
 		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
 		const fetchMock = vi.fn();
 		vi.stubGlobal('fetch', fetchMock);
 		const t = initConvexTest();
 		const run = await startRun(t, 'user_alice');
+		await clearUserEmail(t, 'user_alice');
 
 		await expect(
 			t.withIdentity({ subject: 'user_alice' }).action(api.payments.mandateSetup, setupArgs(run))
-		).rejects.toThrow(/no email address/);
+		).rejects.toThrow(/synced email/);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -9,7 +9,7 @@ import {
 } from '@convex/_generated/server';
 import { api, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { getUserId, requireIdentity } from '@convex/lib/auth';
+import { getUserId, pickPrimaryUser } from '@convex/lib/auth';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import {
 	isMandateStatus,
@@ -401,6 +401,22 @@ export const getOwnedMandate = internalQuery({
 	}
 });
 
+/** The user's WorkOS email, synced onto their users row by
+ * ensureCurrentUser. Executor actions carry no usable caller identity (the
+ * run's auth token is a launch-time snapshot), so capability-gated code reads
+ * it from here instead of ctx.auth. */
+export const getUserEmail = internalQuery({
+	args: { userId: v.string() },
+	returns: v.union(v.string(), v.null()),
+	handler: async (ctx, args) => {
+		const rows = await ctx.db
+			.query('users')
+			.withIndex('by_subject', (query) => query.eq('subject', args.userId))
+			.collect();
+		return pickPrimaryUser(rows)?.email ?? null;
+	}
+});
+
 export const listLocalMandates = internalQuery({
 	args: { userId: v.string() },
 	returns: v.array(mandateDoc),
@@ -756,11 +772,12 @@ async function createMandateSetup(
 	userId: string,
 	args: ObjectType<typeof mandateSetupArgs>
 ): Promise<Infer<typeof vMandateSetupResult>> {
-	// Prava requires a customer email on merchant sessions; the signed-in
-	// WorkOS identity is the single source of truth for it.
-	const userEmail = (await requireIdentity(ctx)).email?.trim();
+	// Prava requires a customer email on merchant sessions. Executor actions
+	// carry no caller identity, so read the WorkOS email that ensureCurrentUser
+	// keeps on the users row instead of ctx.auth.
+	const userEmail = (await ctx.runQuery(internal.payments.getUserEmail, { userId }))?.trim();
 	if (!userEmail) {
-		throw new Error('Your account has no email address to use for payment mandates.');
+		throw new Error('Your account has no synced email yet. Reload Sprocket once, then try again.');
 	}
 	assertMandateFrequencyAllowed(args);
 

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -31,6 +31,7 @@ export default defineSchema({
 		// WorkOS JWT subject; every owned table stores this value as `userId`.
 		subject: v.string(),
 		tokenIdentifier: v.string(),
+		email: v.optional(v.string()),
 		createdAt: v.number()
 	}).index('by_subject', ['subject']),
 	billingCustomers: defineTable({


### PR DESCRIPTION
## What

Fixes the `Uncaught Error: Authentication required.` at `requireIdentity` (`createMandateSetup`) that broke every agent-initiated mandate setup after #205.

**Root cause.** Executor-called Convex actions cannot rely on `ctx.auth`: the agent's Convex client authenticates with a launch-time token snapshot (`static_auth_token_fetcher` passes `payload.auth_token` once; it cannot refresh mid-run), so by the time the agent calls `payments:mandateSetup` there may be no valid user identity. #205 wrongly required identity inside the action.

**Fix — keep it minimal and capability-based:**

- `users` gains an optional `email` field.
- `ensureCurrentUser` syncs `identity.email` onto the row on insert and change. It already runs on every app load via `billing.ensureMySubscription`, so rows backfill themselves after deploy; no migration needed.
- `payments.getUserEmail` (internal query) resolves the row by subject; `createMandateSetup` uses that email instead of `ctx.auth`. With nothing synced yet it fails with an actionable message instead of `Authentication required`.

Nothing else changes: no new runtime coupling, no JWT fallback path.

## Tests

- Calls `mandateSetup` **without any caller identity** (plain `t.action`) — reproduces the exact production breakage; passes via the users-row read.
- Rejects setup with an actionable error when no account email is available.
- Existing suite seeds through `billing.ensureMySubscription`, exercising the sync end to end.

276/276 web tests pass; build/svelte-check/eslint/oxlint/prettier clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves mandate email resolution from action authentication to an email synchronized onto the durable users row.
- Adds an optional users email field and synchronizes it from WorkOS identities.
- Resolves mandate setup email through an internal users query.
- Adds identity-less mandate setup coverage and updates compatibility documentation.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because mandate setup can still fail for legacy users whose email synchronization has not completed or whose one-shot bootstrap failed.

The users-row lookup has no fallback, while the browser starts synchronization asynchronously, swallows failures, and does not retry for that signed-in user; a capability-valid executor mandate request can therefore reach the explicit missing-email rejection.

**Files Needing Attention:** apps/web/src/convex/payments.ts and apps/web/src/routes/+page.svelte
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/auth.ts | Synchronizes the trimmed WorkOS email when creating or updating the canonical users row and returns the updated value. |
| apps/web/src/convex/payments.ts | Replaces action identity lookup with a users-row query for capability-authenticated mandate setup. |
| apps/web/src/convex/payments.test.ts | Covers identity-less mandate setup with a synchronized email and the missing-email rejection path. |
| apps/web/src/convex/schema.ts | Adds an optional email field to users rows while preserving compatibility with existing records. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Convex
    participant Executor
    participant Prava
    Browser->>Convex: ensureMySubscription
    Convex->>Convex: Synchronize identity email onto users row
    Executor->>Convex: mandateSetup with run capability
    Convex->>Convex: Read users.email by subject
    Convex->>Prava: Create approval session with synchronized email
    Prava-->>Executor: Approval URL
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(payments): Resolve the mandate email..."](https://github.com/spikonado/sprocket/commit/d71d11a194aab6577a47c225b2c91604ca2ab0e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56533632)</sub>

<!-- /greptile_comment -->