### PR TITLE
feat(auth): Store tokenIdentifier owners and rotate local session credentials

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -161,9 +161,10 @@ Dual-read shims kept until the rewrites are confirmed in prod:
 - subscription tier and usage-meter reads union the legacy subject's rows
   (`lib/tiers.ts`, `lib/rateLimits.ts`); charges keep writing the key that
   already has the open window, preferring an active monthly window so a
-  weekly reset cannot split the month across keys. Rate-limiter component
-  keys are not rewritten by the owner migrations and last until those
-  windows roll.
+  weekly reset cannot split the month across keys. Quota checks and the
+  usage view add both keys' current used so an already-split month still
+  blocks. Rate-limiter component keys are not rewritten by the owner
+  migrations and last until those windows roll.
 - Prava customer ids stay on each mandate row's original key;
   `payments.getUserEmail` accepts either key form
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,7 +4,7 @@ This file lists shims we still ship. When a removal PR merges, delete its
 entry. Age-out is a prod check for stored rows, or an explicit decision that
 a retired function name can disappear.
 
-Current as of 2026-08-29.
+Current as of 2026-08-30.
 
 ## Stored schema
 
@@ -139,6 +139,52 @@ agents/desktops have dropped `agentRuntime.beginAssistantMessage` calls:
 The prompt-half of `threadMessages` (text, attachments, retention bookkeeping)
 stays: it is the run-capability source of the user prompt and image
 attachments for `agentRuntime.getContext` and dedups repeated submissions.
+
+### 9. Pre-migration `userId` rows (subject vs. tokenIdentifier)
+
+Owned tables used to store `identity.subject` in their `userId` column. New
+writes store `identity.tokenIdentifier` (`getUserId`). `users` rows carry
+both keys (`subject` + `tokenIdentifier`), and the per-table owner-rewrite
+migrations in `migrations.ts` rewrite stored `userId`s into the canonical
+tokenIdentifier.
+
+Dual-read shims kept until the rewrites are confirmed in prod:
+
+- `users.by_subject` index plus by-subject/by-tokenIdentifier fallbacks in
+  `ensureCurrentUser` / `resolveStoredOwnerSubject`
+- `getOwnerKeys` plus the ownership gates in `lib/access.ts` accept a stored
+  `userId` of either form
+- `lib/access.ts` `resolveStoredOwnerKeys` validates a stored key against
+  both forms
+- `threads.listMine` / `threads.create` and run submission lookups union
+  both keys so the sidebar and idempotency survive until rewrite
+- subscription tier and usage-meter reads union the legacy subject's rows
+  (`lib/tiers.ts`, `lib/rateLimits.ts`); charges keep writing the key that
+  already has the open window. Rate-limiter component keys are not rewritten
+  by the owner migrations and last until those windows roll.
+- Prava customer ids stay on each mandate row's original key;
+  `payments.getUserEmail` accepts either key form
+
+Remove after the owner-rewrite migrations have run in production and a prod
+check shows no owned rows (besides `users.subject`) still carrying a
+subject-shaped `userId`.
+
+### 10. Browser-forwarded WorkOS tokens for local Rust clients
+
+Current web clients issue a rotating session credential through authenticated
+Convex, deliver it to the paired local server once, and let Rust renew it every
+five minutes. Identity-sensitive Rust calls send that credential; run-scoped
+calls retain their existing execution secret. A chain remains valid for ten
+minutes after its last successful renewal. Each browser/local-server pairing
+has its own session ID, so one user's local servers rotate independently.
+
+Released clients may still authenticate Rust's Convex connection with a
+browser-forwarded WorkOS JWT. Keep `/auth/convex-token`, the Rust token
+provider, and the identity fallback on `agentRuntime.createGatewayRun` and the
+identity-based transcript functions until all supported clients seed rotating
+credentials and production telemetry shows no legacy calls. Sign-out does not
+actively revoke a credential yet; its remaining authority is bounded by the
+ten-minute renewal window.
 
 ## Client APIs
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -160,8 +160,10 @@ Dual-read shims kept until the rewrites are confirmed in prod:
   both keys so the sidebar and idempotency survive until rewrite
 - subscription tier and usage-meter reads union the legacy subject's rows
   (`lib/tiers.ts`, `lib/rateLimits.ts`); charges keep writing the key that
