### PR TITLE
fix(ui): Improve transcript rendering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,10 +58,10 @@ authorizes the browser or Electron renderer to access the machine-facing API.
 
 | Component         | Owns                                                             | Does not own                           |
 | ----------------- | ---------------------------------------------------------------- | -------------------------------------- |
-| Svelte app        | User interaction, reactive views, submission recovery            | Filesystem access or provider secrets  |
+| Svelte app        | User interaction, reactive views, submission recovery            | Transcript synchronization, filesystem access, or provider secrets |
 | Electron shell    | Desktop lifecycle, trusted renderer bridge, local server process | Conversation or agent state            |
 | CLI               | Process launch and server-mode selection                         | Agent implementation                   |
-| Local server      | Local authorization, workspace attachment, agent task lifetime   | Durable conversation state             |
+| Local server      | Local authorization, transcript replica and live stream, agent task lifetime | Durable conversation source of truth |
 | Agent runtime     | Run claim, model/tool loop, cancellation, finalization           | HTTP presentation or cloud schema      |
 | Workspace crate   | Paths, commands, patches, workspace instructions                 | Authentication or networking           |
 | Convex RPC client | Generic Convex query/mutation/action/subscribe                   | Completion translation                 |
@@ -104,7 +104,9 @@ Sprocket deliberately separates cloud and machine-local state.
 
 | State                                                                | Owner                |
 | -------------------------------------------------------------------- | -------------------- |
-| Users, threads, messages, runs, and tool-job records                 | Convex               |
+| Users, threads, durable transcript parts, runs, and tool-job records | Convex               |
+| Local transcript replica                                            | Local server         |
+| Current assistant stream                                            | Local process memory |
 | Local folder list (`workspacePath` + `repositoryKey`)                | Local server         |
 | Pairing credential and local browser sessions                        | Local server         |
 | Active commands, cancellation tokens, and run execution capabilities | Local process memory |
@@ -132,6 +134,9 @@ sequenceDiagram
     UI->>S: Start run with user token and workspace identity
     S->>A: Prepare local run
     A->>C: Create gateway run and bind execution capability
+    C-->>A: Return authoritative numbered prompt part
+    A-->>S: Add prompt to local transcript replica
+    S-->>UI: Notify transcript update; UI refetches local page
     A->>C: Claim run, load context, mint user gateway token
     A->>G: GET /api/v1/models
     loop Model and tool turns
@@ -140,8 +145,12 @@ sequenceDiagram
         G->>M: Call selected model
         M-->>G: Stream response
         G-->>A: OpenAI SSE
+        A-->>S: Publish live completion snapshot
+        S-->>UI: Stream live completion over SSE
         A->>C: Persist stream events
-        C-->>UI: Publish durable transcript updates
+        C-->>S: Publish durable transcript state
+        S->>C: Fetch missing numbered parts
+        S-->>UI: Notify transcript update; UI refetches local page
         opt Model requests a tool
             A->>C: Record tool job
             A->>W: Execute locally
@@ -163,6 +172,11 @@ on the machine.
 The agent persists model output incrementally to Convex. Stream attempt and
 ordering metadata prevent a delayed completion attempt from replacing a newer
 one.
+
+The transcript renderer never reads transcript content from Convex. It pages
+durable parts from the Rust replica and overlays the current Rust
+live-completion stream. Convex assigns durable part numbers; Svelte renders
+that order and keeps no cross-thread transcript cache.
 
 ## Authentication and trust boundaries
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,7 +136,7 @@ sequenceDiagram
     A->>C: Create gateway run and bind execution capability
     C-->>A: Return authoritative numbered prompt part
     A-->>S: Add prompt to local transcript replica
-    S-->>UI: Notify transcript update; UI refetches local page
+    S-->>UI: Notify transcript update and refetch local page
     A->>C: Claim run, load context, mint user gateway token
     A->>G: GET /api/v1/models
     loop Model and tool turns
@@ -150,7 +150,7 @@ sequenceDiagram
         A->>C: Persist stream events
         C-->>S: Publish durable transcript state
         S->>C: Fetch missing numbered parts
-        S-->>UI: Notify transcript update; UI refetches local page
+        S-->>UI: Notify transcript update and refetch local page
         opt Model requests a tool
             A->>C: Record tool job
             A->>W: Execute locally

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,17 +56,17 @@ authorizes the browser or Electron renderer to access the machine-facing API.
 
 ## Component boundaries
 
-| Component         | Owns                                                             | Does not own                           |
-| ----------------- | ---------------------------------------------------------------- | -------------------------------------- |
-| Svelte app        | User interaction, reactive views, submission recovery            | Transcript synchronization, filesystem access, or provider secrets |
-| Electron shell    | Desktop lifecycle, trusted renderer bridge, local server process | Conversation or agent state            |
-| CLI               | Process launch and server-mode selection                         | Agent implementation                   |
-| Local server      | Local authorization, transcript replica and live stream, agent task lifetime | Durable conversation source of truth |
-| Agent runtime     | Run claim, model/tool loop, cancellation, finalization           | HTTP presentation or cloud schema      |
-| Workspace crate   | Paths, commands, patches, workspace instructions                 | Authentication or networking           |
-| Convex RPC client | Generic Convex query/mutation/action/subscribe                   | Completion translation                 |
-| AI gateway        | Provider routing, OpenAI API, catalog, usage rates               | Subscription limits or remaining quota |
-| Convex backend    | User data, run coordination, transcript, remaining quota         | Local paths, process execution, rates  |
+| Component         | Owns                                                                         | Does not own                                                       |
+| ----------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Svelte app        | User interaction, reactive views, submission recovery                        | Transcript synchronization, filesystem access, or provider secrets |
+| Electron shell    | Desktop lifecycle, trusted renderer bridge, local server process             | Conversation or agent state                                        |
+| CLI               | Process launch and server-mode selection                                     | Agent implementation                                               |
+| Local server      | Local authorization, transcript replica and live stream, agent task lifetime | Durable conversation source of truth                               |
+| Agent runtime     | Run claim, model/tool loop, cancellation, finalization                       | HTTP presentation or cloud schema                                  |
+| Workspace crate   | Paths, commands, patches, workspace instructions                             | Authentication or networking                                       |
+| Convex RPC client | Generic Convex query/mutation/action/subscribe                               | Completion translation                                             |
+| AI gateway        | Provider routing, OpenAI API, catalog, usage rates                           | Subscription limits or remaining quota                             |
+| Convex backend    | User data, run coordination, transcript, remaining quota                     | Local paths, process execution, rates                              |
 
 The Rust dependency direction follows these boundaries:
 
@@ -105,8 +105,8 @@ Sprocket deliberately separates cloud and machine-local state.
 | State                                                                | Owner                |
 | -------------------------------------------------------------------- | -------------------- |
 | Users, threads, durable transcript parts, runs, and tool-job records | Convex               |
-| Local transcript replica                                            | Local server         |
-| Current assistant stream                                            | Local process memory |
+| Local transcript replica                                             | Local server         |
+| Current assistant stream                                             | Local process memory |
 | Local folder list (`workspacePath` + `repositoryKey`)                | Local server         |
 | Pairing credential and local browser sessions                        | Local server         |
 | Active commands, cancellation tokens, and run execution capabilities | Local process memory |

