### PR TITLE
fix(ci): Restrict manual npm releases to the default branch

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -34,6 +34,11 @@ jobs:
       npm-tag: ${{ steps.version.outputs.npm-tag }}
       source-sha: ${{ steps.version.outputs.source-sha }}
     steps:
+      - name: Require default branch for manual dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+        run: |
+          echo "::error::Manual npm releases must be dispatched from the default branch so release builds only run trusted, main-reachable code."
+          exit 1
       - id: version
         name: Resolve version
         shell: bash


### PR DESCRIPTION
## Summary

Closes GitHub code scanning alerts 1–5 (`actions/cache-poisoning/poisonable-step`).

Manual `workflow_dispatch` runs of the npm release workflow previously built and published whatever commit the dispatcher selected. A feature-branch dispatch would run unreviewed code in a job that has default-branch cache write access (and the npm OIDC publish path when enabled) — the poisoned-cache pattern CodeQL flagged.

## Change

The `prepare` job now fails fast when a `workflow_dispatch` is triggered from any ref other than the default branch:

- Tag pushes (`v*`) are unaffected — release tags point at trusted commits.
- The `workflow_run` dev-release flow is unaffected.

This ensures release builds (and thus the cache/publication) only ever run code reachable from the default branch.

## Validation

- `actionlint` clean (`[]`)
- `prek run -a` passes, including YAML checks and GitHub Actions/Workflow validation

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a fail-fast guard that restricts manually dispatched npm releases to the repository’s default branch while leaving tag and tested-development release paths unchanged.

- Rejects non-default-branch `workflow_dispatch` runs during the `prepare` job.
- Prevents downstream build, cache, packaging, and publication jobs from running after rejection.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because rejected manual dispatches cannot proceed to release build, cache, packaging, or publication jobs.

The new guard fails the shared preparation job for non-default-branch manual dispatches, and every downstream release job requires that job to succeed.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Adds an effective default-branch check for manual releases; all sensitive downstream jobs remain gated by successful preparation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): Restrict manual npm releases to..."](https://github.com/spikonado/sprocket/commit/f4e7021e42332f2c59db6f0e80c90f31cf0ddaa6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58171696)</sub>

<!-- /greptile_comment -->