### PR TITLE
ci(dev): Add prod deployment development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,20 @@ bun dev
 After creating a Convex deployment and configuring AuthKit, give the deployment an API key for each model provider you want to enable.
 
 This runs Vite at `http://localhost:5173` and the Rust API at `http://127.0.0.1:7731`, with development state kept in `.sprocket-dev` inside the repository.
+It targets the dev Convex deployment. To run against the production Convex
+deployment with `~/.sprocket` state instead:
+
+```sh
+bun dev:prod
+```
+
 To develop against Electron instead, run:
 
 ```sh
 bun dev:desktop
 ```
+
+The `dev:prod` / `dev:prod:desktop` variants use the production Convex deployment and `~/.sprocket`.
 
 ### Building and testing
 

--- a/apps/web/.env.prod
+++ b/apps/web/.env.prod
@@ -1,0 +1,8 @@
+# Keep Convex CLI updates on the dev deployment while the web client and local
+# Rust runtime target production.
+# team: spikonado, project: sprocket
+CONVEX_DEPLOYMENT=dev:rosy-warthog-871
+
+PUBLIC_CONVEX_URL=https://original-jaguar-930.convex.cloud
+
+PUBLIC_CONVEX_SITE_URL=https://original-jaguar-930.convex.site

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	"scripts": {
 		"build": "node ./scripts/create-turbo-cache-key.js && bunx turbo run build",
 		"build:release": "node ./scripts/create-turbo-cache-key.js && bunx turbo run build:release",
-		"dev": "bun --env-file=apps/web/.env.local scripts/run-dev.mjs",
-		"dev:desktop": "bun --env-file=apps/web/.env.local scripts/run-dev.mjs --desktop",
+		"dev": "bun scripts/run-dev.mjs --env-file=apps/web/.env.local --data-dir=.sprocket-dev",
+		"dev:prod": "bun scripts/run-dev.mjs --env-file=apps/web/.env.prod",
+		"dev:desktop": "bun scripts/run-dev.mjs --env-file=apps/web/.env.local --desktop --data-dir=.sprocket-dev",
+		"dev:prod:desktop": "bun scripts/run-dev.mjs --env-file=apps/web/.env.prod --desktop",
 		"test": "turbo run test && node --test npm/sprocket/test/*.test.js",
 		"lint:oxlint": "oxlint"
 	},

--- a/scripts/run-dev.mjs
+++ b/scripts/run-dev.mjs
@@ -38,6 +38,8 @@ if (envFile) {
 
 if (dataDir) {
 	childEnv.SPROCKET_DATA_DIR = path.resolve(repositoryRoot, dataDir);
+} else {
+	delete childEnv.SPROCKET_DATA_DIR;
 }
 
 const desktop = mode === '--desktop';

--- a/scripts/run-dev.mjs
+++ b/scripts/run-dev.mjs
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseEnv } from 'node:util';
@@ -38,6 +39,8 @@ if (envFile) {
 
 if (dataDir) {
 	childEnv.SPROCKET_DATA_DIR = path.resolve(repositoryRoot, dataDir);
+} else if (mode === '--desktop') {
+	childEnv.SPROCKET_DATA_DIR = path.join(homedir(), '.sprocket');
 } else {
 	delete childEnv.SPROCKET_DATA_DIR;
 }

--- a/scripts/run-dev.mjs
+++ b/scripts/run-dev.mjs
@@ -1,12 +1,43 @@
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseEnv } from 'node:util';
 
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url));
-const [mode, ...unexpectedArguments] = process.argv.slice(2);
+const args = process.argv.slice(2);
+let dataDir = null;
+let envFile = null;
+let mode = null;
+const unexpectedArguments = [];
 