-  already has the open window. Rate-limiter component keys are not rewritten
-  by the owner migrations and last until those windows roll.
+  already has the open window, preferring an active monthly window so a
+  weekly reset cannot split the month across keys. Rate-limiter component
+  keys are not rewritten by the owner migrations and last until those
+  windows roll.
 - Prava customer ids stay on each mandate row's original key;
   `payments.getUserEmail` accepts either key form
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7189,7 +7189,11 @@ dependencies = [
  "anyhow",
  "convex",
  "rustls",
+ "serde",
+ "serde_json",
  "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/web/src/convex/README.md
+++ b/apps/web/src/convex/README.md
@@ -1,88 +1,43 @@
-# Welcome to your Convex functions directory!
+# Convex backend
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+Convex owns durable application state and authorization. Browser calls use the
+WorkOS identity configured in `auth.config.ts`. Persisted ownership uses the
+canonical WorkOS token identifier returned by Convex, not the raw WorkOS
+subject.
 
-A query function that takes two arguments looks like:
+## Local executor authentication
 
-```ts
-// convex/myFunctions.ts
-import { query } from './_generated/server';
-import { v } from 'convex/values';
+After browser authentication is established, `sessionCredentials.issue`
+creates a credential for that browser/local-server pairing. The browser sends
+the initial `{ sessionId, userId, current, next }` ticket to the paired Rust
+server. Only hashes are stored in Convex.
 
-export const myQueryFunction = query({
-	// Validators for arguments.
-	args: {
-		first: v.number(),
-		second: v.string()
-	},
+Rust rotates the ticket every five minutes. Each successful rotation promotes
+`next` to `current`, and Rust generates a new `next`. Convex accepts the current
+or immediately previous secret for authorization, making a lost rotation
+response retryable. A session expires when it has not successfully rotated for
+ten minutes. Sessions are isolated by `sessionId`, so multiple local servers
+for one user do not invalidate each other.
 
-	// Function implementation.
-	handler: async (ctx, args) => {
-		// Read the database as many times as you need here.
-		// See https://docs.convex.dev/database/reading-data.
-		const documents = await ctx.db.query('tablename').collect();
+Identity-sensitive local-executor calls include the session ticket and must
+still check ownership of the target resource. Calls already scoped to one run
+continue to use that run's `executionSecret`; the session ticket does not
+replace capability authorization.
 
-		// Arguments passed from the client are properties of the args object.
-		console.log(args.first, args.second);
+Released clients may still forward a WorkOS JWT to the local server. Keep that
+fallback until the removal gate in `BACKWARDS_COMPATIBILITY.md` is met. Signing
+out does not actively revoke a session ticket yet, so its authority can remain
+for at most the ten-minute expiry window. Expired rows are currently retained.
 
-		// Write arbitrary JavaScript here: filter, aggregate, build derived data,
-		// remove non-public properties, or create new objects.
-		return documents;
-	}
-});
+## Development
+
+From `apps/web`, run:
+
+```sh
+bun run check
+bun run lint
+bun run test
 ```
 
-Using this query function in a React component looks like:
-
-```ts
-const data = useQuery(api.myFunctions.myQueryFunction, {
-	first: 10,
-	second: 'hello'
-});
-```
-
-A mutation function looks like:
-
-```ts
-// convex/myFunctions.ts
-import { mutation } from './_generated/server';
-import { v } from 'convex/values';
-
-export const myMutationFunction = mutation({
-	// Validators for arguments.
-	args: {
-		first: v.string(),
-		second: v.string()
-	},
-
-	// Function implementation.
-	handler: async (ctx, args) => {
-		// Insert or modify documents in the database here.
-		// Mutations can also read from the database like queries.
-		// See https://docs.convex.dev/database/writing-data.
-		const message = { body: args.first, author: args.second };
-		const id = await ctx.db.insert('messages', message);
-
-		// Optionally, return a value from your mutation.
-		return await ctx.db.get('messages', id);
-	}
-});
-```
-
-Using this mutation function in a React component looks like:
-
-```ts
-const mutation = useMutation(api.myFunctions.myMutationFunction);
-function handleButtonPress() {
-	// fire and forget, the most common way to use mutations
-	mutation({ first: 'Hello!', second: 'me' });
-	// OR
-	// use the result once the mutation has completed
-	mutation({ first: 'Hello!', second: 'me' }).then((result) => console.log(result));
-}
-```
-
-Use the Convex CLI to push your functions to a deployment. See everything
-the Convex CLI can do by running `npx convex -h` in your project root
-directory. To learn more, launch the docs with `npx convex docs`.
+Generate `_generated` API types with the Convex CLI against a configured
+deployment; do not hand-edit generated runtime files.

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -59,6 +59,7 @@ import type * as modelCatalog from "../modelCatalog.js";
 import type * as payments from "../payments.js";
 import type * as projects from "../projects.js";
 import type * as runLifecycle from "../runLifecycle.js";
+import type * as sessionCredentials from "../sessionCredentials.js";
 import type * as threads from "../threads.js";
 import type * as transcript from "../transcript.js";
 import type * as uiPreferences from "../uiPreferences.js";
@@ -124,6 +125,7 @@ declare const fullApi: ApiFromModules<{
   payments: typeof payments;
   projects: typeof projects;
   runLifecycle: typeof runLifecycle;
+  sessionCredentials: typeof sessionCredentials;
   threads: typeof threads;
   transcript: typeof transcript;
   uiPreferences: typeof uiPreferences;

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -14,7 +14,7 @@ import {
 	normalizeQuestionAnswer,
 	validateQuestionText
 } from '@convex/lib/agentQuestions';
-import { getExecutionRun, getUserId } from '@convex/lib/auth';
+import { getExecutionRun, getOwnerKeys } from '@convex/lib/auth';
 import { assertRunAcceptsModelCompletion, toAgentToolConvexError } from '@convex/lib/agentErrors';
 import { vAgentQuestionSnapshot } from '@convex/lib/docs';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
@@ -176,8 +176,8 @@ export const answer = mutation({
 	},
 	returns: vAgentQuestionSnapshot,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 
 		const now = Date.now();
 		await expireOverduePendingQuestions(ctx, args.threadId, now);
@@ -263,8 +263,8 @@ export const headPendingForThread = query({
 	},
 	returns: v.union(vAgentQuestionSnapshot, v.null()),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 		const head = await headLivePendingQuestion(ctx, args.threadId, args.now ?? Date.now());
 		return head ? toSnapshot(head) : null;
 	}

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -18,7 +18,9 @@ import {
 	executionSecretHash,
 	getExecutionRun,
 	getOwnerKeys,
-	getUserId
+	getUserId,
+	matchesOwner,
+	ownerKeysFromIdentity
 } from '@convex/lib/auth';
 import {
 	authorizeBySessionCredential,
@@ -338,14 +340,26 @@ export const createGatewayRun = action({
 	handler: async (ctx, args): Promise<Infer<typeof vCreateGatewayRunResult>> => {
 		// New local executors send a session ticket (fail-closed if present
 		// but invalid). Released executors omit it and keep using the WorkOS
-		// identity.
-		const userId = args.sessionTicket
-			? (
-					await ctx.runQuery(internal.sessionCredentials.resolveOwner, {
-						ticket: args.sessionTicket
-					})
-				).userId
-			: await getUserId(ctx);
+		// identity. When both arrive they must name the same owner so a
+		// process-wide ticket from another local sign-in cannot win.
+		const identity = await ctx.auth.getUserIdentity();
+		let userId: string;
+		if (args.sessionTicket) {
+			const ticketOwner = await ctx.runQuery(internal.sessionCredentials.resolveOwner, {
+				ticket: args.sessionTicket
+			});
+			if (identity) {
+				const keys = ownerKeysFromIdentity(identity);
+				if (!matchesOwner(ticketOwner.userId, keys) && !matchesOwner(ticketOwner.subject, keys)) {
+					throw new Error('Invalid session credential.');
+				}
+				userId = keys.userId;
+			} else {
+				userId = ticketOwner.userId;
+			}
+		} else {
+			userId = await getUserId(ctx);
+		}
 		const createArgs: Parameters<typeof createQueuedRunRecord>[1] = {
 			userId,
 			submissionId: args.submissionId,

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -8,8 +8,22 @@ import {
 } from '@convex/_generated/server';
 import { internal } from '@convex/_generated/api';
 import { ConvexError, v, type Infer } from 'convex/values';
-import { getOwnedRun, getOwnedThreadRecord } from '@convex/lib/access';
-import { executionSecretHash, getExecutionRun, getUserId } from '@convex/lib/auth';
+import {
+	getOwnedRun,
+	getOwnedThreadRecordForStoredUserId,
+	resolveStoredOwnerKeys
+} from '@convex/lib/access';
+import {
+	distinctOwnerKeys,
+	executionSecretHash,
+	getExecutionRun,
+	getOwnerKeys,
+	getUserId
+} from '@convex/lib/auth';
+import {
+	authorizeBySessionCredential,
+	vSessionCredentialProof
+} from '@convex/lib/sessionCredentials';
 import { coercePersistedReasoningEffort, coercePersistedSelection } from '@convex/lib/models';
 import { GATEWAY_PROTOCOL_VERSION } from '@convex/lib/gatewayProtocol';
 import { modelGatewayTokenSecret, modelGatewayUrl } from '@convex/lib/gatewayFetch';
@@ -113,19 +127,28 @@ async function createQueuedRunRecord(
 	args: QueuedRunRequest
 ): Promise<{ created: boolean; runId: Id<'runs'>; promptMessageId: Id<'threadMessages'> }> {
 	const secretHash = await executionSecretHash(args.executionSecret);
-	const threadRecord = await getOwnedThreadRecord(ctx.db, args.userId, args.threadId);
+	const threadRecord = await getOwnedThreadRecordForStoredUserId(
+		ctx.db,
+		args.userId,
+		args.threadId
+	);
 	const prompt = args.prompt.trim();
 	if (!prompt && args.imageUploadIds.length === 0) {
 		throw new Error('Message cannot be empty.');
 	}
 	const imageUploads = await getOwnedImageUploads(ctx, args.userId, args.imageUploadIds);
 
-	const existingRun = await ctx.db
-		.query('runs')
-		.withIndex('by_userId_submissionId', (query) =>
-			query.eq('userId', args.userId).eq('submissionId', args.submissionId)
-		)
-		.unique();
+	const ownerKeys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+	let existingRun = null;
+	for (const key of distinctOwnerKeys(ownerKeys)) {
+		existingRun = await ctx.db
+			.query('runs')
+			.withIndex('by_userId_submissionId', (query) =>
+				query.eq('userId', key).eq('submissionId', args.submissionId)
+			)
+			.unique();
+		if (existingRun) break;
+	}
 	if (existingRun) {
 		if (existingRun.executionSecretHash !== secretHash) {
 			const canRecoverExecutor =
@@ -308,13 +331,22 @@ export const createGatewayRun = action({
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
 		executionSecret: v.string(),
+		sessionTicket: v.optional(vSessionCredentialProof),
 		agentVersion: v.optional(v.string())
 	},
 	returns: vCreateGatewayRunResult,
 	handler: async (ctx, args): Promise<Infer<typeof vCreateGatewayRunResult>> => {
-		const userId = await getUserId(ctx);
-		const gatewayUrl = modelGatewayUrl();
-		const created = await ctx.runMutation(internal.agentRuntime.insertGatewayRun, {
+		// New local executors send a session ticket (fail-closed if present
+		// but invalid). Released executors omit it and keep using the WorkOS
+		// identity.
+		const userId = args.sessionTicket
+			? (
+					await ctx.runQuery(internal.sessionCredentials.resolveOwner, {
+						ticket: args.sessionTicket
+					})
+				).userId
+			: await getUserId(ctx);
+		const createArgs: Parameters<typeof createQueuedRunRecord>[1] = {
 			userId,
 			submissionId: args.submissionId,
 			threadId: args.threadId,
@@ -326,6 +358,10 @@ export const createGatewayRun = action({
 			executionSecret: args.executionSecret,
 			protocolVersion: GATEWAY_PROTOCOL_VERSION,
 			agentVersion: args.agentVersion
+		};
+		const gatewayUrl = modelGatewayUrl();
+		const created = await ctx.runMutation(internal.agentRuntime.insertGatewayRun, {
+			...createArgs
 		});
 		return {
 			...created,
@@ -431,7 +467,7 @@ export const getContext = query({
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		const userId = run.userId;
-		const threadRecord = await getOwnedThreadRecord(ctx.db, userId, run.threadId);
+		const threadRecord = await getOwnedThreadRecordForStoredUserId(ctx.db, userId, run.threadId);
 		const promptMessageId = run.promptMessageId;
 		if (!promptMessageId) {
 			throw new Error('Run does not contain a user prompt.');
@@ -529,7 +565,7 @@ export const saveContextCompaction = mutation({
 		if (!args.summary.trim()) {
 			throw new Error('Invalid context compaction.');
 		}
-		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
+		const thread = await getOwnedThreadRecordForStoredUserId(ctx.db, run.userId, run.threadId);
 		await recordThreadUsageEvent(ctx, thread, {
 			eventId: usageEventId('compaction', run._id, args.claimId, run.completionAttemptSeq),
 			processedTokens: args.processedTokens
@@ -583,7 +619,7 @@ export const recordContextUsage = mutation({
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
 		if (!ownsActiveRunClaim(run, args.claimId, Date.now())) return false;
-		const thread = await getOwnedThreadRecord(ctx.db, run.userId, run.threadId);
+		const thread = await getOwnedThreadRecordForStoredUserId(ctx.db, run.userId, run.threadId);
 		await recordThreadUsageEvent(ctx, thread, {
 			eventId: usageEventId('usage', run._id, args.claimId, run.completionAttemptSeq),
 			contextTokens: args.contextTokens,
@@ -692,8 +728,8 @@ export const finalizeRun = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		const run = await getOwnedRun(ctx.db, userId, args.runId);
+		const keys = await getOwnerKeys(ctx);
+		const run = await getOwnedRun(ctx.db, keys, args.runId);
 		if (!matchesFinalizeExpectations(run, args)) {
 			return false;
 		}
@@ -707,8 +743,8 @@ export const reopenRun = mutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		const run = await getOwnedRun(ctx.db, userId, args.runId);
+		const keys = await getOwnerKeys(ctx);
+		const run = await getOwnedRun(ctx.db, keys, args.runId);
 		await reopenRunRecord(ctx, run);
 		return null;
 	}
@@ -745,7 +781,8 @@ export const finalizeFailedStart = mutation({
 		serviceTier: vServiceTier,
 		text: v.string(),
 		lastError: v.string(),
-		executionSecret: v.string()
+		executionSecret: v.string(),
+		sessionTicket: v.optional(vSessionCredentialProof)
 	},
 	// `finalized`: the queued run was terminalized. `pending`: nothing is
 	// visible for the capability; either createGatewayRun is still in flight or, when
@@ -769,15 +806,24 @@ export const finalizeFailedStart = mutation({
 			// secret; when the caller is still authenticated, tell the loser to
 			// stand down instead of retrying until its deadline.
 			const identity = await ctx.auth.getUserIdentity();
-			if (identity !== null) {
-				const submittedRun = await ctx.db
-					.query('runs')
-					.withIndex('by_userId_submissionId', (query) =>
-						query.eq('userId', identity.subject).eq('submissionId', args.submissionId)
-					)
-					.unique();
-				if (submittedRun) {
-					return 'standDown';
+			const sessionOwner =
+				!identity && args.sessionTicket
+					? await authorizeBySessionCredential(ctx, args.sessionTicket)
+					: null;
+			const ownerKeys = identity
+				? { userId: identity.tokenIdentifier, subject: identity.subject }
+				: sessionOwner;
+			if (ownerKeys) {
+				for (const key of distinctOwnerKeys(ownerKeys)) {
+					const submittedRun = await ctx.db
+						.query('runs')
+						.withIndex('by_userId_submissionId', (query) =>
+							query.eq('userId', key).eq('submissionId', args.submissionId)
+						)
+						.unique();
+					if (submittedRun) {
+						return 'standDown';
+					}
 				}
 			}
 			return 'pending';

--- a/apps/web/src/convex/artifacts.ts
+++ b/apps/web/src/convex/artifacts.ts
@@ -1,8 +1,12 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
-import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getExecutionRun, getUserId } from '@convex/lib/auth';
+import {
+	getOwnedThreadRecord,
+	getOwnedThreadRecordForStoredUserId,
+	resolveStoredOwnerKeys
+} from '@convex/lib/access';
+import { getExecutionRun, getOwnerKeys, matchesOwner } from '@convex/lib/auth';
 import { vArtifactType } from '@convex/lib/validators';
 import schema from '@convex/schema';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
@@ -109,7 +113,7 @@ export const createArtifact = mutation({
 			const run = await requireActiveRun(ctx, args.runId, args.claimId, args.executionSecret);
 			const userId = run.userId;
 			const threadId = run.threadId;
-			await getOwnedThreadRecord(ctx.db, userId, threadId);
+			await getOwnedThreadRecordForStoredUserId(ctx.db, userId, threadId);
 
 			const title = args.title.trim();
 			validateArtifactTitle(title);
@@ -174,10 +178,11 @@ export const appendArtifactVersion = mutation({
 			const userId = run.userId;
 
 			const artifact: Doc<'artifacts'> | null = await ctx.db.get('artifacts', args.artifactId);
-			if (!artifact || artifact.userId !== userId || artifact.threadId !== run.threadId) {
+			const keys = await resolveStoredOwnerKeys(ctx.db, userId);
+			if (!artifact || !matchesOwner(artifact.userId, keys) || artifact.threadId !== run.threadId) {
 				throw new Error('Artifact not found.');
 			}
-			await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
+			await getOwnedThreadRecordForStoredUserId(ctx.db, userId, artifact.threadId);
 
 			validateArtifactContent(args.content);
 
@@ -200,12 +205,12 @@ export const getArtifact = query({
 		versions: v.array(schema.doc('artifactVersions'))
 	}),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
+		const keys = await getOwnerKeys(ctx);
 		const artifact = await ctx.db.get('artifacts', args.artifactId);
-		if (!artifact || artifact.userId !== userId) {
+		if (!artifact || (artifact.userId !== keys.userId && artifact.userId !== keys.subject)) {
 			throw new Error('Artifact not found.');
 		}
-		await getOwnedThreadRecord(ctx.db, userId, artifact.threadId);
+		await getOwnedThreadRecord(ctx.db, keys, artifact.threadId);
 
 		const versions = await ctx.db
 			.query('artifactVersions')
@@ -228,8 +233,8 @@ export const listArtifactsForThread = query({
 		})
 	),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 
 		const artifacts = await ctx.db
 			.query('artifacts')

--- a/apps/web/src/convex/billing.ts
+++ b/apps/web/src/convex/billing.ts
@@ -10,7 +10,7 @@ import {
 	mutation,
 	query
 } from '@convex/_generated/server';
-import { ensureCurrentUser, getUserId } from '@convex/lib/auth';
+import { ensureCurrentUser, getUserId, resolveStoredOwnerSubject } from '@convex/lib/auth';
 import { vCheckoutResponse, vCustomerPortalResponse } from '@convex/lib/docs';
 import {
 	ensureSubscription,
@@ -24,11 +24,21 @@ import schema from '@convex/schema';
 export const getBillingCustomer = internalQuery({
 	args: { userId: v.string() },
 	returns: v.union(schema.doc('billingCustomers'), v.null()),
-	handler: async (ctx, { userId }) =>
-		ctx.db
+	handler: async (ctx, { userId }) => {
+		const customer = await ctx.db
 			.query('billingCustomers')
 			.withIndex('by_userId', (q) => q.eq('userId', userId))
-			.unique()
+			.unique();
+		if (customer) return customer;
+		// Owner rows written before the tokenIdentifier switch still carry the
+		// caller's subject; resolve it through the users table.
+		const subject = await resolveStoredOwnerSubject(ctx, userId);
+		if (!subject) return null;
+		return await ctx.db
+			.query('billingCustomers')
+			.withIndex('by_userId', (q) => q.eq('userId', subject))
+			.unique();
+	}
 });
 
 const dodo: DodoPayments = new DodoPayments(
@@ -111,10 +121,9 @@ export const upsertSubscription = internalMutation({
 		const existing = await getSubscriptionDocExclusive(ctx, args.userId);
 
 		const syncBillingCustomer = async () => {
-			const customer = await ctx.db
-				.query('billingCustomers')
-				.withIndex('by_userId', (q) => q.eq('userId', args.userId))
-				.unique();
+			const customer = await ctx.runQuery(internal.billing.getBillingCustomer, {
+				userId: args.userId
+			});
 			if (customer)
 				await ctx.db.patch('billingCustomers', customer._id, {
 					dodoCustomerId: args.dodoCustomerId

--- a/apps/web/src/convex/browserSessions.ts
+++ b/apps/web/src/convex/browserSessions.ts
@@ -1,8 +1,8 @@
 import { v } from 'convex/values';
 import type { Id } from '@convex/_generated/dataModel';
 import { internalMutation, internalQuery, query } from '@convex/_generated/server';
-import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getUserId } from '@convex/lib/auth';
+import { getOwnedThreadRecord, resolveStoredOwnerKeys } from '@convex/lib/access';
+import { getOwnerKeys, matchesOwner } from '@convex/lib/auth';
 
 type BrowserSessionUpsertPatch = {
 	runId: Id<'runs'>;
@@ -33,7 +33,9 @@ export const getForThread = internalQuery({
 			.query('browserSessions')
 			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
 			.first();
-		return session?.userId === args.userId ? session : null;
+		if (!session) return null;
+		const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+		return matchesOwner(session.userId, keys) ? session : null;
 	}
 });
 
@@ -51,8 +53,8 @@ export const liveViewForThread = query({
 		v.null()
 	),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 		const session = await ctx.db
 			.query('browserSessions')
 			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -1,7 +1,7 @@
 import { query } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getUserId } from '@convex/lib/auth';
+import { getOwnerKeys } from '@convex/lib/auth';
 import { vLatestRunForThread } from '@convex/lib/docs';
 
 export const latestRunForThread = query({
@@ -13,8 +13,8 @@ export const latestRunForThread = query({
 	},
 	returns: vLatestRunForThread,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 		const serverNow = args.now ?? Date.now();
 
 		const latestRun = await ctx.db

--- a/apps/web/src/convex/gateway.test.ts
+++ b/apps/web/src/convex/gateway.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { api } from '@convex/_generated/api';
-import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+import {
+	createQueuedRun,
+	initConvexTest,
+	seedOwnedThread,
+	subjectTokenIdentifier
+} from './test.setup';
 
 const gatewayUrl = 'https://preview.gateway.example';
 const tokenSecret = 'test-gateway-token-secret';
@@ -45,7 +50,11 @@ describe('gateway quota', () => {
 			executionSecret
 		});
 		const quota = await t.mutation(api.gateway.checkQuota, { token: credential.token });
-		expect(quota).toMatchObject({ userId: subject, tier: 'admin', exhausted: false });
+		expect(quota).toMatchObject({
+			userId: subjectTokenIdentifier(subject),
+			tier: 'admin',
+			exhausted: false
+		});
 		await expect(
 			t.mutation(api.gateway.consumeQuota, { token: credential.token, units: 12 })
 		).resolves.toBeNull();

--- a/apps/web/src/convex/imageUploads.ts
+++ b/apps/web/src/convex/imageUploads.ts
@@ -1,7 +1,7 @@
 import type { Doc } from '@convex/_generated/dataModel';
 import { internalMutation, mutation, type MutationCtx } from '@convex/_generated/server';
 import { v, type Infer } from 'convex/values';
-import { getUserId } from '@convex/lib/auth';
+import { getOwnerKeys, getUserId } from '@convex/lib/auth';
 import { vRegisterImageUploadResult } from '@convex/lib/docs';
 import {
 	MAX_IMAGE_ATTACHMENT_BYTES,
@@ -32,13 +32,13 @@ export const register = mutation({
 	},
 	returns: vRegisterImageUploadResult,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
+		const ownerKeys = await getOwnerKeys(ctx);
 		const existing = await ctx.db
 			.query('imageUploads')
 			.withIndex('by_storageId', (query) => query.eq('storageId', args.storageId))
 			.unique();
 		if (existing) {
-			if (existing.userId !== userId) {
+			if (existing.userId !== ownerKeys.userId && existing.userId !== ownerKeys.subject) {
 				throw new Error('Uploaded image belongs to another user.');
 			}
 			return await uploadResult(ctx, existing);
@@ -68,7 +68,7 @@ export const register = mutation({
 		}
 
 		const imageUploadId = await ctx.db.insert('imageUploads', {
-			userId,
+			userId: ownerKeys.userId,
 			storageId: args.storageId,
 			name,
 			mediaType,
@@ -92,9 +92,13 @@ export const discard = mutation({
 	},
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
+		const keys = await getOwnerKeys(ctx);
 		const upload = await ctx.db.get('imageUploads', args.imageUploadId);
-		if (!upload || upload.userId !== userId || upload.attached) {
+		if (
+			!upload ||
+			(upload.userId !== keys.userId && upload.userId !== keys.subject) ||
+			upload.attached
+		) {
 			return false;
 		}
 		await ctx.storage.delete(upload.storageId);

--- a/apps/web/src/convex/lib/access.ts
+++ b/apps/web/src/convex/lib/access.ts
@@ -1,14 +1,45 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { DatabaseReader } from '@convex/_generated/server';
+import { pickPrimaryUser, type OwnerKeys } from './auth';
 
-type OwnerScopedTable = 'threadRecords' | 'runs';
+type OwnedTableName = 'threadRecords' | 'runs';
 
-async function assertOwned<TableName extends OwnerScopedTable>(
+/**
+ * Expand a stored owner field into the key pair that can match it. Rows
+ * written pre-migration carry the legacy subject; post-migration rows carry
+ * the tokenIdentifier. When a users row links the two, a stored key of either
+ * form validates rows of both forms; rows without a users record only match
+ * their own literal key.
+ */
+export async function resolveStoredOwnerKeys(
+	db: DatabaseReader,
+	userId: string
+): Promise<OwnerKeys> {
+	const subjectRows = await db
+		.query('users')
+		.withIndex('by_subject', (query) => query.eq('subject', userId))
+		.collect();
+	const bySubject = pickPrimaryUser(subjectRows);
+	if (bySubject) {
+		return { userId: bySubject.tokenIdentifier, subject: bySubject.subject };
+	}
+	const tokenRows = await db
+		.query('users')
+		.withIndex('by_tokenIdentifier', (query) => query.eq('tokenIdentifier', userId))
+		.collect();
+	const byToken = pickPrimaryUser(tokenRows);
+	if (byToken) {
+		return { userId: byToken.tokenIdentifier, subject: byToken.subject };
+	}
+	return { userId, subject: userId };
+}
+
+async function assertOwned<TableName extends OwnedTableName>(
 	record: Doc<TableName> | null,
-	userId: string,
+	keys: OwnerKeys,
 	errorMessage: string
 ): Promise<Doc<TableName>> {
-	if (!record || record.userId !== userId) {
+	if (!record || (record.userId !== keys.userId && record.userId !== keys.subject)) {
 		throw new Error(errorMessage);
 	}
 	return record;
@@ -16,20 +47,35 @@ async function assertOwned<TableName extends OwnerScopedTable>(
 
 export async function getOwnedThreadRecord(
 	db: DatabaseReader,
-	userId: string,
+	keys: OwnerKeys,
 	threadRecordId: Id<'threadRecords'>
 ): Promise<Doc<'threadRecords'>> {
 	return await assertOwned<'threadRecords'>(
 		await db.get('threadRecords', threadRecordId),
-		userId,
+		keys,
 		'Thread not found.'
 	);
 }
 
 export async function getOwnedRun(
 	db: DatabaseReader,
-	userId: string,
+	keys: OwnerKeys,
 	runId: Id<'runs'>
 ): Promise<Doc<'runs'>> {
-	return await assertOwned<'runs'>(await db.get('runs', runId), userId, 'Run not found.');
+	return await assertOwned<'runs'>(await db.get('runs', runId), keys, 'Run not found.');
+}
+
+/** Ownership gate keyed by a stored row's own userId field (executor-side
+ * capability paths hold the run's userId, not the caller identity). Legacy
+ * pre-migration rows carry the subject; expansion covers both forms. */
+export async function getOwnedThreadRecordForStoredUserId(
+	db: DatabaseReader,
+	userId: string,
+	threadRecordId: Id<'threadRecords'>
+): Promise<Doc<'threadRecords'>> {
+	return await assertOwned<'threadRecords'>(
+		await db.get('threadRecords', threadRecordId),
+		await resolveStoredOwnerKeys(db, userId),
+		'Thread not found.'
+	);
 }

--- a/apps/web/src/convex/lib/auth.ts
+++ b/apps/web/src/convex/lib/auth.ts
@@ -6,15 +6,28 @@ import type {
 } from 'convex/server';
 import type { DataModel } from '@convex/_generated/dataModel';
 import type { Doc, Id } from '@convex/_generated/dataModel';
+import { internalQuery } from '@convex/_generated/server';
+import { v } from 'convex/values';
 
-export async function getUserId(
-	ctx: GenericActionCtx<DataModel> | GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>
-): Promise<string> {
-	const identity: UserIdentity | null = await ctx.auth.getUserIdentity();
-	if (!identity) {
-		throw new Error('Authentication required.');
-	}
-	return identity.subject;
+/** The canonical owner key plus its pre-tokenIdentifier predecessor. Owned
+ * tables now store `identity.tokenIdentifier` in `userId`; rows written
+ * before the switch still carry `identity.subject` until the backfill
+ * rewrites them, so callers that read owner-scoped rows resolve both. */
+export type OwnerKeys = {
+	userId: string;
+	subject: string;
+};
+
+export function distinctOwnerKeys(keys: OwnerKeys): string[] {
+	return keys.userId === keys.subject ? [keys.userId] : [keys.userId, keys.subject];
+}
+
+export function matchesOwner(storedUserId: string, keys: OwnerKeys): boolean {
+	return storedUserId === keys.userId || storedUserId === keys.subject;
+}
+
+export function ownerKeysFromIdentity(identity: UserIdentity): OwnerKeys {
+	return { userId: identity.tokenIdentifier, subject: identity.subject };
 }
 
 export async function requireIdentity(
@@ -27,75 +40,104 @@ export async function requireIdentity(
 	return identity;
 }
 
+export async function getOwnerKeys(
+	ctx: GenericActionCtx<DataModel> | GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>
+): Promise<OwnerKeys> {
+	return ownerKeysFromIdentity(await requireIdentity(ctx));
+}
+
+/** Canonical owner key (identity.tokenIdentifier). Every new row stores this
+ * in `userId`. */
+export async function getUserId(
+	ctx: GenericActionCtx<DataModel> | GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>
+): Promise<string> {
+	return (await getOwnerKeys(ctx)).userId;
+}
+
+/** Maps a stored owner key (canonical tokenIdentifier or legacy subject) to
+ * the subject the pre-migration rows were saved under, when a users row
+ * exists for it. Returns null for users without a row; legacy rows for such
+ * users stay reachable only by their subject. */
+export async function resolveStoredOwnerSubject(
+	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
+	userId: string
+): Promise<string | null> {
+	const byToken = await ctx.db
+		.query('users')
+		.withIndex('by_tokenIdentifier', (query) => query.eq('tokenIdentifier', userId))
+		.unique();
+	if (byToken) {
+		return byToken.subject;
+	}
+	const bySubject = await ctx.db
+		.query('users')
+		.withIndex('by_subject', (query) => query.eq('subject', userId))
+		.unique();
+	if (bySubject) {
+		return bySubject.subject;
+	}
+	return null;
+}
+
+/** Public mirror of {@link resolveStoredOwnerSubject} for actions: turns a
+ * stored owner key (tokenIdentifier or legacy subject) into the pre-migration
+ * subject when the users row is known, else null. Used to keep Prava customer
+ * ids stable across the switch. */
+export const storedOwnerSubject = internalQuery({
+	args: { userId: v.string() },
+	returns: v.union(v.string(), v.null()),
+	handler: async (ctx, args) => {
+		return await resolveStoredOwnerSubject(ctx, args.userId);
+	}
+});
+
 /** Earliest row wins so first-login duplicates converge deterministically. */
 export function pickPrimaryUser(rows: Array<Doc<'users'>>): Doc<'users'> | null {
 	if (rows.length === 0) return null;
 	return [...rows].sort((a, b) => a.createdAt - b.createdAt || a._id.localeCompare(b._id))[0];
 }
 
-/** Query-safe lookup of the caller's users row; null until their first
- * ensureCurrentUser ran. */
-export async function getCurrentUser(
-	ctx: GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>
-): Promise<Doc<'users'> | null> {
-	const subject = await getUserId(ctx);
-	const rows = await ctx.db
-		.query('users')
-		.withIndex('by_subject', (query) => query.eq('subject', subject))
-		.collect();
-	return pickPrimaryUser(rows);
-}
-
 /** Mutation/action-only: resolves the caller's users row, creating it on
- * first sight. */
+ * first sight. Rows written before the tokenIdentifier switch lack the
+ * tokenIdentifier match but do carry the caller's subject, so adopt them in
+ * place instead of duplicating the user. */
 export async function ensureCurrentUser(ctx: GenericMutationCtx<DataModel>): Promise<Doc<'users'>> {
 	const identity = await requireIdentity(ctx);
-	const email = identity.email!;
-	const rows = await ctx.db
+	const email = identity.email;
+	const existing = await ctx.db
+		.query('users')
+		.withIndex('by_tokenIdentifier', (query) =>
+			query.eq('tokenIdentifier', identity.tokenIdentifier)
+		)
+		.unique();
+	if (existing) {
+		if (email && email !== existing.email) {
+			await ctx.db.patch('users', existing._id, { email });
+			return { ...existing, email };
+		}
+		return existing;
+	}
+	const legacy = await ctx.db
 		.query('users')
 		.withIndex('by_subject', (query) => query.eq('subject', identity.subject))
-		.collect();
-	if (rows.length > 0) {
-		let primary = pickPrimaryUser(rows);
-		if (!primary) throw new Error('Failed to resolve the user record.');
-		// A first-login race can insert two rows for one subject; converge on
-		// the earliest instead of poisoning later unique reads.
-		for (const extra of rows) {
-			if (extra._id !== primary._id) await ctx.db.delete('users', extra._id);
-		}
-		if (email !== primary.email) {
-			await ctx.db.patch('users', primary._id, { email });
-			primary = { ...primary, email };
-		}
-		return primary;
+		.unique();
+	if (legacy) {
+		const patch = email
+			? { tokenIdentifier: identity.tokenIdentifier, email }
+			: { tokenIdentifier: identity.tokenIdentifier };
+		await ctx.db.patch('users', legacy._id, patch);
+		return { ...legacy, ...patch };
 	}
 	const newUser = {
 		subject: identity.subject,
 		tokenIdentifier: identity.tokenIdentifier,
 		createdAt: Date.now(),
-		email
+		email: email ?? ''
 	};
 	const id = await ctx.db.insert('users', newUser);
 	const created = await ctx.db.get('users', id);
 	if (!created) throw new Error('Failed to create the user record.');
 	return created;
-}
-
-/** Canonical ownership gate for documents whose `userId` holds the auth
- * subject. Throws for missing docs and foreign docs alike so existence
- * never leaks. */
-export async function requireOwner<T extends { userId: string }>(
-	ctx: GenericActionCtx<DataModel> | GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>,
-	doc: T | null
-): Promise<T> {
-	if (!doc) {
-		throw new Error('Not found.');
-	}
-	const identity = await requireIdentity(ctx);
-	if (doc.userId !== identity.subject) {
-		throw new Error('Not found.');
-	}
-	return doc;
 }
 
 async function hashExecutionSecret(secret: string): Promise<string> {

--- a/apps/web/src/convex/lib/imageUploads.ts
+++ b/apps/web/src/convex/lib/imageUploads.ts
@@ -1,5 +1,7 @@
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '@convex/_generated/server';
+import { resolveStoredOwnerKeys } from '@convex/lib/access';
+import { matchesOwner } from '@convex/lib/auth';
 import { MAX_IMAGE_ATTACHMENTS } from '@convex/lib/validators';
 
 export function areImageUploadIdsEqual(
@@ -23,10 +25,11 @@ export async function getOwnedImageUploads(
 		throw new Error('The same image cannot be attached more than once.');
 	}
 
+	const keys = await resolveStoredOwnerKeys(ctx.db, userId);
 	return await Promise.all(
 		imageUploadIds.map(async (imageUploadId) => {
 			const upload = await ctx.db.get('imageUploads', imageUploadId);
-			if (!upload || upload.userId !== userId) {
+			if (!upload || !matchesOwner(upload.userId, keys)) {
 				throw new Error('Image attachment was not found.');
 			}
 			return upload;

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -2,7 +2,6 @@ import {
 	DAY,
 	HOUR,
 	MINUTE,
-	RateLimiter,
 	SECOND,
 	WEEK,
 	calculateRateLimit,
@@ -10,10 +9,10 @@ import {
 	type RunMutationCtx,
 	type RunQueryCtx
 } from '@convex-dev/rate-limiter';
-import { components } from '@convex/_generated/api';
+import { components, internal } from '@convex/_generated/api';
 import type { DataModel } from '@convex/_generated/dataModel';
 import { internalMutation } from '@convex/_generated/server';
-import { type GenericMutationCtx } from 'convex/server';
+import type { GenericMutationCtx } from 'convex/server';
 import { ConvexError, v } from 'convex/values';
 import {
 	ensureSubscription,
@@ -31,7 +30,6 @@ import {
 export { usageMeters, usagePeriods, type UsageMeterId, type UsagePeriod };
 
 const MONTH = 30 * DAY;
-export const rateLimiter = new RateLimiter(components.rateLimiter, {});
 
 const periodDurations = { weekly: WEEK, monthly: MONTH } as const satisfies Record<
 	UsagePeriod,
@@ -73,8 +71,69 @@ function formatRetryAfter(milliseconds: number): string {
 	return parts.join(' ');
 }
 
-async function blockedMeterLimit(
-	ctx: RunMutationCtx,
+/** A meter window read straight from the rate-limiter component. */
+type MeterWindow = {
+	value: number;
+	ts: number;
+	shard: number;
+	config: RateLimitConfig;
+};
+
+/**
+ * Writes always go to the canonical tokenIdentifier; rows charged before the
+ * migration live under the legacy subject, so readers fold both into one
+ * window. Without the legacy read a pre-migration overage would silently
+ * become a fresh free window.
+ */
+async function readMeterWindow(
+	ctx: RunQueryCtx,
+	userId: string,
+	name: string,
+	config: RateLimitConfig
+): Promise<MeterWindow> {
+	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId });
+	const canonical = await ctx.runQuery(components.rateLimiter.lib.getValue, {
+		name,
+		key: userId,
+		config
+	});
+	const canonicalWindow: MeterWindow = {
+		value: canonical.value,
+		ts: canonical.ts,
+		shard: canonical.shard,
+		config
+	};
+	if (!subject || subject === userId) return canonicalWindow;
+	const legacy = await ctx.runQuery(components.rateLimiter.lib.getValue, {
+		name,
+		key: subject,
+		config
+	});
+	return largestMeterWindow(canonicalWindow, {
+		value: legacy.value,
+		ts: legacy.ts,
+		shard: legacy.shard,
+		config
+	});
+}
+
+/** The original whose window reports more usage (or the only one started). */
+function largestMeterWindow(left: MeterWindow, right: MeterWindow): MeterWindow {
+	if (left.ts === 0) return right;
+	if (right.ts === 0) return left;
+	// Fixed-window shards keep usage as (rate - value); older windows have
+	// decayed further, so the larger user-visible used amount is the tighter
+	// bound for both blocking and display.
+	const leftUsed = Math.max(0, left.config.rate - left.value);
+	const rightUsed = Math.max(0, right.config.rate - right.value);
+	// Shard zero holds the full window; nonzero shards are partial chunks.
+	if (left.shard === 0 && right.shard !== 0) return left;
+	if (right.shard === 0 && left.shard !== 0) return right;
+	return leftUsed >= rightUsed ? left : right;
+}
+
+async function blockedForKey(
+	ctx: RunQueryCtx,
 	meterId: UsageMeterId,
 	key: string,
 	limits: TierLimits
@@ -82,7 +141,8 @@ async function blockedMeterLimit(
 	const statuses = await Promise.all(
 		usagePeriods.map(async (period) => ({
 			period,
-			status: await rateLimiter.check(ctx, meterLimitName(meterId, period), {
+			status: await ctx.runQuery(components.rateLimiter.lib.checkRateLimit, {
+				name: meterLimitName(meterId, period),
 				key,
 				config: meterLimitConfig(meterId, period, limits)
 			})
@@ -95,6 +155,21 @@ async function blockedMeterLimit(
 		return { period: blocked.period, retryAfter: blocked.status.retryAfter ?? 0 };
 	}
 	return undefined;
+}
+
+async function blockedMeterLimit(
+	ctx: RunMutationCtx,
+	meterId: UsageMeterId,
+	key: string,
+	limits: TierLimits
+): Promise<{ period: UsagePeriod; retryAfter: number } | undefined> {
+	const canonical = await blockedForKey(ctx, meterId, key, limits);
+	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId: key });
+	if (!subject || subject === key) return canonical;
+	const legacy = await blockedForKey(ctx, meterId, subject, limits);
+	if (!canonical) return legacy;
+	if (!legacy) return canonical;
+	return legacy.retryAfter > canonical.retryAfter ? legacy : canonical;
 }
 
 async function checkMeterLimits(
@@ -112,6 +187,62 @@ async function checkMeterLimits(
 	);
 }
 
+async function chargeOwnerKey(
+	ctx: RunQueryCtx,
+	userId: string,
+	meterId: UsageMeterId,
+	limits: TierLimits
+): Promise<string> {
+	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId });
+	if (!subject || subject === userId) return userId;
+	const config = meterLimitConfig(meterId, 'weekly', limits);
+	const name = meterLimitName(meterId, 'weekly');
+	const canonical = await ctx.runQuery(components.rateLimiter.lib.getValue, {
+		name,
+		key: userId,
+		config
+	});
+	const legacy = await ctx.runQuery(components.rateLimiter.lib.getValue, {
+		name,
+		key: subject,
+		config
+	});
+	if (legacy.ts === 0) return userId;
+	if (canonical.ts === 0) return subject;
+	const left: MeterWindow = {
+		value: canonical.value,
+		ts: canonical.ts,
+		shard: canonical.shard,
+		config
+	};
+	const right: MeterWindow = {
+		value: legacy.value,
+		ts: legacy.ts,
+		shard: legacy.shard,
+		config
+	};
+	return largestMeterWindow(left, right) === left ? userId : subject;
+}
+
+async function chargeMeterLimits(
+	ctx: RunMutationCtx,
+	meterId: UsageMeterId,
+	key: string,
+	limits: TierLimits,
+	count: number
+): Promise<void> {
+	const chargeKey = await chargeOwnerKey(ctx, key, meterId, limits);
+	for (const period of usagePeriods) {
+		await ctx.runMutation(components.rateLimiter.lib.rateLimit, {
+			name: meterLimitName(meterId, period),
+			key: chargeKey,
+			config: meterLimitConfig(meterId, period, limits),
+			count,
+			reserve: true
+		});
+	}
+}
+
 export async function gatewayQuotaStatus(
 	ctx: GenericMutationCtx<DataModel>,
 	userId: string
@@ -127,23 +258,6 @@ export async function gatewayQuotaStatus(
 	};
 }
 
-async function chargeMeterLimits(
-	ctx: RunMutationCtx,
-	meterId: UsageMeterId,
-	key: string,
-	limits: TierLimits,
-	count: number
-): Promise<void> {
-	for (const period of usagePeriods) {
-		await rateLimiter.limit(ctx, meterLimitName(meterId, period), {
-			key,
-			config: meterLimitConfig(meterId, period, limits),
-			count,
-			reserve: true
-		});
-	}
-}
-
 export async function getMeterWindow(
 	ctx: RunQueryCtx,
 	meterId: UsageMeterId,
@@ -153,17 +267,14 @@ export async function getMeterWindow(
 	now: number = Date.now()
 ): Promise<{ used: number; limit: number; resetsAt: number | null }> {
 	const config = meterLimitConfig(meterId, period, limits);
-	const stored = await rateLimiter.getValue(ctx, meterLimitName(meterId, period), {
-		key: userId,
-		config
-	});
+	const stored = await readMeterWindow(ctx, userId, meterLimitName(meterId, period), config);
 	// A fixed window starts on first use; ts === 0 means it never has.
 	if (stored.ts === 0) return { used: 0, limit: config.rate, resetsAt: null };
-	const current = calculateRateLimit({ value: stored.value, ts: stored.ts }, config, now);
+	const current = calculateRateLimit({ value: stored.value, ts: stored.ts }, stored.config, now);
 	return {
-		used: Math.max(0, config.rate - current.value),
+		used: Math.max(0, stored.config.rate - current.value),
 		limit: config.rate,
-		resetsAt: current.ts + config.period
+		resetsAt: current.ts + stored.config.period
 	};
 }
 

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -187,6 +187,40 @@ async function checkMeterLimits(
 	);
 }
 
+async function meterWindowForKey(
+	ctx: RunQueryCtx,
+	key: string,
+	name: string,
+	config: RateLimitConfig
+): Promise<MeterWindow> {
+	const stored = await ctx.runQuery(components.rateLimiter.lib.getValue, {
+		name,
+		key,
+		config
+	});
+	return {
+		value: stored.value,
+		ts: stored.ts,
+		shard: stored.shard,
+		config
+	};
+}
+
+/** Prefer the key that already has an open window so a weekly reset cannot
+ *  open a fresh monthly window on the other key. Monthly is checked first
+ *  because it outlives the weekly meter. */
+function chargeKeyForWindows(
+	userId: string,
+	subject: string,
+	canonical: MeterWindow,
+	legacy: MeterWindow
+): string | undefined {
+	if (legacy.ts === 0 && canonical.ts === 0) return undefined;
+	if (legacy.ts === 0) return userId;
+	if (canonical.ts === 0) return subject;
+	return largestMeterWindow(canonical, legacy) === canonical ? userId : subject;
+}
+
 async function chargeOwnerKey(
 	ctx: RunQueryCtx,
 	userId: string,
@@ -195,33 +229,18 @@ async function chargeOwnerKey(
 ): Promise<string> {
 	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId });
 	if (!subject || subject === userId) return userId;
-	const config = meterLimitConfig(meterId, 'weekly', limits);
-	const name = meterLimitName(meterId, 'weekly');
-	const canonical = await ctx.runQuery(components.rateLimiter.lib.getValue, {
-		name,
-		key: userId,
-		config
-	});
-	const legacy = await ctx.runQuery(components.rateLimiter.lib.getValue, {
-		name,
-		key: subject,
-		config
-	});
-	if (legacy.ts === 0) return userId;
-	if (canonical.ts === 0) return subject;
-	const left: MeterWindow = {
-		value: canonical.value,
-		ts: canonical.ts,
-		shard: canonical.shard,
-		config
-	};
-	const right: MeterWindow = {
-		value: legacy.value,
-		ts: legacy.ts,
-		shard: legacy.shard,
-		config
-	};
-	return largestMeterWindow(left, right) === left ? userId : subject;
+	for (const period of ['monthly', 'weekly'] as const) {
+		const config = meterLimitConfig(meterId, period, limits);
+		const name = meterLimitName(meterId, period);
+		const chargeKey = chargeKeyForWindows(
+			userId,
+			subject,
+			await meterWindowForKey(ctx, userId, name, config),
+			await meterWindowForKey(ctx, subject, name, config)
+		);
+		if (chargeKey) return chargeKey;
+	}
+	return userId;
 }
 
 async function chargeMeterLimits(

--- a/apps/web/src/convex/lib/rateLimits.ts
+++ b/apps/web/src/convex/lib/rateLimits.ts
@@ -79,114 +79,6 @@ type MeterWindow = {
 	config: RateLimitConfig;
 };
 
-/**
- * Writes always go to the canonical tokenIdentifier; rows charged before the
- * migration live under the legacy subject, so readers fold both into one
- * window. Without the legacy read a pre-migration overage would silently
- * become a fresh free window.
- */
-async function readMeterWindow(
-	ctx: RunQueryCtx,
-	userId: string,
-	name: string,
-	config: RateLimitConfig
-): Promise<MeterWindow> {
-	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId });
-	const canonical = await ctx.runQuery(components.rateLimiter.lib.getValue, {
-		name,
-		key: userId,
-		config
-	});
-	const canonicalWindow: MeterWindow = {
-		value: canonical.value,
-		ts: canonical.ts,
-		shard: canonical.shard,
-		config
-	};
-	if (!subject || subject === userId) return canonicalWindow;
-	const legacy = await ctx.runQuery(components.rateLimiter.lib.getValue, {
-		name,
-		key: subject,
-		config
-	});
-	return largestMeterWindow(canonicalWindow, {
-		value: legacy.value,
-		ts: legacy.ts,
-		shard: legacy.shard,
-		config
-	});
-}
-
-/** The original whose window reports more usage (or the only one started). */
-function largestMeterWindow(left: MeterWindow, right: MeterWindow): MeterWindow {
-	if (left.ts === 0) return right;
-	if (right.ts === 0) return left;
-	// Fixed-window shards keep usage as (rate - value); older windows have
-	// decayed further, so the larger user-visible used amount is the tighter
-	// bound for both blocking and display.
-	const leftUsed = Math.max(0, left.config.rate - left.value);
-	const rightUsed = Math.max(0, right.config.rate - right.value);
-	// Shard zero holds the full window; nonzero shards are partial chunks.
-	if (left.shard === 0 && right.shard !== 0) return left;
-	if (right.shard === 0 && left.shard !== 0) return right;
-	return leftUsed >= rightUsed ? left : right;
-}
-
-async function blockedForKey(
-	ctx: RunQueryCtx,
-	meterId: UsageMeterId,
-	key: string,
-	limits: TierLimits
-): Promise<{ period: UsagePeriod; retryAfter: number } | undefined> {
-	const statuses = await Promise.all(
-		usagePeriods.map(async (period) => ({
-			period,
-			status: await ctx.runQuery(components.rateLimiter.lib.checkRateLimit, {
-				name: meterLimitName(meterId, period),
-				key,
-				config: meterLimitConfig(meterId, period, limits)
-			})
-		}))
-	);
-	const blocked = statuses
-		.filter(({ status }) => !status.ok)
-		.sort((a, b) => (b.status.retryAfter ?? 0) - (a.status.retryAfter ?? 0))[0];
-	if (blocked && !blocked.status.ok) {
-		return { period: blocked.period, retryAfter: blocked.status.retryAfter ?? 0 };
-	}
-	return undefined;
-}
-
-async function blockedMeterLimit(
-	ctx: RunMutationCtx,
-	meterId: UsageMeterId,
-	key: string,
-	limits: TierLimits
-): Promise<{ period: UsagePeriod; retryAfter: number } | undefined> {
-	const canonical = await blockedForKey(ctx, meterId, key, limits);
-	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId: key });
-	if (!subject || subject === key) return canonical;
-	const legacy = await blockedForKey(ctx, meterId, subject, limits);
-	if (!canonical) return legacy;
-	if (!legacy) return canonical;
-	return legacy.retryAfter > canonical.retryAfter ? legacy : canonical;
-}
-
-async function checkMeterLimits(
-	ctx: RunMutationCtx,
-	meterId: UsageMeterId,
-	key: string,
-	limits: TierLimits
-): Promise<void> {
-	const blocked = await blockedMeterLimit(ctx, meterId, key, limits);
-	if (!blocked) return;
-	// A ConvexError keeps its message through production error masking, and
-	// the executor only retries masked server failures.
-	throw new ConvexError(
-		`${meterLimitLabel(meterId, blocked.period)} reached. Try again in ${formatRetryAfter(blocked.retryAfter)}.`
-	);
-}
-
 async function meterWindowForKey(
 	ctx: RunQueryCtx,
 	key: string,
@@ -204,6 +96,98 @@ async function meterWindowForKey(
 		shard: stored.shard,
 		config
 	};
+}
+
+/** Canonical plus legacy-subject windows. Charge writes one key; a weekly
+ * reset can still leave usage on both until those windows roll, so readers
+ * add them. */
+async function ownerMeterWindows(
+	ctx: RunQueryCtx,
+	userId: string,
+	name: string,
+	config: RateLimitConfig
+): Promise<MeterWindow[]> {
+	const canonical = await meterWindowForKey(ctx, userId, name, config);
+	const subject = await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId });
+	if (!subject || subject === userId) return [canonical];
+	return [canonical, await meterWindowForKey(ctx, subject, name, config)];
+}
+
+function windowUsed(window: MeterWindow, now: number): number {
+	if (window.ts === 0) return 0;
+	const current = calculateRateLimit({ value: window.value, ts: window.ts }, window.config, now);
+	return Math.max(0, window.config.rate - current.value);
+}
+
+/** How long until combined used falls back under `limit` as windows reset. */
+function combinedRetryAfter(windows: MeterWindow[], limit: number, now: number): number {
+	const active = windows
+		.map((window) => ({
+			used: windowUsed(window, now),
+			resetAt: window.ts + window.config.period
+		}))
+		.filter((window) => window.used > 0)
+		.sort((left, right) => left.resetAt - right.resetAt);
+	let remaining = active.reduce((sum, window) => sum + window.used, 0);
+	for (const window of active) {
+		remaining -= window.used;
+		if (remaining < limit) return Math.max(SECOND, window.resetAt - now);
+	}
+	const last = active.at(-1);
+	return last ? Math.max(SECOND, last.resetAt - now) : 0;
+}
+
+/** The original whose window reports more usage (or the only one started). */
+function largestMeterWindow(left: MeterWindow, right: MeterWindow): MeterWindow {
+	if (left.ts === 0) return right;
+	if (right.ts === 0) return left;
+	// Fixed-window shards keep usage as (rate - value); older windows have
+	// decayed further, so the larger user-visible used amount is the tighter
+	// bound for charge-key selection.
+	const leftUsed = Math.max(0, left.config.rate - left.value);
+	const rightUsed = Math.max(0, right.config.rate - right.value);
+	// Shard zero holds the full window; nonzero shards are partial chunks.
+	if (left.shard === 0 && right.shard !== 0) return left;
+	if (right.shard === 0 && left.shard !== 0) return right;
+	return leftUsed >= rightUsed ? left : right;
+}
+
+async function blockedMeterLimit(
+	ctx: RunMutationCtx,
+	meterId: UsageMeterId,
+	key: string,
+	limits: TierLimits,
+	now: number = Date.now()
+): Promise<{ period: UsagePeriod; retryAfter: number } | undefined> {
+	const blocked = (
+		await Promise.all(
+			usagePeriods.map(async (period) => {
+				const config = meterLimitConfig(meterId, period, limits);
+				const windows = await ownerMeterWindows(ctx, key, meterLimitName(meterId, period), config);
+				const used = windows.reduce((sum, window) => sum + windowUsed(window, now), 0);
+				if (used < config.rate) return undefined;
+				return { period, retryAfter: combinedRetryAfter(windows, config.rate, now) };
+			})
+		)
+	)
+		.filter((entry) => entry !== undefined)
+		.sort((left, right) => right.retryAfter - left.retryAfter)[0];
+	return blocked;
+}
+
+async function checkMeterLimits(
+	ctx: RunMutationCtx,
+	meterId: UsageMeterId,
+	key: string,
+	limits: TierLimits
+): Promise<void> {
+	const blocked = await blockedMeterLimit(ctx, meterId, key, limits);
+	if (!blocked) return;
+	// A ConvexError keeps its message through production error masking, and
+	// the executor only retries masked server failures.
+	throw new ConvexError(
+		`${meterLimitLabel(meterId, blocked.period)} reached. Try again in ${formatRetryAfter(blocked.retryAfter)}.`
+	);
 }
 
 /** Prefer the key that already has an open window so a weekly reset cannot
@@ -286,15 +270,15 @@ export async function getMeterWindow(
 	now: number = Date.now()
 ): Promise<{ used: number; limit: number; resetsAt: number | null }> {
 	const config = meterLimitConfig(meterId, period, limits);
-	const stored = await readMeterWindow(ctx, userId, meterLimitName(meterId, period), config);
-	// A fixed window starts on first use; ts === 0 means it never has.
-	if (stored.ts === 0) return { used: 0, limit: config.rate, resetsAt: null };
-	const current = calculateRateLimit({ value: stored.value, ts: stored.ts }, stored.config, now);
-	return {
-		used: Math.max(0, stored.config.rate - current.value),
-		limit: config.rate,
-		resetsAt: current.ts + stored.config.period
-	};
+	const windows = await ownerMeterWindows(ctx, userId, meterLimitName(meterId, period), config);
+	const used = windows.reduce((sum, window) => sum + windowUsed(window, now), 0);
+	if (used === 0) return { used: 0, limit: config.rate, resetsAt: null };
+	const resetsAt = Math.min(
+		...windows
+			.filter((window) => windowUsed(window, now) > 0)
+			.map((window) => window.ts + window.config.period)
+	);
+	return { used, limit: config.rate, resetsAt };
 }
 
 export async function applyGatewayUsageCharge(

--- a/apps/web/src/convex/lib/sessionCredentials.ts
+++ b/apps/web/src/convex/lib/sessionCredentials.ts
@@ -1,0 +1,172 @@
+import { v } from 'convex/values';
+import type { GenericMutationCtx, GenericQueryCtx } from 'convex/server';
+import type { DataModel, Doc } from '@convex/_generated/dataModel';
+
+/** A session credential lets a local executor act for a user without holding
+ * the WorkOS access token. The row stores only hashes; the rotation is
+ * client-driven (the executor generates the next secret and presents it), so
+ * losing a rotation response cannot desynchronize the chain. */
+/** Proof presented on identity-sensitive calls. `next` is ignored if present
+ * so a leaked Convex argument cannot steal the rotation chain. */
+export const vSessionCredentialProof = v.object({
+	sessionId: v.string(),
+	userId: v.string(),
+	current: v.string(),
+	next: v.optional(v.string())
+});
+
+export const vSessionCredentialTicket = v.object({
+	sessionId: v.string(),
+	userId: v.string(),
+	current: v.string(),
+	next: v.string()
+});
+
+export type SessionCredentialProof = {
+	sessionId: string;
+	userId: string;
+	current: string;
+};
+
+export type SessionCredentialTicket = SessionCredentialProof & {
+	next: string;
+};
+
+/** The Rust rotator refreshes at this cadence. */
+export const SESSION_CREDENTIAL_REFRESH_MS = 5 * 60_000;
+
+/** A credential whose chain was not advanced for this long is dead. Two
+ * refresh marks. Missing one mark (rotating at 10 minutes instead of 5) is
+ * still accepted. */
+export const SESSION_CREDENTIAL_MAX_GAP_MS = 2 * SESSION_CREDENTIAL_REFRESH_MS;
+
+async function hashSecret(secret: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+	let difference = left.length ^ right.length;
+	const length = Math.max(left.length, right.length);
+	for (let index = 0; index < length; index += 1) {
+		difference |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+	}
+	return difference === 0;
+}
+
+export function sessionCredentialExpiresAt(lastRefreshTime: number): number {
+	return lastRefreshTime + SESSION_CREDENTIAL_MAX_GAP_MS;
+}
+
+export async function sessionCredentialRow(
+	ctx: GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>,
+	sessionId: string
+): Promise<Doc<'sessionCredentials'> | null> {
+	return await ctx.db
+		.query('sessionCredentials')
+		.withIndex('by_sessionId', (query) => query.eq('sessionId', sessionId))
+		.unique();
+}
+
+/** Mints the initial {current, next} pair for a freshly authorized user. The
+ * browser relays these to the local server once; from then on the server
+ * rotates on its own. */
+export async function issueSessionCredentialPair(
+	ctx: GenericMutationCtx<DataModel>,
+	userId: string,
+	subject: string
+): Promise<{
+	sessionId: string;
+	current: string;
+	next: string;
+	expiresAt: number;
+	refreshAfterMs: number;
+}> {
+	const sessionId = crypto.randomUUID();
+	const current = crypto.randomUUID();
+	const next = crypto.randomUUID();
+	const now = Date.now();
+	await ctx.db.insert('sessionCredentials', {
+		sessionId,
+		userId,
+		subject,
+		currentHash: await hashSecret(current),
+		previousHash: '',
+		lastRefreshTime: now,
+		createdAt: now
+	});
+	return {
+		sessionId,
+		current,
+		next,
+		expiresAt: sessionCredentialExpiresAt(now),
+		refreshAfterMs: SESSION_CREDENTIAL_REFRESH_MS
+	};
+}
+
+/** Advances the chain to the presented `next` secret. Idempotent: if the
+ * presented pair matches the previous chain element (a retry after the
+ * original rotation commit was lost), the row is not advanced again and the
+ * same success is returned. */
+export async function rotateSessionCredential(
+	ctx: GenericMutationCtx<DataModel>,
+	row: Doc<'sessionCredentials'>,
+	ticket: SessionCredentialTicket
+): Promise<{ expiresAt: number; refreshAfterMs: number }> {
+	const now = Date.now();
+	if (row.userId !== ticket.userId) {
+		throw new Error('Invalid session credential.');
+	}
+	if (now - row.lastRefreshTime >= SESSION_CREDENTIAL_MAX_GAP_MS) {
+		throw new Error('Session credential expired.');
+	}
+	const presentedHash = await hashSecret(ticket.current);
+	const nextHash = await hashSecret(ticket.next);
+
+	const isRetry =
+		constantTimeEqual(presentedHash, row.previousHash) &&
+		constantTimeEqual(nextHash, row.currentHash);
+	if (isRetry) {
+		return {
+			expiresAt: sessionCredentialExpiresAt(row.lastRefreshTime),
+			refreshAfterMs: SESSION_CREDENTIAL_REFRESH_MS
+		};
+	}
+
+	if (!constantTimeEqual(presentedHash, row.currentHash)) {
+		throw new Error('Invalid session credential.');
+	}
+	await ctx.db.patch('sessionCredentials', row._id, {
+		currentHash: nextHash,
+		previousHash: presentedHash,
+		lastRefreshTime: now
+	});
+	return {
+		expiresAt: sessionCredentialExpiresAt(now),
+		refreshAfterMs: SESSION_CREDENTIAL_REFRESH_MS
+	};
+}
+
+/** Resolves the owning identity for a presented credential, or null. Used by
+ * endpoints that are otherwise callable without the WorkOS identity. */
+export async function authorizeBySessionCredential(
+	ctx: GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>,
+	ticket: SessionCredentialProof
+): Promise<{ userId: string; subject: string } | null> {
+	const row = await sessionCredentialRow(ctx, ticket.sessionId);
+	if (
+		!row ||
+		row.userId !== ticket.userId ||
+		Date.now() - row.lastRefreshTime >= SESSION_CREDENTIAL_MAX_GAP_MS
+	) {
+		return null;
+	}
+	const presentedHash = await hashSecret(ticket.current);
+	const valid =
+		constantTimeEqual(presentedHash, row.currentHash) ||
+		constantTimeEqual(presentedHash, row.previousHash);
+	if (!valid) {
+		return null;
+	}
+	return { userId: row.userId, subject: row.subject };
+}

--- a/apps/web/src/convex/lib/threadMessages.ts
+++ b/apps/web/src/convex/lib/threadMessages.ts
@@ -2,7 +2,7 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '@convex/_generated/server';
 import { ConvexError } from 'convex/values';
 import type { ThreadMessageType } from '@convex/lib/validators';
-import { getOwnedThreadRecord } from './access';
+import { getOwnedThreadRecordForStoredUserId } from './access';
 
 export async function getThreadMessage(
 	ctx: MutationCtx | QueryCtx,
@@ -27,7 +27,7 @@ export async function appendThreadMessage(
 		parts?: Doc<'threadMessages'>['parts'];
 	}
 ): Promise<Id<'threadMessages'>> {
-	const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecord(
+	const threadRecord: Doc<'threadRecords'> = await getOwnedThreadRecordForStoredUserId(
 		ctx.db,
 		args.userId,
 		args.threadId

--- a/apps/web/src/convex/lib/tiers.ts
+++ b/apps/web/src/convex/lib/tiers.ts
@@ -1,5 +1,6 @@
 import type { GenericMutationCtx, GenericQueryCtx } from 'convex/server';
 import type { DataModel, Doc } from '@convex/_generated/dataModel';
+import { resolveStoredOwnerSubject } from './auth';
 
 export const subscriptionTierIds = ['free', 'pro', 'admin'] as const;
 export type SubscriptionTier = (typeof subscriptionTierIds)[number];
@@ -67,10 +68,19 @@ async function listSubscriptions(
 	ctx: GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
 	userId: string
 ): Promise<Doc<'subscriptions'>[]> {
-	return await ctx.db
+	const canonical = await ctx.db
 		.query('subscriptions')
 		.withIndex('by_userId', (query) => query.eq('userId', userId))
 		.collect();
+	const subject = await resolveStoredOwnerSubject(ctx, userId);
+	if (!subject || subject === userId) return canonical;
+	const legacy = await ctx.db
+		.query('subscriptions')
+		.withIndex('by_userId', (query) => query.eq('userId', subject))
+		.collect();
+	// Fold both keys so pending rows under either original participate in
+	// collapse/pick decisions until the owner-rewrite migration runs.
+	return [...canonical, ...legacy];
 }
 
 export async function getSubscriptionDoc(

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -1,6 +1,7 @@
 import { Migrations } from '@convex-dev/migrations';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation } from '@convex/_generated/server';
+import { pickPrimaryUser } from '@convex/lib/auth';
 import schema from '@convex/schema';
 
 export const migrations = new Migrations(components.migrations, {
@@ -11,7 +12,28 @@ export const migrations = new Migrations(components.migrations, {
 // `run` targets the currently live migration(s). Each deploy's cron calls it
 // with no args; the runner picks up the pinned migration refs itself. Swap in
 // the next migration when a future cleanup lands.
-export const run = migrations.runner([internal.migrations.clearResponseMessageParts]);
+export const run = migrations.runner([
+	internal.migrations.clearResponseMessageParts,
+	internal.migrations.rewriteBillingCustomerOwners,
+	internal.migrations.rewriteSubscriptionOwners,
+	internal.migrations.rewriteUiPreferenceOwners,
+	internal.migrations.rewriteProjectOwners,
+	internal.migrations.rewriteProjectConnectionOwners,
+	internal.migrations.rewriteThreadRecordOwners,
+	internal.migrations.rewriteThreadUsageOwners,
+	internal.migrations.rewriteThreadUsageEventOwners,
+	internal.migrations.rewriteRunOwners,
+	internal.migrations.rewriteThreadMessageOwners,
+	internal.migrations.rewriteTranscriptStateOwners,
+	internal.migrations.rewriteTranscriptPartOwners,
+	internal.migrations.rewriteCompletionStreamStateOwners,
+	internal.migrations.rewriteImageUploadOwners,
+	internal.migrations.rewriteArtifactOwners,
+	internal.migrations.rewriteArtifactVersionOwners,
+	internal.migrations.rewriteMandateOwners,
+	internal.migrations.rewriteMandateChargeOwners,
+	internal.migrations.rewriteBrowserSessionOwners
+]);
 
 /**
  * Clears the response-half payloads (`text`, `parts`) that runs wrote to
@@ -40,3 +62,53 @@ export const clearResponseMessageParts = migrations.define({
 		await ctx.db.patch('threadMessages', message._id, { text: '', parts: [] });
 	}
 });
+
+/**
+ * Owner-key transition: owned tables move from storing the WorkOS JWT
+ * subject in `userId` to the canonical `identity.tokenIdentifier`. Rows
+ * written before the switch stay reachable through the caller's subject
+ * (kept on `users.subject`) until a later unset rewrite removes the shims.
+ */
+type OwnedTable = Exclude<
+	Parameters<typeof migrations.define>[0]['table'],
+	// Tables without an owning userId handle ownership transitively.
+	'users' | 'executorJobs' | 'agentQuestions' | 'sessionCredentials'
+>;
+
+function rewriteOwnerKey(table: OwnedTable) {
+	return migrations.define({
+		table,
+		batchSize: 25,
+		migrateOne: async (ctx, doc) => {
+			const user = pickPrimaryUser(
+				await ctx.db
+					.query('users')
+					.withIndex('by_subject', (query) => query.eq('subject', doc.userId))
+					.collect()
+			);
+			if (user && user.tokenIdentifier !== doc.userId) {
+				return { userId: user.tokenIdentifier };
+			}
+		}
+	});
+}
+
+export const rewriteBillingCustomerOwners = rewriteOwnerKey('billingCustomers');
+export const rewriteSubscriptionOwners = rewriteOwnerKey('subscriptions');
+export const rewriteUiPreferenceOwners = rewriteOwnerKey('uiPreferences');
+export const rewriteProjectOwners = rewriteOwnerKey('projects');
+export const rewriteProjectConnectionOwners = rewriteOwnerKey('projectConnections');
+export const rewriteThreadRecordOwners = rewriteOwnerKey('threadRecords');
+export const rewriteThreadUsageOwners = rewriteOwnerKey('threadUsage');
+export const rewriteThreadUsageEventOwners = rewriteOwnerKey('threadUsageEvents');
+export const rewriteRunOwners = rewriteOwnerKey('runs');
+export const rewriteThreadMessageOwners = rewriteOwnerKey('threadMessages');
+export const rewriteTranscriptStateOwners = rewriteOwnerKey('threadTranscriptStates');
+export const rewriteTranscriptPartOwners = rewriteOwnerKey('threadTranscriptParts');
+export const rewriteCompletionStreamStateOwners = rewriteOwnerKey('completionStreamStates');
+export const rewriteImageUploadOwners = rewriteOwnerKey('imageUploads');
+export const rewriteArtifactOwners = rewriteOwnerKey('artifacts');
+export const rewriteArtifactVersionOwners = rewriteOwnerKey('artifactVersions');
+export const rewriteMandateOwners = rewriteOwnerKey('mandates');
+export const rewriteMandateChargeOwners = rewriteOwnerKey('mandateCharges');
+export const rewriteBrowserSessionOwners = rewriteOwnerKey('browserSessions');

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -6,6 +6,7 @@ import {
 	createQueuedRun,
 	initConvexTest,
 	seedOwnedThread,
+	subjectTokenIdentifier,
 	type ConvexTestInstance
 } from '@convex/test.setup';
 
@@ -195,6 +196,8 @@ describe('payments mandates', () => {
 		});
 		const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
 		expect(body).toMatchObject({
+			// Prava customer keys stay on the pre-migration subject; the local
+			// row's userId now holds the canonical tokenIdentifier.
 			user_id: 'user_alice',
 			// The email comes from the caller's WorkOS identity, not tool args.
 			user_email: 'user_alice@example.com',
@@ -219,7 +222,7 @@ describe('payments mandates', () => {
 		});
 		const stored = await t.run(async (ctx) => ctx.db.get('mandates', result.mandateId));
 		expect(stored).toMatchObject({
-			userId: 'user_alice',
+			userId: subjectTokenIdentifier('user_alice'),
 			status: 'pending',
 			amountCap: 12_000,
 			description: 'Monthly budget',
@@ -304,7 +307,7 @@ describe('payments mandates', () => {
 
 		const stored = await t.run(async (ctx) => ctx.db.get('mandateCharges', charge.chargeId));
 		expect(stored).toMatchObject({
-			userId: 'user_alice',
+			userId: subjectTokenIdentifier('user_alice'),
 			pravaTransactionId: 'txn_9',
 			amount: 4_000,
 			status: 'awaiting_result'

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -11,7 +11,8 @@ import {
 } from '@convex/_generated/server';
 import { api, components, internal } from '@convex/_generated/api';
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import { getUserId, pickPrimaryUser } from '@convex/lib/auth';
+import { distinctOwnerKeys, getUserId, matchesOwner, pickPrimaryUser } from '@convex/lib/auth';
+import { resolveStoredOwnerKeys } from '@convex/lib/access';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
 import { toAgentToolConvexError } from '@convex/lib/agentErrors';
 import { unsupportedClient } from '@convex/lib/unsupportedClient';
@@ -308,7 +309,8 @@ async function ownedCharge(
 	userId: string
 ): Promise<Doc<'mandateCharges'>> {
 	const charge = await ctx.db.get('mandateCharges', chargeId);
-	if (!charge || charge.userId !== userId) {
+	const keys = await resolveStoredOwnerKeys(ctx.db, userId);
+	if (!charge || !matchesOwner(charge.userId, keys)) {
 		throw new Error('Charge not found.');
 	}
 	return charge;
@@ -420,25 +422,36 @@ export const getOwnedMandate = internalQuery({
 	returns: v.union(mandateDoc, v.null()),
 	handler: async (ctx, args) => {
 		const mandate = await ctx.db.get('mandates', args.mandateId);
-		return mandate?.userId === args.userId ? mandate : null;
+		if (!mandate) return null;
+		const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+		return matchesOwner(mandate.userId, keys) ? mandate : null;
 	}
 });
 
 /** The user's WorkOS email, synced onto their users row by
- * ensureCurrentUser. Executor actions carry no usable caller identity (the
- * run's auth token is a launch-time snapshot), so capability-gated code reads
- * it from here instead of ctx.auth. */
+ * ensureCurrentUser. Executor actions have no WorkOS identity, so
+ * capability-gated code reads the email from here instead of ctx.auth. */
 export const getUserEmail = internalQuery({
 	args: { userId: v.string() },
 	returns: v.string(),
 	handler: async (ctx, args) => {
+		// Executor userIds are stored rows that may hold the legacy subject or
+		// the canonical tokenIdentifier, so match against both columns.
 		const rows = await ctx.db
 			.query('users')
 			.withIndex('by_subject', (query) => query.eq('subject', args.userId))
 			.collect();
-		const primary = pickPrimaryUser(rows);
-		if (!primary) throw new Error(`No user record for ${args.userId}.`);
-		return primary.email;
+		if (rows[0]) {
+			return pickPrimaryUser(rows)!.email;
+		}
+		const byToken = await ctx.db
+			.query('users')
+			.withIndex('by_tokenIdentifier', (query) => query.eq('tokenIdentifier', args.userId))
+			.unique();
+		if (byToken) {
+			return byToken.email;
+		}
+		throw new Error(`No user record for ${args.userId}.`);
 	}
 });
 
@@ -446,10 +459,17 @@ export const listLocalMandates = internalQuery({
 	args: { userId: v.string() },
 	returns: v.array(mandateDoc),
 	handler: async (ctx, args) => {
-		return await ctx.db
-			.query('mandates')
-			.withIndex('by_user', (query) => query.eq('userId', args.userId))
-			.collect();
+		const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+		return (
+			await Promise.all(
+				distinctOwnerKeys(keys).map((key) =>
+					ctx.db
+						.query('mandates')
+						.withIndex('by_user', (query) => query.eq('userId', key))
+						.collect()
+				)
+			)
+		).flat();
 	}
 });
 
@@ -467,7 +487,8 @@ export const syncMandate = internalMutation({
 	handler: async (ctx, args) => {
 		try {
 			const mandate = await ctx.db.get('mandates', args.mandateId);
-			if (!mandate || mandate.userId !== args.userId) {
+			const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+			if (!mandate || !matchesOwner(mandate.userId, keys)) {
 				throw new Error('Mandate not found.');
 			}
 			const patch: MandateSyncPatch = { updatedAt: Date.now() };
@@ -537,7 +558,8 @@ export const reserveCharge = internalMutation({
 				}
 				const existing = matches[0];
 				if (existing) {
-					if (existing.userId !== args.userId) {
+					const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+					if (!matchesOwner(existing.userId, keys)) {
 						throw new Error('Charge not found.');
 					}
 					if (existing.amount !== amount || existing.currency !== args.currency) {
@@ -663,7 +685,9 @@ export const getOwnedCharge = internalQuery({
 	returns: v.union(chargeDoc, v.null()),
 	handler: async (ctx, args) => {
 		const charge = await ctx.db.get('mandateCharges', args.chargeId);
-		return charge?.userId === args.userId ? charge : null;
+		if (!charge) return null;
+		const keys = await resolveStoredOwnerKeys(ctx.db, args.userId);
+		return matchesOwner(charge.userId, keys) ? charge : null;
 	}
 });
 
@@ -919,10 +943,13 @@ async function createMandateSetup(
 	if (args.userEmail !== undefined) {
 		unsupportedClient();
 	}
-	// Prava requires a customer email on merchant sessions. Executor actions
-	// carry no caller identity, so read the WorkOS email that ensureCurrentUser
-	// keeps on the users row instead of ctx.auth.
+	// Executor actions carry no caller identity, so the Prava customer key is
+	// the same stored userId the mandate rows keep (its legacy subject, when
+	// this run was written before the tokenIdentifier migration) and the
+	// email is what ensureCurrentUser synced onto the users row.
 	const userEmail = await ctx.runQuery(internal.payments.getUserEmail, { userId });
+	const pravaUserId =
+		(await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId })) ?? userId;
 	assertMandateFrequencyAllowed(args);
 
 	// Generic (any-scope) mandates are one-time only; Prava still needs a
@@ -954,7 +981,7 @@ async function createMandateSetup(
 		method: 'POST',
 		body: JSON.stringify({
 			integration_type: 'embedding',
-			user_id: userId,
+			user_id: pravaUserId,
 			user_email: userEmail,
 			total_amount: args.amountCap,
 			currency: args.currency,
@@ -1101,13 +1128,17 @@ async function resolvePravaMandate(
 	userId: string,
 	mandate: Doc<'mandates'>
 ): Promise<PravaMandate & { id: string }> {
+	// List under the original Prava customer key: pre-migration rows carry
+	// the subject while the caller now hands us the tokenIdentifier.
+	const pravaUserId =
+		(await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId })) ?? userId;
 	if (mandate.pravaMandateId) {
 		const found = await pravaRequest<PravaMandate>(
 			`/v1/mandates/${encodeURIComponent(mandate.pravaMandateId)}`
 		);
 		return { ...found, id: mandate.pravaMandateId };
 	}
-	const list = await listPravaMandates(userId, false);
+	const list = await listPravaMandates(pravaUserId, false);
 	const local = await ctx.runQuery(internal.payments.listLocalMandates, { userId });
 	const match = uniquelyAttributablePravaMandate(mandate, list, local);
 	// Require a unique live match. Charging an arbitrary same-merchant+amount
@@ -1170,7 +1201,9 @@ async function listLinkedMandates(
 	ctx: ActionCtx,
 	userId: string
 ): Promise<Infer<typeof vMandateListResult>> {
-	const list = (await listPravaMandates(userId, false)).filter((m) =>
+	const pravaUserId =
+		(await ctx.runQuery(internal.lib.auth.storedOwnerSubject, { userId })) ?? userId;
+	const list = (await listPravaMandates(pravaUserId, false)).filter((m) =>
 		LIVE_MANDATE_STATUSES.has(m.status ?? '')
 	);
 	const { localByPravaId, localById } = await linkLocalMandates(ctx, userId, list);
@@ -1463,8 +1496,8 @@ export const mandateReport = action({
 
 // ---------------------------------------------------------------------------
 // User-facing actions (settings screen; authenticated user, no agent run).
-// These resolve the same identity.subject as the executor tools, so mandate
-// ownership checks are identical on both paths.
+// These resolve the same owner key as the executor tools (the caller's stored
+// userId), so mandate ownership checks are identical on both paths.
 // ---------------------------------------------------------------------------
 
 export const listMyMandates = action({

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -31,12 +31,15 @@ import {
 
 export default defineSchema({
 	users: defineTable({
-		// WorkOS JWT subject; every owned table stores this value as `userId`.
+		// The WorkOS JWT subject. Legacy owner rows store it in their `userId`;
+		// post-tokenIdentifier rows store the canonical identity key instead.
 		subject: v.string(),
 		tokenIdentifier: v.string(),
 		email: v.string(),
 		createdAt: v.number()
-	}).index('by_subject', ['subject']),
+	})
+		.index('by_subject', ['subject'])
+		.index('by_tokenIdentifier', ['tokenIdentifier']),
 	billingCustomers: defineTable({
 		userId: v.string(),
 		dodoCustomerId: v.string()
@@ -323,5 +326,16 @@ export default defineSchema({
 		browserbaseSessionId: v.string(),
 		liveViewUrl: v.optional(v.string()),
 		startedAt: v.number()
-	}).index('by_thread', ['threadId'])
+	}).index('by_thread', ['threadId']),
+	sessionCredentials: defineTable({
+		sessionId: v.string(),
+		userId: v.string(),
+		subject: v.string(),
+		currentHash: v.string(),
+		previousHash: v.string(),
+		lastRefreshTime: v.number(),
+		createdAt: v.number()
+	})
+		.index('by_sessionId', ['sessionId'])
+		.index('by_userId', ['userId'])
 });

--- a/apps/web/src/convex/sessionCredentials.test.ts
+++ b/apps/web/src/convex/sessionCredentials.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { api, internal } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread, subjectTokenIdentifier } from '@convex/test.setup';
+
+describe('sessionCredentials', () => {
+	it('issues a credential for the authenticated user', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const credential = await asUser.mutation(api.sessionCredentials.issue, {});
+		expect(credential.userId).toBe(subjectTokenIdentifier('user_alice'));
+		expect(credential.current).not.toBe(credential.next);
+		expect(credential.refreshAfterMs).toBe(5 * 60_000);
+
+		const row = await t.run(async (ctx) =>
+			ctx.db
+				.query('sessionCredentials')
+				.withIndex('by_userId', (query) => query.eq('userId', credential.userId))
+				.first()
+		);
+		expect(row).not.toBeNull();
+	});
+
+	it('keeps two sessions for the same user independently valid', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const first = await asUser.mutation(api.sessionCredentials.issue, {});
+		const second = await asUser.mutation(api.sessionCredentials.issue, {});
+		expect(second.sessionId).not.toBe(first.sessionId);
+
+		const firstTicket = {
+			sessionId: first.sessionId,
+			userId: first.userId,
+			current: first.current,
+			next: first.next
+		};
+		const secondTicket = {
+			sessionId: second.sessionId,
+			userId: second.userId,
+			current: second.current,
+			next: second.next
+		};
+		await t.mutation(api.sessionCredentials.rotate, { ticket: firstTicket });
+
+		await expect(
+			t.query(internal.sessionCredentials.resolveOwner, { ticket: secondTicket })
+		).resolves.toMatchObject({ userId: second.userId });
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('sessionCredentials')
+				.withIndex('by_userId', (query) => query.eq('userId', first.userId))
+				.collect()
+		);
+		expect(rows).toHaveLength(2);
+	});
+
+	it('rotates with the issued pair and makes the old pair invalid', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const issued = await asUser.mutation(api.sessionCredentials.issue, {});
+		const ticket = {
+			sessionId: issued.sessionId,
+			userId: issued.userId,
+			current: issued.current,
+			next: issued.next
+		};
+
+		// The issued pair verifies before any rotation.
+		const owner = await t.query(internal.sessionCredentials.resolveOwner, { ticket });
+		expect(owner).toEqual({
+			userId: subjectTokenIdentifier('user_alice'),
+			subject: 'user_alice'
+		});
+
+		// Rotation 1 advances the chain to the issued next element.
+		const rotated = await t.mutation(api.sessionCredentials.rotate, { ticket });
+		expect(rotated.refreshAfterMs).toBe(5 * 60_000);
+
+		// The new current verifies; the old pair remains valid as the
+		// previous element (in-flight rotation tolerance) but cannot rotate.
+		const updatedTicket = {
+			sessionId: issued.sessionId,
+			userId: issued.userId,
+			current: issued.next,
+			next: crypto.randomUUID()
+		};
+		const ownerAfter = await t.query(internal.sessionCredentials.resolveOwner, {
+			ticket: updatedTicket
+		});
+		expect(ownerAfter?.userId).toBe(subjectTokenIdentifier('user_alice'));
+		expect((await t.query(internal.sessionCredentials.resolveOwner, { ticket }))?.userId).toBe(
+			subjectTokenIdentifier('user_alice')
+		);
+
+		// Rotation 2 ratchets further, proving the client generates each next.
+		const freshNext = crypto.randomUUID();
+		const secondRotation = {
+			sessionId: issued.sessionId,
+			userId: issued.userId,
+			current: issued.next,
+			next: freshNext
+		};
+		await expect(
+			t.mutation(api.sessionCredentials.rotate, { ticket: secondRotation })
+		).resolves.toMatchObject({ refreshAfterMs: 5 * 60_000 });
+
+		const rotatedOwn = await t.query(internal.sessionCredentials.resolveOwner, {
+			ticket: {
+				sessionId: issued.sessionId,
+				userId: issued.userId,
+				current: freshNext,
+				next: crypto.randomUUID()
+			}
+		});
+		expect(rotatedOwn?.userId).toBe(subjectTokenIdentifier('user_alice'));
+
+		// Now the original pair has aged out of the chain entirely.
+		await expect(t.query(internal.sessionCredentials.resolveOwner, { ticket })).rejects.toThrow(
+			'Invalid session credential.'
+		);
+	});
+
+	it('rejects rotation of a bogus pair and keeps the chain intact', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const issued = await asUser.mutation(api.sessionCredentials.issue, {});
+
+		await expect(
+			t.mutation(api.sessionCredentials.rotate, {
+				ticket: {
+					sessionId: issued.sessionId,
+					userId: issued.userId,
+					current: 'wrong',
+					next: 'also-wrong'
+				}
+			})
+		).rejects.toThrow('Invalid session credential.');
+
+		// The real pair still verifies.
+		const owner = await t.query(internal.sessionCredentials.resolveOwner, {
+			ticket: {
+				sessionId: issued.sessionId,
+				userId: issued.userId,
+				current: issued.current,
+				next: issued.next
+			}
+		});
+		expect(owner?.userId).toBe(subjectTokenIdentifier('user_alice'));
+	});
+
+	it('rejects a valid secret paired with a different user id', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const issued = await asUser.mutation(api.sessionCredentials.issue, {});
+		const ticket = {
+			sessionId: issued.sessionId,
+			userId: subjectTokenIdentifier('user_mallory'),
+			current: issued.current,
+			next: issued.next
+		};
+
+		await expect(t.mutation(api.sessionCredentials.rotate, { ticket })).rejects.toThrow(
+			'Invalid session credential.'
+		);
+		await expect(t.query(internal.sessionCredentials.resolveOwner, { ticket })).rejects.toThrow(
+			'Invalid session credential.'
+		);
+	});
+
+	it('expires credentials that missed two refresh marks', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		const issued = await asUser.mutation(api.sessionCredentials.issue, {});
+		const ticket = {
+			sessionId: issued.sessionId,
+			userId: issued.userId,
+			current: issued.current,
+			next: issued.next
+		};
+
+		// One refresh mark (5 minutes): still valid.
+		await t.run(async (ctx) => {
+			const row = await ctx.db
+				.query('sessionCredentials')
+				.withIndex('by_userId', (query) => query.eq('userId', ticket.userId))
+				.first();
+			if (!row) throw new Error('credential row missing');
+			await ctx.db.patch('sessionCredentials', row._id, {
+				lastRefreshTime: Date.now() - 5 * 60_000
+			});
+		});
+		expect(await t.query(internal.sessionCredentials.resolveOwner, { ticket })).not.toBeNull();
+
+		// A second refresh mark (10 minutes total): expired.
+		await t.run(async (ctx) => {
+			const row = await ctx.db
+				.query('sessionCredentials')
+				.withIndex('by_userId', (query) => query.eq('userId', ticket.userId))
+				.first();
+			if (!row) throw new Error('credential row missing');
+			await ctx.db.patch('sessionCredentials', row._id, {
+				lastRefreshTime: Date.now() - 10 * 60_000 - 1
+			});
+		});
+		await expect(t.query(internal.sessionCredentials.resolveOwner, { ticket })).rejects.toThrow(
+			'Invalid session credential.'
+		);
+	});
+
+	describe('createGatewayRun', () => {
+		beforeEach(() => {
+			process.env.MODEL_GATEWAY_URL = 'https://preview.gateway.example';
+			process.env.MODEL_GATEWAY_TOKEN_SECRET = 'test-gateway-token-secret';
+		});
+
+		afterEach(() => {
+			delete process.env.MODEL_GATEWAY_URL;
+			delete process.env.MODEL_GATEWAY_TOKEN_SECRET;
+		});
+
+		it('binds a run with a credential and no identity', async () => {
+			const t = initConvexTest();
+			const { asUser, threadId } = await seedOwnedThread(t);
+			const issued = await asUser.mutation(api.sessionCredentials.issue, {});
+
+			const created = await t.action(api.agentRuntime.createGatewayRun, {
+				submissionId: 'credential-bound-run',
+				threadId,
+				prompt: 'Run with a session credential',
+				imageUploadIds: [],
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				executionSecret: 'credential-bound-secret',
+				sessionTicket: {
+					sessionId: issued.sessionId,
+					userId: issued.userId,
+					current: issued.current
+				}
+			});
+
+			expect(created.created).toBe(true);
+			const run = await t.run(async (ctx) => ctx.db.get('runs', created.runId));
+			expect(run?.userId).toBe(subjectTokenIdentifier('user_alice'));
+			expect(run?.executionSecretHash).toBeTruthy();
+		});
+
+		it('does not bind a credential to another user’s thread', async () => {
+			const t = initConvexTest();
+			const alice = await seedOwnedThread(t);
+			const issued = await alice.asUser.mutation(api.sessionCredentials.issue, {});
+			const bob = await seedOwnedThread(t, 'user_bob');
+
+			await expect(
+				t.action(api.agentRuntime.createGatewayRun, {
+					submissionId: 'cross-user-credential-run',
+					threadId: bob.threadId,
+					prompt: 'Run on another user’s thread',
+					imageUploadIds: [],
+					selectedModel: 'gpt-5.6-sol',
+					reasoningEffort: 'medium',
+					serviceTier: 'standard',
+					executionSecret: 'cross-user-secret',
+					sessionTicket: {
+						sessionId: issued.sessionId,
+						userId: issued.userId,
+						current: issued.current
+					}
+				})
+			).rejects.toThrow();
+		});
+	});
+});

--- a/apps/web/src/convex/sessionCredentials.test.ts
+++ b/apps/web/src/convex/sessionCredentials.test.ts
@@ -245,6 +245,31 @@ describe('sessionCredentials', () => {
 			expect(run?.executionSecretHash).toBeTruthy();
 		});
 
+		it('rejects a credential that does not match the caller identity', async () => {
+			const t = initConvexTest();
+			const alice = await seedOwnedThread(t);
+			const bob = await seedOwnedThread(t, 'user_bob');
+			const issued = await bob.asUser.mutation(api.sessionCredentials.issue, {});
+
+			await expect(
+				alice.asUser.action(api.agentRuntime.createGatewayRun, {
+					submissionId: 'mismatched-credential-run',
+					threadId: alice.threadId,
+					prompt: 'Run with another user’s credential',
+					imageUploadIds: [],
+					selectedModel: 'gpt-5.6-sol',
+					reasoningEffort: 'medium',
+					serviceTier: 'standard',
+					executionSecret: 'mismatched-secret',
+					sessionTicket: {
+						sessionId: issued.sessionId,
+						userId: issued.userId,
+						current: issued.current
+					}
+				})
+			).rejects.toThrow(/Invalid session credential/);
+		});
+
 		it('does not bind a credential to another user’s thread', async () => {
 			const t = initConvexTest();
 			const alice = await seedOwnedThread(t);

--- a/apps/web/src/convex/sessionCredentials.ts
+++ b/apps/web/src/convex/sessionCredentials.ts
@@ -1,0 +1,63 @@
+import { internalQuery, mutation } from '@convex/_generated/server';
+import { v } from 'convex/values';
+import { getOwnerKeys } from '@convex/lib/auth';
+import {
+	vSessionCredentialProof,
+	vSessionCredentialTicket,
+	authorizeBySessionCredential,
+	issueSessionCredentialPair,
+	rotateSessionCredential,
+	sessionCredentialRow
+} from '@convex/lib/sessionCredentials';
+
+export const issue = mutation({
+	args: {},
+	returns: v.object({
+		sessionId: v.string(),
+		userId: v.string(),
+		subject: v.string(),
+		current: v.string(),
+		next: v.string(),
+		expiresAt: v.number(),
+		refreshAfterMs: v.number()
+	}),
+	handler: async (ctx) => {
+		const keys = await getOwnerKeys(ctx);
+		const pair = await issueSessionCredentialPair(ctx, keys.userId, keys.subject);
+		return { userId: keys.userId, subject: keys.subject, ...pair };
+	}
+});
+
+export const rotate = mutation({
+	args: v.object({
+		ticket: vSessionCredentialTicket
+	}),
+	returns: v.object({
+		expiresAt: v.number(),
+		refreshAfterMs: v.number()
+	}),
+	handler: async (ctx, args) => {
+		const row = await sessionCredentialRow(ctx, args.ticket.sessionId);
+		if (!row) {
+			throw new Error('Invalid session credential.');
+		}
+		return await rotateSessionCredential(ctx, row, args.ticket);
+	}
+});
+
+export const resolveOwner = internalQuery({
+	args: v.object({
+		ticket: vSessionCredentialProof
+	}),
+	returns: v.object({
+		userId: v.string(),
+		subject: v.string()
+	}),
+	handler: async (ctx, args) => {
+		const owner = await authorizeBySessionCredential(ctx, args.ticket);
+		if (!owner) {
+			throw new Error('Invalid session credential.');
+		}
+		return owner;
+	}
+});

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { api, internal } from '@convex/_generated/api';
-import { initConvexTest } from './test.setup';
+import { initConvexTest, subjectTokenIdentifier } from './test.setup';
+
+/** Seed the canonical owner's users row and return the tokenIdentifier. */
+async function seedUser(t: ReturnType<typeof initConvexTest>, subject: string): Promise<string> {
+	const userId = subjectTokenIdentifier(subject);
+	await t.run(async (ctx) => {
+		await ctx.db.insert('users', {
+			subject,
+			tokenIdentifier: userId,
+			email: `${subject}@example.com`,
+			createdAt: 1
+		});
+	});
+	return userId;
+}
 
 describe('subscription and usage backend', () => {
 	it('reports usage overdraft and preserves it', async () => {
 		const t = initConvexTest();
-		const userId = 'user_usage';
-		const asUser = t.withIdentity({ subject: userId });
+		const subject = 'user_usage';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject, email: `${subject}@example.com` });
 		await t.mutation(internal.lib.rateLimits.chargeUsageUnits, {
 			userId,
 			count: 20_000
@@ -28,8 +43,9 @@ describe('subscription and usage backend', () => {
 
 	it('uses only active subscriptions and ignores stale webhook events', async () => {
 		const t = initConvexTest();
-		const userId = 'user_billing';
-		const asUser = t.withIdentity({ subject: userId });
+		const subject = 'user_billing';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject });
 		const currentTier = async () => (await asUser.query(api.usage.getMyUsage, {})).tier;
 		const subscription = {
 			userId,
@@ -65,8 +81,9 @@ describe('subscription and usage backend', () => {
 
 	it('dedupes to the newest event so a cancellation beats an older active row', async () => {
 		const t = initConvexTest();
-		const userId = 'user_dedup';
-		const asUser = t.withIdentity({ subject: userId, email: `${userId}@example.com` });
+		const subject = 'user_dedup';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject, email: `${subject}@example.com` });
 		const shared = {
 			userId,
 			tier: 'pro',
@@ -94,8 +111,9 @@ describe('subscription and usage backend', () => {
 
 	it('ensures a free subscription row and leaves existing grants alone', async () => {
 		const t = initConvexTest();
-		const userId = 'user_ensure_free';
-		const asUser = t.withIdentity({ subject: userId, email: `${userId}@example.com` });
+		const subject = 'user_ensure_free';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject, email: `${subject}@example.com` });
 		const readSubscription = () =>
 			t.run(async (ctx) =>
 				ctx.db
@@ -126,8 +144,9 @@ describe('subscription and usage backend', () => {
 
 	it('lets paid webhooks replace a bootstrap free row', async () => {
 		const t = initConvexTest();
-		const userId = 'user_bootstrap_upgrade';
-		const asUser = t.withIdentity({ subject: userId, email: `${userId}@example.com` });
+		const subject = 'user_bootstrap_upgrade';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject, email: `${subject}@example.com` });
 		await asUser.mutation(api.billing.ensureMySubscription, {});
 
 		await t.mutation(internal.billing.upsertSubscription, {
@@ -144,8 +163,9 @@ describe('subscription and usage backend', () => {
 
 	it('keeps admin grants above Dodo webhook upserts', async () => {
 		const t = initConvexTest();
-		const userId = 'user_admin_grant';
-		const asUser = t.withIdentity({ subject: userId });
+		const subject = 'user_admin_grant';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject });
 		const currentTier = async () => (await asUser.query(api.usage.getMyUsage, {})).tier;
 		await t.run(async (ctx) => {
 			await ctx.db.insert('subscriptions', {
@@ -189,8 +209,9 @@ describe('subscription and usage backend', () => {
 
 	it('lets admin bypass meters after free overdraft', async () => {
 		const t = initConvexTest();
-		const userId = 'user_admin_bypass';
-		const asUser = t.withIdentity({ subject: userId });
+		const subject = 'user_admin_bypass';
+		const userId = await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject });
 		await t.mutation(internal.lib.rateLimits.chargeUsageUnits, {
 			userId,
 			count: 20_000
@@ -239,5 +260,57 @@ describe('subscription and usage backend', () => {
 		);
 		expect(rows).toHaveLength(1);
 		expect(rows[0]).toMatchObject({ subject: userId });
+	});
+
+	// Backwards-compat shim: rows written before the tokenIdentifier migration
+	// still carry the subject in userId and must stay visible until the
+	// owner-rewrite migration runs.
+	it('honors legacy subject-keyed subscription and meter rows until the rewrite', async () => {
+		const t = initConvexTest();
+		const subject = 'user_legacy';
+		// startRun-style legacy fixture: users row already adopted the
+		// canonical key, but the subscription and meter rows predate the switch.
+		await seedUser(t, subject);
+		const asUser = t.withIdentity({ subject, email: `${subject}@example.com` });
+		await t.run(async (ctx) => {
+			await ctx.db.insert('subscriptions', {
+				userId: subject,
+				tier: 'free',
+				dodoSubscriptionId: '',
+				dodoProductId: '',
+				status: 'active',
+				eventAt: 1
+			});
+		});
+
+		// ensure sees the legacy grant and does not create a second row.
+		expect((await asUser.query(api.usage.getMyUsage, {})).tier).toBe('free');
+		await asUser.mutation(api.billing.ensureMySubscription, {});
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('subscriptions')
+				.withIndex('by_userId', (query) => query.eq('userId', subject))
+				.collect()
+		);
+		expect(rows).toHaveLength(1);
+
+		// Meter rows charged under the legacy subject still block the caller
+		// under their canonical key, and the usage view shows that overdraft.
+		await t.mutation(internal.lib.rateLimits.chargeUsageUnits, {
+			userId: subject,
+			count: 20_000
+		});
+		const canonicalUserId = subjectTokenIdentifier(subject);
+		await expect(
+			t.mutation(internal.lib.rateLimits.checkUsageLimits, {
+				userId: canonicalUserId
+			})
+		).rejects.toThrow(/model usage limit reached/);
+		const usage = await asUser.query(api.usage.getMyUsage, {});
+		expect(usage.exhausted).toBe(true);
+		const weekly = usage.meters
+			.find((meter) => meter.id === 'modelUsage')
+			?.windows.find((window) => window.period === 'weekly');
+		expect(weekly && weekly.used > weekly.limit).toBe(true);
 	});
 });

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -30,6 +30,15 @@ export type ConvexTestInstance = TestConvex<typeof schema>;
 
 type AuthenticatedTest = ReturnType<ConvexTestInstance['withIdentity']>;
 
+const identitySubjectPlaceholder = 'https://convex.test';
+
+/** The canonical owner key (identity.tokenIdentifier) for a test subject:
+ * APIs write `userId` with it and every backfill/rewrite migrates rows onto
+ * it. Subjects alone still exercise legacy rows. */
+export function subjectTokenIdentifier(subject: string): string {
+	return `${identitySubjectPlaceholder}|${subject}`;
+}
+
 /** Fresh mock backend with our schema, functions, and registered components. */
 export function initConvexTest(): ConvexTestInstance {
 	const t = convexTest(schema, modules);
@@ -57,10 +66,23 @@ export async function seedOwnedThread(
 	threadId: Id<'threadRecords'>;
 }> {
 	const asUser = t.withIdentity({ subject });
+	const userId = subjectTokenIdentifier(subject);
 	// Integration fixtures exercise every model; grant admin so free-tier allowlists do not block them.
 	await t.run(async (ctx) => {
+		const existingUser = await ctx.db
+			.query('users')
+			.withIndex('by_subject', (query) => query.eq('subject', subject))
+			.unique();
+		if (!existingUser) {
+			await ctx.db.insert('users', {
+				subject,
+				tokenIdentifier: userId,
+				email: `${subject}@example.com`,
+				createdAt: 1
+			});
+		}
 		await ctx.db.insert('subscriptions', {
-			userId: subject,
+			userId,
 			tier: 'admin',
 			dodoSubscriptionId: '',
 			dodoProductId: '',

--- a/apps/web/src/convex/threads.test.ts
+++ b/apps/web/src/convex/threads.test.ts
@@ -85,3 +85,26 @@ describe('threads.rekeyRepository', () => {
 		);
 	});
 });
+
+describe('threads owner-key dual-read', () => {
+	it('lists and reuses a pre-migration subject-keyed thread', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, repositoryKey } = await seedOwnedThread(t, 'user_legacy_thread');
+		await t.run(async (ctx) => {
+			await ctx.db.patch('threadRecords', threadId, { userId: 'user_legacy_thread' });
+		});
+
+		const listed = await asUser.query(api.threads.listMine, {});
+		const seeded = listed.find((thread) => thread.threadId === threadId);
+		expect(seeded).toBeDefined();
+
+		const created = await asUser.mutation(api.threads.create, {
+			submissionId: seeded?.submissionId ?? '',
+			repositoryKey,
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard'
+		});
+		expect(created.threadId).toBe(threadId);
+	});
+});

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -2,7 +2,7 @@ import type { Doc, Id } from '@convex/_generated/dataModel';
 import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getUserId } from '@convex/lib/auth';
+import { distinctOwnerKeys, getOwnerKeys } from '@convex/lib/auth';
 import { vThreadSummary, vThreadWithUsageDoc } from '@convex/lib/docs';
 import { getThreadUsageValues } from '@convex/lib/threadUsage';
 import {
@@ -17,8 +17,8 @@ async function patchOwnedThread(
 	threadId: Id<'threadRecords'>,
 	patch: Partial<Doc<'threadRecords'>>
 ) {
-	const userId = await getUserId(ctx);
-	await getOwnedThreadRecord(ctx.db, userId, threadId);
+	const keys = await getOwnerKeys(ctx);
+	await getOwnedThreadRecord(ctx.db, keys, threadId);
 	await ctx.db.patch('threadRecords', threadId, patch);
 }
 
@@ -35,17 +35,22 @@ export const create = mutation({
 		submissionRunStatus: v.union(vRunStatus, v.null())
 	}),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
+		const keys = await getOwnerKeys(ctx);
+		const userId = keys.userId;
 		const repositoryKey = args.repositoryKey.trim();
 		if (repositoryKey.length === 0) {
 			throw new Error('Repository key is required.');
 		}
-		const existingRecord = await ctx.db
-			.query('threadRecords')
-			.withIndex('by_userId_submissionId', (query) =>
-				query.eq('userId', userId).eq('submissionId', args.submissionId)
-			)
-			.unique();
+		let existingRecord = null;
+		for (const key of distinctOwnerKeys(keys)) {
+			existingRecord = await ctx.db
+				.query('threadRecords')
+				.withIndex('by_userId_submissionId', (query) =>
+					query.eq('userId', key).eq('submissionId', args.submissionId)
+				)
+				.unique();
+			if (existingRecord) break;
+		}
 		if (existingRecord) {
 			if (
 				existingRecord.repositoryKey !== repositoryKey ||
@@ -60,12 +65,16 @@ export const create = mutation({
 				await ctx.db.patch('threadRecords', existingRecord._id, { archivedAt: undefined });
 			}
 
-			const submissionRun = await ctx.db
-				.query('runs')
-				.withIndex('by_userId_submissionId', (query) =>
-					query.eq('userId', userId).eq('submissionId', args.submissionId)
-				)
-				.unique();
+			let submissionRun = null;
+			for (const key of distinctOwnerKeys(keys)) {
+				submissionRun = await ctx.db
+					.query('runs')
+					.withIndex('by_userId_submissionId', (query) =>
+						query.eq('userId', key).eq('submissionId', args.submissionId)
+					)
+					.unique();
+				if (submissionRun) break;
+			}
 
 			return {
 				threadId: existingRecord._id,
@@ -75,7 +84,7 @@ export const create = mutation({
 
 		const now = Date.now();
 		const recordId = await ctx.db.insert('threadRecords', {
-			userId: userId,
+			userId,
 			submissionId: args.submissionId,
 			repositoryKey,
 			selectedModel: args.selectedModel,
@@ -100,12 +109,18 @@ export const listMine = query({
 	args: {},
 	returns: v.array(vThreadSummary),
 	handler: async (ctx) => {
-		const userId = await getUserId(ctx);
-		const records = await ctx.db
-			.query('threadRecords')
-			.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
-			.order('desc')
-			.collect();
+		const keys = await getOwnerKeys(ctx);
+		const records = (
+			await Promise.all(
+				distinctOwnerKeys(keys).map((key) =>
+					ctx.db
+						.query('threadRecords')
+						.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', key))
+						.order('desc')
+						.collect()
+				)
+			)
+		).flat();
 		const summaries = await Promise.all(
 			records.map(async (record) => {
 				const latestRun = await ctx.db
@@ -131,7 +146,11 @@ export const listMine = query({
 		// Running threads first, then most recently active. The index already
 		// returns lastMessageAt-desc, so the comparator only needs to promote
 		// active runs while staying stable for the rest.
-		return summaries.sort((left, right) => Number(right.hasActiveRun) - Number(left.hasActiveRun));
+		return summaries.sort((left, right) => {
+			const active = Number(right.hasActiveRun) - Number(left.hasActiveRun);
+			if (active !== 0) return active;
+			return right.lastMessageAt - left.lastMessageAt;
+		});
 	}
 });
 
@@ -141,8 +160,8 @@ export const getByThreadId = query({
 	},
 	returns: vThreadWithUsageDoc,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		const thread = await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 		const usage = await getThreadUsageValues(ctx, thread);
 		return { ...thread, ...usage };
 	}
@@ -169,8 +188,8 @@ export const archive = mutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await getOwnerKeys(ctx);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 
 		for (const status of ['queued', 'running', 'awaiting_executor'] as const) {
 			const activeRun = await ctx.db
@@ -205,7 +224,6 @@ export const rekeyRepository = mutation({
 	},
 	returns: v.number(),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
 		const from = args.from.trim();
 		const to = args.to.trim();
 		if (from.length === 0 || to.length === 0) {
@@ -215,12 +233,21 @@ export const rekeyRepository = mutation({
 			return 0;
 		}
 
-		const threads = await ctx.db
-			.query('threadRecords')
-			.withIndex('by_userId_repositoryKey', (query) =>
-				query.eq('userId', userId).eq('repositoryKey', from)
+		const keys = await getOwnerKeys(ctx);
+		const threads = (
+			await Promise.all(
+				[keys.userId, keys.subject]
+					.filter((key, index, all) => all.indexOf(key) === index)
+					.map((key) =>
+						ctx.db
+							.query('threadRecords')
+							.withIndex('by_userId_repositoryKey', (query) =>
+								query.eq('userId', key).eq('repositoryKey', from)
+							)
+							.collect()
+					)
 			)
-			.collect();
+		).flat();
 		for (const thread of threads) {
 			await ctx.db.patch('threadRecords', thread._id, { repositoryKey: to });
 		}

--- a/apps/web/src/convex/transcript.ts
+++ b/apps/web/src/convex/transcript.ts
@@ -2,7 +2,12 @@ import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_gener
 import { v } from 'convex/values';
 import type { Id } from '@convex/_generated/dataModel';
 import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getExecutionRun, getUserId } from '@convex/lib/auth';
+import { getExecutionRun, ownerKeysFromIdentity, type OwnerKeys } from '@convex/lib/auth';
+import {
+	vSessionCredentialProof,
+	authorizeBySessionCredential,
+	type SessionCredentialProof
+} from '@convex/lib/sessionCredentials';
 import {
 	vAttachmentDownloadResult,
 	vTranscriptPartsResult,
@@ -55,22 +60,40 @@ async function transcriptStateResult(
 	};
 }
 
-async function requireOwnedThread(ctx: QueryCtx, threadId: Id<'threadRecords'>) {
-	await getOwnedThreadRecord(ctx.db, await getUserId(ctx), threadId);
+/** Resolves owner keys from the WorkOS identity when present, otherwise from
+ * an executor's session credential. Lets released server binaries keep using
+ * their JWTs while new ones authenticate with the rotating credential. */
+async function resolveCallerKeys(
+	ctx: QueryCtx | MutationCtx,
+	ticket?: SessionCredentialProof
+): Promise<OwnerKeys> {
+	const identity = await ctx.auth.getUserIdentity();
+	if (identity) {
+		return ownerKeysFromIdentity(identity);
+	}
+	if (!ticket) {
+		throw new Error('Authentication required.');
+	}
+	const owner = await authorizeBySessionCredential(ctx, ticket);
+	if (!owner) {
+		throw new Error('Authentication required.');
+	}
+	return owner;
 }
 
 /** Name is frozen for current desktop/server callers. Creates transcript state only. */
 export const ensureMigrated = mutation({
 	args: {
-		threadId: v.id('threadRecords')
+		threadId: v.id('threadRecords'),
+		sessionTicket: v.optional(vSessionCredentialProof)
 	},
 	returns: vTranscriptStateResult,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		const keys = await resolveCallerKeys(ctx, args.sessionTicket);
+		await getOwnedThreadRecord(ctx.db, keys, args.threadId);
 		await getOrCreateTranscriptState(ctx, {
 			threadId: args.threadId,
-			userId
+			userId: keys.userId
 		});
 		return await transcriptStateResult(ctx, args.threadId);
 	}
@@ -78,11 +101,16 @@ export const ensureMigrated = mutation({
 
 export const getState = query({
 	args: {
-		threadId: v.id('threadRecords')
+		threadId: v.id('threadRecords'),
+		sessionTicket: v.optional(vSessionCredentialProof)
 	},
 	returns: vTranscriptStateResult,
 	handler: async (ctx, args) => {
-		await requireOwnedThread(ctx, args.threadId);
+		await getOwnedThreadRecord(
+			ctx.db,
+			await resolveCallerKeys(ctx, args.sessionTicket),
+			args.threadId
+		);
 		return await transcriptStateResult(ctx, args.threadId);
 	}
 });
@@ -90,11 +118,16 @@ export const getState = query({
 export const getParts = query({
 	args: {
 		threadId: v.id('threadRecords'),
-		numbers: v.array(v.number())
+		numbers: v.array(v.number()),
+		sessionTicket: v.optional(vSessionCredentialProof)
 	},
 	returns: vTranscriptPartsResult,
 	handler: async (ctx, args) => {
-		await requireOwnedThread(ctx, args.threadId);
+		await getOwnedThreadRecord(
+			ctx.db,
+			await resolveCallerKeys(ctx, args.sessionTicket),
+			args.threadId
+		);
 		const parts = await hydrateTranscriptPartUrls(
 			ctx,
 			await loadTranscriptPartsByNumbers(ctx, args.threadId, args.numbers)
@@ -134,13 +167,14 @@ export const getPartsForRun = query({
 
 export const attachmentDownload = query({
 	args: {
-		imageUploadId: v.id('imageUploads')
+		imageUploadId: v.id('imageUploads'),
+		sessionTicket: v.optional(vSessionCredentialProof)
 	},
 	returns: vAttachmentDownloadResult,
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
+		const keys = await resolveCallerKeys(ctx, args.sessionTicket);
 		const upload = await ctx.db.get('imageUploads', args.imageUploadId);
-		if (!upload || upload.userId !== userId) {
+		if (!upload || (upload.userId !== keys.userId && upload.userId !== keys.subject)) {
 			return null;
 		}
 		const url = await ctx.storage.getUrl(upload.storageId);

--- a/apps/web/src/convex/transcript.ts
+++ b/apps/web/src/convex/transcript.ts
@@ -2,7 +2,12 @@ import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_gener
 import { v } from 'convex/values';
 import type { Id } from '@convex/_generated/dataModel';
 import { getOwnedThreadRecord } from '@convex/lib/access';
-import { getExecutionRun, ownerKeysFromIdentity, type OwnerKeys } from '@convex/lib/auth';
+import {
+	getExecutionRun,
+	matchesOwner,
+	ownerKeysFromIdentity,
+	type OwnerKeys
+} from '@convex/lib/auth';
 import {
 	vSessionCredentialProof,
 	authorizeBySessionCredential,
@@ -68,17 +73,20 @@ async function resolveCallerKeys(
 	ticket?: SessionCredentialProof
 ): Promise<OwnerKeys> {
 	const identity = await ctx.auth.getUserIdentity();
-	if (identity) {
-		return ownerKeysFromIdentity(identity);
-	}
-	if (!ticket) {
+	const ticketOwner = ticket ? await authorizeBySessionCredential(ctx, ticket) : null;
+	if (ticket && !ticketOwner) {
 		throw new Error('Authentication required.');
 	}
-	const owner = await authorizeBySessionCredential(ctx, ticket);
-	if (!owner) {
-		throw new Error('Authentication required.');
+	if (identity && ticketOwner) {
+		const keys = ownerKeysFromIdentity(identity);
+		if (!matchesOwner(ticketOwner.userId, keys) && !matchesOwner(ticketOwner.subject, keys)) {
+			throw new Error('Authentication required.');
+		}
+		return keys;
 	}
-	return owner;
+	if (identity) return ownerKeysFromIdentity(identity);
+	if (ticketOwner) return ticketOwner;
+	throw new Error('Authentication required.');
 }
 
 /** Name is frozen for current desktop/server callers. Creates transcript state only. */

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,6 +1,6 @@
 import { mutation, query } from '@convex/_generated/server';
 import { v } from 'convex/values';
-import { getUserId } from '@convex/lib/auth';
+import { getOwnerKeys, resolveStoredOwnerSubject } from '@convex/lib/auth';
 import { unsupportedClient } from '@convex/lib/unsupportedClient';
 import schema from '@convex/schema';
 
@@ -10,10 +10,21 @@ export const getMine = query({
 	args: {},
 	returns: v.union(schema.doc('uiPreferences'), v.null()),
 	handler: async (ctx) => {
-		const userId = await getUserId(ctx);
+		const keys = await getOwnerKeys(ctx);
+		const canonical = await ctx.db
+			.query('uiPreferences')
+			.withIndex('by_userId', (query) => query.eq('userId', keys.userId))
+			.unique();
+		if (canonical) {
+			return canonical;
+		}
+		const subject = await resolveStoredOwnerSubject(ctx, keys.userId);
+		if (!subject || subject === keys.userId) {
+			return null;
+		}
 		return await ctx.db
 			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', userId))
+			.withIndex('by_userId', (query) => query.eq('userId', subject))
 			.unique();
 	}
 });
@@ -35,11 +46,27 @@ export const setTheme = mutation({
 	},
 	returns: v.union(schema.doc('uiPreferences'), v.null()),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		const existing = await ctx.db
+		const keys = await getOwnerKeys(ctx);
+		let existing = await ctx.db
 			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', userId))
+			.withIndex('by_userId', (query) => query.eq('userId', keys.userId))
 			.unique();
+		if (!existing) {
+			const subject = await resolveStoredOwnerSubject(ctx, keys.userId);
+			if (subject) {
+				existing = await ctx.db
+					.query('uiPreferences')
+					.withIndex('by_userId', (query) => query.eq('userId', subject))
+					.unique();
+				if (existing) {
+					await ctx.db.patch('uiPreferences', existing._id, {
+						userId: keys.userId,
+						theme: args.theme
+					});
+					return await ctx.db.get('uiPreferences', existing._id);
+				}
+			}
+		}
 
 		if (existing) {
 			await ctx.db.patch('uiPreferences', existing._id, {
@@ -49,7 +76,7 @@ export const setTheme = mutation({
 		}
 
 		const id = await ctx.db.insert('uiPreferences', {
-			userId,
+			userId: keys.userId,
 			theme: args.theme
 		});
 		return await ctx.db.get('uiPreferences', id);

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,8 +1,9 @@
 import { browser, dev } from '$app/environment';
-import { createClient, type User } from '@workos-inc/authkit-js';
+import { LoginRequiredError, RefreshError, createClient, type User } from '@workos-inc/authkit-js';
 import { z } from 'zod';
 import { api } from '$convex/_generated/api';
 import { usesLoopbackBrowserAuth } from '../../../desktop/local-config.mjs';
+import { pushConvexToken, pushSessionCredential } from '$lib/authTokenPush';
 import { get, writable } from 'svelte/store';
 
 type AuthStatus = {
@@ -31,11 +32,25 @@ export const convexAuthRetryVersion = writable(0);
 export const convexAuthRetryPending = writable(false);
 
 type AuthClient = Awaited<ReturnType<typeof createClient>>;
+type SessionCredentialIssue = {
+	sessionId: string;
+	userId: string;
+	subject: string;
+	current: string;
+	next: string;
+	expiresAt: number;
+	refreshAfterMs: number;
+};
+
 type AuthBootstrapClient = {
 	query: (
 		query: typeof api.authBootstrap.getClientConfig,
 		args: Record<string, never>
 	) => Promise<{ workosClientId: string }>;
+	mutation: (
+		mutation: typeof api.sessionCredentials.issue,
+		args: Record<string, never>
+	) => Promise<SessionCredentialIssue>;
 };
 
 const DESKTOP_LOGIN_POLL_INTERVAL_MS = 1_500;
@@ -44,6 +59,8 @@ const DESKTOP_LOGIN_TIMEOUT_MS = 5 * 60 * 1_000;
 let authClientPromise: Promise<AuthClient | null> | null = null;
 let authConfigPromise: Promise<{ workosClientId: string }> | null = null;
 let bootstrapClient: AuthBootstrapClient | null = null;
+let sessionCredentialIssued = false;
+let sessionCredentialIssuePromise: Promise<void> | null = null;
 let isSigningOut = false;
 type DesktopSignInAttempt = {
 	nonce: string;
@@ -130,7 +147,8 @@ async function getAuthClient() {
 				onRedirectCallback: () => {
 					window.location.replace('/');
 				},
-				onRefresh: () => {
+				onRefresh: ({ accessToken }) => {
+					void pushConvexToken(accessToken);
 					authState.update((current) => ({
 						...current,
 						user: client?.getUser() ?? null,
@@ -143,7 +161,11 @@ async function getAuthClient() {
 						user: null,
 						error: current.user && !isSigningOut ? 'Session refresh failed. Sign in again.' : null
 					}));
-				}
+				},
+				// Keep refreshing in background tabs so the in-memory 5-minute
+				// access token is current when the user refocuses, instead of
+				// forcing a refresh exactly at window/network churn time.
+				onBeforeAutoRefresh: () => true
 			});
 
 			authState.set({
@@ -193,6 +215,12 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 				error: null
 			};
 		});
+		if (client?.getUser() && !sessionCredentialIssued && !sessionCredentialIssuePromise) {
+			sessionCredentialIssuePromise = issueAndDeliverSessionCredential().finally(() => {
+				sessionCredentialIssuePromise = null;
+			});
+			void sessionCredentialIssuePromise;
+		}
 	} catch (error) {
 		authState.update((current) => ({
 			...current,
@@ -203,6 +231,29 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 			user: null,
 			error: error instanceof Error ? error.message : 'Failed to initialize authentication.'
 		}));
+	}
+}
+
+async function issueAndDeliverSessionCredential(): Promise<void> {
+	const retryDelays = [200, 500, 1_000, 2_000, 4_000];
+	let attempt = 0;
+	let credential: SessionCredentialIssue | null = null;
+	while (get(authState).user) {
+		try {
+			credential ??= await getAuthBootstrapClient().mutation(api.sessionCredentials.issue, {});
+			await pushSessionCredential({
+				sessionId: credential.sessionId,
+				userId: credential.userId,
+				current: credential.current,
+				next: credential.next
+			});
+			sessionCredentialIssued = true;
+			return;
+		} catch {
+			const delay = retryDelays[Math.min(attempt, retryDelays.length - 1)];
+			attempt += 1;
+			await new Promise((resolve) => window.setTimeout(resolve, delay));
+		}
 	}
 }
 
@@ -579,6 +630,7 @@ export async function signOut() {
 			returnTo: window.location.origin
 		});
 		convexAuthRetryPending.set(false);
+		sessionCredentialIssued = false;
 		authState.set({
 			isLoading: false,
 			isReady: true,
@@ -608,15 +660,81 @@ export async function getAccessToken({
 	}
 
 	try {
-		return await client.getAccessToken({ forceRefresh: forceRefreshToken });
+		const token = await client.getAccessToken({ forceRefresh: forceRefreshToken });
+		lastAccessToken = token;
+		return token;
 	} catch (error) {
-		if (error instanceof Error && error.name === 'LoginRequiredError') {
+		if (error instanceof LoginRequiredError) {
 			authState.update((current) => ({ ...current, user: null }));
+			lastAccessToken = null;
 			return null;
+		}
+
+		if (isTransientAuthError(error)) {
+			// Transient refresh failures (network blips, refresh-lock races,
+			// 408/429/5xx from WorkOS) keep the session alive. Without a forced
+			// refresh we hand Convex the last accepted token, so it retains its
+			// auth instead of tearing down to a sticky signed-out state. A
+			// forced refresh means Convex already rejected that token, so we
+			// must mint a new one.
+			if (!forceRefreshToken && lastAccessToken) {
+				return lastAccessToken;
+			}
+			const retried = await retryTransientAccessToken(client, forceRefreshToken);
+			if (retried) {
+				lastAccessToken = retried;
+				return retried;
+			}
+			throw error;
 		}
 
 		throw error;
 	}
+}
+
+/** The most recent token that authkit accepted; the candidate we retry with
+ * while WorkOS is unreachable but the session hasn't died yet. */
+let lastAccessToken: string | null = null;
+
+// Disabled: `error` is genuinely opaque here (authkit-js rethrows whatever its
+// raw fetch rejected with). Classifying the shape is the point of the
+// function; widening can't be moved to an I/O boundary.
+// oxlint-disable-next-line anti-slop/no-unknown-parameters
+function isTransientAuthError(error: unknown): boolean {
+	if (error instanceof RefreshError) {
+		// RefreshTimeoutError and 408/429/5xx responses carry isTransient.
+		return error.isTransient;
+	}
+	// authkit-js uses raw fetch, so network failures surface as plain
+	// TypeErrors while the session is still alive.
+	return isCurrentSessionAlive();
+}
+
+function isCurrentSessionAlive(): boolean {
+	return get(authState).user !== null;
+}
+
+async function retryTransientAccessToken(
+	client: AuthClient,
+	forceRefreshToken: boolean
+): Promise<string | null> {
+	const holdups = [200, 500, 1000];
+	for (const holdMs of holdups) {
+		await new Promise((resolve) => setTimeout(resolve, holdMs));
+		try {
+			return await client.getAccessToken({ forceRefresh: forceRefreshToken });
+		} catch (retryError) {
+			if (retryError instanceof LoginRequiredError) {
+				authState.update((current) => ({ ...current, user: null }));
+				lastAccessToken = null;
+				return null;
+			}
+			if (!isTransientAuthError(retryError)) {
+				throw retryError;
+			}
+		}
+	}
+	return null;
 }
 
 export type ConvexAuthRetryAdvance = {

--- a/apps/web/src/lib/authTokenPush.ts
+++ b/apps/web/src/lib/authTokenPush.ts
@@ -1,0 +1,39 @@
+import { resolveDesktopApi } from '$lib/local/client';
+import type { DesktopApi, SessionCredentialSeed } from '$lib/types/sprocket';
+
+let desktopApiPromise: Promise<DesktopApi> | null = null;
+
+/** Shared lazy resolution of the local Sprocket server client. Failed
+ * resolutions are forgotten so callers can retry once the server is up. */
+export function getDesktopApi(): Promise<DesktopApi> {
+	if (!desktopApiPromise) {
+		desktopApiPromise = resolveDesktopApi().catch((error) => {
+			desktopApiPromise = null;
+			throw error;
+		});
+	}
+	return desktopApiPromise;
+}
+
+/**
+ * Best-effort push of a freshly minted WorkOS access token to the local
+ * server, which forwards it to Convex when its own auth token is expiring.
+ * Failures are safe to ignore: the server keeps serving its last cached
+ * token as a fallback.
+ */
+export async function pushConvexToken(token: string): Promise<void> {
+	if (!token) {
+		return;
+	}
+	try {
+		const api = await getDesktopApi();
+		await api.pushConvexToken(token);
+	} catch {
+		// No local server (or not paired yet): nothing to push to.
+	}
+}
+
+export async function pushSessionCredential(credential: SessionCredentialSeed): Promise<void> {
+	const api = await getDesktopApi();
+	await api.pushSessionCredential(credential);
+}

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -45,7 +45,9 @@ function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
 		watchTranscript: unusedDesktopCall,
 		watchLiveCompletion: unusedDesktopCall,
 		clearTranscriptReplica: unusedDesktopCall,
-		fetchTranscriptAttachment: unusedDesktopCall
+		fetchTranscriptAttachment: unusedDesktopCall,
+		pushConvexToken: unusedDesktopCall,
+		pushSessionCredential: unusedDesktopCall
 	};
 }
 

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -566,6 +566,28 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 				return null;
 			}
 			return await response.blob();
+		},
+		pushConvexToken: async (token) => {
+			const response = await fetch(`${baseUrl}/api/auth/convex-token`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ token })
+			});
+			if (!response.ok) {
+				throw await errorFromFailedResponse(response);
+			}
+		},
+		pushSessionCredential: async (credential) => {
+			const response = await fetch(`${baseUrl}/api/auth/session-credential`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(credential)
+			});
+			if (!response.ok) {
+				throw await errorFromFailedResponse(response);
+			}
 		}
 	};
 }

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -118,6 +118,15 @@ export type AgentRunRequest = {
 	workspacePath: string;
 };
 
+export type SessionCredentialTicket = {
+	sessionId: string;
+	userId: string;
+	current: string;
+	next: string;
+};
+
+export type SessionCredentialSeed = SessionCredentialTicket;
+
 export type AgentRunStart = {
 	runId: Id<'runs'>;
 };
@@ -248,6 +257,8 @@ export type DesktopApi = {
 	fetchTranscriptAttachment: (
 		request: TranscriptScopeRequest & { imageUploadId: Id<'imageUploads'> }
 	) => Promise<Blob | null>;
+	pushConvexToken: (token: string) => Promise<void>;
+	pushSessionCredential: (credential: SessionCredentialSeed) => Promise<void>;
 };
 
 export type WorkspacePathResolution = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -89,11 +89,8 @@
 		type PendingAgentLaunches
 	} from '$lib/project/threads';
 	import { mergePagedTranscriptWithLive, mergeTranscriptParts } from '$lib/project/transcript';
-	import {
-		clearLaunchHash,
-		readWorkspaceLaunchFromHash,
-		resolveDesktopApi
-	} from '$lib/local/client';
+	import { clearLaunchHash, readWorkspaceLaunchFromHash } from '$lib/local/client';
+	import { getDesktopApi } from '$lib/authTokenPush';
 	import { resolve } from '$app/paths';
 	import { applyTheme, resolveTheme, type SprocketTheme } from '$lib/theme';
 	import type {
@@ -2290,7 +2287,7 @@
 			initialProjectLaunchResolved = true;
 		}
 
-		void resolveDesktopApi()
+		void getDesktopApi()
 			.then((client) => {
 				desktopApi = client;
 				desktopApiResolved = true;

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, anyhow};
 use convex::{FunctionResult, QuerySubscription, Value};
 use serde::Deserialize;
 use sprocket_convex::Client as ConvexRpcClient;
+use sprocket_convex::{SessionCredentialProvider, session_proof_value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -26,6 +27,7 @@ pub(crate) enum FailedStartCleanup {
 pub(crate) struct RuntimeClient {
     pub(crate) client: ConvexRpcClient,
     execution_secret: String,
+    session_credential: Option<SessionCredentialProvider>,
 }
 
 impl RuntimeClient {
@@ -45,6 +47,7 @@ impl RuntimeClient {
         Ok(Self {
             client,
             execution_secret: request.execution_secret.clone(),
+            session_credential: request.session_credential.clone(),
         })
     }
 
@@ -164,6 +167,7 @@ impl RuntimeClient {
             env!("CARGO_PKG_VERSION").to_string().into(),
         );
         self.add_execution_secret(&mut args);
+        self.add_session_ticket(&mut args).await;
 
         let mut retry_delay = CREATE_RUN_INITIAL_RETRY_DELAY;
         let mut last_error = None;
@@ -293,6 +297,7 @@ impl RuntimeClient {
         );
         args.insert("text".to_string(), text.to_string().into());
         args.insert("lastError".to_string(), last_error.to_string().into());
+        self.add_session_ticket(&mut args).await;
         self.mutation_json("agentRuntime:finalizeFailedStart", args)
             .await
     }
@@ -469,6 +474,15 @@ impl RuntimeClient {
             "executionSecret".to_string(),
             self.execution_secret.clone().into(),
         );
+    }
+
+    async fn add_session_ticket(&self, args: &mut BTreeMap<String, Value>) {
+        if let Some(session) = &self.session_credential {
+            args.insert(
+                "sessionTicket".to_string(),
+                session_proof_value(&session.current_ticket().await),
+            );
+        }
     }
 
     fn run_args_with_claim(&self, run_id: &str, claim_id: &str) -> BTreeMap<String, Value> {

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -5,7 +5,7 @@ use rig::message::{
     ToolCallId, ToolFunction, ToolResult, ToolResultContent, UserContent,
 };
 use serde::{Deserialize, Deserializer, Serialize};
-use sprocket_convex::AuthTokenFetcher;
+use sprocket_convex::{AuthTokenFetcher, SessionCredentialProvider};
 
 pub(crate) fn gateway_api_v1_url(gateway_url: &str) -> String {
     format!("{}/api/v1", gateway_url.trim_end_matches('/'))
@@ -15,6 +15,9 @@ pub(crate) fn gateway_api_v1_url(gateway_url: &str) -> String {
 pub struct RunAgentRequest {
     pub deployment_url: String,
     pub auth_token_fetcher: AuthTokenFetcher,
+    /// When set, the local server authenticates Convex calls with the
+    /// rotating session credential instead of a forwarded WorkOS token.
+    pub session_credential: Option<SessionCredentialProvider>,
     pub execution_secret: String,
     pub submission_id: String,
     pub thread_id: String,

--- a/crates/sprocket-convex/Cargo.toml
+++ b/crates/sprocket-convex/Cargo.toml
@@ -8,4 +8,8 @@ license.workspace = true
 anyhow = "1.0.102"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 rustls = { version = "0.23.40", features = ["ring"] }
-tokio = { version = "1.52.1", features = ["sync", "time"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+uuid = { version = "1.19.0", features = ["v4"] }
+tokio = { version = "1.52.1", features = ["fs", "io-util", "sync", "time"] }
+tracing = "0.1.44"

--- a/crates/sprocket-convex/src/lib.rs
+++ b/crates/sprocket-convex/src/lib.rs
@@ -15,6 +15,12 @@ const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 pub type AuthTokenFetcher =
     Arc<dyn Fn(bool) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>> + Send + Sync>;
 
+pub mod session;
+pub use session::{
+    SessionCredentialProvider, SessionSnapshot, SessionTicket, session_proof_value,
+    session_ticket_value,
+};
+
 #[derive(Clone)]
 pub struct Client {
     inner: Arc<Mutex<ConvexClient>>,

--- a/crates/sprocket-convex/src/session.rs
+++ b/crates/sprocket-convex/src/session.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, bail};
@@ -33,6 +34,7 @@ struct CredentialState {
 pub struct SessionCredentialProvider {
     state: Arc<Mutex<CredentialState>>,
     persist_path: Option<Arc<PathBuf>>,
+    persist_enabled: Arc<AtomicBool>,
     client: Arc<Client>,
 }
 
@@ -48,6 +50,7 @@ impl SessionCredentialProvider {
                 generation: 0,
             })),
             persist_path: persist_path.map(Arc::new),
+            persist_enabled: Arc::new(AtomicBool::new(true)),
             client,
         }
     }
@@ -66,7 +69,17 @@ impl SessionCredentialProvider {
         self.persist_now().await
     }
 
+    /// Stops writing this provider's ticket to disk so a later account can
+    /// take over `session-credential.json` without an in-flight rotator
+    /// clobbering it.
+    pub fn disable_persist(&self) {
+        self.persist_enabled.store(false, Ordering::Release);
+    }
+
     pub async fn persist_now(&self) -> anyhow::Result<()> {
+        if !self.persist_enabled.load(Ordering::Acquire) {
+            return Ok(());
+        }
         let Some(path) = &self.persist_path else {
             return Ok(());
         };

--- a/crates/sprocket-convex/src/session.rs
+++ b/crates/sprocket-convex/src/session.rs
@@ -1,0 +1,216 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, bail};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::Client;
+
+pub const SESSION_CREDENTIAL_REFRESH: Duration = Duration::from_secs(5 * 60);
+const SESSION_CREDENTIAL_RETRY: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SessionTicket {
+    pub session_id: String,
+    pub user_id: String,
+    pub current: String,
+    pub next: String,
+}
+
+pub type SessionSnapshot = SessionTicket;
+
+#[derive(Clone)]
+struct CredentialState {
+    ticket: SessionTicket,
+    generation: u64,
+}
+
+#[derive(Clone)]
+pub struct SessionCredentialProvider {
+    state: Arc<Mutex<CredentialState>>,
+    persist_path: Option<Arc<PathBuf>>,
+    client: Arc<Client>,
+}
+
+impl SessionCredentialProvider {
+    pub fn from_snapshot(
+        client: Arc<Client>,
+        snapshot: SessionSnapshot,
+        persist_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(CredentialState {
+                ticket: snapshot,
+                generation: 0,
+            })),
+            persist_path: persist_path.map(Arc::new),
+            client,
+        }
+    }
+
+    pub async fn load_persist(path: &Path) -> Option<SessionSnapshot> {
+        let contents = tokio::fs::read_to_string(path).await.ok()?;
+        serde_json::from_str(contents.trim()).ok()
+    }
+
+    pub async fn replace(&self, snapshot: SessionSnapshot) -> anyhow::Result<()> {
+        {
+            let mut state = self.state.lock().await;
+            state.ticket = snapshot;
+            state.generation = state.generation.wrapping_add(1);
+        }
+        self.persist_now().await
+    }
+
+    pub async fn persist_now(&self) -> anyhow::Result<()> {
+        let Some(path) = &self.persist_path else {
+            return Ok(());
+        };
+        let ticket = self.current_ticket().await;
+        let data = serde_json::to_vec_pretty(&ticket).context("serialize session credential")?;
+        write_private_file(path, &data).await
+    }
+
+    pub async fn current_ticket(&self) -> SessionTicket {
+        self.state.lock().await.ticket.clone()
+    }
+
+    pub async fn run_rotator(self) -> anyhow::Result<()> {
+        sleep(SESSION_CREDENTIAL_REFRESH).await;
+        loop {
+            match self.rotate_once().await {
+                Ok(()) => sleep(SESSION_CREDENTIAL_REFRESH).await,
+                Err(error) => {
+                    tracing::warn!("session credential rotation failed: {error:#}");
+                    sleep(SESSION_CREDENTIAL_RETRY).await;
+                }
+            }
+        }
+    }
+
+    async fn rotate_once(&self) -> anyhow::Result<()> {
+        let state = self.state.lock().await.clone();
+        let mut args = std::collections::BTreeMap::new();
+        args.insert("ticket".to_string(), session_ticket_value(&state.ticket));
+        match self
+            .client
+            .mutation("sessionCredentials:rotate", args)
+            .await
+        {
+            Ok(convex::FunctionResult::Value(_)) => {}
+            Ok(convex::FunctionResult::ErrorMessage(message)) => {
+                bail!("rotate rejected: {message}")
+            }
+            Ok(convex::FunctionResult::ConvexError(error)) => {
+                bail!("rotate convex error: {}", error.message)
+            }
+            Err(error) => return Err(error).context("sessionCredentials:rotate"),
+        }
+
+        {
+            let mut current = self.state.lock().await;
+            if current.generation != state.generation || current.ticket != state.ticket {
+                return Ok(());
+            }
+            current.ticket = SessionTicket {
+                session_id: state.ticket.session_id,
+                user_id: state.ticket.user_id,
+                current: state.ticket.next,
+                next: Uuid::new_v4().to_string(),
+            };
+            current.generation = current.generation.wrapping_add(1);
+        }
+        if let Err(error) = self.persist_now().await {
+            tracing::warn!("failed to persist rotated session credential: {error:#}");
+        }
+        Ok(())
+    }
+}
+
+async fn write_private_file(path: &Path, data: &[u8]) -> anyhow::Result<()> {
+    let temporary = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temporary)
+        .await
+        .with_context(|| format!("create {}", temporary.display()))?;
+    let result = async {
+        use tokio::io::AsyncWriteExt;
+        file.write_all(data).await?;
+        file.sync_all().await?;
+        tokio::fs::rename(&temporary, path).await?;
+        anyhow::Ok(())
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+    }
+    result.with_context(|| format!("persist session credential to {}", path.display()))
+}
+
+pub fn session_proof_value(ticket: &SessionTicket) -> convex::Value {
+    let mut map = std::collections::BTreeMap::new();
+    map.insert("sessionId".to_string(), ticket.session_id.clone().into());
+    map.insert("userId".to_string(), ticket.user_id.clone().into());
+    map.insert("current".to_string(), ticket.current.clone().into());
+    convex::Value::Object(map)
+}
+
+pub fn session_ticket_value(ticket: &SessionTicket) -> convex::Value {
+    let mut map = std::collections::BTreeMap::new();
+    let convex::Value::Object(mut fields) = session_proof_value(ticket) else {
+        unreachable!("session proof is an object");
+    };
+    map.append(&mut fields);
+    map.insert("next".to_string(), ticket.next.clone().into());
+    convex::Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ticket_value_uses_convex_field_names() {
+        let ticket = SessionTicket {
+            session_id: "session".to_string(),
+            user_id: "owner".to_string(),
+            current: "current".to_string(),
+            next: "next".to_string(),
+        };
+        let proof = session_proof_value(&ticket);
+        let convex::Value::Object(proof_fields) = &proof else {
+            panic!("proof should be an object");
+        };
+        assert!(proof_fields.get("next").is_none());
+        let value = session_ticket_value(&ticket);
+        let convex::Value::Object(fields) = value else {
+            panic!("ticket should be an object");
+        };
+        assert_eq!(
+            fields.get("sessionId"),
+            Some(&convex::Value::String("session".into()))
+        );
+        assert_eq!(
+            fields.get("userId"),
+            Some(&convex::Value::String("owner".into()))
+        );
+        assert_eq!(
+            fields.get("current"),
+            Some(&convex::Value::String("current".into()))
+        );
+        assert_eq!(
+            fields.get("next"),
+            Some(&convex::Value::String("next".into()))
+        );
+    }
+}

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -368,6 +368,10 @@ pub fn verify_pairing_proof(credential: &str, message: &str, proof: &[u8]) -> bo
 }
 
 impl AuthState {
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
     pub async fn session_state(&self, session_token: Option<&str>) -> AuthSessionResponse {
         let Some(session_token) = session_token else {
             return AuthSessionResponse {

--- a/crates/sprocket-server/src/convex_auth.rs
+++ b/crates/sprocket-server/src/convex_auth.rs
@@ -169,12 +169,12 @@ pub async fn matching_session_credential(
 }
 
 /// True when `user_id` is this access token's subject or Convex
-/// `tokenIdentifier` (`iss|sub`). Empty tokens have no identity to conflict
-/// with, so they match.
+/// `tokenIdentifier` (`iss|sub`). An empty token is not an identity, so it
+/// never matches the process-wide credential.
 pub fn token_matches_owner(token: &str, user_id: &str) -> bool {
     let token = token.trim();
     if token.is_empty() {
-        return true;
+        return false;
     }
     let Some(claims) = access_token_claims(token) else {
         return false;
@@ -351,7 +351,7 @@ mod tests {
         assert!(!token_matches_owner(&token, "bob"));
         let issued = unsigned_jwt_with_claims(300, Some("alice"), Some("https://issuer.example"));
         assert!(token_matches_owner(&issued, "https://issuer.example|alice"));
-        assert!(token_matches_owner("", "anyone"));
+        assert!(!token_matches_owner("", "anyone"));
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/convex_auth.rs
+++ b/crates/sprocket-server/src/convex_auth.rs
@@ -1,0 +1,257 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::anyhow;
+use tokio::sync::Mutex;
+
+use sprocket_convex::AuthTokenFetcher;
+
+// WorkOS access tokens live ~5 minutes. Treat a token as stale a minute
+// before its real expiry so an in-flight request never rides a dying token.
+const EXPIRY_BUFFER: Duration = Duration::from_secs(60);
+// How long a force_refresh waits for the browser to push a renewed token
+// before falling back to the freshest cached copy.
+const FORCE_REFRESH_WAIT: Duration = Duration::from_secs(10);
+const FORCE_REFRESH_POLL: Duration = Duration::from_millis(150);
+
+struct CachedToken {
+    token: String,
+    refresh_after: Option<Instant>,
+}
+
+/// Holds the caller's Convex JWT and hands fresh copies to the Convex client.
+///
+/// The browser owns the WorkOS session, so it pushes renewed access tokens to
+/// the server (`POST /api/auth/convex-token`), which calls [`update`]. The
+/// Convex client pulls via [`Self::fetcher`]. On `force_refresh` we wait
+/// briefly for a pushed token that is fresher than the one Convex just
+/// rejected, instead of replaying a token the backend already refused.
+///
+/// [`update`]: ConvexTokenProvider::update
+/// [`Self::fetcher`]: ConvexTokenProvider::fetcher
+#[derive(Clone, Default)]
+pub struct ConvexTokenProvider {
+    inner: Arc<Mutex<Option<CachedToken>>>,
+}
+
+impl ConvexTokenProvider {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seeds the provider with an initial token (e.g. the one the browser sent
+    /// when launching a run) before it is shared.
+    pub async fn seeded(token: String) -> Self {
+        let provider = Self::new();
+        provider.update(token).await;
+        provider
+    }
+
+    pub async fn update(&self, token: String) {
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return;
+        }
+        let refresh_after =
+            access_token_expiry(&token).and_then(|expiry| expiry.checked_sub(EXPIRY_BUFFER));
+        *self.inner.lock().await = Some(CachedToken {
+            token,
+            refresh_after,
+        });
+    }
+
+    pub fn fetcher(&self, label: &'static str) -> AuthTokenFetcher {
+        let provider = self.clone();
+        Arc::new(move |force_refresh| {
+            let provider = provider.clone();
+            Box::pin(async move {
+                let token = if force_refresh {
+                    provider.wait_for_fresh().await
+                } else {
+                    provider.current().await
+                };
+                match token {
+                    Some(token) if !token.trim().is_empty() => Ok(token),
+                    _ => Err(anyhow!("{label} auth token is unavailable")),
+                }
+            })
+        })
+    }
+
+    async fn current(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .await
+            .as_ref()
+            .map(|cached| cached.token.clone())
+    }
+
+    /// Returns the cached token once it is fresh, waiting for a push. Falls
+    /// back to the freshest cached copy after [`FORCE_REFRESH_WAIT`] so a dead
+    /// browser degrades to the old behavior instead of hanging the client.
+    async fn wait_for_fresh(&self) -> Option<String> {
+        let deadline = Instant::now() + FORCE_REFRESH_WAIT;
+        loop {
+            {
+                let guard = self.inner.lock().await;
+                if let Some(cached) = guard.as_ref() {
+                    if cached.is_fresh() {
+                        return Some(cached.token.clone());
+                    }
+                }
+            }
+            if Instant::now() >= deadline {
+                return self.current().await;
+            }
+            tokio::time::sleep(FORCE_REFRESH_POLL).await;
+        }
+    }
+}
+
+impl CachedToken {
+    fn is_fresh(&self) -> bool {
+        match self.refresh_after {
+            Some(refresh_after) => Instant::now() < refresh_after,
+            // Unknown expiry: treat as fresh and let Convex reject it if not.
+            None => true,
+        }
+    }
+}
+
+/// Reads the `exp` claim without verifying the signature. The server never
+/// trusts this token for its own authorization — it only forwards it to
+/// Convex — so decoding (not verifying) is the correct operation here.
+fn access_token_expiry(token: &str) -> Option<Instant> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = base64_url_decode(payload)?;
+    let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    let exp_secs = claims.get("exp")?.as_u64()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?;
+    let expires_in = exp_secs.checked_sub(now.as_secs())?;
+    Some(Instant::now() + Duration::from_secs(expires_in))
+}
+
+fn base64_url_decode(input: &str) -> Option<Vec<u8>> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const TABLE: [u8; 128] = {
+        let mut table = [0xFFu8; 128];
+        let mut i = 0;
+        while i < 64 {
+            table[ALPHABET[i] as usize] = i as u8;
+            i += 1;
+        }
+        table
+    };
+
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut acc: u32 = 0;
+    let mut bits = 0;
+    for byte in input.bytes() {
+        if byte == b'=' {
+            break;
+        }
+        if byte >= 128 {
+            return None;
+        }
+        let value = TABLE[byte as usize];
+        if value == 0xFF {
+            return None;
+        }
+        acc = (acc << 6) | u32::from(value);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((acc >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base64_url_encode(bytes: &[u8]) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        for chunk in bytes.chunks(3) {
+            let b0 = chunk[0];
+            let b1 = chunk.get(1).copied().unwrap_or(0);
+            let b2 = chunk.get(2).copied().unwrap_or(0);
+            let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+            out.push(ALPHABET[(n >> 18) as usize & 63] as char);
+            out.push(ALPHABET[(n >> 12) as usize & 63] as char);
+            if chunk.len() > 1 {
+                out.push(ALPHABET[(n >> 6) as usize & 63] as char);
+            }
+            if chunk.len() > 2 {
+                out.push(ALPHABET[n as usize & 63] as char);
+            }
+        }
+        out
+    }
+
+    fn unsigned_jwt(exp_offset_secs: i64) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let exp = now + exp_offset_secs;
+        let header = base64_url_encode(br#"{"alg":"none"}"#);
+        let payload = base64_url_encode(format!(r#"{{"exp":{exp}}}"#).as_bytes());
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn base64_roundtrip() {
+        let data = b"hello world, this is a test!";
+        let encoded = base64_url_encode(data);
+        assert_eq!(base64_url_decode(&encoded).unwrap(), data);
+    }
+
+    #[tokio::test]
+    async fn serves_seeded_token_without_force_refresh() {
+        let provider = ConvexTokenProvider::seeded(unsigned_jwt(300)).await;
+        let fetcher = provider.fetcher("test");
+        let token = fetcher(false).await.expect("seeded token");
+        assert!(!token.is_empty());
+    }
+
+    #[tokio::test]
+    async fn force_refresh_returns_fresh_token_immediately() {
+        let provider = ConvexTokenProvider::seeded(unsigned_jwt(300)).await;
+        let fetcher = provider.fetcher("test");
+        let token = tokio::time::timeout(Duration::from_millis(500), fetcher(true))
+            .await
+            .expect("fresh token should not wait")
+            .expect("token");
+        assert!(!token.is_empty());
+    }
+
+    #[tokio::test]
+    async fn force_refresh_waits_for_pushed_token() {
+        // Seed with an already-expired token so force_refresh must wait.
+        let provider = ConvexTokenProvider::seeded(unsigned_jwt(-3600)).await;
+        let fetcher = provider.fetcher("test");
+        let pusher = provider.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            pusher.update(unsigned_jwt(300)).await;
+        });
+        let token = tokio::time::timeout(Duration::from_secs(3), fetcher(true))
+            .await
+            .expect("pushed token should arrive before the deadline")
+            .expect("token");
+        assert!(!token.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_token_is_rejected() {
+        let provider = ConvexTokenProvider::new();
+        let fetcher = provider.fetcher("test");
+        assert!(fetcher(false).await.is_err());
+    }
+}

--- a/crates/sprocket-server/src/convex_auth.rs
+++ b/crates/sprocket-server/src/convex_auth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -19,19 +20,28 @@ struct CachedToken {
     refresh_after: Option<Instant>,
 }
 
+#[derive(Default)]
+struct TokenStore {
+    by_subject: HashMap<String, CachedToken>,
+    last_subject: Option<String>,
+}
+
 /// Holds the caller's Convex JWT and hands fresh copies to the Convex client.
 ///
 /// The browser owns the WorkOS session, so it pushes renewed access tokens to
-/// the server (`POST /api/auth/convex-token`), which calls [`update`]. The
-/// Convex client pulls via [`Self::fetcher`]. On `force_refresh` we wait
-/// briefly for a pushed token that is fresher than the one Convex just
-/// rejected, instead of replaying a token the backend already refused.
+/// the server (`POST /api/auth/convex-token`), which calls [`update`]. Tokens
+/// are stored by JWT `sub` so a long-lived agent or transcript client keeps
+/// using the account it started with after another local session updates the
+/// process-wide cache. The Convex client pulls via [`Self::fetcher_for_token`].
+/// On `force_refresh` we wait briefly for a pushed token that is fresher than
+/// the one Convex just rejected, instead of replaying a token the backend
+/// already refused.
 ///
 /// [`update`]: ConvexTokenProvider::update
-/// [`Self::fetcher`]: ConvexTokenProvider::fetcher
+/// [`Self::fetcher_for_token`]: ConvexTokenProvider::fetcher_for_token
 #[derive(Clone, Default)]
 pub struct ConvexTokenProvider {
-    inner: Arc<Mutex<Option<CachedToken>>>,
+    inner: Arc<Mutex<TokenStore>>,
 }
 
 impl ConvexTokenProvider {
@@ -52,23 +62,39 @@ impl ConvexTokenProvider {
         if token.is_empty() {
             return;
         }
+        let subject = access_token_subject(&token).unwrap_or_default();
         let refresh_after =
             access_token_expiry(&token).and_then(|expiry| expiry.checked_sub(EXPIRY_BUFFER));
-        *self.inner.lock().await = Some(CachedToken {
-            token,
-            refresh_after,
-        });
+        let mut store = self.inner.lock().await;
+        store.by_subject.insert(
+            subject.clone(),
+            CachedToken {
+                token,
+                refresh_after,
+            },
+        );
+        store.last_subject = Some(subject);
     }
 
     pub fn fetcher(&self, label: &'static str) -> AuthTokenFetcher {
+        self.bound_fetcher(label, None)
+    }
+
+    /// Fetcher that only returns tokens for `token`'s JWT subject.
+    pub fn fetcher_for_token(&self, label: &'static str, token: &str) -> AuthTokenFetcher {
+        self.bound_fetcher(label, Some(access_token_subject(token).unwrap_or_default()))
+    }
+
+    fn bound_fetcher(&self, label: &'static str, subject: Option<String>) -> AuthTokenFetcher {
         let provider = self.clone();
         Arc::new(move |force_refresh| {
             let provider = provider.clone();
+            let subject = subject.clone();
             Box::pin(async move {
                 let token = if force_refresh {
-                    provider.wait_for_fresh().await
+                    provider.wait_for_fresh(subject.as_deref()).await
                 } else {
-                    provider.current().await
+                    provider.current(subject.as_deref()).await
                 };
                 match token {
                     Some(token) if !token.trim().is_empty() => Ok(token),
@@ -78,30 +104,29 @@ impl ConvexTokenProvider {
         })
     }
 
-    async fn current(&self) -> Option<String> {
-        self.inner
-            .lock()
-            .await
-            .as_ref()
-            .map(|cached| cached.token.clone())
+    async fn current(&self, subject: Option<&str>) -> Option<String> {
+        let store = self.inner.lock().await;
+        let key = subject.or(store.last_subject.as_deref())?;
+        store.by_subject.get(key).map(|cached| cached.token.clone())
     }
 
     /// Returns the cached token once it is fresh, waiting for a push. Falls
     /// back to the freshest cached copy after [`FORCE_REFRESH_WAIT`] so a dead
     /// browser degrades to the old behavior instead of hanging the client.
-    async fn wait_for_fresh(&self) -> Option<String> {
+    async fn wait_for_fresh(&self, subject: Option<&str>) -> Option<String> {
         let deadline = Instant::now() + FORCE_REFRESH_WAIT;
         loop {
             {
-                let guard = self.inner.lock().await;
-                if let Some(cached) = guard.as_ref() {
-                    if cached.is_fresh() {
-                        return Some(cached.token.clone());
-                    }
+                let store = self.inner.lock().await;
+                if let Some(key) = subject.or(store.last_subject.as_deref())
+                    && let Some(cached) = store.by_subject.get(key)
+                    && cached.is_fresh()
+                {
+                    return Some(cached.token.clone());
                 }
             }
             if Instant::now() >= deadline {
-                return self.current().await;
+                return self.current(subject).await;
             }
             tokio::time::sleep(FORCE_REFRESH_POLL).await;
         }
@@ -118,13 +143,24 @@ impl CachedToken {
     }
 }
 
-/// Reads the `exp` claim without verifying the signature. The server never
-/// trusts this token for its own authorization — it only forwards it to
-/// Convex — so decoding (not verifying) is the correct operation here.
-fn access_token_expiry(token: &str) -> Option<Instant> {
+/// Reads JWT claims without verifying the signature. The server never trusts
+/// this token for its own authorization — it only forwards it to Convex — so
+/// decoding (not verifying) is the correct operation here.
+fn access_token_claims(token: &str) -> Option<serde_json::Value> {
     let payload = token.split('.').nth(1)?;
     let decoded = base64_url_decode(payload)?;
-    let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn access_token_subject(token: &str) -> Option<String> {
+    access_token_claims(token)?
+        .get("sub")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn access_token_expiry(token: &str) -> Option<Instant> {
+    let claims = access_token_claims(token)?;
     let exp_secs = claims.get("exp")?.as_u64()?;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -195,14 +231,21 @@ mod tests {
     }
 
     fn unsigned_jwt(exp_offset_secs: i64) -> String {
+        unsigned_jwt_with_subject(exp_offset_secs, None)
+    }
+
+    fn unsigned_jwt_with_subject(exp_offset_secs: i64, subject: Option<&str>) -> String {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
         let exp = now + exp_offset_secs;
+        let payload = match subject {
+            Some(subject) => format!(r#"{{"exp":{exp},"sub":"{subject}"}}"#),
+            None => format!(r#"{{"exp":{exp}}}"#),
+        };
         let header = base64_url_encode(br#"{"alg":"none"}"#);
-        let payload = base64_url_encode(format!(r#"{{"exp":{exp}}}"#).as_bytes());
-        format!("{header}.{payload}.sig")
+        format!("{header}.{}.sig", base64_url_encode(payload.as_bytes()))
     }
 
     #[test]
@@ -253,5 +296,17 @@ mod tests {
         let provider = ConvexTokenProvider::new();
         let fetcher = provider.fetcher("test");
         assert!(fetcher(false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetcher_stays_on_original_subject_after_another_account_updates() {
+        let provider = ConvexTokenProvider::new();
+        let alice = unsigned_jwt_with_subject(300, Some("alice"));
+        let bob = unsigned_jwt_with_subject(300, Some("bob"));
+        provider.update(alice.clone()).await;
+        let fetcher = provider.fetcher_for_token("test", &alice);
+        provider.update(bob).await;
+        let token = fetcher(false).await.expect("alice token");
+        assert_eq!(token, alice);
     }
 }

--- a/crates/sprocket-server/src/convex_auth.rs
+++ b/crates/sprocket-server/src/convex_auth.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use tokio::sync::Mutex;
 
-use sprocket_convex::AuthTokenFetcher;
+use sprocket_convex::{AuthTokenFetcher, SessionCredentialProvider};
 
 // WorkOS access tokens live ~5 minutes. Treat a token as stale a minute
 // before its real expiry so an in-flight request never rides a dying token.
@@ -159,6 +159,40 @@ fn access_token_subject(token: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+pub async fn matching_session_credential(
+    session: Option<SessionCredentialProvider>,
+    token: &str,
+) -> Option<SessionCredentialProvider> {
+    let provider = session?;
+    let user_id = provider.current_ticket().await.user_id;
+    token_matches_owner(token, &user_id).then_some(provider)
+}
+
+/// True when `user_id` is this access token's subject or Convex
+/// `tokenIdentifier` (`iss|sub`). Empty tokens have no identity to conflict
+/// with, so they match.
+pub fn token_matches_owner(token: &str, user_id: &str) -> bool {
+    let token = token.trim();
+    if token.is_empty() {
+        return true;
+    }
+    let Some(claims) = access_token_claims(token) else {
+        return false;
+    };
+    let Some(subject) = claims.get("sub").and_then(|value| value.as_str()) else {
+        return false;
+    };
+    if user_id == subject {
+        return true;
+    }
+    if let Some(issuer) = claims.get("iss").and_then(|value| value.as_str())
+        && user_id == format!("{issuer}|{subject}")
+    {
+        return true;
+    }
+    user_id.ends_with(&format!("|{subject}"))
+}
+
 fn access_token_expiry(token: &str) -> Option<Instant> {
     let claims = access_token_claims(token)?;
     let exp_secs = claims.get("exp")?.as_u64()?;
@@ -235,15 +269,27 @@ mod tests {
     }
 
     fn unsigned_jwt_with_subject(exp_offset_secs: i64, subject: Option<&str>) -> String {
+        unsigned_jwt_with_claims(exp_offset_secs, subject, None)
+    }
+
+    fn unsigned_jwt_with_claims(
+        exp_offset_secs: i64,
+        subject: Option<&str>,
+        issuer: Option<&str>,
+    ) -> String {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
         let exp = now + exp_offset_secs;
-        let payload = match subject {
-            Some(subject) => format!(r#"{{"exp":{exp},"sub":"{subject}"}}"#),
-            None => format!(r#"{{"exp":{exp}}}"#),
-        };
+        let mut payload = format!(r#"{{"exp":{exp}"#);
+        if let Some(subject) = subject {
+            payload.push_str(&format!(r#","sub":"{subject}""#));
+        }
+        if let Some(issuer) = issuer {
+            payload.push_str(&format!(r#","iss":"{issuer}""#));
+        }
+        payload.push('}');
         let header = base64_url_encode(br#"{"alg":"none"}"#);
         format!("{header}.{}.sig", base64_url_encode(payload.as_bytes()))
     }
@@ -296,6 +342,16 @@ mod tests {
         let provider = ConvexTokenProvider::new();
         let fetcher = provider.fetcher("test");
         assert!(fetcher(false).await.is_err());
+    }
+
+    #[test]
+    fn token_matches_owner_accepts_subject_and_token_identifier() {
+        let token = unsigned_jwt_with_subject(300, Some("alice"));
+        assert!(token_matches_owner(&token, "alice"));
+        assert!(!token_matches_owner(&token, "bob"));
+        let issued = unsigned_jwt_with_claims(300, Some("alice"), Some("https://issuer.example"));
+        assert!(token_matches_owner(&issued, "https://issuer.example|alice"));
+        assert!(token_matches_owner("", "anyone"));
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod config;
+mod convex_auth;
 mod project_attachments;
 pub mod repo_env;
 mod routes;
@@ -9,6 +10,7 @@ mod transcript_client;
 mod transcript_watch;
 
 pub use config::{DEFAULT_DEV_WEB_URL, DEFAULT_PORT, SESSION_COOKIE_NAME, ServerConfig};
+use sprocket_convex::SessionCredentialProvider;
 use static_dir::is_valid_static_dir;
 pub use static_dir::{INSTALLED_WEB_DIR, resolve_static_dir};
 
@@ -27,6 +29,7 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
 
 use crate::transcript_watch::TranscriptWatchers;
+pub use convex_auth::ConvexTokenProvider;
 
 pub(crate) fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -87,6 +90,8 @@ pub struct AppState {
     pub desktop_login_callback_url: String,
     pub loopback_desktop_login_supported: bool,
     pub convex_deployment_url: String,
+    pub convex_tokens: ConvexTokenProvider,
+    pub session_credentials: Arc<Mutex<Option<SessionCredentialProvider>>>,
     pub web_ui_enabled: bool,
     pub desktop_bootstrap_token: Option<Arc<Mutex<Option<String>>>>,
 }
@@ -115,8 +120,33 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     let pairing_credential = auth.pairing_credential().to_string();
     let project_attachments = project_attachments::ProjectAttachmentStore::new(data_dir.clone());
     let transcript = TranscriptStore::new(data_dir.join("transcripts"));
-    let transcript_watchers =
-        TranscriptWatchers::new(convex_deployment_url.clone(), Arc::clone(&transcript));
+    let convex_tokens = ConvexTokenProvider::new();
+    let session_credentials = Arc::new(Mutex::new(None::<SessionCredentialProvider>));
+    let credential_path = data_dir.join("session-credential.json");
+    if let Some(snapshot) = SessionCredentialProvider::load_persist(&credential_path).await {
+        match sprocket_convex::Client::new(&convex_deployment_url).await {
+            Ok(client) => {
+                let provider = SessionCredentialProvider::from_snapshot(
+                    Arc::new(client),
+                    snapshot,
+                    Some(credential_path),
+                );
+                *session_credentials.lock().await = Some(provider.clone());
+                tokio::spawn(async move {
+                    let _ = provider.run_rotator().await;
+                });
+            }
+            Err(error) => {
+                tracing::warn!("failed to resume the session credential: {error:#}");
+            }
+        }
+    }
+    let transcript_watchers = TranscriptWatchers::new(
+        convex_deployment_url.clone(),
+        Arc::clone(&transcript),
+        convex_tokens.clone(),
+        session_credentials.clone(),
+    );
     let http_base_url = config.listen_url();
     let web_ui_enabled = config
         .resolve_static_dir()
@@ -140,6 +170,8 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         desktop_login_callback_url: auth::desktop_login_callback_url(config.port),
         loopback_desktop_login_supported: auth::host_supports_loopback_desktop_login(&config.host),
         convex_deployment_url,
+        convex_tokens,
+        session_credentials,
         web_ui_enabled,
         desktop_bootstrap_token,
     };

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -29,7 +29,7 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
 
 use crate::transcript_watch::TranscriptWatchers;
-pub use convex_auth::ConvexTokenProvider;
+pub use convex_auth::{ConvexTokenProvider, matching_session_credential};
 
 pub(crate) fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -75,7 +75,11 @@ async fn run_agent_handler(
     let auth_token_fetcher = state
         .convex_tokens
         .fetcher_for_token("agent", &payload.auth_token);
-    let session_credential = state.session_credentials.lock().await.clone();
+    let session_credential = crate::matching_session_credential(
+        state.session_credentials.lock().await.clone(),
+        &payload.auth_token,
+    )
+    .await;
     let request = RunAgentRequest {
         deployment_url: state.convex_deployment_url.clone(),
         auth_token_fetcher: auth_token_fetcher.clone(),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -71,8 +71,10 @@ async fn run_agent_handler(
         .await
         .map_err(ApiError::bad_request)?;
 
-    state.convex_tokens.update(payload.auth_token).await;
-    let auth_token_fetcher = state.convex_tokens.fetcher("agent");
+    state.convex_tokens.update(payload.auth_token.clone()).await;
+    let auth_token_fetcher = state
+        .convex_tokens
+        .fetcher_for_token("agent", &payload.auth_token);
     let session_credential = state.session_credentials.lock().await.clone();
     let request = RunAgentRequest {
         deployment_url: state.convex_deployment_url.clone(),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -14,8 +14,8 @@ use futures::StreamExt;
 use futures::stream::{self, unfold};
 use serde::Deserialize;
 use sprocket_agent::{
-    AuthTokenFetcher, LiveCompletionHub, LiveCompletionWatchEvent, RunAgentRequest,
-    finalize_failed_start, run_agent, start_agent_run,
+    LiveCompletionHub, LiveCompletionWatchEvent, RunAgentRequest, finalize_failed_start, run_agent,
+    start_agent_run,
 };
 use tokio::sync::broadcast;
 use tokio::sync::oneshot;
@@ -49,18 +49,6 @@ struct RunAgentStartResponse {
     run_id: String,
 }
 
-fn static_auth_token_fetcher(token: String) -> AuthTokenFetcher {
-    Arc::new(move |_force_refresh| {
-        let token = token.clone();
-        Box::pin(async move {
-            if token.trim().is_empty() {
-                return Err(anyhow!("agent auth token is empty"));
-            }
-            Ok(token)
-        })
-    })
-}
-
 pub fn routes() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/agent/run", post(run_agent_handler))
@@ -83,10 +71,13 @@ async fn run_agent_handler(
         .await
         .map_err(ApiError::bad_request)?;
 
-    let auth_token_fetcher = static_auth_token_fetcher(payload.auth_token);
+    state.convex_tokens.update(payload.auth_token).await;
+    let auth_token_fetcher = state.convex_tokens.fetcher("agent");
+    let session_credential = state.session_credentials.lock().await.clone();
     let request = RunAgentRequest {
         deployment_url: state.convex_deployment_url.clone(),
         auth_token_fetcher: auth_token_fetcher.clone(),
+        session_credential,
         execution_secret: format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple()),
         submission_id: payload.submission_id,
         thread_id: payload.thread_id,
@@ -264,19 +255,6 @@ mod tests {
         fn drop(&mut self) {
             self.0.store(true, Ordering::SeqCst);
         }
-    }
-
-    #[tokio::test]
-    async fn static_fetcher_returns_the_launch_token_without_waiting() {
-        let fetcher = static_auth_token_fetcher("token-1".to_string());
-        assert_eq!(fetcher(false).await.expect("initial token"), "token-1");
-        assert_eq!(
-            timeout(Duration::from_millis(20), fetcher(true))
-                .await
-                .expect("forced refresh must be noninteractive")
-                .expect("same launch token"),
-            "token-1"
-        );
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{ConnectInfo, Query, State};
@@ -39,6 +40,21 @@ struct DesktopLoginCancelRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConvexTokenPushRequest {
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionCredentialRequest {
+    session_id: String,
+    user_id: String,
+    current: String,
+    next: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct DesktopLoginCallbackQuery {
     code: Option<String>,
     state: Option<String>,
@@ -56,6 +72,65 @@ pub fn routes() -> axum::Router<AppState> {
         .route("/auth/desktop-login/callback", get(desktop_login_callback))
         .route("/auth/desktop-login/result", get(desktop_login_result))
         .route("/auth/desktop-login/cancel", post(desktop_login_cancel))
+        .route("/auth/convex-token", post(push_convex_token))
+        .route("/auth/session-credential", post(push_session_credential))
+}
+
+async fn push_convex_token(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<ConvexTokenPushRequest>,
+) -> Result<StatusCode, ApiError> {
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    state.convex_tokens.update(payload.token).await;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn push_session_credential(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<SessionCredentialRequest>,
+) -> Result<StatusCode, ApiError> {
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    let data_dir = state.auth.data_dir();
+    let credential_path = data_dir.join("session-credential.json");
+    let snapshot = sprocket_convex::SessionSnapshot {
+        session_id: payload.session_id,
+        user_id: payload.user_id,
+        current: payload.current,
+        next: payload.next,
+    };
+    let mut active = state.session_credentials.lock().await;
+    if let Some(provider) = active.as_ref() {
+        provider
+            .replace(snapshot)
+            .await
+            .map_err(|error| ApiError::internal_with("failed to save session credential", error))?;
+    } else {
+        let client = sprocket_convex::Client::new(&state.convex_deployment_url)
+            .await
+            .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
+        let provider = sprocket_convex::SessionCredentialProvider::from_snapshot(
+            Arc::new(client),
+            snapshot,
+            Some(credential_path),
+        );
+        provider
+            .persist_now()
+            .await
+            .map_err(|error| ApiError::internal_with("failed to save session credential", error))?;
+        *active = Some(provider.clone());
+        tokio::spawn(async move {
+            let _ = provider.run_rotator().await;
+        });
+    }
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn session(
@@ -366,6 +441,10 @@ mod tests {
         let transcript_watchers = crate::transcript_watch::TranscriptWatchers::new(
             "https://example.convex.cloud".to_string(),
             transcript.clone(),
+            crate::ConvexTokenProvider::new(),
+            Arc::new(tokio::sync::Mutex::new(
+                None::<sprocket_convex::SessionCredentialProvider>,
+            )),
         );
 
         let state = AppState {
@@ -379,6 +458,8 @@ mod tests {
             desktop_login_callback_url: auth::desktop_login_callback_url(7731),
             loopback_desktop_login_supported: loopback_supported,
             convex_deployment_url: "https://example.convex.cloud".to_string(),
+            convex_tokens: crate::ConvexTokenProvider::new(),
+            session_credentials: Arc::new(tokio::sync::Mutex::new(None)),
             web_ui_enabled: true,
             desktop_bootstrap_token: None,
         };

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -107,29 +107,34 @@ async fn push_session_credential(
         next: payload.next,
     };
     let mut active = state.session_credentials.lock().await;
-    if let Some(provider) = active.as_ref() {
+    if let Some(provider) = active.as_ref()
+        && provider.current_ticket().await.user_id == snapshot.user_id
+    {
         provider
             .replace(snapshot)
             .await
             .map_err(|error| ApiError::internal_with("failed to save session credential", error))?;
-    } else {
-        let client = sprocket_convex::Client::new(&state.convex_deployment_url)
-            .await
-            .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
-        let provider = sprocket_convex::SessionCredentialProvider::from_snapshot(
-            Arc::new(client),
-            snapshot,
-            Some(credential_path),
-        );
-        provider
-            .persist_now()
-            .await
-            .map_err(|error| ApiError::internal_with("failed to save session credential", error))?;
-        *active = Some(provider.clone());
-        tokio::spawn(async move {
-            let _ = provider.run_rotator().await;
-        });
+        return Ok(StatusCode::NO_CONTENT);
     }
+    if let Some(previous) = active.as_ref() {
+        previous.disable_persist();
+    }
+    let client = sprocket_convex::Client::new(&state.convex_deployment_url)
+        .await
+        .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
+    let provider = sprocket_convex::SessionCredentialProvider::from_snapshot(
+        Arc::new(client),
+        snapshot,
+        Some(credential_path),
+    );
+    provider
+        .persist_now()
+        .await
+        .map_err(|error| ApiError::internal_with("failed to save session credential", error))?;
+    *active = Some(provider.clone());
+    tokio::spawn(async move {
+        let _ = provider.run_rotator().await;
+    });
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -160,9 +160,14 @@ async fn attachment_handler(
         return Ok(blob_response(blob.media_type, blob.bytes));
     }
 
-    let client = UserConvexClient::connect(&state.convex_deployment_url, payload.auth_token)
-        .await
-        .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
+    let client = UserConvexClient::connect(
+        &state.convex_deployment_url,
+        payload.auth_token,
+        state.convex_tokens.clone(),
+        state.session_credentials.lock().await.clone(),
+    )
+    .await
+    .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
     let Some(remote) = client
         .attachment_download(&payload.image_upload_id)
         .await

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -160,11 +160,16 @@ async fn attachment_handler(
         return Ok(blob_response(blob.media_type, blob.bytes));
     }
 
+    let auth_token = payload.auth_token;
     let client = UserConvexClient::connect(
         &state.convex_deployment_url,
-        payload.auth_token,
+        auth_token.clone(),
         state.convex_tokens.clone(),
-        state.session_credentials.lock().await.clone(),
+        crate::matching_session_credential(
+            state.session_credentials.lock().await.clone(),
+            &auth_token,
+        )
+        .await,
     )
     .await
     .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
@@ -7,25 +6,41 @@ use convex::{FunctionResult, QuerySubscription, Value};
 use sprocket_agent::{
     RemoteTranscriptState, TranscriptPart, TranscriptStore, fetch_missing_parts, parse_remote_parts,
 };
-use sprocket_convex::{AuthTokenFetcher, Client as ConvexClient};
+use sprocket_convex::{Client as ConvexClient, SessionCredentialProvider, session_proof_value};
 use tokio::time::sleep;
+
+use crate::convex_auth::ConvexTokenProvider;
 
 #[derive(Clone)]
 pub struct UserConvexClient {
     client: ConvexClient,
+    session_credential: Option<SessionCredentialProvider>,
 }
 
 impl UserConvexClient {
-    pub async fn connect(deployment_url: &str, auth_token: String) -> anyhow::Result<Self> {
+    pub async fn connect(
+        deployment_url: &str,
+        auth_token: String,
+        tokens: ConvexTokenProvider,
+        session_credential: Option<SessionCredentialProvider>,
+    ) -> anyhow::Result<Self> {
         let client = ConvexClient::new(deployment_url).await?;
-        let fetcher = static_token_fetcher(auth_token);
-        client.set_auth_token_fetcher(fetcher).await;
-        Ok(Self { client })
+        // Keep the JWT fetcher even when a session credential is present so
+        // an expired on-disk ticket can still fall back to a live access token.
+        tokens.update(auth_token).await;
+        client
+            .set_auth_token_fetcher(tokens.fetcher("transcript"))
+            .await;
+        Ok(Self {
+            client,
+            session_credential,
+        })
     }
 
     pub async fn ensure_migrated(&self, thread_id: &str) -> anyhow::Result<RemoteTranscriptState> {
-        self.mutation_json("transcript:ensureMigrated", thread_id_args(thread_id))
-            .await
+        let mut args = thread_id_args(thread_id);
+        self.add_session_ticket(&mut args).await;
+        self.mutation_json("transcript:ensureMigrated", args).await
     }
 
     pub async fn transcript_parts(
@@ -43,14 +58,15 @@ impl UserConvexClient {
                     .collect(),
             ),
         );
+        self.add_session_ticket(&mut args).await;
         let value: serde_json::Value = self.query_json("transcript:getParts", args).await?;
         parse_remote_parts(value)
     }
 
     pub async fn subscribe_state(&self, thread_id: &str) -> anyhow::Result<QuerySubscription> {
-        self.client
-            .subscribe("transcript:getState", thread_id_args(thread_id))
-            .await
+        let mut args = thread_id_args(thread_id);
+        self.add_session_ticket(&mut args).await;
+        self.client.subscribe("transcript:getState", args).await
     }
 
     pub async fn attachment_download(
@@ -62,6 +78,7 @@ impl UserConvexClient {
             "imageUploadId".to_string(),
             image_upload_id.to_string().into(),
         );
+        self.add_session_ticket(&mut args).await;
         self.query_json("transcript:attachmentDownload", args).await
     }
 
@@ -80,6 +97,15 @@ impl UserConvexClient {
     ) -> anyhow::Result<T> {
         decode_function_result(self.client.mutation(function, args).await?, function)
     }
+
+    async fn add_session_ticket(&self, args: &mut BTreeMap<String, Value>) {
+        if let Some(session) = &self.session_credential {
+            args.insert(
+                "sessionTicket".to_string(),
+                session_proof_value(&session.current_ticket().await),
+            );
+        }
+    }
 }
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -89,18 +115,6 @@ pub struct RemoteAttachmentDownload {
     pub media_type: String,
     pub storage_id: String,
     pub url: String,
-}
-
-fn static_token_fetcher(token: String) -> AuthTokenFetcher {
-    Arc::new(move |_force_refresh| {
-        let token = token.clone();
-        Box::pin(async move {
-            if token.trim().is_empty() {
-                return Err(anyhow!("transcript auth token is empty"));
-            }
-            Ok(token)
-        })
-    })
 }
 
 fn thread_id_args(thread_id: &str) -> BTreeMap<String, Value> {

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -27,9 +27,9 @@ impl UserConvexClient {
         let client = ConvexClient::new(deployment_url).await?;
         // Keep the JWT fetcher even when a session credential is present so
         // an expired on-disk ticket can still fall back to a live access token.
-        tokens.update(auth_token).await;
+        tokens.update(auth_token.clone()).await;
         client
-            .set_auth_token_fetcher(tokens.fetcher("transcript"))
+            .set_auth_token_fetcher(tokens.fetcher_for_token("transcript", &auth_token))
             .await;
         Ok(Self {
             client,

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -6,6 +6,7 @@ use sprocket_agent::{TRANSCRIPT_PAGE_SIZE, TranscriptStore, apply_remote_state};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 
+use crate::convex_auth::ConvexTokenProvider;
 use crate::transcript_client::{
     UserConvexClient, decode_state_update, retry_after_failure, sync_range,
 };
@@ -39,12 +40,17 @@ struct WatchStart {
     user_id: String,
     thread_id: String,
     auth_token: String,
+    tokens: ConvexTokenProvider,
+    session_credential: Option<sprocket_convex::SessionCredentialProvider>,
     events: broadcast::Sender<TranscriptWatchEvent>,
 }
 
 pub struct TranscriptWatchers {
     deployment_url: String,
     store: Arc<TranscriptStore>,
+    tokens: ConvexTokenProvider,
+    session_credentials:
+        Arc<tokio::sync::Mutex<Option<sprocket_convex::SessionCredentialProvider>>>,
     inner: Mutex<HashMap<WatchKey, WatchSlot>>,
     start: WatchStarter,
 }
@@ -56,18 +62,37 @@ pub struct TranscriptWatchSession {
 }
 
 impl TranscriptWatchers {
-    pub fn new(deployment_url: String, store: Arc<TranscriptStore>) -> Arc<Self> {
-        Self::with_starter(deployment_url, store, Arc::new(spawn_convex_watch))
+    pub fn new(
+        deployment_url: String,
+        store: Arc<TranscriptStore>,
+        tokens: ConvexTokenProvider,
+        session_credentials: Arc<
+            tokio::sync::Mutex<Option<sprocket_convex::SessionCredentialProvider>>,
+        >,
+    ) -> Arc<Self> {
+        Self::with_starter(
+            deployment_url,
+            store,
+            tokens,
+            session_credentials,
+            Arc::new(spawn_convex_watch),
+        )
     }
 
     fn with_starter(
         deployment_url: String,
         store: Arc<TranscriptStore>,
+        tokens: ConvexTokenProvider,
+        session_credentials: Arc<
+            tokio::sync::Mutex<Option<sprocket_convex::SessionCredentialProvider>>,
+        >,
         start: WatchStarter,
     ) -> Arc<Self> {
         Arc::new(Self {
             deployment_url,
             store,
+            tokens,
+            session_credentials,
             inner: Mutex::new(HashMap::new()),
             start,
         })
@@ -104,12 +129,15 @@ impl TranscriptWatchers {
             };
         }
         let (events, rx) = broadcast::channel(16);
+        let session_credential = self.session_credentials.lock().await.clone();
         let task = (self.start)(WatchStart {
             deployment_url: self.deployment_url.clone(),
             store: Arc::clone(&self.store),
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
             auth_token,
+            tokens: self.tokens.clone(),
+            session_credential,
             events: events.clone(),
         });
         inner.insert(
@@ -198,7 +226,13 @@ fn spawn_convex_watch(start: WatchStart) -> JoinHandle<()> {
 }
 
 async fn run_watch_loop(start: &WatchStart) -> anyhow::Result<()> {
-    let client = UserConvexClient::connect(&start.deployment_url, start.auth_token.clone()).await?;
+    let client = UserConvexClient::connect(
+        &start.deployment_url,
+        start.auth_token.clone(),
+        start.tokens.clone(),
+        start.session_credential.clone(),
+    )
+    .await?;
     let remote = client.ensure_migrated(&start.thread_id).await?;
     apply_remote_state(
         &start.store,
@@ -271,6 +305,10 @@ mod tests {
         let watchers = TranscriptWatchers::with_starter(
             "https://example.convex.cloud".into(),
             store,
+            ConvexTokenProvider::new(),
+            Arc::new(tokio::sync::Mutex::new(
+                None::<sprocket_convex::SessionCredentialProvider>,
+            )),
             Arc::new(move |_start| {
                 let live_task = live_task.clone();
                 live_task.fetch_add(1, Ordering::SeqCst);

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -129,7 +129,11 @@ impl TranscriptWatchers {
             };
         }
         let (events, rx) = broadcast::channel(16);
-        let session_credential = self.session_credentials.lock().await.clone();
+        let session_credential = crate::matching_session_credential(
+            self.session_credentials.lock().await.clone(),
+            &auth_token,
+        )
+        .await;
         let task = (self.start)(WatchStart {
             deployment_url: self.deployment_url.clone(),
             store: Arc::clone(&self.store),


### PR DESCRIPTION
## Summary
- Store new Convex owner keys as the WorkOS `tokenIdentifier` instead of `identity.subject`, with dual-read shims and rewrite migrations so existing subject-keyed rows stay reachable.
- Issue a rotating session credential from authenticated Convex, deliver it once to the paired local Rust server, and let Rust renew it every five minutes instead of forwarding a browser JWT.
- Keep `/auth/convex-token` and the identity fallback so released clients that still send a WorkOS JWT continue to work until they age out.

## Test plan
- [ ] Sign in on a current desktop client, confirm a session credential is issued and the local server can create threads / start runs without a forwarded JWT
- [ ] Confirm an already-released client that still forwards a WorkOS JWT can still create threads and start runs
- [ ] Confirm a pre-migration thread owned by a WorkOS subject still appears in the sidebar and accepts new messages after deploy, then after the owner-rewrite migrations
- [ ] Confirm quota checks still apply to an in-progress usage window keyed by the legacy subject
- [ ] Sign out and confirm leftover credential authority dies with the ten-minute renewal window (no active revoke yet)
- [ ] `nix develop -c bunx vitest run src/convex/sessionCredentials.test.ts src/convex/subscriptionUsage.test.ts src/convex/threads.test.ts src/convex/payments.test.ts src/convex/gateway.test.ts src/convex/agentRuntime.test.ts src/convex/artifacts.test.ts src/convex/browserSessions.test.ts` from `apps/web`
- [ ] `nix develop -c cargo test -p sprocket-convex -p sprocket-server -p sprocket-agent`







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates persisted ownership to WorkOS token identifiers and adds renewable local session credentials while retaining legacy identity paths. The quota fixes now aggregate legacy and canonical windows, but the credential-isolation fix still trusts unverified JWT claims when selecting the process-wide credential.
- Adds dual-read ownership shims and owner-rewrite migrations.
- Introduces issued, persisted, and periodically rotated session credentials.
- Updates Rust agent and transcript clients to use session tickets while preserving legacy JWT support.
- Aggregates split usage windows and prefers an existing monthly charge key.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not safe to merge until session credentials can only be selected through a cryptographically verified, issuer-bound account identity.

The local server currently trusts caller-controlled JWT claims to select the process-wide session credential, and Convex then accepts that valid ticket without an authenticated JWT identity and creates the run as the ticket owner.

**Files Needing Attention:** crates/sprocket-server/src/convex_auth.rs, crates/sprocket-server/src/routes/agent.rs, apps/web/src/convex/agentRuntime.ts
</details>


<details open><summary><h3>Security Review</h3></summary>

The local server matches a caller-supplied token to the process-wide session credential using unverified JWT claims and an issuer-independent subject suffix. A forged or cross-issuer token can therefore select the stored credential, after which Convex's identity-free ticket branch authorizes run creation as that credential's owner. **How this was verified:** The request path decodes unverified claims to attach the credential, and `createGatewayRun` explicitly uses the valid ticket owner when no authenticated JWT identity exists.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/convex_auth.rs | Adds subject-keyed token refresh and credential matching, but the latter trusts unsigned claims and ignores issuer identity in its fallback. |
| crates/sprocket-server/src/routes/agent.rs | Binds each launch's token fetcher by subject and conditionally attaches the shared session credential using the unsafe local claim match. |
| apps/web/src/convex/agentRuntime.ts | Accepts session-ticket authorization without JWT identity, making correctness dependent on secure credential selection by the local server. |
| apps/web/src/convex/lib/rateLimits.ts | Aggregates legacy and canonical usage windows and selects an existing monthly window, addressing the previously reported split-quota bypass. |
| crates/sprocket-convex/src/session.rs | Implements session-ticket persistence and periodic current/next credential rotation. |
| apps/web/src/convex/lib/sessionCredentials.ts | Implements hashed credential issuance, rotation, expiry, and owner resolution for Convex authorization. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Local client
    participant Server as Local server
    participant Runtime as Rust runtime
    participant Convex
    Client->>Server: Agent request with crafted authToken
    Server->>Server: Decode unverified sub/iss
    Server->>Server: Match singleton session credential
    Server->>Runtime: RunAgentRequest with credential
    Runtime->>Convex: createGatewayRun with invalid JWT + valid ticket
    Convex->>Convex: JWT identity absent
    Convex->>Convex: Resolve ticket owner
    Convex-->>Runtime: Run created as credential owner
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/sprocket-server/src/convex_auth.rs:193
**Unverified claims select credentials**

When an authenticated local client supplies an unsigned JWT or a token from another issuer whose subject matches the stored credential owner's subject, `token_matches_owner` accepts the unverified claim and attaches that owner's session credential. Convex then accepts the valid ticket in the identity-free branch and creates the run under the credential owner's account rather than the account represented by the supplied token.

**How this was verified:** The request path decodes unverified claims to attach the credential, and `createGatewayRun` explicitly selects the valid ticket owner when no authenticated JWT identity exists.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(auth): Do not attach a session ticke..."](https://github.com/spikonado/sprocket/commit/fdbf05256d3506d03009df2d15e2da686fd3a873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58359035)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Local server authentication](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-authentication.md)
- Knowledge Base — [Agent and workspace API routes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-agent-workspace-routes.md)
- Knowledge Base — [Agent run lifecycle](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-run-lifecycle.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->