### PR TITLE
fix(agent): Clean transport noise out of tool call errors

### DIFF
--- a/apps/web/src/convex/_generated/server.d.ts
+++ b/apps/web/src/convex/_generated/server.d.ts
@@ -45,7 +45,8 @@ type Env = {
   readonly FIREWORKS_API_KEY: string | undefined;
   readonly OPENAI_API_KEY: string | undefined;
   readonly OPENROUTER_API_KEY: string | undefined;
-  readonly PRAVA_BACKEND_URL: "https://sandbox.api.prava.space" | "https://api.prava.space";
+  readonly PRAVA_BACKEND_URL:
+    "https://sandbox.api.prava.space" | "https://api.prava.space";
   readonly PRAVA_SECRET_KEY: string | undefined;
   readonly WORKOS_CLIENT_ID: string;
   readonly ZAI_API_KEY: string | undefined;

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -30,7 +30,7 @@ export function isUnparseablePageFailure(error: Error): boolean {
 	return error.message.includes('ReturnsValidationError');
 }
 
-const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and failed to parse as markdown.';
+const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -458,9 +458,40 @@ fn decode_function_result<T: for<'de> Deserialize<'de>>(
                 )
             })
         }
-        FunctionResult::ErrorMessage(message) => Err(anyhow!("{function} failed: {message}")),
-        FunctionResult::ConvexError(error) => Err(anyhow!("{function} failed: {}", error.message)),
+        FunctionResult::ErrorMessage(message) => {
+            Err(anyhow!(clean_function_error_message(&message)))
+        }
+        FunctionResult::ConvexError(error) => {
+            Err(anyhow!(clean_function_error_message(&error.message)))
+        }
     }
+}
+
+/// Strips the transport noise Convex wraps around failed function calls:
+/// production masking lines ("[Request ID ...] Server Error"), `Uncaught`
+/// prefixes, and stack frames. Tool results show only the readable sentence.
+fn clean_function_error_message(raw: &str) -> String {
+    let mut content: Vec<&str> = Vec::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("[Request ID") {
+            continue;
+        }
+        if line.starts_with([' ', '\t']) && trimmed.starts_with("at ") {
+            continue;
+        }
+        let message = trimmed
+            .strip_prefix("Uncaught ConvexError: ")
+            .or_else(|| trimmed.strip_prefix("Uncaught Error: "))
+            .unwrap_or(trimmed);
+        content.push(message);
+    }
+    if content.is_empty() {
+        // Production masking left nothing readable behind; the request id
+        // stays available in the Convex dashboard logs.
+        return "The server failed without a readable error.".to_string();
+    }
+    content.join(" ")
 }
 
 fn convex_value_to_plain_json(value: Value) -> serde_json::Value {
@@ -483,5 +514,43 @@ fn convex_value_to_plain_json(value: Value) -> serde_json::Value {
                 .map(|(key, value)| (key, convex_value_to_plain_json(value)))
                 .collect(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleans_masking_lines_prefixes_and_stack_frames() {
+        let raw = "[Request ID: 84f5068c0836218d] Server Error\nUncaught ConvexError: The webpage is too complex and could not be parsed as Markdown.\n    at handler (../src/convex/webTools.ts:130:2)";
+        assert_eq!(
+            clean_function_error_message(raw),
+            "The webpage is too complex and could not be parsed as Markdown."
+        );
+    }
+
+    #[test]
+    fn keeps_plain_messages_untouched() {
+        assert_eq!(
+            clean_function_error_message("Mandate not found."),
+            "Mandate not found."
+        );
+    }
+
+    #[test]
+    fn strips_uncaught_error_prefixes() {
+        assert_eq!(
+            clean_function_error_message("Uncaught Error: Prava request failed (500): boom"),
+            "Prava request failed (500): boom"
+        );
+    }
+
+    #[test]
+    fn falls_back_when_production_masks_the_whole_error() {
+        assert_eq!(
+            clean_function_error_message("[Request ID: 0d45611fde71c0f2] Server Error"),
+            "The server failed without a readable error."
+        );
     }
 }


### PR DESCRIPTION
Stacked on #209. Follow-up to the scrape failure reported after that change, where the agent still saw:

```
webTools:scrapeUrl failed: [Request ID: 84f5068c0836218d] Server Error
Uncaught ConvexError: The webpage is too complex and failed to parse as markdown.
    at handler (../src/convex/webTools.ts:130:2)
```

The friendly sentence was in there, but so was everything the transport wraps around function failures: the masked production line, the `Uncaught ConvexError:` prefix, a stack frame, and the `{function} failed:` prefix our decoder prepends.

## Changes

- `sprocket-agent/convex.rs`: sanitize messages in `decode_function_result` before they become tool errors. Drops `[Request ID ...] Server Error` masking lines, stack frames, and `Uncaught ConvexError:/Uncaught Error:` prefixes, then drops the `{function} failed:` prefix entirely. When production masking leaves nothing readable (a plain `[Request ID] Server Error`), the message falls back to "The server failed without a readable error." instead of showing garbage.
- Applies to every tool at once, since all cloud tool calls decode through this one path. Completion retry classification is untouched; it lives in the provider crate and matches sentinel substrings that survive sanitizing.
- The scrape failure now reads exactly: "The webpage is too complex and could not be parsed as Markdown."

## Checks

- cargo test -p sprocket-agent: 45 passed, including 4 new sanitizer tests
- vitest, prek run -a clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes cleanup of Convex function-error text before errors reach the agent and updates the scrape failure to use a concise user-facing sentence.
- Removes request masking lines, stack frames, and supported `Uncaught` prefixes from decoded Convex errors.
- Provides a readable fallback when production masking leaves no useful message.
- Adds focused sanitizer tests and updates the unparseable-page wording.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security defects identified.

The shared decoder preserves readable error content while removing the transport wrappers targeted by the change, and the added tests cover the intended masking, prefix, stack-frame, plain-message, and fallback behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/convex.rs | Adds centralized Convex error sanitization and focused unit coverage without leaving a concrete blocking failure. |
| apps/web/src/convex/webTools.ts | Revises the unparseable-page error to the exact concise wording expected after transport cleanup. |
| apps/web/src/convex/_generated/server.d.ts | Contains only a formatting change to the generated environment type declaration. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Convex function failure] --> B[decode_function_result]
    B --> C[Remove transport noise]
    C --> D{Readable content remains?}
    D -->|Yes| E[Return cleaned tool error]
    D -->|No| F[Return readable fallback]
    E --> G[Agent]
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Clean transport noise out of..."](https://github.com/spikonado/sprocket/commit/fa3078df0a456f4e1d8fcff14d19407aeed60906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56537446)</sub>

<!-- /greptile_comment -->