### PR TITLE
fix(agent-runtime): finalize runs without threadMessages backfill

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -106,6 +106,40 @@ backfill. Current writes do not set it.
 
 Remove after an unset rewrite, then drop it from the schema.
 
+### 8. Response-half of `threadMessages`
+
+Runs used to keep a response `threadMessages` row: started by the executor,
+scrubbed on superseded attempts, backfilled with the merged transcript parts
+when the run terminalized. The per-completion and terminal-cleanup code paths
+already record every completed model call and settled tool into the numbered
+transcript (`threadTranscriptParts`), the agent replays history from
+transcripts and jobs, and the UI builds its thread from transcripts alone.
+The backfill could also exceed the 1 MiB document limit with enough tool
+output, failing `agentRuntime:finalizeRun`.
+
+New runs no longer create the row: `finalizeRunRecord` writes nothing to
+`threadMessages`, `beginAssistantMessage` is a no-op kept for the agent
+contract, and `runs.responseMessageId` stays unset. Abstracted terminal text
+is deliberately not preserved anywhere; an incomplete completion call stays
+incomplete in the transcript.
+
+`clearResponseMessageParts` (the live `migrations` entry, driven by the
+migrations cron) rewrites every remaining response row to `{ text: "", parts:
+[] }` and doubles as the read/write gate for the future schema change. Once
+its status in prod is `success` with zero remaining rows, `runs` gets an
+unset rewrite for `responseMessageId` and then, only after all released
+agents/desktops have dropped `agentRuntime.beginAssistantMessage` calls:
+
+1. Delete `agentRuntime.beginAssistantMessage` (or convert it to the
+   unsupported-client stub like the other retired function names).
+2. Drop `runs.responseMessageId` and `threadMessages.parts`, and the
+   `by_type_runId` index, from `convex/schema.ts` and regenerate.
+3. Delete `migrations.clearResponseMessageParts` and its `run` pin.
+
+The prompt-half of `threadMessages` (text, attachments, retention bookkeeping)
+stays: it is the run-capability source of the user prompt and image
+attachments for `agentRuntime.getContext` and dedups repeated submissions.
+
 ## Client APIs
 
 Released desktop/CLI builds that still call retired Convex functions get a

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -380,14 +380,9 @@ describe('agentRuntime.insertGatewayRun', () => {
 			status: 'failed',
 			lastError: 'The local agent stopped responding before this run finished.'
 		});
