### PR TITLE
fix(ui): Restore the xAI provider logo

### DIFF
--- a/apps/web/src/lib/components/provider-logo.svelte
+++ b/apps/web/src/lib/components/provider-logo.svelte
@@ -25,6 +25,18 @@
 			d="M17.304 3.541h-3.672l6.696 16.918H24Zm-10.608 0L0 20.459h3.744l1.37-3.553h7.005l1.369 3.553h3.744L10.536 3.541Zm-.371 10.223 2.291-5.945 2.292 5.945Z"
 		/>
 	</svg>
+{:else if provider === 'xai'}
+	<svg
+		viewBox="0 0 24 24"
+		class={cn('text-foreground size-4', className)}
+		role="img"
+		aria-label="xAI"
+		fill="currentColor"
+	>
+		<path
+			d="M6.469 8.776 16.512 23h-4.464L2.005 8.776H6.47Zm-.004 7.9 2.233 3.164L6.467 23H2l4.465-6.324ZM22 2.582V23h-3.659V7.764L22 2.582ZM22 1l-9.952 14.095-2.233-3.163L17.533 1H22Z"
+		/>
+	</svg>
 {:else if provider === 'zai'}
 	<svg
 		viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- Restore the xAI glyph on `provider === 'xai'` in the model picker. The gateway catalog reports Grok 4.6 as `xai`, and that branch was dropped when Z.AI was added, so Grok fell through to the generic clock icon.

## Test plan
- [ ] Open the model picker on a catalog that includes `grok-4.6` with `provider: "xai"` and confirm the xAI logo renders.
- [ ] Confirm OpenAI, Anthropic, Z.AI, DeepSeek, and Kimi logos are unchanged.
- [ ] Confirm an unknown provider still uses the generic glyph.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores the xAI glyph in the model picker for catalog entries whose provider is `xai`.
- Adds a dedicated xAI SVG branch before the existing Z.AI branch.
- Preserves the existing provider logos and unknown-provider fallback.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the restored branch matching the documented gateway provider identifier and existing component conventions.

The change only adds the missing static SVG branch for `xai`; no concrete behavioral, accessibility, security, or compatibility regression was identified.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/provider-logo.svelte | Adds a convention-consistent xAI logo branch for the provider identifier documented by the gateway catalog. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): Restore the xAI provider logo"](https://github.com/spikonado/sprocket/commit/26ad62d73adc3b23a0623494042ad370badb3876) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58545799)</sub>

<!-- /greptile_comment -->