### PR TITLE
fix(agent-runtime): Page settled tool transcript sweep past the Convex read limit

### DIFF
--- a/apps/web/src/convex/lib/transcriptWrites.ts
+++ b/apps/web/src/convex/lib/transcriptWrites.ts
@@ -11,6 +11,8 @@ import {
 import { isSettledExecutorJobStatus } from '@convex/lib/runs';
 import type { TranscriptCompletionItem, TranscriptToolBody } from '@convex/lib/validators';
 
+const SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE = 32;
+
 export async function recordPromptTranscript(
 	ctx: MutationCtx,
 	args: {
@@ -92,18 +94,6 @@ export async function recordToolTranscript(
 	) {
 		return;
 	}
-	const status: TranscriptToolBody['status'] = args.job.status;
-	const output =
-		args.job.status === 'completed' && args.job.result !== undefined
-			? args.job.result
-			: {
-					error:
-						args.job.error ??
-						(args.job.status === 'cancelled'
-							? 'Executor job cancelled before completion.'
-							: 'Executor job failed.'),
-					status
-				};
 	await ensureThreadTranscriptMigrated(ctx, {
 		threadId: args.threadId,
 		userId: args.userId
@@ -114,14 +104,30 @@ export async function recordToolTranscript(
 		sourceKey: toolSourceKey(args.job._id),
 		kind: 'tool',
 		runId: args.runId,
-		tool: {
-			jobId: args.job._id,
-			callId: args.job.callId ?? `executor-job:${args.job._id}`,
-			name: args.job.kind,
-			output,
-			status
-		}
+		tool: settledToolBody(args.job)
 	});
+}
+
+async function runCompletionContainsToolCall(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>,
+	runId: Id<'runs'>,
+	callId: string
+): Promise<boolean> {
+	const parts = ctx.db
+		.query('threadTranscriptParts')
+		.withIndex('by_threadId_and_runId_and_number', (query) =>
+			query.eq('threadId', threadId).eq('runId', runId)
+		);
+	for await (const part of parts) {
+		if (
+			part.kind === 'completion' &&
+			part.completion?.items.some((item) => item.type === 'tool-call' && item.callId === callId)
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 export async function recordSettledToolTranscripts(
@@ -132,35 +138,108 @@ export async function recordSettledToolTranscripts(
 		runId: Id<'runs'>;
 	}
 ): Promise<void> {
-	const jobs = await ctx.db
-		.query('executorJobs')
-		.withIndex('by_runId_sequence', (query) => query.eq('runId', args.runId))
-		.collect();
-	for (const job of jobs) {
-		await recordToolTranscript(ctx, {
-			threadId: args.threadId,
-			userId: args.userId,
-			runId: args.runId,
-			job
-		});
+	// finalizeCompletionCall runs this after every completion, so the scan must
+	// stay roughly constant in the run's history: page jobs and parts, skip
+	// jobs whose part already exists, and insert the rest from one in-memory
+	// number counter instead of per-job lookups.
+	const state = await ensureThreadTranscriptMigrated(ctx, {
+		threadId: args.threadId,
+		userId: args.userId
+	});
+	let nextNumber = state.totalParts;
+
+	const recordedSourceKeys = new Set<string>();
+	const completedCallIds = new Set<string>();
+	let partsCursor: string | null = null;
+	for (;;) {
+		const page = await ctx.db
+			.query('threadTranscriptParts')
+			.withIndex('by_threadId_and_runId_and_number', (query) =>
+				query.eq('threadId', args.threadId).eq('runId', args.runId)
+			)
+			.paginate({ numItems: SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE, cursor: partsCursor });
+		for (const part of page.page) {
+			recordedSourceKeys.add(part.sourceKey);
+			if (part.kind !== 'completion') {
+				continue;
+			}
+			for (const item of part.completion?.items ?? []) {
+				if (item.type === 'tool-call') {
+					completedCallIds.add(item.callId);
+				}
+			}
+		}
+		if (page.isDone) {
+			break;
+		}
+		partsCursor = page.continueCursor;
+	}
+
+	let afterSequence = -1;
+	for (;;) {
+		const jobs = await ctx.db
+			.query('executorJobs')
+			.withIndex('by_runId_hidden_sequence', (query) =>
+				query.eq('runId', args.runId).eq('hidden', false).gt('sequence', afterSequence)
+			)
+			.take(SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE);
+		for (const job of jobs) {
+			if (!isSettledExecutorJobStatus(job.status)) {
+				continue;
+			}
+			if (job.callId && !completedCallIds.has(job.callId)) {
+				continue;
+			}
+			const sourceKey = toolSourceKey(job._id);
+			if (recordedSourceKeys.has(sourceKey)) {
+				continue;
+			}
+			await ctx.db.insert('threadTranscriptParts', {
+				threadId: args.threadId,
+				userId: args.userId,
+				number: nextNumber,
+				sourceKey,
+				kind: 'tool',
+				runId: args.runId,
+				tool: settledToolBody(job)
+			});
+			recordedSourceKeys.add(sourceKey);
+			nextNumber += 1;
+		}
+		if (jobs.length < SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE) {
+			break;
+		}
+		afterSequence = jobs.at(-1)?.sequence ?? afterSequence;
+	}
+
+	if (nextNumber !== state.totalParts) {
+		await ctx.db.patch('threadTranscriptStates', state._id, { totalParts: nextNumber });
 	}
 }
 
-async function runCompletionContainsToolCall(
-	ctx: MutationCtx,
-	threadId: Id<'threadRecords'>,
-	runId: Id<'runs'>,
-	callId: string
-): Promise<boolean> {
-	const parts = await ctx.db
-		.query('threadTranscriptParts')
-		.withIndex('by_threadId_and_runId_and_number', (query) =>
-			query.eq('threadId', threadId).eq('runId', runId)
-		)
-		.collect();
-	return parts.some(
-		(part) =>
-			part.kind === 'completion' &&
-			part.completion?.items.some((item) => item.type === 'tool-call' && item.callId === callId)
-	);
+function settledToolBody(
+	job: Pick<Doc<'executorJobs'>, '_id' | 'status' | 'callId' | 'kind' | 'result' | 'error'>
+): TranscriptToolBody {
+	if (!isSettledExecutorJobStatus(job.status)) {
+		throw new Error('settledToolBody requires a settled executor job.');
+	}
+	const status: TranscriptToolBody['status'] = job.status;
+	const output =
+		job.status === 'completed' && job.result !== undefined
+			? job.result
+			: {
+					error:
+						job.error ??
+						(job.status === 'cancelled'
+							? 'Executor job cancelled before completion.'
+							: 'Executor job failed.'),
+					status
+				};
+	return {
+		jobId: job._id,
+		callId: job.callId ?? `executor-job:${job._id}`,
+		name: job.kind,
+		output,
+		status
+	};
 }


### PR DESCRIPTION
## Problem

`agentRuntime:finalizeCompletionCall` intermittently fails with:

```
Uncaught Error: Too many bytes read in a single function execution (limit: 16777216 bytes).
    at async appendTranscriptPart (src/convex/lib/transcriptParts.ts)
    at async recordToolTranscript (src/convex/lib/transcriptWrites.ts)
    at async recordSettledToolTranscripts (src/convex/lib/transcriptWrites.ts)
    at async handler (src/convex/agentRuntime.ts)
```

## Root cause

The settled-tool sweep ran `recordToolTranscript` per job, and each call:

1. re-collected **all** of the run's transcript parts (`runCompletionContainsToolCall` with `.collect()` — full completion bodies: text, reasoning, tool inputs), and
2. did another existence-check read in `appendTranscriptPart`.

That is O(jobs × transcript bytes) inside a single mutation, and it runs after **every** completion turn — so long tool loops with fat outputs cross the 16 MiB transaction read budget. Most of the reads were redundant: jobs already get their transcript part at settle time via `applyExecutorJobSuccess`/`applyExecutorJobFailure`.

## Fix

Rewrote `recordSettledToolTranscripts` as two paged passes with matching done in memory:

- One paged pass over the run's transcript parts (32/page) builds a `Set` of recorded `sourceKey`s (idempotency check) and a `Set` of tool-call `callId`s present in recorded completions (the deferral check).
- One paged pass over the run's non-hidden jobs via the existing `by_runId_hidden_sequence` index inserts any missing `tool:{jobId}` parts from an in-memory `nextNumber` counter, patching `totalParts` once at the end.

Semantics are unchanged: same deferral rule (skip jobs whose tool-call isn't in a recorded completion yet), same ordering, same idempotency on retry.

Also: `runCompletionContainsToolCall` now streams with early exit instead of `.collect()`, and the tool-body construction is shared via `settledToolBody`.

## Checks

- `bunx vitest --run --project convex` — 154/154 pass
- `bunx convex typecheck` — clean
- `prek run -a` — all hooks pass