-		const abandonedResponse = await t.run(async (ctx) =>
-			abandonedRun?.responseMessageId
-				? ctx.db.get('threadMessages', abandonedRun.responseMessageId)
-				: null
-		);
-		expect(abandonedResponse?.text).toBe(
-			'Run aborted: The local agent stopped responding before this run finished.'
-		);
+		// Aborted terminal text is not preserved: only runs and transcript
+		// parts written by completed model calls hold response content.
+		expect(abandonedRun?.responseMessageId ?? undefined).toBeUndefined();
 	});
 
 	it('rejects a new submission while the latest run holds an active claim', async () => {

--- a/apps/web/src/convex/agentRuntime.start.test.ts
+++ b/apps/web/src/convex/agentRuntime.start.test.ts
@@ -98,7 +98,7 @@ describe('agentRuntime.start', () => {
 		expect(await t.run(async (ctx) => (await ctx.db.get('runs', runId))?.status)).toBe('failed');
 	});
 
-	it('takes over an expired claim, hides in-flight jobs, and clears partial response', async () => {
+	it('takes over an expired claim and hides in-flight jobs', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const executionSecret = 'start-takeover-secret';
@@ -114,14 +114,6 @@ describe('agentRuntime.start', () => {
 			await ctx.db.patch('completionStreamStates', run.completionStreamStateId, {
 				sequence: 3,
 				streamAttemptId: 'attempt-a'
-			});
-			const responseMessageId = await ctx.db.insert('threadMessages', {
-				threadId,
-				runId,
-				userId: 'user_alice',
-				type: 'response',
-				text: 'partial',
-				parts: [{ type: 'text', id: 'text-1', text: 'partial', turnId: 'turn-1' }]
 			});
 			const pendingJobId = await ctx.db.insert('executorJobs', {
 				threadId,
@@ -157,13 +149,11 @@ describe('agentRuntime.start', () => {
 				sequence: 1
 			});
 			await ctx.db.patch('runs', runId, {
-				responseMessageId,
 				activeJobId: pendingJobId,
 				completionAttemptSeq: 4,
 				claimExpiresAt: Date.now() - 1
 			});
 			return {
-				responseMessageId,
 				streamStateId: run.completionStreamStateId,
 				pendingJobId,
 				completedJobId
@@ -180,11 +170,10 @@ describe('agentRuntime.start', () => {
 
 		const state = await t.run(async (ctx) => {
 			const run = await ctx.db.get('runs', runId);
-			const response = await ctx.db.get('threadMessages', seeded.responseMessageId);
 			const stream = await ctx.db.get('completionStreamStates', seeded.streamStateId);
 			const pending = await ctx.db.get('executorJobs', seeded.pendingJobId);
 			const completed = await ctx.db.get('executorJobs', seeded.completedJobId);
-			return { run, response, stream, pending, completed };
+			return { run, stream, pending, completed };
 		});
 
 		expect(state.run).toMatchObject({
@@ -194,10 +183,6 @@ describe('agentRuntime.start', () => {
 		});
 		expect(state.run?.activeJobId ?? undefined).toBeUndefined();
 		expect(state.run?.claimExpiresAt).toBe(takeover.claimExpiresAt);
-		expect(state.response).toMatchObject({
-			text: '',
-			parts: []
-		});
 		expect(state.stream).toMatchObject({
 			sequence: 0
 		});

--- a/apps/web/src/convex/agentRuntime.stream.test.ts
+++ b/apps/web/src/convex/agentRuntime.stream.test.ts
@@ -3,7 +3,7 @@ import { api } from '@convex/_generated/api';
 import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
 
 describe('agentRuntime completion stream state', () => {
-	it('creates a response message without writing live tokens on Convex', async () => {
+	it('tracks completion attempts without writing live tokens on Convex', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const executionSecret = 'stream-state-secret';
@@ -21,7 +21,6 @@ describe('agentRuntime completion stream state', () => {
 			runId,
 			executionSecret
 		});
-		await asUser.mutation(api.agentRuntime.beginAssistantMessage, { runId, executionSecret });
 		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
 			runId,
 			claimId: 'claim-stream',
@@ -31,15 +30,20 @@ describe('agentRuntime completion stream state', () => {
 
 		const stored = await t.run(async (ctx) => {
 			const run = await ctx.db.get('runs', runId);
-			if (!run?.responseMessageId || !run.completionStreamStateId) {
-				throw new Error('Expected response and stream state records');
+			if (!run?.completionStreamStateId) {
+				throw new Error('Expected stream state record');
 			}
 			return {
-				message: await ctx.db.get('threadMessages', run.responseMessageId),
 				state: await ctx.db.get('completionStreamStates', run.completionStreamStateId)
 			};
 		});
-		expect(stored.message).toMatchObject({ text: '' });
+		expect(
+			(await t.run(async (ctx) => (await ctx.db.get('runs', runId))?.responseMessageId)) ??
+				undefined
+		).toBeUndefined();
+		expect(
+			await t.run(async (ctx) => (await ctx.db.get('runs', runId))?.completionAttemptSeq)
+		).toBe(1);
 		expect(stored.state).toMatchObject({
 			runId,
 			sequence: 0

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -17,7 +17,6 @@ import { gatewayTokenExpiresAt, mintGatewayToken } from '@convex/lib/gatewayToke
 import { vCompletionActor, vGetContextResult } from '@convex/lib/docs';
 import { appendThreadMessage } from '@convex/lib/threadMessages';
 import {
-	beginAssistantMessageForRun,
 	getCompletionStreamState,
 	registerCompletionAttemptForRun
 } from '@convex/lib/assistantStreamWrites';
@@ -178,7 +177,7 @@ async function createQueuedRunRecord(
 		isClaimedRunStatus(latestRun.status) &&
 		!isRunClaimLeaseActive(latestRun, Date.now())
 	) {
-		await finalizeRunRecord(ctx, args.userId, latestRun, {
+		await finalizeRunRecord(ctx, latestRun, {
 			text: `Run aborted: ${RUN_ABANDONED_BY_AGENT}`,
 			status: 'failed',
 			lastError: RUN_ABANDONED_BY_AGENT
@@ -612,14 +611,7 @@ export const registerCompletionAttempt = mutation({
 		if (!canRegisterCompletionAttempt(run, args.claimId, args.attemptSeq)) {
 			throw new ConvexError(COMPLETION_STREAM_SUPERSEDED);
 		}
-		// Completion turns stamp parts with turnId = streamId, so a retry can
-		// drop the partial parts its prior attempts persisted.
-		await registerCompletionAttemptForRun(
-			ctx,
-			run,
-			args.attemptSeq,
-			args.supersededStreamIds ?? []
-		);
+		await registerCompletionAttemptForRun(ctx, run, args.attemptSeq);
 	}
 });
 
@@ -630,12 +622,10 @@ export const beginAssistantMessage = mutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (isRunFinalStatus(run.status)) {
-			return;
-		}
-		await getCompletionStreamState(ctx, run);
-		await beginAssistantMessageForRun(ctx, run);
+		// Retired: agent responses no longer maintain a `threadMessages` row.
+		// Kept for the pre-backfill agent contract so old clients fail fast.
+		await getExecutionRun(ctx, args.runId, args.executionSecret);
+		return null;
 	}
 });
 
@@ -675,7 +665,6 @@ export const finalizeCompletionCall = mutation({
 		if (!isCurrentCompletionAttempt(run, args.claimId, args.attemptSeq)) {
 			return null;
 		}
-		await beginAssistantMessageForRun(ctx, run);
 		const number = await recordCompletionTranscript(ctx, {
 			threadId: run.threadId,
 			userId: run.userId,
@@ -708,7 +697,7 @@ export const finalizeRun = mutation({
 		if (!matchesFinalizeExpectations(run, args)) {
 			return false;
 		}
-		return finalizeRunRecord(ctx, userId, run, args);
+		return finalizeRunRecord(ctx, run, args);
 	}
 });
 
@@ -741,7 +730,7 @@ export const finalizeExecutorRun = mutation({
 		if (!matchesFinalizeExpectations(run, args)) {
 			return false;
 		}
-		return finalizeRunRecord(ctx, run.userId, run, args);
+		return finalizeRunRecord(ctx, run, args);
 	}
 });
 
@@ -811,7 +800,7 @@ export const finalizeFailedStart = mutation({
 		) {
 			return 'standDown';
 		}
-		await finalizeRunRecord(ctx, run.userId, run, {
+		await finalizeRunRecord(ctx, run, {
 			text: args.text,
 			status: 'failed',
 			lastError: args.lastError
@@ -831,11 +820,10 @@ export const finalizeClaimFailure = mutation({
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const userId = run.userId;
 		if (!canFinalizeAfterClaimFailure(run, args.claimId)) {
 			return false;
 		}
-		return finalizeRunRecord(ctx, userId, run, {
+		return finalizeRunRecord(ctx, run, {
 			text: args.text,
 			status: 'failed',
 			lastError: args.lastError

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -9,4 +9,6 @@ crons.interval(
 	internal.imageUploads.cleanupOrphans
 );
 
+crons.interval('run convex component migrations', { minutes: 10 }, internal.migrations.run, {});
+
 export default crons;

--- a/apps/web/src/convex/lib/assistantStreamWrites.ts
+++ b/apps/web/src/convex/lib/assistantStreamWrites.ts
@@ -1,7 +1,5 @@
 import type { MutationCtx, QueryCtx } from '@convex/_generated/server';
 import type { Doc } from '@convex/_generated/dataModel';
-import { joinAssistantTextParts } from '@convex/lib/assistantParts';
-import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 
 export async function getCompletionStreamState(
 	ctx: MutationCtx | QueryCtx,
@@ -17,38 +15,13 @@ export async function getCompletionStreamState(
 	return state;
 }
 
-export async function beginAssistantMessageForRun(
-	ctx: MutationCtx,
-	run: Doc<'runs'>
-): Promise<void> {
-	if (run.responseMessageId) return;
-	const messageId = await appendThreadMessage(ctx, {
-		threadId: run.threadId,
-		runId: run._id,
-		userId: run.userId,
-		type: 'response',
-		text: ''
-	});
-	await ctx.db.patch('runs', run._id, { responseMessageId: messageId });
-}
-
 export async function registerCompletionAttemptForRun(
 	ctx: MutationCtx,
 	run: Doc<'runs'>,
-	attemptSeq: number,
-	supersededStreamIds: string[]
+	attemptSeq: number
 ): Promise<void> {
+	// The response `threadMessages` document is no longer maintained (see
+	// BACKWARDS_COMPATIBILITY.md). Superseded-attempt scrubbing retires with it:
+	// partial turns are discarded on the agent side, not in Convex.
 	await ctx.db.patch('runs', run._id, { completionAttemptSeq: attemptSeq });
-	if (supersededStreamIds.length === 0 || !run.responseMessageId) return;
-	const superseded = new Set(supersededStreamIds);
-	const message = await getThreadMessage(ctx, run.responseMessageId);
-	const parts = message.parts.filter(
-		(part) => !('turnId' in part && part.turnId && superseded.has(part.turnId))
-	);
-	if (parts.length !== message.parts.length) {
-		await ctx.db.patch('threadMessages', run.responseMessageId, {
-			text: joinAssistantTextParts(parts),
-			parts
-		});
-	}
 }

--- a/apps/web/src/convex/lib/runFinalize.ts
+++ b/apps/web/src/convex/lib/runFinalize.ts
@@ -1,14 +1,7 @@
 import type { Doc } from '@convex/_generated/dataModel';
 import type { MutationCtx } from '@convex/_generated/server';
 import type { Infer } from 'convex/values';
-import {
-	ensureAssistantToolPartsFromJobs,
-	joinAssistantTextParts,
-	toPersistableExecutorToolJobs,
-	type AssistantPart
-} from '@convex/lib/assistantParts';
 import { isRunFinalStatus, type vRunFinalStatus, type vRunStatus } from '@convex/lib/validators';
-import { appendThreadMessage, getThreadMessage } from '@convex/lib/threadMessages';
 import { reconcileTerminalRunPages } from '@convex/lib/runTerminal';
 import { cancelWebToolWork } from '@convex/webToolPool';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
@@ -42,7 +35,6 @@ export function matchesFinalizeExpectations(
 
 export async function finalizeRunRecord(
 	ctx: MutationCtx,
-	userId: string,
 	run: Doc<'runs'>,
 	args: FinalizeRunArgs
 ): Promise<boolean> {
@@ -67,26 +59,12 @@ export async function finalizeRunRecord(
 		return true;
 	}
 
-	const responseMessageId =
-		run.responseMessageId ??
-		(await appendThreadMessage(ctx, {
-			threadId: run.threadId,
-			runId: run._id,
-			userId,
-			type: 'response',
-			text: ''
-		}));
-	const message = run.responseMessageId
-		? await getThreadMessage(ctx, run.responseMessageId)
-		: undefined;
-
 	await ctx.db.patch('runs', run._id, {
 		status: finalStatus,
 		claimExpiresAt: undefined,
 		lastError: args.lastError,
 		activeJobId: undefined,
-		completedAt,
-		responseMessageId
+		completedAt
 	});
 
 	const latest = await ctx.db.get('runs', run._id);
@@ -96,20 +74,6 @@ export async function finalizeRunRecord(
 	await reconcileTerminalRunPages(ctx, latest, {
 		lastError: args.lastError,
 		completedAt
-	});
-
-	const jobs = await ctx.db
-		.query('executorJobs')
-		.withIndex('by_runId_sequence', (query) => query.eq('runId', run._id))
-		.take(256);
-	const nextParts: AssistantPart[] = ensureAssistantToolPartsFromJobs(
-		message?.parts ?? [],
-		toPersistableExecutorToolJobs(jobs)
-	);
-	const streamedText: string = joinAssistantTextParts(nextParts);
-	await ctx.db.patch('threadMessages', responseMessageId, {
-		text: streamedText || args.text,
-		parts: nextParts
 	});
 	return true;
 }

--- a/apps/web/src/convex/lib/runResume.ts
+++ b/apps/web/src/convex/lib/runResume.ts
@@ -50,12 +50,6 @@ export async function clearInFlightWork(
 			completedAt: now
 		});
 	}
-	if (run.responseMessageId) {
-		await ctx.db.patch('threadMessages', run.responseMessageId, {
-			text: '',
-			parts: []
-		});
-	}
 	if (run.completionStreamStateId) {
 		const streamState = await getCompletionStreamState(ctx, run);
 		await ctx.db.patch('completionStreamStates', streamState._id, {

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -1,5 +1,5 @@
 import { Migrations } from '@convex-dev/migrations';
-import { components } from '@convex/_generated/api';
+import { components, internal } from '@convex/_generated/api';
 import { internalMutation } from '@convex/_generated/server';
 import schema from '@convex/schema';
 
@@ -8,4 +8,35 @@ export const migrations = new Migrations(components.migrations, {
 	internalMutation
 });
 
-export const run = migrations.runner();
+// `run` targets the currently live migration(s). Each deploy's cron calls it
+// with no args; the runner picks up the pinned migration refs itself. Swap in
+// the next migration when a future cleanup lands.
+export const run = migrations.runner([internal.migrations.clearResponseMessageParts]);
+
+/**
+ * Clears the response-half payloads (`text`, `parts`) that runs wrote to
+ * `threadMessages` before the local-transcript cleanup. Once every remaining
+ * row is rewritable this way, `runs.responseMessageId` and
+ * `threadMessages.parts` can be dropped from the schema. Run via:
+ *   npx convex run migrations:clearResponseMessageParts '{ dryRun: true }'
+ */
+export const clearResponseMessageParts = migrations.define({
+	table: 'threadMessages',
+	customRange: (query) => query.withIndex('by_type_runId'),
+	migrateOne: async (ctx, message) => {
+		if (message.type !== 'response') {
+			return;
+		}
+		if (message.text === '' && message.parts.length === 0) {
+			return;
+		}
+		// Reads/writes the whole document on purpose: this migration's success
+		// is part of the gate for deleting the oversized `parts` field, which
+		// requires every stored row to survive a patch transaction.
+		const current = await ctx.db.get('threadMessages', message._id);
+		if (!current) {
+			return;
+		}
+		await ctx.db.patch('threadMessages', message._id, { text: '', parts: [] });
+	}
+});

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -19,14 +19,14 @@ export const run = migrations.runner([internal.migrations.clearResponseMessagePa
  * row is rewritable this way, `runs.responseMessageId` and
  * `threadMessages.parts` can be dropped from the schema. Run via:
  *   npx convex run migrations:clearResponseMessageParts '{ dryRun: true }'
+ *
+ * Scoped to `type === 'response'` rows so prompts are not re-read on every
+ * cron tick while the compatibility gate is still open.
  */
 export const clearResponseMessageParts = migrations.define({
 	table: 'threadMessages',
-	customRange: (query) => query.withIndex('by_type_runId'),
+	customRange: (query) => query.withIndex('by_type_runId', (range) => range.eq('type', 'response')),
 	migrateOne: async (ctx, message) => {
-		if (message.type !== 'response') {
-			return;
-		}
 		if (message.text === '' && message.parts.length === 0) {
 			return;
 		}

--- a/apps/web/src/convex/runLifecycle.ts
+++ b/apps/web/src/convex/runLifecycle.ts
@@ -89,7 +89,7 @@ export const abandonExpiredRun = internalMutation({
 		if (state.kind !== 'abandon') {
 			return false;
 		}
-		return await finalizeRunRecord(ctx, run.userId, run, {
+		return await finalizeRunRecord(ctx, run, {
 			text: RUN_ABANDONED_BY_AGENT,
 			status: 'failed',
 			lastError: RUN_ABANDONED_BY_AGENT

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -145,6 +145,8 @@ export default defineSchema({
 		lastError: v.optional(v.string()),
 		activeJobId: v.optional(v.id('executorJobs')),
 		promptMessageId: v.optional(v.id('threadMessages')),
+		// Deprecated: new runs do not write a response message. Kept on leftover
+		// rows until a migration removes them; then this field can go away.
 		responseMessageId: v.optional(v.id('threadMessages')),
 		completionStreamStateId: v.optional(v.id('completionStreamStates')),
 		lifecycleWorkflowId: v.optional(v.string())
@@ -160,8 +162,13 @@ export default defineSchema({
 		type: vThreadMessageType,
 		text: v.string(),
 		imageUploadIds: v.optional(v.array(v.id('imageUploads'))),
+		// Deprecated: only response rows written before the local-transcript
+		// cleanup populate this. New response rows (none are written anymore)
+		// would store an empty array. Remove the field once all existing rows
+		// have been rewritten by `migrations.clearResponseMessageParts` and the
+		// rust/desktop read gates pass; see BACKWARDS_COMPATIBILITY.md.
 		parts: v.array(vAssistantMessagePart)
-	}),
+	}).index('by_type_runId', ['type', 'runId']),
 	// Durable numbered transcript replica source. Kept off threadRecords so
 	// appends do not invalidate the thread list subscription.
 	threadTranscriptStates: defineTable({


### PR DESCRIPTION
## Problem

`agentRuntime:finalizeRun` crashes with `Uncaught Error: Value is too large (1.03 MiB > maximum size 1 MiB)` in `finalizeRunRecord` (runFinalize.ts). At end-of-run the mutation merged every streamed part plus one full tool result per executor job into a single `threadMessages` document; enough tool output makes the write exceed Convex's 1 MiB document limit. The same code path also fires in the run-abandon workflow, turning every retry into an unmonitored retry-failure loop.

## Context

- The threads table's `threadMessages` also still carries prompts (used by the executor, dedup, and the UI) — see the note below.
- Convex's 1 MiB document cap is a hard limit for `db.patch`; there is no per-document limit override.

## Change

- `finalizeRunRecord` no longer touches `threadMessages` at all. It now only:
  1. cancels in-flight web-tool work,
  2. patches the run to its terminal status + `lastError`/cleared claim,
  3. runs the existing terminal cleanup (cancel in-flight executor work, record any settled tool transcripts).
- Its `text` argument is deliberately dropped: per the PR conversation, terminal text for an incomplete completion call is not preserved anywhere.
- The executor still writes each completed model call to the numbered transcript (`agentRuntime:finalizeCompletionCall`), and tool results are recorded per settlement; the UI already reads only those transcripts.
- Deleted the now-dead response-row plumbing: `beginAssistantMessageForRun`, response-row scrub in `registerCompletionAttemptForRun`, takeover wipe in `clearInFlightWork`, and the end-of-run merge in `finalizeRunRecord`.
- `beginAssistantMessage` stays as a validation-only no-op so already-released agents fail fast instead of silently misbehaving.
- `runs.responseMessageId` is left unset on new runs (field kept for existing rows).

## Reproduction

Unit/integration coverage: replaced the prior end-of-run assertions with checks that no `threadMessages` row is created/backfilled and that aborted terminal text is not preserved. A 1.03 MiB tool output can be seeded into an executor job to verify the old failure; the new code path never writes it anywhere.

## Testing

- `bun run test` — 44 files, 257 tests
- `bun run build`
- `bun run lint`
- `prek run -a`

All green.

## Migration / forwards-compatibility

- Added `clearResponseMessageParts`, a pinned `@convex-dev/migrations` run that rewrites every existing response row to `{ text: "", parts: [] }` (run by the re-added migrations cron); it doubles as the read/write gate for the future schema change.
- Documented the `threadMessages.parts` / `runs.responseMessageId` removal gate in `BACKWARDS_COMPATIBILITY.md`.
- Note: `threadMessages` still stores prompts (used by the agent boot path, submission dedup, and the UI); that split is out of scope for this PR.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR stops terminal run finalization from rebuilding oversized response documents and introduces a targeted compatibility migration for legacy response rows.
- Finalization now persists terminal run state and transcript cleanup without writing `threadMessages`.
- New runs no longer create response-message rows or populate `runs.responseMessageId`.
- A scheduled migration clears legacy response payloads using a response-only indexed range.
- Tests and compatibility documentation now reflect transcript-backed response storage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/runFinalize.ts | Removes response-message construction and merged-parts persistence while retaining terminal run and child-work reconciliation. |
| apps/web/src/convex/agentRuntime.ts | Retires response-row lifecycle plumbing and routes all terminalization through the simplified finalizer. |
| apps/web/src/convex/migrations.ts | Adds a pinned migration whose indexed range selects only legacy response rows before clearing their payloads. |
| apps/web/src/convex/schema.ts | Documents deprecated response fields and adds the compound index required for the targeted migration. |
| apps/web/src/convex/crons.ts | Schedules the pinned Convex component migration every ten minutes. |
| BACKWARDS_COMPATIBILITY.md | Documents the migration gate and ordered removal plan for legacy response-message fields. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant Runtime as Agent Runtime
    participant Runs as runs
    participant Transcript as Numbered Transcript
    participant Messages as threadMessages
    participant Migration

    Agent->>Runtime: Finalize completion call
    Runtime->>Transcript: Record completed model call
    Agent->>Runtime: Finalize run
    Runtime->>Runs: Store terminal status and clear claim
    Runtime->>Transcript: Record settled tool transcripts
    Note over Runtime,Messages: Finalization no longer creates or backfills a response row
    Migration->>Messages: Scan response rows via by_type_runId
    Migration->>Messages: Clear legacy text and parts
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agent-runtime): scope response-messa..."](https://github.com/spikonado/sprocket/commit/72b3bbd400f4c208772c7462e4dc3cd578081416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58230405)</sub>

<!-- /greptile_comment -->