-if (unexpectedArguments.length > 0 || (mode !== undefined && mode !== '--desktop')) {
-	console.error('Usage: bun scripts/run-dev.mjs [--desktop]');
+for (const arg of args) {
+	if (arg === '--desktop') {
+		mode = '--desktop';
+	} else if (arg.startsWith('--data-dir=')) {
+		dataDir = arg.slice('--data-dir='.length);
+	} else if (arg.startsWith('--env-file=')) {
+		envFile = arg.slice('--env-file='.length);
+	} else {
+		unexpectedArguments.push(arg);
+	}
+}
+
+if (unexpectedArguments.length > 0) {
+	console.error(
+		'Usage: bun scripts/run-dev.mjs [--desktop] [--data-dir=<path>] [--env-file=<path>]'
+	);
 	process.exit(1);
+}
+
+const childEnv = { ...process.env };
+if (envFile) {
+	const filePath = path.resolve(repositoryRoot, envFile);
+	Object.assign(childEnv, parseEnv(readFileSync(filePath, 'utf8')));
+}
+
+if (dataDir) {
+	childEnv.SPROCKET_DATA_DIR = path.resolve(repositoryRoot, dataDir);
 }
 
 const desktop = mode === '--desktop';
@@ -18,7 +49,7 @@ const commands = desktop
 			'bun run --cwd apps/desktop dev'
 		]
 	: [
-			'cargo run -p sprocket-cli -- serve --port 7731 --data-dir .sprocket-dev --api-only',
+			'cargo run -p sprocket-cli -- serve --port 7731 --api-only',
 			'node scripts/wait-for-api.mjs && bun run --cwd apps/web dev'
 		];
 
@@ -27,6 +58,7 @@ const child = spawn(
 	['x', 'concurrently', '-k', '-n', names, '-c', colors, ...commands],
 	{
 		cwd: repositoryRoot,
+		env: childEnv,
 		stdio: 'inherit'
 	}
 );


### PR DESCRIPTION
## Summary

- make `bun dev` and `bun dev:desktop` target dev Convex with repository-local `.sprocket-dev` state
- add `bun dev:prod` and `bun dev:prod:desktop` for the production Convex client and default `~/.sprocket` state
- load the selected env profile deterministically so ambient shell or Nix variables cannot override it

## Validation

- smoke-tested `bun dev`: dev Convex, `.sprocket-dev`
- smoke-tested `bun dev:prod`: production `/api/config`, `~/.sprocket`
- `node --check scripts/run-dev.mjs`
- package JSON parse
- `nix develop -c bun run lint:oxlint`
- `nix develop -c bunx prettier --check README.md package.json scripts/run-dev.mjs apps/web/.env.prod`

The full pre-commit hook was stopped after `convex typecheck` continued running for several minutes; all other targeted checks above passed.






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates development and production launch profiles so each selects the intended Convex deployment and local state directory.
- Adds browser and desktop production-development commands.
- Loads the selected environment file into a controlled child environment.
- Routes development commands to repository-local state and production commands to the normal user state.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the production desktop command resolves the same user state directory as normal production launches on supported Windows environments.

When Windows has differing HOME and USERPROFILE values, the new production desktop branch selects USERPROFILE through Node's homedir resolution while the existing CLI and desktop defaults prefer HOME, exposing a different production state profile.

**Files Needing Attention:** scripts/run-dev.mjs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/run-dev.mjs | Adds deterministic profile loading and state selection, but production desktop state can diverge from the repository's established home-directory resolution on Windows. |
| package.json | Adds explicit development and production launch commands wired to the corresponding environment and state profiles. |
| apps/web/.env.prod | Defines the development Convex CLI target alongside production public client endpoints. |
| README.md | Documents the new production-development commands and their intended production deployment and state profile. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Dev["bun dev / dev:desktop"] --> DevEnv["apps/web/.env.local"]
  Dev --> DevState["repository .sprocket-dev"]
  Prod["bun dev:prod / dev:prod:desktop"] --> ProdEnv["apps/web/.env.prod"]
  Prod --> ProdState["user .sprocket"]
  DevEnv --> Runner["scripts/run-dev.mjs"]
  ProdEnv --> Runner
  DevState --> Runner
  ProdState --> Runner
  Runner --> Browser["Rust API + Vite"]
  Runner --> Desktop["Electron + local server"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/run-dev.mjs:43
**Production desktop selects wrong home**

If a Windows environment defines different `HOME` and `USERPROFILE` directories, `homedir()` selects a different production state location from the CLI and desktop defaults, causing existing authentication, sessions, attachments, and configuration to appear missing or be written under the wrong profile.

```suggestion
	childEnv.SPROCKET_DATA_DIR = path.join(
		process.env.HOME || process.env.USERPROFILE || '.',
		'.sprocket'
	);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dev): use production state for deskt..."](https://github.com/spikonado/sprocket/commit/47676583a677f5088f8680330477edc0bea3dc7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58257865)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->