### PR TITLE
fix(workspace): Allow browsing other Windows drives from the project picker

### DIFF
--- a/apps/web/src/lib/components/home/project-picker.svelte
+++ b/apps/web/src/lib/components/home/project-picker.svelte
@@ -2,10 +2,11 @@
 	import { CornerLeftUp, Folder, FolderPlus, LoaderCircle } from '@lucide/svelte';
 	import type { DesktopApi, FilesystemBrowseEntry } from '$lib/types/sprocket';
 	import {
-		appendBrowsePathSegment,
 		getBrowseLeafPathSegment,
 		isFilesystemBrowseQuery,
+		isWindowsVolumeListQuery,
 		resolveWorkspacePathFromBrowse,
+		withTrailingPathSeparator,
 		workspacePathRequiresCreation
 	} from '$lib/workspace/paths';
 
@@ -43,6 +44,7 @@
 	let query = $state('~/');
 	let browseEntries = $state<FilesystemBrowseEntry[]>([]);
 	let browseParentPath = $state('');
+	let volumeList = $state(false);
 	let highlightedPath = $state<string | null>(null);
 	let isLoadingBrowse = $state(false);
 	let isSubmitting = $state(false);
@@ -52,12 +54,29 @@
 
 	const browseFilterQuery = $derived(getBrowseLeafPathSegment(query).toLowerCase());
 	const filteredEntries = $derived.by(() => {
+		if (volumeList) {
+			const needle = query
+				.trim()
+				.replace(/^[\\/]+/, '')
+				.toLowerCase();
+			return browseEntries.filter(
+				(entry) =>
+					entry.name.toLowerCase().startsWith(needle) ||
+					entry.fullPath.toLowerCase().startsWith(needle)
+			);
+		}
+
 		const showHidden = browseFilterQuery.startsWith('.');
-		return browseEntries.filter(
-			(entry) =>
+		return browseEntries.filter((entry) => {
+			if (entry.name === '..') {
+				return browseFilterQuery.length === 0;
+			}
+
+			return (
 				entry.name.toLowerCase().startsWith(browseFilterQuery) &&
 				(showHidden || !entry.name.startsWith('.'))
-		);
+			);
+		});
 	});
 	const selectedPath = $derived(query.trim());
 	const resolvedWorkspacePath = $derived(
@@ -75,7 +94,8 @@
 		})
 	);
 	const canSubmit = $derived(
-		resolvedWorkspacePath.length > 0 &&
+		!volumeList &&
+			resolvedWorkspacePath.length > 0 &&
 			(isFilesystemBrowseQuery(selectedPath) || browseParentPath.length > 0)
 	);
 	const submitLabel = $derived(
@@ -101,15 +121,17 @@
 	const emptyListMessage = $derived(
 		isLoadingBrowse
 			? 'Loading directories…'
-			: resolvedWorkspacePath.length > 0 && !willCreateDirectory
-				? mode === 'reconnect'
-					? 'Press Enter to reconnect this directory.'
-					: 'Press Enter to add this directory.'
-				: willCreateDirectory
+			: volumeList
+				? 'Select a drive.'
+				: resolvedWorkspacePath.length > 0 && !willCreateDirectory
 					? mode === 'reconnect'
-						? 'Press Enter to create and reconnect this directory.'
-						: 'Press Enter to create and add this directory.'
-					: 'No matching directories in this path.'
+						? 'Press Enter to reconnect this directory.'
+						: 'Press Enter to add this directory.'
+					: willCreateDirectory
+						? mode === 'reconnect'
+							? 'Press Enter to create and reconnect this directory.'
+							: 'Press Enter to create and add this directory.'
+						: 'No matching directories in this path.'
 	);
 
 	$effect(() => {
@@ -126,6 +148,7 @@
 		query = '~/';
 		highlightedPath = null;
 		errorMessage = null;
+		volumeList = false;
 		void loadBrowse(query);
 	});
 
@@ -136,6 +159,10 @@
 
 		const nextQuery = query;
 		const timeout = window.setTimeout(() => {
+			if (volumeList && isWindowsVolumeListQuery(nextQuery)) {
+				return;
+			}
+
 			void loadBrowse(nextQuery);
 		}, 180);
 
@@ -159,6 +186,7 @@
 
 			browseParentPath = result.parentPath;
 			browseEntries = result.entries;
+			volumeList = result.volumeList === true;
 			errorMessage = null;
 		} catch (error) {
 			if (requestId !== browseRequestId) {
@@ -174,27 +202,20 @@
 	}
 
 	function selectEntry(entry: FilesystemBrowseEntry) {
-		if (entry.name === '..') {
-			query = `${entry.fullPath}/`;
-			highlightedPath = entry.fullPath;
-			return;
-		}
-
-		query = appendBrowsePathSegment(
-			browseParentPath.endsWith('/') || browseParentPath.endsWith('\\')
-				? browseParentPath
-				: `${browseParentPath}/`,
-			entry.name
-		);
+		query = withTrailingPathSeparator(entry.fullPath);
 		highlightedPath = entry.fullPath;
 	}
 
 	function selectRecentProjectPath(recent: RecentProjectPath) {
-		query = `${recent.workspacePath}/`;
+		query = withTrailingPathSeparator(recent.workspacePath);
 		highlightedPath = recent.workspacePath;
 	}
 
 	async function confirmSelection() {
+		if (volumeList) {
+			return;
+		}
+
 		const workspacePath = resolvedWorkspacePath;
 		if (!workspacePath) {
 			errorMessage = 'Enter a project directory path.';

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -28,7 +28,8 @@ const localBootstrapSchema = z.object({
 });
 const filesystemBrowseResultSchema = z.object({
 	parentPath: z.string(),
-	entries: z.array(z.object({ name: z.string(), fullPath: z.string() }))
+	entries: z.array(z.object({ name: z.string(), fullPath: z.string() })),
+	volumeList: z.boolean().optional()
 });
 const workspaceSkillsResultSchema = z.object({
 	skills: z.array(z.object({ name: z.string(), description: z.string() })),

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -203,6 +203,7 @@ export type FilesystemBrowseEntry = {
 export type FilesystemBrowseResult = {
 	parentPath: string;
 	entries: FilesystemBrowseEntry[];
+	volumeList?: boolean;
 };
 
 export type SkillSummary = {

--- a/apps/web/src/lib/workspace/paths.test.ts
+++ b/apps/web/src/lib/workspace/paths.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
-	appendBrowsePathSegment,
 	getBrowseLeafPathSegment,
 	isFilesystemBrowseQuery,
+	isWindowsVolumeListQuery,
 	resolveWorkspacePathFromBrowse,
+	withTrailingPathSeparator,
 	workspacePathRequiresCreation
 } from '$lib/workspace/paths';
 
@@ -11,6 +12,9 @@ describe('workspace paths', () => {
 	it('detects filesystem browse queries', () => {
 		expect(isFilesystemBrowseQuery('~/projects')).toBe(true);
 		expect(isFilesystemBrowseQuery('C:\\dev')).toBe(true);
+		expect(isFilesystemBrowseQuery('D:')).toBe(true);
+		expect(isFilesystemBrowseQuery('\\\\server\\share')).toBe(true);
+		expect(isFilesystemBrowseQuery('\\')).toBe(true);
 		expect(isFilesystemBrowseQuery('my-project')).toBe(false);
 	});
 
@@ -19,8 +23,22 @@ describe('workspace paths', () => {
 		expect(getBrowseLeafPathSegment('~/projects/demo')).toBe('demo');
 	});
 
-	it('appends browse segments with separators', () => {
-		expect(appendBrowsePathSegment('~/projects/', 'demo')).toBe('~/projects/demo/');
+	it('adds a trailing separator without rewriting drive roots', () => {
+		expect(withTrailingPathSeparator('/home/me/robot')).toBe('/home/me/robot/');
+		expect(withTrailingPathSeparator('D:\\code')).toBe('D:\\code\\');
+		expect(withTrailingPathSeparator('D:')).toBe('D:\\');
+		expect(withTrailingPathSeparator('D:\\')).toBe('D:\\');
+		expect(withTrailingPathSeparator('/')).toBe('/');
+	});
+
+	it('keeps Windows drive-list queries from being treated as concrete paths', () => {
+		expect(isWindowsVolumeListQuery('\\')).toBe(true);
+		expect(isWindowsVolumeListQuery('/')).toBe(true);
+		expect(isWindowsVolumeListQuery('D')).toBe(true);
+		expect(isWindowsVolumeListQuery('D:')).toBe(true);
+		expect(isWindowsVolumeListQuery('\\D')).toBe(true);
+		expect(isWindowsVolumeListQuery('D:\\code')).toBe(false);
+		expect(isWindowsVolumeListQuery('\\\\server\\share')).toBe(false);
 	});
 
 	it('resolves a typed directory path when browse is inside that directory', () => {

--- a/apps/web/src/lib/workspace/paths.ts
+++ b/apps/web/src/lib/workspace/paths.ts
@@ -5,9 +5,10 @@ export function isFilesystemBrowseQuery(value: string): boolean {
 		value.startsWith('.\\') ||
 		value.startsWith('..\\') ||
 		value.startsWith('/') ||
+		value.startsWith('\\') ||
 		value.startsWith('~/') ||
 		value === '~' ||
-		/^[a-zA-Z]:[\\/]/.test(value)
+		/^[a-zA-Z]:([\\/]|$)/.test(value)
 	);
 }
 
@@ -32,10 +33,27 @@ export function getBrowseLeafPathSegment(currentPath: string): string {
 	return currentPath.slice(directoryPath.length);
 }
 
-export function appendBrowsePathSegment(currentPath: string, segment: string): string {
-	const separator = currentPath.includes('\\') ? '\\' : '/';
-	const directoryPath = getBrowseDirectoryPath(currentPath);
-	return `${directoryPath}${segment}${separator}`;
+export function withTrailingPathSeparator(path: string): string {
+	if (!path || hasTrailingPathSeparator(path)) {
+		return path;
+	}
+
+	return `${path}${pathSeparator(path)}`;
+}
+
+/** True while the Windows drive list should keep filtering locally instead of browsing. */
+export function isWindowsVolumeListQuery(value: string): boolean {
+	const trimmed = value.trim();
+	return (
+		trimmed === '/' ||
+		trimmed === '\\' ||
+		/^[a-zA-Z]:?$/.test(trimmed) ||
+		/^[\\/][a-zA-Z]:?$/.test(trimmed)
+	);
+}
+
+function pathSeparator(path: string): string {
+	return path.includes('\\') || /^[a-zA-Z]:$/.test(path) ? '\\' : '/';
 }
 
 function hasTrailingPathSeparator(value: string): boolean {

--- a/crates/sprocket-workspace/src/browse.rs
+++ b/crates/sprocket-workspace/src/browse.rs
@@ -15,33 +15,34 @@ pub struct FilesystemBrowseEntry {
 pub struct FilesystemBrowseResult {
     pub parent_path: String,
     pub entries: Vec<FilesystemBrowseEntry>,
+    #[serde(default)]
+    pub volume_list: bool,
 }
 
 pub fn browse_filesystem(partial_path: &str, cwd: Option<&str>) -> Result<FilesystemBrowseResult> {
+    #[cfg(windows)]
+    if is_windows_volume_list_query(partial_path.trim()) {
+        return list_windows_volumes();
+    }
+
     let directory = resolve_browse_directory(partial_path, cwd)?;
-    let parent_path = directory.to_string_lossy().to_string();
+    let parent_path = display_path(&directory);
     let mut entries = list_directory_entries(&directory)?;
 
-    if let Some(parent) = directory.parent() {
-        if parent != directory {
-            entries.insert(
-                0,
-                FilesystemBrowseEntry {
-                    name: "..".to_string(),
-                    full_path: parent.to_string_lossy().to_string(),
-                },
-            );
-        }
+    if let Some(parent_entry) = parent_browse_entry(&directory) {
+        entries.insert(0, parent_entry);
     }
 
     Ok(FilesystemBrowseResult {
         parent_path,
         entries,
+        volume_list: false,
     })
 }
 
 pub fn resolve_or_create_workspace_root(path: &str) -> Result<PathBuf> {
-    let expanded = crate::paths::expand_home(path.trim());
+    let expanded =
+        crate::paths::expand_home(&crate::paths::normalize_windows_drive_root(path.trim()));
     let candidate = PathBuf::from(&expanded);
 
     if candidate.exists() {
@@ -54,15 +55,15 @@ pub fn resolve_or_create_workspace_root(path: &str) -> Result<PathBuf> {
 }
 
 fn resolve_browse_directory(partial_path: &str, cwd: Option<&str>) -> Result<PathBuf> {
-    let trimmed = partial_path.trim();
+    let trimmed = crate::paths::normalize_windows_drive_root(partial_path.trim());
     if trimmed.is_empty() {
         return default_browse_directory();
     }
 
-    let expanded = crate::paths::expand_home(trimmed);
+    let expanded = crate::paths::expand_home(&trimmed);
     let mut candidate = PathBuf::from(expanded);
 
-    if is_relative_path(trimmed) {
+    if is_relative_path(&trimmed) {
         let Some(cwd_path) = cwd.map(PathBuf::from) else {
             bail!("relative paths require a current directory");
         };
@@ -111,35 +112,90 @@ fn resolve_browse_directory(partial_path: &str, cwd: Option<&str>) -> Result<Pat
 }
 
 fn list_directory_entries(directory: &Path) -> Result<Vec<FilesystemBrowseEntry>> {
-    let mut entries = Vec::new();
-
-    for entry in std::fs::read_dir(directory)
+    let mut entries: Vec<_> = std::fs::read_dir(directory)
         .with_context(|| format!("failed to read directory {}", directory.display()))?
-    {
-        let entry =
-            entry.with_context(|| format!("failed to read entry in {}", directory.display()))?;
-        let file_type = entry
-            .file_type()
-            .with_context(|| format!("failed to read type for {}", entry.path().display()))?;
-
-        if !file_type.is_dir() {
-            continue;
-        }
-
-        let canonical = entry
-            .path()
-            .canonicalize()
-            .with_context(|| format!("failed to resolve {}", entry.path().display()))?;
-        let name = entry.file_name().to_string_lossy().to_string();
-
-        entries.push(FilesystemBrowseEntry {
-            name,
-            full_path: canonical.to_string_lossy().to_string(),
-        });
-    }
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            if !file_type.is_dir() && !file_type.is_symlink() {
+                return None;
+            }
+            let canonical = entry.path().canonicalize().ok()?;
+            if !canonical.is_dir() {
+                return None;
+            }
+            Some(FilesystemBrowseEntry {
+                name: entry.file_name().to_string_lossy().into_owned(),
+                full_path: display_path(&canonical),
+            })
+        })
+        .collect();
 
     entries.sort_by(|left, right| left.name.to_lowercase().cmp(&right.name.to_lowercase()));
     Ok(entries)
+}
+
+fn parent_browse_entry(directory: &Path) -> Option<FilesystemBrowseEntry> {
+    let full_path = match directory.parent() {
+        Some(parent) if parent != directory => display_path(parent),
+        #[cfg(windows)]
+        _ => "\\".to_string(),
+        #[cfg(not(windows))]
+        _ => return None,
+    };
+
+    Some(FilesystemBrowseEntry {
+        name: "..".to_string(),
+        full_path,
+    })
+}
+
+fn display_path(path: &Path) -> String {
+    crate::paths::simplified_path(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(any(windows, test))]
+fn is_windows_volume_list_query(path: &str) -> bool {
+    path == "/" || path == "\\"
+}
+
+#[cfg(any(windows, test))]
+fn drive_letters_from_mask(mask: u32) -> Vec<char> {
+    (b'A'..=b'Z')
+        .enumerate()
+        .filter(|(index, _)| mask & (1 << *index) != 0)
+        .map(|(_, letter)| char::from(letter))
+        .collect()
+}
+
+#[cfg(windows)]
+fn list_windows_volumes() -> Result<FilesystemBrowseResult> {
+    let entries = drive_letters_from_mask(logical_drive_mask())
+        .into_iter()
+        .map(|letter| FilesystemBrowseEntry {
+            name: format!("{letter}:\\"),
+            full_path: format!("{letter}:\\"),
+        })
+        .collect();
+
+    Ok(FilesystemBrowseResult {
+        parent_path: "\\".to_string(),
+        entries,
+        volume_list: true,
+    })
+}
+
+#[cfg(windows)]
+fn logical_drive_mask() -> u32 {
+    // SAFETY: GetLogicalDrives is a parameterless Win32 query.
+    unsafe { GetLogicalDrives() }
+}
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn GetLogicalDrives() -> u32;
 }
 
 fn default_browse_directory() -> Result<PathBuf> {
@@ -237,5 +293,49 @@ mod tests {
         assert_eq!(result.parent_path, root.to_string_lossy());
 
         fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn listing_succeeds_when_a_child_cannot_be_resolved() {
+        let root = temp_dir("sprocket-browse-mixed");
+        fs::create_dir(root.join("visible")).expect("visible dir");
+        fs::write(root.join("notes.txt"), "hi").expect("file");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("missing", root.join("broken")).expect("dangling symlink");
+
+        let result = browse_filesystem(&root.to_string_lossy(), None).expect("browse");
+        let names: Vec<&str> = result
+            .entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect();
+
+        assert!(names.contains(&"visible"));
+        assert!(!names.contains(&"notes.txt"));
+        #[cfg(unix)]
+        assert!(!names.contains(&"broken"));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn filesystem_root_can_be_browsed() {
+        let result = browse_filesystem("/", None).expect("browse root");
+        assert!(!result.entries.is_empty());
+        assert!(!result.entries.iter().any(|entry| entry.name == ".."));
+    }
+
+    #[test]
+    fn parses_windows_logical_drive_mask() {
+        assert_eq!(drive_letters_from_mask(0b1101), vec!['A', 'C', 'D']);
+    }
+
+    #[test]
+    fn detects_windows_volume_list_query() {
+        assert!(is_windows_volume_list_query("/"));
+        assert!(is_windows_volume_list_query("\\"));
+        assert!(!is_windows_volume_list_query("//server/share"));
+        assert!(!is_windows_volume_list_query(r"D:\"));
     }
 }

--- a/crates/sprocket-workspace/src/paths.rs
+++ b/crates/sprocket-workspace/src/paths.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn expand_home(path: &str) -> String {
     if path == "~" {
@@ -26,4 +26,62 @@ pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+pub fn normalize_windows_drive_root(path: &str) -> String {
+    let bytes = path.as_bytes();
+    if bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        format!("{path}\\")
+    } else {
+        path.to_string()
+    }
+}
+
+/// Strips Windows `\\?\` drive and UNC prefixes so paths are usable in the UI.
+pub fn simplified_path(path: impl AsRef<Path>) -> PathBuf {
+    PathBuf::from(simplified_path_str(&path.as_ref().to_string_lossy()))
+}
+
+fn simplified_path_str(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        if rest.len() >= 2 && rest.as_bytes()[0].is_ascii_alphabetic() && rest.as_bytes()[1] == b':'
+        {
+            rest.to_string()
+        } else {
+            path.to_string()
+        }
+    } else {
+        path.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simplified_path_strips_windows_verbatim_prefixes() {
+        assert_eq!(
+            simplified_path_str(r"\\?\D:\projects\robot"),
+            r"D:\projects\robot"
+        );
+        assert_eq!(
+            simplified_path_str(r"\\?\UNC\server\share\dir"),
+            r"\\server\share\dir"
+        );
+        assert_eq!(
+            simplified_path_str(r"\\?\Volume{abcd}\foo"),
+            r"\\?\Volume{abcd}\foo"
+        );
+        assert_eq!(simplified_path_str("/home/me/robot"), "/home/me/robot");
+    }
+
+    #[test]
+    fn normalize_windows_drive_root_appends_slash() {
+        assert_eq!(normalize_windows_drive_root("D:"), r"D:\");
+        assert_eq!(normalize_windows_drive_root(r"D:\code"), r"D:\code");
+        assert_eq!(normalize_windows_drive_root("/home/me"), "/home/me");
+    }
 }

--- a/crates/sprocket-workspace/src/workspace.rs
+++ b/crates/sprocket-workspace/src/workspace.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 pub fn resolve_workspace_root(path: &str) -> Result<PathBuf> {
-    let expanded = crate::paths::expand_home(path.trim());
+    let expanded =
+        crate::paths::expand_home(&crate::paths::normalize_windows_drive_root(path.trim()));
     let root: PathBuf = PathBuf::from(&expanded);
     if !root.exists() {
         bail!("workspace does not exist: {path}");
@@ -16,5 +17,5 @@ pub fn resolve_workspace_root(path: &str) -> Result<PathBuf> {
         bail!("workspace is not a directory: {}", canonical.display());
     }
 
-    Ok(canonical)
+    Ok(crate::paths::simplified_path(canonical))
 }


### PR DESCRIPTION
## Summary
- On Windows, `/` and `\` in the project picker list logical drives instead of trapping the user on the current volume
- Drive roots like `D:` resolve as drive roots, and canonical paths drop the `\\?\` prefix so they stay usable in the UI

## Test plan
- [ ] On Windows, go up from a drive root in the project picker and confirm other drives are listed
- [ ] Select another drive, browse into a folder, and add it as a project
- [ ] Type a drive letter to filter the list, then a path like `D:\code` to browse that drive
- [ ] On macOS/Linux, `/` still browses the filesystem root and does not show a `..` entry
- [ ] A directory that contains files or a broken symlink still lists the remaining folders


Made with [Cursor](https://cursor.com)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the project picker to browse logical Windows drives while preserving normal filesystem-root behavior on macOS and Linux.
- Adds Windows volume enumeration and drive-root normalization to the workspace service.
- Extends the browse-result contract with volume-list state and updates the picker to filter and select drives.
- Converts canonical Windows drive and UNC paths into UI-friendly forms while preserving volume GUID paths.
- Makes directory listing tolerate unreadable entries, files, and broken symlinks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/project-picker.svelte | Adds drive-list state, local drive filtering, separator-aware selection, and submission guards while browsing volumes. |
| apps/web/src/lib/workspace/paths.ts | Adds recognition of Windows volume-list queries, bare drive roots, and platform-appropriate trailing separators. |
| crates/sprocket-workspace/src/browse.rs | Adds Windows logical-drive enumeration, root-to-volume-list navigation, display-path simplification, and resilient directory entry handling. |
| crates/sprocket-workspace/src/paths.rs | Adds bare-drive normalization and UI-friendly simplification for canonical Windows drive and UNC paths while retaining volume GUID prefixes. |
| crates/sprocket-workspace/src/workspace.rs | Normalizes bare drive roots and returns the intended UI-usable spelling of canonical workspace paths. |
| apps/web/src/lib/local/client.ts | Extends runtime validation of browse responses with the optional volume-list indicator. |
| apps/web/src/lib/types/sprocket.ts | Extends the shared filesystem browse result type with optional volume-list state. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[Project picker query] --> B[Filesystem browse API]
    B -->|Windows root query| V[List logical drives]
    B -->|Directory query| D[List child directories]
    V --> P[Picker filters drive entries]
    D --> P
    P --> S[Selected workspace path]
    S --> R[Normalize and resolve workspace root]
    R --> A[Persist project attachment]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(workspace): Allow browsing other Win..."](https://github.com/spikonado/sprocket/commit/f88334529cc2bbd0302a9bd58f49122dcd135281) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57873248)</sub>

<!-- /greptile_comment -->