--- a/apps/web/src/convex/agentRuntime.createRun.test.ts
+++ b/apps/web/src/convex/agentRuntime.createRun.test.ts
@@ -23,12 +23,24 @@ describe('agentRuntime.insertGatewayRun', () => {
 
 	it('creates a queued run and is idempotent for the same submission', async () => {
 		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
+		const { asUser, subject, threadId } = await seedOwnedThread(t);
+		const imageUploadId = await t.run(async (ctx) => {
+			const storageId = await ctx.storage.store(new Blob(['image'], { type: 'image/png' }));
+			return await ctx.db.insert('imageUploads', {
+				userId: subject,
+				storageId,
+				name: 'robot.png',
+				mediaType: 'image/png',
+				size: 5,
+				messageIds: [],
+				attached: false
+			});
+		});
 		const args = {
 			submissionId: 'sub-1',
 			threadId,
 			prompt: 'Hello',
-			imageUploadIds: [],
+			imageUploadIds: [imageUploadId],
 			selectedModel: 'gpt-5.6-sol' as const,
 			reasoningEffort: 'medium' as const,
 			serviceTier: 'standard' as const,
@@ -42,7 +54,27 @@ describe('agentRuntime.insertGatewayRun', () => {
 		expect(again).toEqual({
 			created: false,
 			runId: created.runId,
-			promptMessageId: created.promptMessageId
+			promptMessageId: created.promptMessageId,
+			userId: created.userId,
+			promptPart: created.promptPart
+		});
+		expect(created.promptPart).toMatchObject({
+			number: 0,
+			sourceKey: `prompt:${created.runId}`,
+			kind: 'prompt',
+			runId: created.runId,
+			prompt: {
+				text: 'Hello',
+				imageUploads: [
+					{
+						imageUploadId,
+						name: 'robot.png',
+						mediaType: 'image/png',
+						size: 5,
+						storageId: expect.any(String)
+					}
+				]
+			}
 		});
 
 		const run = await t.run(async (ctx) => ctx.db.get('runs', created.runId));

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -7,6 +7,7 @@ import {
 	type MutationCtx
 } from '@convex/_generated/server';
 import { internal } from '@convex/_generated/api';
+import schema from '@convex/schema';
 import { ConvexError, v, type Infer } from 'convex/values';
 import { getOwnedRun, getOwnedThreadRecord } from '@convex/lib/access';
 import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
@@ -111,7 +112,13 @@ type GatewayRunTelemetry = {
 async function createQueuedRunRecord(
 	ctx: MutationCtx,
 	args: QueuedRunRequest
-): Promise<{ created: boolean; runId: Id<'runs'>; promptMessageId: Id<'threadMessages'> }> {
+): Promise<{
+	created: boolean;
+	runId: Id<'runs'>;
+	promptMessageId: Id<'threadMessages'>;
+	userId: string;
+	promptPart: Doc<'threadTranscriptParts'>;
+}> {
 	const secretHash = await executionSecretHash(args.executionSecret);
 	const threadRecord = await getOwnedThreadRecord(ctx.db, args.userId, args.threadId);
 	const prompt = args.prompt.trim();
@@ -160,11 +167,20 @@ async function createQueuedRunRecord(
 			const lifecycleWorkflowId = await startRunLifecycle(ctx, existingRun._id);
 			await ctx.db.patch('runs', existingRun._id, { lifecycleWorkflowId });
 		}
+		const promptPart = await recordPromptTranscript(ctx, {
+			threadId: args.threadId,
+			userId: args.userId,
+			runId: existingRun._id,
+			text: prompt,
+			imageUploadIds: args.imageUploadIds
+		});
 
 		return {
 			created: false,
 			runId: existingRun._id,
-			promptMessageId: existingRun.promptMessageId
+			promptMessageId: existingRun.promptMessageId,
+			userId: args.userId,
+			promptPart
 		};
 	}
 	const latestRun = await ctx.db
@@ -224,7 +240,7 @@ async function createQueuedRunRecord(
 		promptMessageId,
 		completionStreamStateId
 	});
-	await recordPromptTranscript(ctx, {
+	const promptPart = await recordPromptTranscript(ctx, {
 		threadId: args.threadId,
 		userId: args.userId,
 		runId,
@@ -243,7 +259,9 @@ async function createQueuedRunRecord(
 	return {
 		created: true,
 		runId,
-		promptMessageId
+		promptMessageId,
+		userId: args.userId,
+		promptPart
 	};
 }
 
@@ -270,6 +288,8 @@ const vCreateGatewayRunResult = v.object({
 	created: v.boolean(),
 	runId: v.id('runs'),
 	promptMessageId: v.id('threadMessages'),
+	userId: v.string(),
+	promptPart: schema.doc('threadTranscriptParts'),
 	gatewayUrl: v.string(),
 	protocolVersion: v.number()
 });
@@ -291,7 +311,9 @@ export const insertGatewayRun = internalMutation({
 	returns: v.object({
 		created: v.boolean(),
 		runId: v.id('runs'),
-		promptMessageId: v.id('threadMessages')
+		promptMessageId: v.id('threadMessages'),
+		userId: v.string(),
+		promptPart: schema.doc('threadTranscriptParts')
 	}),
 	handler: async (ctx, args) => {
 		return await createQueuedRunRecord(ctx, args);

--- a/apps/web/src/convex/lib/transcriptParts.ts
+++ b/apps/web/src/convex/lib/transcriptParts.ts
@@ -76,7 +76,7 @@ type TranscriptPartInsert = {
 export async function appendTranscriptPart(
 	ctx: MutationCtx,
 	args: AppendTranscriptPartArgs
-): Promise<{ number: number; inserted: boolean }> {
+): Promise<{ part: Doc<'threadTranscriptParts'>; inserted: boolean }> {
 	const existing = await ctx.db
 		.query('threadTranscriptParts')
 		.withIndex('by_threadId_and_sourceKey', (query) =>
@@ -84,7 +84,7 @@ export async function appendTranscriptPart(
 		)
 		.unique();
 	if (existing) {
-		return { number: existing.number, inserted: false };
+		return { part: existing, inserted: false };
 	}
 
 	const state = await getOrCreateTranscriptState(ctx, {
@@ -103,9 +103,13 @@ export async function appendTranscriptPart(
 	if (args.prompt) part.prompt = args.prompt;
 	if (args.completion) part.completion = args.completion;
 	if (args.tool) part.tool = args.tool;
-	await ctx.db.insert('threadTranscriptParts', part);
+	const partId = await ctx.db.insert('threadTranscriptParts', part);
 	await ctx.db.patch('threadTranscriptStates', state._id, { totalParts: number + 1 });
-	return { number, inserted: true };
+	const inserted = await ctx.db.get('threadTranscriptParts', partId);
+	if (!inserted) {
+		throw new Error('Failed to create transcript part.');
+	}
+	return { part: inserted, inserted: true };
 }
 
 export async function loadTranscriptPartsByNumbers(

--- a/apps/web/src/convex/lib/transcriptWrites.ts
+++ b/apps/web/src/convex/lib/transcriptWrites.ts
@@ -42,8 +42,8 @@ export async function recordPromptTranscript(
 		text: string;
 		imageUploadIds?: Id<'imageUploads'>[];
 	}
-): Promise<void> {
-	await appendTranscriptPart(ctx, {
+): Promise<Doc<'threadTranscriptParts'>> {
+	const result = await appendTranscriptPart(ctx, {
 		threadId: args.threadId,
 		userId: args.userId,
 		sourceKey: promptSourceKey(args.runId),
@@ -54,6 +54,7 @@ export async function recordPromptTranscript(
 			imageUploads: await attachmentMetaForUploads(ctx, args.imageUploadIds)
 		}
 	});
+	return result.part;
 }
 
 export async function recordCompletionTranscript(
@@ -77,7 +78,7 @@ export async function recordCompletionTranscript(
 		runId: args.runId,
 		completion: { streamId: args.streamId, items: args.items }
 	});
-	return result.number;
+	return result.part.number;
 }
 
 export async function recordToolTranscript(

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -111,6 +111,20 @@ describe('mergePagedTranscriptWithLive', () => {
 			threadId: threadRecordId('thread-a')
 		});
 		expect(pendingLatestRun).toEqual([]);
+		const completedLatestRun = mergePagedTranscriptWithLive({
+			parts: [],
+			live: null,
+			latestRun: {
+				_id: runId('run-1'),
+				status: 'completed',
+				startedAt: 200_000,
+				completedAt: 210_000
+			},
+			liveRestore: { threadId: threadRecordId('thread-a'), overlay: initial },
+			userId: 'user_1',
+			threadId: threadRecordId('thread-a')
+		});
+		expect(completedLatestRun).toEqual([]);
 
 		const kept = mergePagedTranscriptWithLive({
 			parts: [

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -27,6 +27,13 @@ function part(
 	};
 }
 
+function lastLive(args: {
+	threadId: Id<'threadRecords'>;
+	override: Omit<LiveCompletionOverlay, 'threadId'>;
+}): LiveCompletionOverlay {
+	return { threadId: args.threadId, ...args.override };
+}
+
 describe('messagesFromTranscriptParts', () => {
 	it('orders prompts, completions, and tools into chat messages', () => {
 		const messages = messagesFromTranscriptParts({
@@ -74,6 +81,128 @@ describe('messagesFromTranscriptParts', () => {
 });
 
 describe('mergePagedTranscriptWithLive', () => {
+	it('keeps the live completion while reconnecting after a thread switch', () => {
+		const initial = lastLive({
+			threadId: threadRecordId('thread-a'),
+			override: {
+				runId: runId('run-1'),
+				runStatus: 'running',
+				streamId: 's1',
+				text: 'working',
+				parts: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }],
+				runStartedAt: 200_000
+			}
+		});
+		const restored = mergePagedTranscriptWithLive({
+			parts: [],
+			live: initial,
+			latestRun: null,
+			liveRestore: { threadId: threadRecordId('thread-b'), overlay: null },
+			userId: 'user_1',
+			threadId: threadRecordId('thread-b')
+		});
+		expect(restored).toEqual([]);
+
+		const kept = mergePagedTranscriptWithLive({
+			parts: [
+				part({
+					number: 0,
+					kind: 'prompt',
+					runId: runId('run-0'),
+					prompt: { text: 'Hi', imageUploads: [] }
+				}),
+				part({
+					number: 1,
+					kind: 'completion',
+					runId: runId('run-0'),
+					completion: { items: [{ type: 'text', id: 't', text: 'Hello', turnId: 's0' }] }
+				})
+			],
+			live: null,
+			latestRun: null,
+			liveRestore: {
+				threadId: threadRecordId('thread-a'),
+				overlay: initial
+			},
+			userId: 'user_1',
+			threadId: threadRecordId('thread-a')
+		});
+		expect(kept).toHaveLength(3);
+		expect(kept.map((message) => message.type)).toEqual(['prompt', 'response', 'response']);
+	});
+
+	it('keeps the live overlay while the same thread reconnects', () => {
+		const live = lastLive({
+			threadId: threadRecordId('thread-1'),
+			override: {
+				runId: runId('run-1'),
+				runStatus: 'running',
+				streamId: 's1',
+				text: 'working',
+				parts: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }],
+				runStartedAt: 200_000
+			}
+		});
+		const result = mergePagedTranscriptWithLive({
+			parts: [
+				part({
+					number: 0,
+					kind: 'prompt',
+					runId: runId('run-1'),
+					prompt: { text: 'Do it', imageUploads: [] }
+				}),
+				part({
+					number: 1,
+					kind: 'tool',
+					runId: runId('run-1'),
+					tool: {
+						callId: 'c1',
+						name: 'exec_command',
+						output: 'ok',
+						status: 'completed'
+					}
+				})
+			],
+			live: null,
+			latestRun: {
+				_id: runId('run-1'),
+				status: 'running',
+				startedAt: 200_000
+			},
+			liveRestore: { threadId: threadRecordId('thread-1'), overlay: live },
+			userId: 'user_1',
+			threadId: threadRecordId('thread-1')
+		});
+		expect(result.map((message) => message.type)).toEqual(['prompt', 'response']);
+		expect(result.at(-1)?.text).toBe('working');
+	});
+
+	it('never places the live run prompt below its own response', () => {
+		const messages = mergePagedTranscriptWithLive({
+			parts: [
+				part({
+					number: 0,
+					kind: 'completion',
+					runId: runId('run-1'),
+					completion: { items: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }] }
+				})
+			],
+			live: null,
+			latestRun: {
+				_id: runId('run-1'),
+				status: 'running',
+				startedAt: 200_000
+			},
+			latestPrompt: { text: 'Do it', imageUploadIds: [] },
+			userId: 'user_1',
+			threadId: threadRecordId('thread-1')
+		});
+		expect(messages.map((message) => message.type)).toEqual(['prompt', 'response']);
+		expect(messages[0]?.text).toBe('Do it');
+		expect(messages[0]?.runStatus).toBe('running');
+		expect(messages[1]?.text).toBe('working');
+	});
+
 	it('keeps the live completion until the matching finalized record is present', () => {
 		const live: LiveCompletionOverlay = {
 			threadId: threadRecordId('thread-1'),
@@ -127,6 +256,7 @@ describe('mergePagedTranscriptWithLive', () => {
 		});
 		expect(withFinal.at(-1)?.text).toBe('done');
 		expect(withoutFinal.at(-1)?._id).toBe(withFinal.at(-1)?._id);
+		expect(withoutFinal.at(-1)?.order).toBe(10);
 	});
 
 	it('keeps replica tool results while the live overlay is still streaming', () => {

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -7,343 +7,101 @@ import {
 	messagesFromTranscriptParts
 } from '$lib/project/transcript';
 
-function threadRecordId(value: string): Id<'threadRecords'> {
-	// SAFETY: fixture strings are only compared as opaque Convex document ids.
-	return value as Id<'threadRecords'>;
-}
-
-function runId(value: string): Id<'runs'> {
-	// SAFETY: fixture strings are only compared as opaque Convex document ids.
-	return value as Id<'runs'>;
-}
+const threadId = (value = 'thread-1') => value as Id<'threadRecords'>;
+const runId = (value = 'run-1') => value as Id<'runs'>;
 
 function part(
 	overrides: Partial<LocalTranscriptPart> & Pick<LocalTranscriptPart, 'number' | 'kind'>
 ): LocalTranscriptPart {
+	return { sourceKey: `part:${overrides.number}`, runId: runId(), ...overrides };
+}
+
+function live(overrides: Partial<LiveCompletionOverlay> = {}): LiveCompletionOverlay {
 	return {
-		sourceKey: `part:${overrides.number}`,
-		runId: runId('run-1'),
+		threadId: threadId(),
+		runId: runId(),
+		runStatus: 'running',
+		streamId: 's2',
+		text: 'working',
+		parts: [{ type: 'text', id: 't2', text: 'working', turnId: 's2' }],
+		runStartedAt: 10,
 		...overrides
 	};
 }
 
-function lastLive(args: {
-	threadId: Id<'threadRecords'>;
-	override: Omit<LiveCompletionOverlay, 'threadId'>;
-}): LiveCompletionOverlay {
-	return { threadId: args.threadId, ...args.override };
-}
-
 describe('messagesFromTranscriptParts', () => {
-	it('orders prompts, completions, and tools into chat messages', () => {
+	it('orders durable messages by transcript part number', () => {
 		const messages = messagesFromTranscriptParts({
 			userId: 'user_1',
-			threadId: threadRecordId('thread-1'),
+			threadId: threadId(),
 			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				}),
 				part({
 					number: 1,
 					kind: 'completion',
-					completion: {
-						streamId: 's1',
-						items: [{ type: 'text', id: 't', text: 'Hello', turnId: 's1' }]
-					}
+					completion: { items: [{ type: 'text', id: 't', text: 'Hello', turnId: 's1' }] }
 				}),
-				part({
-					number: 2,
-					kind: 'tool',
-					tool: {
-						callId: 'c1',
-						name: 'exec_command',
-						output: 'ok',
-						status: 'completed'
-					}
-				}),
-				part({
-					number: 3,
-					kind: 'completion',
-					completion: {
-						streamId: 's2',
-						items: [{ type: 'text', id: 't2', text: 'Done', turnId: 's2' }]
-					}
-				})
+				part({ number: 0, kind: 'prompt', prompt: { text: 'Hi', imageUploads: [] } })
 			]
 		});
-		expect(messages.map((message) => message.type)).toEqual(['prompt', 'response']);
-		expect(messages[0]?.text).toBe('Hi');
-		expect(messages[1]?.text).toBe('HelloDone');
-		expect(messages[1]?.parts.map((entry) => entry.type)).toEqual(['text', 'tool-result', 'text']);
+
+		expect(messages.map((message) => [message.type, message.text])).toEqual([
+			['prompt', 'Hi'],
+			['response', 'Hello']
+		]);
 	});
 });
 
 describe('mergePagedTranscriptWithLive', () => {
-	it('does not leak or prematurely restore a live completion after a thread switch', () => {
-		const initial = lastLive({
-			threadId: threadRecordId('thread-a'),
-			override: {
-				runId: runId('run-1'),
-				runStatus: 'running',
-				streamId: 's1',
-				text: 'working',
-				parts: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }],
-				runStartedAt: 200_000
-			}
-		});
-		const restored = mergePagedTranscriptWithLive({
+	it('never displays a live completion from another thread', () => {
+		const messages = mergePagedTranscriptWithLive({
 			parts: [],
-			live: initial,
-			latestRun: null,
-			liveRestore: { threadId: threadRecordId('thread-b'), overlay: null },
+			live: live({ threadId: threadId('thread-a') }),
 			userId: 'user_1',
-			threadId: threadRecordId('thread-b')
+			threadId: threadId('thread-b')
 		});
-		expect(restored).toEqual([]);
-		const pendingLatestRun = mergePagedTranscriptWithLive({
-			parts: [],
-			live: null,
-			latestRun: null,
-			liveRestore: { threadId: threadRecordId('thread-a'), overlay: initial },
-			userId: 'user_1',
-			threadId: threadRecordId('thread-a')
-		});
-		expect(pendingLatestRun).toEqual([]);
-		const completedLatestRun = mergePagedTranscriptWithLive({
-			parts: [],
-			live: null,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'completed',
-				startedAt: 200_000,
-				completedAt: 210_000
-			},
-			liveRestore: { threadId: threadRecordId('thread-a'), overlay: initial },
-			userId: 'user_1',
-			threadId: threadRecordId('thread-a')
-		});
-		expect(completedLatestRun).toEqual([]);
 
-		const kept = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					runId: runId('run-0'),
-					prompt: { text: 'Hi', imageUploads: [] }
-				}),
-				part({
-					number: 1,
-					kind: 'completion',
-					runId: runId('run-0'),
-					completion: { items: [{ type: 'text', id: 't', text: 'Hello', turnId: 's0' }] }
-				})
-			],
-			live: null,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 200_000
-			},
-			liveRestore: {
-				threadId: threadRecordId('thread-a'),
-				overlay: initial
-			},
-			userId: 'user_1',
-			threadId: threadRecordId('thread-a')
-		});
-		expect(kept).toHaveLength(3);
-		expect(kept.map((message) => message.type)).toEqual(['prompt', 'response', 'response']);
+		expect(messages).toEqual([]);
 	});
 
-	it('keeps the live overlay while the same thread reconnects', () => {
-		const live = lastLive({
-			threadId: threadRecordId('thread-1'),
-			override: {
-				runId: runId('run-1'),
-				runStatus: 'running',
-				streamId: 's1',
-				text: 'working',
-				parts: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }],
-				runStartedAt: 200_000
-			}
-		});
-		const result = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					runId: runId('run-1'),
-					prompt: { text: 'Do it', imageUploads: [] }
-				}),
-				part({
-					number: 1,
-					kind: 'tool',
-					runId: runId('run-1'),
-					tool: {
-						callId: 'c1',
-						name: 'exec_command',
-						output: 'ok',
-						status: 'completed'
-					}
-				})
-			],
-			live: null,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 200_000
-			},
-			liveRestore: { threadId: threadRecordId('thread-1'), overlay: live },
+	it('places a numbered replica prompt before its live response', () => {
+		const messages = mergePagedTranscriptWithLive({
+			parts: [part({ number: 7, kind: 'prompt', prompt: { text: 'Do it', imageUploads: [] } })],
+			live: live(),
 			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
+			threadId: threadId()
 		});
-		expect(result.map((message) => message.type)).toEqual(['prompt', 'response']);
-		expect(result.at(-1)?.text).toBe('working');
+
+		expect(messages.map((message) => [message.type, message.text])).toEqual([
+			['prompt', 'Do it'],
+			['response', 'working']
+		]);
 	});
 
-	it('never places the live run prompt below its own response', () => {
+	it('suppresses live output once its durable completion is present', () => {
 		const messages = mergePagedTranscriptWithLive({
 			parts: [
-				part({
-					number: 0,
-					kind: 'completion',
-					runId: runId('run-1'),
-					completion: { items: [{ type: 'text', id: 't', text: 'working', turnId: 's1' }] }
-				})
-			],
-			live: null,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 200_000
-			},
-			latestPrompt: { text: 'Do it', imageUploadIds: [] },
-			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
-		});
-		expect(messages.map((message) => message.type)).toEqual(['prompt', 'response']);
-		expect(messages[0]?.text).toBe('Do it');
-		expect(messages[0]?.runStatus).toBe('running');
-		expect(messages[1]?.text).toBe('working');
-	});
-
-	it('keeps the live completion until the matching finalized record is present', () => {
-		const live: LiveCompletionOverlay = {
-			threadId: threadRecordId('thread-1'),
-			runId: runId('run-1'),
-			runStatus: 'running',
-			streamId: 's1',
-			text: 'partial',
-			parts: [{ type: 'text', id: 't', text: 'partial', turnId: 's1' }],
-			runStartedAt: 10
-		};
-		const withoutFinal = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				})
-			],
-			live,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'failed',
-				startedAt: 10
-			},
-			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
-		});
-		expect(withoutFinal.at(-1)?.text).toBe('partial');
-		expect(withoutFinal.at(-1)?.runStatus).toBe('failed');
-
-		const withFinal = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				}),
+				part({ number: 0, kind: 'prompt', prompt: { text: 'Hi', imageUploads: [] } }),
 				part({
 					number: 1,
 					kind: 'completion',
 					completion: {
-						streamId: 's1',
-						items: [{ type: 'text', id: 't', text: 'done', turnId: 's1' }]
+						streamId: 's2',
+						items: [{ type: 'text', id: 'done', text: 'done', turnId: 's2' }]
 					}
 				})
 			],
-			live,
-			latestRun: null,
+			live: live(),
 			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
+			threadId: threadId()
 		});
-		expect(withFinal.at(-1)?.text).toBe('done');
-		expect(withoutFinal.at(-1)?._id).toBe(withFinal.at(-1)?._id);
-		expect(withoutFinal.at(-1)?.order).toBe(10);
+
+		expect(messages.at(-1)?.text).toBe('done');
 	});
 
-	it('keeps replica tool results while the live overlay is still streaming', () => {
-		const live: LiveCompletionOverlay = {
-			threadId: threadRecordId('thread-1'),
-			runId: runId('run-1'),
-			runStatus: 'running',
-			streamId: 's2',
-			text: 'working',
-			parts: [{ type: 'text', id: 't', text: 'working', turnId: 's2' }],
-			runStartedAt: 10
-		};
+	it('keeps durable tool results while overlaying the current stream', () => {
 		const messages = mergePagedTranscriptWithLive({
 			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				}),
-				part({
-					number: 1,
-					kind: 'tool',
-					tool: {
-						callId: 'c1',
-						name: 'exec_command',
-						output: 'ok',
-						status: 'completed'
-					}
-				})
-			],
-			live,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 10
-			},
-			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
-		});
-		const response = messages.find((message) => message.type === 'response');
-		expect(response?.parts.map((entry) => entry.type)).toEqual(['tool-result', 'text']);
-	});
-
-	it('keeps earlier finalized turns while a later stream is live', () => {
-		const live: LiveCompletionOverlay = {
-			threadId: threadRecordId('thread-1'),
-			runId: runId('run-1'),
-			runStatus: 'running',
-			streamId: 's2',
-			text: 'working',
-			parts: [{ type: 'text', id: 't2', text: 'working', turnId: 's2' }],
-			runStartedAt: 10
-		};
-		const messages = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				}),
+				part({ number: 0, kind: 'prompt', prompt: { text: 'Hi', imageUploads: [] } }),
 				part({
 					number: 1,
 					kind: 'completion',
@@ -363,44 +121,25 @@ describe('mergePagedTranscriptWithLive', () => {
 					}
 				})
 			],
-			live,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 10
-			},
+			live: live(),
 			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
+			threadId: threadId()
 		});
+
 		const response = messages.find((message) => message.type === 'response');
 		expect(response?.text).toBe('Hello\n\nworking');
 		expect(response?.parts.map((entry) => entry.type)).toEqual(['text', 'tool-result', 'text']);
 	});
-
-	it('applies latest-run status onto the matching replica messages', () => {
-		const messages = mergePagedTranscriptWithLive({
-			parts: [
-				part({
-					number: 0,
-					kind: 'prompt',
-					prompt: { text: 'Hi', imageUploads: [] }
-				})
-			],
-			live: null,
-			latestRun: {
-				_id: runId('run-1'),
-				status: 'running',
-				startedAt: 50
-			},
-			userId: 'user_1',
-			threadId: threadRecordId('thread-1')
-		});
-		expect(messages[0]?.runStatus).toBe('running');
-		expect(messages[0]?.runStartedAt).toBe(50);
-	});
 });
 
 describe('mergeTranscriptParts', () => {
+	it('deduplicates an optimistic prompt when replica sync returns it', () => {
+		const prompt = part({ number: 2, kind: 'prompt', prompt: { text: 'new', imageUploads: [] } });
+		const merged = mergeTranscriptParts([prompt], [{ ...prompt }]);
+
+		expect(merged).toEqual([prompt]);
+	});
+
 	it('keeps already-fetched parts when an older page arrives', () => {
 		const merged = mergeTranscriptParts(
 			[part({ number: 2, kind: 'prompt', prompt: { text: 'new', imageUploads: [] } })],

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -81,7 +81,7 @@ describe('messagesFromTranscriptParts', () => {
 });
 
 describe('mergePagedTranscriptWithLive', () => {
-	it('keeps the live completion while reconnecting after a thread switch', () => {
+	it('does not leak or prematurely restore a live completion after a thread switch', () => {
 		const initial = lastLive({
 			threadId: threadRecordId('thread-a'),
 			override: {
@@ -102,6 +102,15 @@ describe('mergePagedTranscriptWithLive', () => {
 			threadId: threadRecordId('thread-b')
 		});
 		expect(restored).toEqual([]);
+		const pendingLatestRun = mergePagedTranscriptWithLive({
+			parts: [],
+			live: null,
+			latestRun: null,
+			liveRestore: { threadId: threadRecordId('thread-a'), overlay: initial },
+			userId: 'user_1',
+			threadId: threadRecordId('thread-a')
+		});
+		expect(pendingLatestRun).toEqual([]);
 
 		const kept = mergePagedTranscriptWithLive({
 			parts: [
@@ -119,7 +128,11 @@ describe('mergePagedTranscriptWithLive', () => {
 				})
 			],
 			live: null,
-			latestRun: null,
+			latestRun: {
+				_id: runId('run-1'),
+				status: 'running',
+				startedAt: 200_000
+			},
 			liveRestore: {
 				threadId: threadRecordId('thread-a'),
 				overlay: initial

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -7,7 +7,9 @@ import {
 	messagesFromTranscriptParts
 } from '$lib/project/transcript';
 
+// SAFETY: Tests use stable opaque strings where only ID equality matters.
 const threadId = (value = 'thread-1') => value as Id<'threadRecords'>;
+// SAFETY: Tests use stable opaque strings where only ID equality matters.
 const runId = (value = 'run-1') => value as Id<'runs'>;
 
 function part(

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -220,7 +220,12 @@ function resolveLiveOverlay(args: {
 		return null;
 	}
 	const latestRun = args.latestRun;
-	if (latestRun?._id === restore.overlay.runId) {
+	if (
+		latestRun?._id === restore.overlay.runId &&
+		(latestRun.status === 'queued' ||
+			latestRun.status === 'running' ||
+			latestRun.status === 'awaiting_executor')
+	) {
 		return restore.overlay;
 	}
 	return null;

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -9,19 +9,38 @@ import type {
 import type { Infer } from 'convex/values';
 import { vRunStatus } from '$convex/lib/validators';
 
-function compareMessagesChronologically(left: ThreadMessage, right: ThreadMessage): number {
+function messageTypeRank(message: ThreadMessage): number {
+	return message.type === 'prompt' ? 0 : 1;
+}
+
+function compareMessagesByOrder(left: ThreadMessage, right: ThreadMessage): number {
+	// Latest-run messages carry their wall-clock startedAt as their order so they
+	// always sort after the other runs' transcript parts. Within a run the
+	// prompt and its response share that value, so the type rank keeps the
+	// prompt above the response.
+	if (left.order !== right.order) {
+		if (left.order === undefined) {
+			return 1;
+		}
+		if (right.order === undefined) {
+			return -1;
+		}
+		return left.order - right.order;
+	}
 	if (left.runStartedAt !== right.runStartedAt) {
 		return left.runStartedAt - right.runStartedAt;
+	}
+	const leftRank = messageTypeRank(left);
+	const rightRank = messageTypeRank(right);
+	if (leftRank !== rightRank) {
+		return leftRank - rightRank;
 	}
 	const leftCreated = left._creationTime ?? 0;
 	const rightCreated = right._creationTime ?? 0;
 	if (leftCreated !== rightCreated) {
 		return leftCreated - rightCreated;
 	}
-	if (left.type !== right.type) {
-		return left.type === 'prompt' ? -1 : 1;
-	}
-	return left._id.localeCompare(right._id);
+	return String(left._id).localeCompare(String(right._id));
 }
 
 function promptMessageId(runId: Id<'runs'>): Id<'threadMessages'> {
@@ -87,6 +106,7 @@ export function messagesFromTranscriptParts(args: {
 			messages.push({
 				_id: promptMessageId(part.runId),
 				_creationTime: part.number,
+				order: part.number,
 				threadId: args.threadId,
 				runId: part.runId,
 				userId: args.userId,
@@ -114,6 +134,7 @@ export function messagesFromTranscriptParts(args: {
 			pendingResponse = {
 				_id: responseMessageId(part.runId),
 				_creationTime: part.number,
+				order: part.number,
 				threadId: args.threadId,
 				runId: part.runId,
 				userId: args.userId,
@@ -139,6 +160,7 @@ export function messagesFromTranscriptParts(args: {
 					pendingResponse = {
 						_id: responseMessageId(part.runId),
 						_creationTime: part.number,
+						order: part.number,
 						threadId: args.threadId,
 						runId: part.runId,
 						userId: args.userId,
@@ -175,9 +197,39 @@ function historyHasLiveCompletion(
 	});
 }
 
+function resolveLiveOverlay(args: {
+	threadId: Id<'threadRecords'>;
+	live: LiveCompletionOverlay | null;
+	latestRun: {
+		_id: Id<'runs'>;
+		status: Infer<typeof vRunStatus>;
+		startedAt: number;
+		completedAt?: number;
+	} | null;
+	liveRestore?: { threadId: Id<'threadRecords'>; overlay: LiveCompletionOverlay | null };
+}): LiveCompletionOverlay | null {
+	if (args.live) {
+		if (args.live.threadId !== args.threadId) {
+			// The stream belongs to a different thread; never leak it into this view.
+			return null;
+		}
+		return args.live;
+	}
+	const restore = args.liveRestore;
+	if (!restore || restore.threadId !== args.threadId || !restore.overlay) {
+		return null;
+	}
+	const latestRun = args.latestRun;
+	if (!latestRun || latestRun._id === restore.overlay.runId) {
+		return restore.overlay;
+	}
+	return null;
+}
+
 export function mergePagedTranscriptWithLive(args: {
 	parts: LocalTranscriptPart[];
 	live: LiveCompletionOverlay | null;
+	liveRestore?: { threadId: Id<'threadRecords'>; overlay: LiveCompletionOverlay | null };
 	latestRun: {
 		_id: Id<'runs'>;
 		status: Infer<typeof vRunStatus>;
@@ -203,6 +255,7 @@ export function mergePagedTranscriptWithLive(args: {
 			}
 			message.runStatus = latestRun.status;
 			message.runStartedAt = latestRun.startedAt;
+			message.order = latestRun.startedAt;
 			if (latestRun.completedAt !== undefined) {
 				message.runCompletedAt = latestRun.completedAt;
 			}
@@ -217,6 +270,7 @@ export function mergePagedTranscriptWithLive(args: {
 		messages.push({
 			_id: promptMessageId(latestRun._id),
 			_creationTime: latestRun.startedAt,
+			order: latestRun.startedAt,
 			threadId: args.threadId,
 			runId: latestRun._id,
 			userId: args.userId,
@@ -236,7 +290,12 @@ export function mergePagedTranscriptWithLive(args: {
 		});
 	}
 
-	const live = args.live;
+	const live = resolveLiveOverlay({
+		threadId: args.threadId,
+		live: args.live,
+		latestRun: args.latestRun,
+		liveRestore: args.liveRestore
+	});
 	if (live && !historyHasLiveCompletion(args.parts, live)) {
 		const existingIndex = messages.findIndex(
 			(message) => message.type === 'response' && message.runId === live.runId
@@ -262,6 +321,7 @@ export function mergePagedTranscriptWithLive(args: {
 		const overlay: ThreadMessage = {
 			_id: existing?._id ?? responseMessageId(live.runId),
 			_creationTime: live.runStartedAt,
+			order: live.runStartedAt,
 			threadId: args.threadId,
 			runId: live.runId,
 			userId: args.userId,
@@ -279,7 +339,7 @@ export function mergePagedTranscriptWithLive(args: {
 		}
 	}
 
-	return messages.sort(compareMessagesChronologically);
+	return messages.sort(compareMessagesByOrder);
 }
 
 export function mergeTranscriptParts(

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -220,7 +220,7 @@ function resolveLiveOverlay(args: {
 		return null;
 	}
 	const latestRun = args.latestRun;
-	if (!latestRun || latestRun._id === restore.overlay.runId) {
+	if (latestRun?._id === restore.overlay.runId) {
 		return restore.overlay;
 	}
 	return null;

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -6,42 +6,6 @@ import type {
 	MessageAttachment,
 	ThreadMessage
 } from '$lib/types/sprocket';
-import type { Infer } from 'convex/values';
-import { vRunStatus } from '$convex/lib/validators';
-
-function messageTypeRank(message: ThreadMessage): number {
-	return message.type === 'prompt' ? 0 : 1;
-}
-
-function compareMessagesByOrder(left: ThreadMessage, right: ThreadMessage): number {
-	// Latest-run messages carry their wall-clock startedAt as their order so they
-	// always sort after the other runs' transcript parts. Within a run the
-	// prompt and its response share that value, so the type rank keeps the
-	// prompt above the response.
-	if (left.order !== right.order) {
-		if (left.order === undefined) {
-			return 1;
-		}
-		if (right.order === undefined) {
-			return -1;
-		}
-		return left.order - right.order;
-	}
-	if (left.runStartedAt !== right.runStartedAt) {
-		return left.runStartedAt - right.runStartedAt;
-	}
-	const leftRank = messageTypeRank(left);
-	const rightRank = messageTypeRank(right);
-	if (leftRank !== rightRank) {
-		return leftRank - rightRank;
-	}
-	const leftCreated = left._creationTime ?? 0;
-	const rightCreated = right._creationTime ?? 0;
-	if (leftCreated !== rightCreated) {
-		return leftCreated - rightCreated;
-	}
-	return String(left._id).localeCompare(String(right._id));
-}
 
 function promptMessageId(runId: Id<'runs'>): Id<'threadMessages'> {
 	// SAFETY: local replica rows are not Convex threadMessages documents.
@@ -106,7 +70,6 @@ export function messagesFromTranscriptParts(args: {
 			messages.push({
 				_id: promptMessageId(part.runId),
 				_creationTime: part.number,
-				order: part.number,
 				threadId: args.threadId,
 				runId: part.runId,
 				userId: args.userId,
@@ -134,7 +97,6 @@ export function messagesFromTranscriptParts(args: {
 			pendingResponse = {
 				_id: responseMessageId(part.runId),
 				_creationTime: part.number,
-				order: part.number,
 				threadId: args.threadId,
 				runId: part.runId,
 				userId: args.userId,
@@ -160,7 +122,6 @@ export function messagesFromTranscriptParts(args: {
 					pendingResponse = {
 						_id: responseMessageId(part.runId),
 						_creationTime: part.number,
-						order: part.number,
 						threadId: args.threadId,
 						runId: part.runId,
 						userId: args.userId,
@@ -197,51 +158,9 @@ function historyHasLiveCompletion(
 	});
 }
 
-function resolveLiveOverlay(args: {
-	threadId: Id<'threadRecords'>;
-	live: LiveCompletionOverlay | null;
-	latestRun: {
-		_id: Id<'runs'>;
-		status: Infer<typeof vRunStatus>;
-		startedAt: number;
-		completedAt?: number;
-	} | null;
-	liveRestore?: { threadId: Id<'threadRecords'>; overlay: LiveCompletionOverlay | null };
-}): LiveCompletionOverlay | null {
-	if (args.live) {
-		if (args.live.threadId !== args.threadId) {
-			// The stream belongs to a different thread; never leak it into this view.
-			return null;
-		}
-		return args.live;
-	}
-	const restore = args.liveRestore;
-	if (!restore || restore.threadId !== args.threadId || !restore.overlay) {
-		return null;
-	}
-	const latestRun = args.latestRun;
-	if (
-		latestRun?._id === restore.overlay.runId &&
-		(latestRun.status === 'queued' ||
-			latestRun.status === 'running' ||
-			latestRun.status === 'awaiting_executor')
-	) {
-		return restore.overlay;
-	}
-	return null;
-}
-
 export function mergePagedTranscriptWithLive(args: {
 	parts: LocalTranscriptPart[];
 	live: LiveCompletionOverlay | null;
-	liveRestore?: { threadId: Id<'threadRecords'>; overlay: LiveCompletionOverlay | null };
-	latestRun: {
-		_id: Id<'runs'>;
-		status: Infer<typeof vRunStatus>;
-		startedAt: number;
-		completedAt?: number;
-	} | null;
-	latestPrompt?: { text: string; imageUploadIds: Id<'imageUploads'>[] };
 	userId: string;
 	threadId: Id<'threadRecords'>;
 	attachmentUrls?: Map<string, string>;
@@ -252,55 +171,7 @@ export function mergePagedTranscriptWithLive(args: {
 		threadId: args.threadId,
 		attachmentUrls: args.attachmentUrls
 	});
-	const latestRun = args.latestRun;
-	if (latestRun) {
-		for (const message of messages) {
-			if (message.runId !== latestRun._id) {
-				continue;
-			}
-			message.runStatus = latestRun.status;
-			message.runStartedAt = latestRun.startedAt;
-			message.order = latestRun.startedAt;
-			if (latestRun.completedAt !== undefined) {
-				message.runCompletedAt = latestRun.completedAt;
-			}
-		}
-	}
-
-	if (
-		latestRun &&
-		args.latestPrompt &&
-		!messages.some((message) => message.type === 'prompt' && message.runId === latestRun._id)
-	) {
-		messages.push({
-			_id: promptMessageId(latestRun._id),
-			_creationTime: latestRun.startedAt,
-			order: latestRun.startedAt,
-			threadId: args.threadId,
-			runId: latestRun._id,
-			userId: args.userId,
-			type: 'prompt',
-			text: args.latestPrompt.text,
-			attachments: args.latestPrompt.imageUploadIds.map((imageUploadId) => ({
-				imageUploadId,
-				name: 'attachment',
-				mediaType: 'application/octet-stream',
-				size: 0,
-				url: args.attachmentUrls?.get(imageUploadId) ?? null
-			})),
-			parts: [],
-			runStatus: latestRun.status,
-			runStartedAt: latestRun.startedAt,
-			runCompletedAt: latestRun.completedAt
-		});
-	}
-
-	const live = resolveLiveOverlay({
-		threadId: args.threadId,
-		live: args.live,
-		latestRun: args.latestRun,
-		liveRestore: args.liveRestore
-	});
+	const live = args.live?.threadId === args.threadId ? args.live : null;
 	if (live && !historyHasLiveCompletion(args.parts, live)) {
 		const existingIndex = messages.findIndex(
 			(message) => message.type === 'response' && message.runId === live.runId
@@ -326,7 +197,6 @@ export function mergePagedTranscriptWithLive(args: {
 		const overlay: ThreadMessage = {
 			_id: existing?._id ?? responseMessageId(live.runId),
 			_creationTime: live.runStartedAt,
-			order: live.runStartedAt,
 			threadId: args.threadId,
 			runId: live.runId,
 			userId: args.userId,
@@ -334,7 +204,7 @@ export function mergePagedTranscriptWithLive(args: {
 			text: joinAssistantTextParts(parts),
 			attachments: [],
 			parts,
-			runStatus: latestRun && latestRun._id === live.runId ? latestRun.status : live.runStatus,
+			runStatus: live.runStatus,
 			runStartedAt: live.runStartedAt
 		};
 		if (existingIndex >= 0) {
@@ -344,7 +214,7 @@ export function mergePagedTranscriptWithLive(args: {
 		}
 	}
 
-	return messages.sort(compareMessagesByOrder);
+	return messages;
 }
 
 export function mergeTranscriptParts(

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -94,9 +94,6 @@ export type MessageAttachment = {
 export type ThreadMessage = {
 	_id: Id<'threadMessages'>;
 	_creationTime?: number;
-	// Monotonic transcript position (part number for history, wall-clock for the
-	// latest run) used to order messages coming from different replica viewers.
-	order?: number;
 	threadId: Id<'threadRecords'>;
 	runId: Id<'runs'>;
 	userId: string;

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -94,6 +94,9 @@ export type MessageAttachment = {
 export type ThreadMessage = {
 	_id: Id<'threadMessages'>;
 	_creationTime?: number;
+	// Monotonic transcript position (part number for history, wall-clock for the
+	// latest run) used to order messages coming from different replica viewers.
+	order?: number;
 	threadId: Id<'threadRecords'>;
 	runId: Id<'runs'>;
 	userId: string;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -513,80 +513,24 @@
 	let replicaNextBefore = $state<number | null>(null);
 	let replicaStale = $state(false);
 	let replicaThreadId = $state<Id<'threadRecords'> | null>(null);
-	let replicaReachedHistoryStart = $state(false);
 	let replicaLoading = $state(false);
 	let replicaContextSummary = $state<string | null>(null);
 	let replicaError = $state<string | null>(null);
 	let loadingOlderTranscript = $state(false);
 	let liveCompletion = $state<LiveCompletionOverlay | null>(null);
-	let liveRestore = $state<{
-		threadId: Id<'threadRecords'>;
-		overlay: LiveCompletionOverlay | null;
-	} | null>(null);
-	const lastLiveByThread = new SvelteMap<Id<'threadRecords'>, LiveCompletionOverlay>();
-	let liveWatchGenerationForThread = 0;
-	const replicaCache = new SvelteMap<
-		Id<'threadRecords'>,
-		{
-			parts: LocalTranscriptPart[];
-			nextBefore: number | null;
-			stale: boolean;
-			reachedHistoryStart: boolean;
-			contextSummary: string | null;
-		}
-	>();
 
 	function applyOlderPageCursor(nextBefore: number | undefined) {
-		replicaReachedHistoryStart = nextBefore == null;
 		replicaNextBefore = nextBefore ?? null;
 	}
 
-	function rememberReplica(threadId: Id<'threadRecords'>) {
-		replicaCache.set(threadId, {
-			parts: replicaParts.slice(),
-			nextBefore: replicaNextBefore,
-			stale: replicaStale,
-			reachedHistoryStart: replicaReachedHistoryStart,
-			contextSummary: replicaContextSummary
-		});
-	}
-
 	function showReplicaForThread(threadId: Id<'threadRecords'> | null) {
-		if (replicaThreadId && replicaThreadId !== threadId) {
-			rememberReplica(replicaThreadId);
-		}
-		if (threadId) {
-			liveRestore = { threadId, overlay: lastLiveByThread.get(threadId) ?? null };
-		} else {
-			liveRestore = null;
-		}
 		replicaThreadId = threadId;
 		liveCompletion = null;
 		replicaError = null;
-		if (!threadId) {
-			replicaParts = [];
-			replicaNextBefore = null;
-			replicaStale = false;
-			replicaReachedHistoryStart = false;
-			replicaLoading = false;
-			replicaContextSummary = null;
-			return;
-		}
-		const cached = replicaCache.get(threadId);
-		if (cached) {
-			replicaParts = cached.parts.slice();
-			replicaNextBefore = cached.nextBefore;
-			replicaStale = cached.stale;
-			replicaReachedHistoryStart = cached.reachedHistoryStart;
-			replicaLoading = false;
-			replicaContextSummary = cached.contextSummary;
-			return;
-		}
 		replicaParts = [];
 		replicaNextBefore = null;
 		replicaStale = false;
-		replicaReachedHistoryStart = false;
-		replicaLoading = true;
+		replicaLoading = threadId !== null;
 		replicaContextSummary = null;
 	}
 
@@ -625,7 +569,6 @@
 				replicaError = null;
 				replicaContextSummary = page.contextSummary ?? null;
 				applyOlderPageCursor(page.nextBefore);
-				rememberReplica(watchedThreadId);
 			} catch {
 				if (!ac.signal.aborted) {
 					replicaLoading = false;
@@ -646,6 +589,9 @@
 					{
 						signal: ac.signal,
 						onEvent: (event) => {
+							if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
+								return;
+							}
 							replicaStale = event.stale;
 							void refreshNewestTranscriptPage(watchedThreadId, userId);
 						}
@@ -674,11 +620,6 @@
 		}
 		const ac = new AbortController();
 		const watchedThreadId = threadId;
-		const watchGeneration = ++liveWatchGenerationForThread;
-		const restoredOverlay = untrack(() => lastLiveByThread.get(watchedThreadId));
-		if (restoredOverlay) {
-			liveRestore = { threadId: watchedThreadId, overlay: restoredOverlay };
-		}
 		void (async () => {
 			while (!ac.signal.aborted) {
 				try {
@@ -695,17 +636,10 @@
 									if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
 										return;
 									}
-									if (watchGeneration !== liveWatchGenerationForThread) {
-										return;
-									}
 									if (event.eventType === 'updated') {
-										lastLiveByThread.set(watchedThreadId, event.live);
 										liveCompletion = event.live;
-										liveRestore = null;
 									} else {
-										lastLiveByThread.delete(watchedThreadId);
 										liveCompletion = null;
-										liveRestore = { threadId: watchedThreadId, overlay: null };
 									}
 								}
 							}
@@ -746,20 +680,9 @@
 			return [];
 		}
 		const live = latestRunResumeKind ? null : liveCompletion;
-		const liveRestoreForThread = latestRunResumeKind ? null : liveRestore;
-		const latestRun = currentLatestRunData?.run ?? null;
 		return mergePagedTranscriptWithLive({
 			parts: replicaParts,
 			live,
-			liveRestore: liveRestoreForThread ?? undefined,
-			latestRun,
-			latestPrompt:
-				latestRun && currentLatestRunData?.prompt
-					? {
-							text: currentLatestRunData.prompt,
-							imageUploadIds: currentLatestRunData.imageUploadIds ?? []
-						}
-					: undefined,
 			userId,
 			threadId: currentThreadId
 		});
@@ -1359,7 +1282,6 @@
 		replicaParts = mergeTranscriptParts(replicaParts, page.parts);
 		replicaStale = page.stale;
 		replicaContextSummary = page.contextSummary ?? replicaContextSummary;
-		rememberReplica(threadId);
 	}
 
 	async function loadOlderTranscript() {
@@ -1382,7 +1304,6 @@
 			replicaParts = mergeTranscriptParts(replicaParts, page.parts);
 			replicaStale = page.stale;
 			applyOlderPageCursor(page.nextBefore);
-			rememberReplica(threadId);
 		} catch {
 			replicaStale = true;
 		} finally {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -519,6 +519,12 @@
 	let replicaError = $state<string | null>(null);
 	let loadingOlderTranscript = $state(false);
 	let liveCompletion = $state<LiveCompletionOverlay | null>(null);
+	let liveRestore = $state<{
+		threadId: Id<'threadRecords'>;
+		overlay: LiveCompletionOverlay | null;
+	} | null>(null);
+	const lastLiveByThread = new SvelteMap<Id<'threadRecords'>, LiveCompletionOverlay>();
+	let liveWatchGenerationForThread = 0;
 	const replicaCache = new SvelteMap<
 		Id<'threadRecords'>,
 		{
@@ -548,6 +554,11 @@
 	function showReplicaForThread(threadId: Id<'threadRecords'> | null) {
 		if (replicaThreadId && replicaThreadId !== threadId) {
 			rememberReplica(replicaThreadId);
+		}
+		if (threadId) {
+			liveRestore = { threadId, overlay: lastLiveByThread.get(threadId) ?? null };
+		} else {
+			liveRestore = null;
 		}
 		replicaThreadId = threadId;
 		liveCompletion = null;
@@ -663,6 +674,11 @@
 		}
 		const ac = new AbortController();
 		const watchedThreadId = threadId;
+		const watchGeneration = ++liveWatchGenerationForThread;
+		const restoredOverlay = untrack(() => lastLiveByThread.get(watchedThreadId));
+		if (restoredOverlay) {
+			liveRestore = { threadId: watchedThreadId, overlay: restoredOverlay };
+		}
 		void (async () => {
 			while (!ac.signal.aborted) {
 				try {
@@ -679,10 +695,17 @@
 									if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
 										return;
 									}
+									if (watchGeneration !== liveWatchGenerationForThread) {
+										return;
+									}
 									if (event.eventType === 'updated') {
+										lastLiveByThread.set(watchedThreadId, event.live);
 										liveCompletion = event.live;
+										liveRestore = null;
 									} else {
+										lastLiveByThread.delete(watchedThreadId);
 										liveCompletion = null;
+										liveRestore = { threadId: watchedThreadId, overlay: null };
 									}
 								}
 							}
@@ -723,10 +746,12 @@
 			return [];
 		}
 		const live = latestRunResumeKind ? null : liveCompletion;
+		const liveRestoreForThread = latestRunResumeKind ? null : liveRestore;
 		const latestRun = currentLatestRunData?.run ?? null;
 		return mergePagedTranscriptWithLive({
 			parts: replicaParts,
 			live,
+			liveRestore: liveRestoreForThread ?? undefined,
 			latestRun,
 			latestPrompt:
 				latestRun && currentLatestRunData?.prompt

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -17,7 +17,7 @@ use crate::live::LiveCompletionHub;
 use crate::provider::{AgentProvider, AgentProviderRequest, AgentProviderResult};
 use crate::transcript::{
     TranscriptStore, agent_history_from_parts, apply_remote_state, current_run_has_finished_turns,
-    fetch_missing_parts, fetch_parts_by_numbers,
+    fetch_missing_parts, fetch_parts_by_numbers, parse_remote_parts,
 };
 use crate::types::{RunAgentRequest, RunContextResponse, deserialize_agent_history};
 
@@ -47,6 +47,8 @@ pub struct AgentRun {
     request: RunAgentRequest,
     runtime: RuntimeClient,
     run_id: String,
+    user_id: String,
+    prompt_part: crate::transcript::TranscriptPart,
     claim_id: String,
     workspace_root: std::path::PathBuf,
     gateway_url: String,
@@ -55,6 +57,14 @@ pub struct AgentRun {
 impl AgentRun {
     pub fn run_id(&self) -> &str {
         &self.run_id
+    }
+
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
+    pub fn prompt_part(&self) -> &crate::transcript::TranscriptPart {
+        &self.prompt_part
     }
 }
 
@@ -595,11 +605,19 @@ pub async fn start_agent_run(request: RunAgentRequest) -> anyhow::Result<AgentRu
             request.submission_id, created_run.run_id
         );
     }
+    let mut prompt_parts = parse_remote_parts(serde_json::json!({
+        "parts": [created_run.prompt_part]
+    }))?;
+    let prompt_part = prompt_parts
+        .pop()
+        .ok_or_else(|| anyhow!("create run response omitted the prompt transcript part"))?;
     let run_id = created_run.run_id;
     Ok(AgentRun {
         request,
         runtime,
         run_id,
+        user_id: created_run.user_id,
+        prompt_part,
         claim_id,
         workspace_root,
         gateway_url: created_run.gateway_url,
@@ -743,6 +761,7 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
         claim_id,
         workspace_root,
         gateway_url,
+        ..
     } = run;
 
     let context: RunContextResponse = match runtime.run_context(&run_id).await {

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -33,6 +33,8 @@ pub struct CreateRunResponse {
     pub created: bool,
     pub run_id: String,
     pub prompt_message_id: String,
+    pub user_id: String,
+    pub prompt_part: serde_json::Value,
     pub gateway_url: String,
     #[serde(deserialize_with = "deserialize_convex_u64")]
     pub protocol_version: u64,
@@ -500,6 +502,24 @@ mod tests {
             "created": true,
             "runId": "jd7run",
             "promptMessageId": "jd7msg",
+            "userId": "user_1",
+            "promptPart": {
+                "number": 0.0,
+                "sourceKey": "prompt:jd7run",
+                "kind": "prompt",
+                "runId": "jd7run",
+                "prompt": {
+                    "text": "hello",
+                    "imageUploads": [{
+                        "imageUploadId": "image_1",
+                        "name": "robot.png",
+                        "mediaType": "image/png",
+                        "size": 42.0,
+                        "storageId": "storage_1",
+                        "url": "https://example.com/robot.png"
+                    }]
+                }
+            },
             "gatewayUrl": "https://preview.gateway.example",
             "protocolVersion": 1.0
         }))
@@ -507,6 +527,15 @@ mod tests {
 
         assert_eq!(created.gateway_url, "https://preview.gateway.example");
         assert_eq!(created.protocol_version, 1);
+        let parts = crate::transcript::parse_remote_parts(serde_json::json!({
+            "parts": [created.prompt_part]
+        }))
+        .expect("prompt transcript part");
+        assert_eq!(parts[0].number, 0);
+        let attachment = &parts[0].prompt.as_ref().expect("prompt body").image_uploads[0];
+        assert_eq!(attachment.name, "robot.png");
+        assert_eq!(attachment.size, 42);
+        assert_eq!(attachment.storage_id, "storage_1");
     }
 
     #[test]

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -101,6 +101,9 @@ async fn run_agent_handler(
 
     let cleanup_request = request.clone();
     let live = Arc::clone(&state.live_completions);
+    let transcript = Arc::clone(&state.transcript);
+    let transcript_watchers = Arc::clone(&state.transcript_watchers);
+    let thread_id = request.thread_id.clone();
     let (start_result_sender, start_result_receiver) = oneshot::channel();
 
     // Detach the complete launch before waiting for its acknowledgement. Hyper
@@ -122,6 +125,28 @@ async fn run_agent_handler(
         match run {
             Ok(run) => {
                 let run_id = run.run_id().to_string();
+                let user_id = run.user_id().to_string();
+                let prompt_part = run.prompt_part().clone();
+                match transcript
+                    .append_parts(&user_id, &thread_id, std::slice::from_ref(&prompt_part))
+                    .await
+                {
+                    Ok(state) => {
+                        transcript_watchers
+                            .notify_local_update(
+                                &user_id,
+                                &thread_id,
+                                prompt_part.number + 1,
+                                state.stale,
+                            )
+                            .await;
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "sprocket-server: failed to update local transcript for run {run_id}: {error:#}"
+                        );
+                    }
+                }
                 let _ = start_result_sender.send(Ok(run_id));
                 if let Err(error) = run_agent(run, live).await {
                     eprintln!("sprocket-server: agent run failed: {error:#}");

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -196,9 +196,10 @@ async fn live_handler(
         .map_err(ApiError::unauthorized)?;
     let hub = Arc::clone(&state.live_completions);
     let subscription = hub.subscribe(&payload.thread_id);
-    let snapshot = subscription
-        .snapshot
-        .and_then(|live| encode_live_event(LiveCompletionWatchEvent::Updated { live }));
+    let snapshot = encode_live_event(match subscription.snapshot {
+        Some(live) => LiveCompletionWatchEvent::Updated { live },
+        None => LiveCompletionWatchEvent::Cleared,
+    });
     let rest = unfold(
         LiveSseStream {
             receiver: subscription.receiver,

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -84,6 +84,26 @@ impl TranscriptWatchers {
         }
     }
 
+    pub async fn notify_local_update(
+        &self,
+        user_id: &str,
+        thread_id: &str,
+        total_parts: u32,
+        stale: bool,
+    ) {
+        let key = WatchKey {
+            user_id: user_id.to_string(),
+            thread_id: thread_id.to_string(),
+        };
+        if let Some(slot) = self.inner.lock().await.get(&key) {
+            let _ = slot.events.send(TranscriptWatchEvent {
+                event_type: "updated",
+                total_parts: Some(total_parts),
+                stale,
+            });
+        }
+    }
+
     pub async fn open(
         self: &Arc<Self>,
         user_id: &str,
@@ -298,6 +318,28 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(40)).await;
         assert_eq!(watchers.active_count().await, 0);
         assert_eq!(live.load(Ordering::SeqCst), 0);
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[tokio::test]
+    async fn local_updates_are_sent_to_open_sessions() {
+        let dir = std::env::temp_dir().join(format!("sprocket-watch-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        let watchers = TranscriptWatchers::with_starter(
+            "https://example.convex.cloud".into(),
+            store,
+            Arc::new(|_start| tokio::spawn(std::future::pending())),
+        );
+        let mut session = watchers.open("user", "thread", "token".into()).await;
+
+        watchers
+            .notify_local_update("user", "thread", 4, true)
+            .await;
+
+        let event = session.receiver().recv().await.expect("local update");
+        assert_eq!(event.total_parts, Some(4));
+        assert!(event.stale);
+        drop(session);
         let _ = tokio::fs::remove_dir_all(dir).await;
     }
 }


### PR DESCRIPTION
## Summary

- route durable transcript content through the Rust transcript replica instead of reading or synthesizing it from Convex in Svelte
- return Convex's authoritative numbered prompt part during run creation so Rust can expose a submitted prompt immediately without guessing its order
- stream live completions from Rust, remove the UI's per-thread transcript caches, and reject cross-thread overlays
- document the transcript ownership and synchronization path in `ARCHITECTURE.md`

## Validation

- `nix develop -c bun run test` (44 files, 255 tests)
- `nix develop -c cargo test -p sprocket-agent` (70 tests)
- `nix develop -c cargo test -p sprocket-server` (41 tests)
- `nix develop -c cargo check -p sprocket-server`
- `nix develop -c cargo fmt --check`
- `nix develop -c bun run check`
- focused ESLint over changed web files
- `nix develop -c bunx convex typecheck`
- `nix develop -c bun run build`
- `git diff --check`

Full `bun run lint` and `prek run -a` exceeded the local command timeout. Their component checks passed separately; CI will run the complete suites.








<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Rust transcript replica and live-completion stream the web renderer’s transcript sources.
- Returns Convex’s authoritative numbered prompt part during idempotent run creation and immediately inserts it into the local replica.
- Removes per-thread UI transcript caching and synthetic prompt/run metadata merging.
- Rejects cross-thread live overlays and emits an explicit cleared snapshot when a live stream reconnects without active output.
- Documents the revised transcript ownership and synchronization flow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/+page.svelte | Removes per-thread transcript caches, clears live state during thread transitions, and guards asynchronous watch events against stale thread writes. |
| apps/web/src/lib/project/transcript.ts | Renders numbered replica parts directly and overlays only live completion data belonging to the selected thread. |
| crates/sprocket-server/src/routes/agent.rs | Inserts the authoritative prompt into the local replica before startup acknowledgement and sends explicit cleared snapshots on live-stream connection. |
| crates/sprocket-server/src/transcript_watch.rs | Adds local transcript-update notifications for active user-and-thread watch sessions. |
| crates/sprocket-agent/src/run.rs | Parses and carries the authoritative prompt transcript part returned by Convex into the server launch boundary. |
| apps/web/src/convex/agentRuntime.ts | Returns the authoritative user and prompt transcript part for both newly created and idempotently recovered runs. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Svelte UI
    participant Server as Local Rust server
    participant Agent as Rust agent
    participant Convex
    UI->>Server: Start run
    Server->>Agent: Prepare run
    Agent->>Convex: Create or recover run
    Convex-->>Agent: Run and numbered prompt part
    Agent-->>Server: Authoritative prompt part
    Server->>Server: Append to transcript replica
    Server-->>UI: Transcript update
    Agent-->>Server: Live completion snapshots
    Server-->>UI: Updated or cleared SSE events
    Convex-->>Server: Durable transcript state
    Server->>Convex: Fetch missing numbered parts
    UI->>Server: Read transcript page
    Server-->>UI: Durable parts
```
</details>

<sub>Reviews (8): Last reviewed commit: ["docs: fix transcript sequence diagram"](https://github.com/spikonado/sprocket/commit/afca382c8f58acd62f64d198c180a60bfede0e4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58256868)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Agent run lifecycle](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-run-lifecycle.md)
- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)
- Knowledge Base — [Agent and workspace API routes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-agent-workspace-routes.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->