### PR TITLE
fix(migrations): Page transcript replica verification past the Convex read limit

### DIFF
--- a/apps/web/src/convex/lib/transcriptMigrate.ts
+++ b/apps/web/src/convex/lib/transcriptMigrate.ts
@@ -10,6 +10,39 @@ import {
 	promptSourceKey
 } from '@convex/lib/transcriptParts';
 
+export const TRANSCRIPT_NUMBERING_VERIFY_BATCH = 64;
+
+const VERIFY_READ_RESERVE_DOCS = 64;
+const VERIFY_READ_RESERVE_BYTES = 256 * 1024;
+const VERIFY_QUERY_RESERVE = 8;
+
+export type TranscriptNumberingResult =
+	{ status: 'complete' } | { status: 'continue'; nextNumber: number } | { status: 'incomplete' };
+
+export function isReadBudgetError(error: Error): boolean {
+	return /too many .{0,40}read/i.test(error.message);
+}
+
+async function markTranscriptMigrated(
+	ctx: MutationCtx,
+	stateId: Id<'threadTranscriptStates'>
+): Promise<void> {
+	await ctx.db.patch('threadTranscriptStates', stateId, { migratedAt: Date.now() });
+}
+
+async function isTransactionNearLimit(ctx: MutationCtx): Promise<boolean> {
+	try {
+		const metrics = await ctx.meta.getTransactionMetrics();
+		return (
+			metrics.documentsRead.remaining < VERIFY_READ_RESERVE_DOCS ||
+			metrics.bytesRead.remaining < VERIFY_READ_RESERVE_BYTES ||
+			metrics.databaseQueries.remaining < VERIFY_QUERY_RESERVE
+		);
+	} catch {
+		return false;
+	}
+}
+
 export async function ensureThreadTranscriptMigrated(
 	ctx: MutationCtx,
 	args: { threadId: Id<'threadRecords'>; userId: string }
@@ -87,25 +120,52 @@ export async function migrateLegacyRunTranscript(
 export async function verifyThreadTranscriptNumbering(
 	ctx: MutationCtx,
 	threadId: Id<'threadRecords'>,
-	userId: string
-): Promise<boolean> {
-	const state = await getOrCreateTranscriptState(ctx, { threadId, userId });
-	if (state.migratedAt !== undefined) {
-		return true;
-	}
-	for (let number = 0; number < state.totalParts; number += 1) {
-		const part = await ctx.db
+	userId: string,
+	fromNumber = 0
+): Promise<TranscriptNumberingResult> {
+	const start = Number.isInteger(fromNumber) && fromNumber > 0 ? fromNumber : 0;
+	let expected = start;
+	try {
+		const state = await getOrCreateTranscriptState(ctx, { threadId, userId });
+		if (state.migratedAt !== undefined) {
+			return { status: 'complete' };
+		}
+		if (start >= state.totalParts) {
+			await markTranscriptMigrated(ctx, state._id);
+			return { status: 'complete' };
+		}
+		if (await isTransactionNearLimit(ctx)) {
+			return { status: 'continue', nextNumber: start };
+		}
+
+		const parts = ctx.db
 			.query('threadTranscriptParts')
 			.withIndex('by_threadId_and_number', (query) =>
-				query.eq('threadId', threadId).eq('number', number)
-			)
-			.unique();
-		if (!part) {
-			return false;
+				query.eq('threadId', threadId).gte('number', start).lt('number', state.totalParts)
+			);
+		for await (const part of parts) {
+			if (part.number !== expected) {
+				return { status: 'incomplete' };
+			}
+			expected += 1;
+			if (expected >= state.totalParts) {
+				await markTranscriptMigrated(ctx, state._id);
+				return { status: 'complete' };
+			}
+			if (
+				expected - start >= TRANSCRIPT_NUMBERING_VERIFY_BATCH ||
+				(await isTransactionNearLimit(ctx))
+			) {
+				return { status: 'continue', nextNumber: expected };
+			}
 		}
+		return { status: 'incomplete' };
+	} catch (error) {
+		if (error instanceof Error && isReadBudgetError(error)) {
+			return { status: 'continue', nextNumber: expected };
+		}
+		throw error;
 	}
-	await ctx.db.patch('threadTranscriptStates', state._id, { migratedAt: Date.now() });
-	return true;
 }
 
 export async function migrateLegacyThreadTranscript(

--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -1,6 +1,56 @@
 import { describe, expect, it } from 'vitest';
 import { internal } from '@convex/_generated/api';
-import { initConvexTest, seedOwnedThread } from './test.setup';
+import type { Id } from '@convex/_generated/dataModel';
+import {
+	TRANSCRIPT_NUMBERING_VERIFY_BATCH,
+	verifyThreadTranscriptNumbering
+} from '@convex/lib/transcriptMigrate';
+import { getTranscriptState } from '@convex/lib/transcriptParts';
+import { initConvexTest, seedOwnedThread, type ConvexTestInstance } from './test.setup';
+
+async function seedUnmigratedTranscript(
+	t: ConvexTestInstance,
+	args: {
+		threadId: Id<'threadRecords'>;
+		userId: string;
+		totalParts: number;
+		submissionId: string;
+		numbers?: number[];
+	}
+) {
+	const numbers = args.numbers ?? Array.from({ length: args.totalParts }, (_, number) => number);
+	await t.run(async (ctx) => {
+		const runId = await ctx.db.insert('runs', {
+			threadId: args.threadId,
+			userId: args.userId,
+			submissionId: args.submissionId,
+			status: 'completed',
+			executionSecretHash: 'hash',
+			completionAttemptSeq: 0,
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard',
+			startedAt: 1,
+			completedAt: 2
+		});
+		await ctx.db.insert('threadTranscriptStates', {
+			threadId: args.threadId,
+			userId: args.userId,
+			totalParts: args.totalParts
+		});
+		for (const number of numbers) {
+			await ctx.db.insert('threadTranscriptParts', {
+				threadId: args.threadId,
+				userId: args.userId,
+				number,
+				sourceKey: `part:${number}`,
+				kind: 'prompt',
+				runId,
+				prompt: { text: `p${number}`, imageUploads: [] }
+			});
+		}
+	});
+}
 
 describe('retired model migrations', () => {
 	it('rewrites retired thread and run model ids', async () => {
@@ -138,5 +188,45 @@ describe('projectId rewrite', () => {
 		const thread = await t.run(async (ctx) => ctx.db.get('threadRecords', threadId));
 		expect(thread?.repositoryKey).toBeUndefined();
 		expect(thread?.projectId).toBe(projectId);
+	});
+});
+
+describe('transcript numbering verification', () => {
+	it('pages past the per-transaction part cap and still sets migratedAt', async () => {
+		const t = initConvexTest();
+		const { subject, threadId } = await seedOwnedThread(t);
+		const totalParts = TRANSCRIPT_NUMBERING_VERIFY_BATCH + 8;
+		await seedUnmigratedTranscript(t, {
+			threadId,
+			userId: subject,
+			totalParts,
+			submissionId: 'verify-many-parts'
+		});
+
+		await t.mutation(internal.migrations.verifyThreadTranscriptReplicas, {});
+		await t.finishAllScheduledFunctions(() => {});
+
+		const state = await t.run(async (ctx) => getTranscriptState(ctx, threadId));
+		expect(state?.migratedAt).toEqual(expect.any(Number));
+		expect(state?.totalParts).toBe(totalParts);
+	});
+
+	it('does not mark a gapped transcript as migrated', async () => {
+		const t = initConvexTest();
+		const { subject, threadId } = await seedOwnedThread(t);
+		await seedUnmigratedTranscript(t, {
+			threadId,
+			userId: subject,
+			totalParts: 3,
+			numbers: [0, 2],
+			submissionId: 'verify-gap'
+		});
+
+		await expect(
+			t.run(async (ctx) => verifyThreadTranscriptNumbering(ctx, threadId, subject))
+		).resolves.toEqual({ status: 'incomplete' });
+
+		const state = await t.run(async (ctx) => getTranscriptState(ctx, threadId));
+		expect(state?.migratedAt).toBeUndefined();
 	});
 });

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -1,9 +1,12 @@
 import { Migrations } from '@convex-dev/migrations';
+import { v } from 'convex/values';
 import { components, internal } from '@convex/_generated/api';
-import { internalMutation } from '@convex/_generated/server';
+import type { Id } from '@convex/_generated/dataModel';
+import { internalMutation, type MutationCtx } from '@convex/_generated/server';
 import schema from '@convex/schema';
 import { coercePersistedSelection, retiredModelIds } from '@convex/lib/models';
 import {
+	isReadBudgetError,
 	migrateLegacyRunTranscript,
 	verifyThreadTranscriptNumbering
 } from '@convex/lib/transcriptMigrate';
@@ -20,6 +23,31 @@ export const run = migrations.runner();
 
 function isTransientMigrationError(error: Error): boolean {
 	return /conflict|optimistic|try again|too much contention/i.test(error.message);
+}
+
+const TRANSCRIPT_NUMBERING_INCOMPLETE = 'Transcript numbering incomplete';
+
+async function verifyTranscriptNumberingOrContinue(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>,
+	userId: string,
+	fromNumber = 0
+): Promise<void> {
+	const result = await verifyThreadTranscriptNumbering(ctx, threadId, userId, fromNumber);
+	if (result.status === 'complete') {
+		return;
+	}
+	if (result.status === 'incomplete') {
+		throw new Error(`${TRANSCRIPT_NUMBERING_INCOMPLETE} for thread ${threadId}`);
+	}
+	if (fromNumber > 0 && result.nextNumber <= fromNumber) {
+		throw new Error(`Transcript numbering verify made no progress for thread ${threadId}`);
+	}
+	await ctx.scheduler.runAfter(0, internal.migrations.continueVerifyThreadTranscriptReplicas, {
+		threadId,
+		userId,
+		fromNumber: result.nextNumber
+	});
 }
 
 function rewriteSelection(modelId: string, serviceTier: string) {
@@ -61,19 +89,47 @@ export const migrateLegacyRunTranscriptParts = migrations.define({
 
 export const verifyThreadTranscriptReplicas = migrations.define({
 	table: 'threadRecords',
+	// One function execution verifies many threads; keep this small so part
+	// scans stay under Convex's per-transaction read budget.
+	batchSize: 20,
 	migrateOne: async (ctx, thread) => {
 		try {
-			const complete = await verifyThreadTranscriptNumbering(ctx, thread._id, thread.userId);
-			if (!complete) {
-				throw new Error(`Transcript numbering incomplete for thread ${thread._id}`);
-			}
+			await verifyTranscriptNumberingOrContinue(ctx, thread._id, thread.userId);
 		} catch (error) {
 			if (!(error instanceof Error)) throw error;
-			if (isTransientMigrationError(error) || error.message.includes('numbering incomplete')) {
+			if (
+				isTransientMigrationError(error) ||
+				error.message.includes(TRANSCRIPT_NUMBERING_INCOMPLETE)
+			) {
 				throw error;
+			}
+			if (isReadBudgetError(error)) {
+				await ctx.scheduler.runAfter(
+					0,
+					internal.migrations.continueVerifyThreadTranscriptReplicas,
+					{
+						threadId: thread._id,
+						userId: thread.userId,
+						fromNumber: 0
+					}
+				);
+				return;
 			}
 			console.error(`Skipping poison transcript thread ${thread._id}:`, error);
 		}
+	}
+});
+
+export const continueVerifyThreadTranscriptReplicas = internalMutation({
+	args: {
+		threadId: v.id('threadRecords'),
+		userId: v.string(),
+		fromNumber: v.number()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		await verifyTranscriptNumberingOrContinue(ctx, args.threadId, args.userId, args.fromNumber);
+		return null;
 	}
 });
 


### PR DESCRIPTION
## Summary
- Transcript numbering verification no longer does one unique() read per part, which skipped long threads as poison after Convex's 4096-read cap
- `verifyThreadTranscriptReplicas` now pages the scan and continues in a fresh transaction via `continueVerifyThreadTranscriptReplicas`

## Test plan
- [ ] Run `apps/web` Convex tests (`migrations.test.ts`, `transcript.test.ts`, `components.test.ts`)
- [ ] After deploy, reset the pass so already-skipped threads are revisited: `npx convex run migrations:verifyThreadTranscriptReplicas '{"reset": true}'`
- [ ] Confirm a previously poison-skipped long thread gets `threadTranscriptStates.migratedAt` and is not logged as poison
- [ ] Confirm the 10-minute `runSeries` cron still completes the other migration passes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces per-part transcript verification reads with bounded indexed scans that continue in fresh Convex transactions.
- Adds transaction-metric reserves and read-budget handling.
- Schedules verification continuations with numeric cursors.
- Adds coverage for paged verification and gapped transcripts.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The verifier advances through bounded indexed batches, persists completion only after finding every expected number, and schedules fresh transactions when more work remains; current transcript writers are append-only and serialize numbering through shared state.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/transcriptMigrate.ts | Replaces one lookup per transcript part with bounded indexed iteration, transaction-budget checks, and resumable result states. |
| apps/web/src/convex/migrations.ts | Adds continuation scheduling for paged verification and reduces migration batch size to preserve transaction capacity. |
| apps/web/src/convex/migrations.test.ts | Adds regression coverage for transcripts exceeding one verification batch and for missing part numbers. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Migration
    participant Verifier
    participant Scheduler
    participant State as Transcript State

    Migration->>Verifier: Verify from part 0
    Verifier->>State: Read state and indexed part batch
    alt Numbering is incomplete
        Verifier-->>Migration: incomplete
        Migration-->>Migration: Raise migration error
    else More parts remain
        Verifier-->>Migration: continue(nextNumber)
        Migration->>Scheduler: Schedule continuation
        Scheduler->>Verifier: Verify from nextNumber
    else All expected parts exist
        Verifier->>State: Set migratedAt
        Verifier-->>Migration: complete
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): Page transcript replica..."](https://github.com/spikonado/sprocket/commit/839fc5737af28c79303b7348af651d2d241793bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58157368)</sub>

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)

<!-- /greptile_comment -->