### PR TITLE
perf(agent): Avoid duplicate command output streams

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -140,6 +140,33 @@ The prompt-half of `threadMessages` (text, attachments, retention bookkeeping)
 stays: it is the run-capability source of the user prompt and image
 attachments for `agentRuntime.getContext` and dedups repeated submissions.
 
+### 9. Duplicate command output streams
+
+Older `exec_command` and `write_stdin` results contain `stdout` and `stderr` in
+addition to the combined, bounded `output`. The same result may exist in both
+`executorJobs.result` and `threadTranscriptParts.tool.output`.
+
+`removeExecutorJobCommandStreams` removes the duplicate fields from stored job
+results and `removeTranscriptCommandStreams` does the same for transcript
+copies. Both are pinned in `migrations.run`, which the migrations cron invokes
+every ten minutes. They can also be inspected before deployment with:
+
+```sh
+npx convex run migrations:removeExecutorJobCommandStreams '{ dryRun: true }'
+npx convex run migrations:removeTranscriptCommandStreams '{ dryRun: true }'
+```
+
+`applyExecutorJobSuccess` removes those fields before writing a result, so
+released executors that still return the old wire shape cannot reintroduce
+them after the sweep. The executor input validator temporarily accepts both
+command shapes so deployment can precede the online rewrites.
+
+Removal gate: both migration statuses are `success`, a production scan finds
+no `stdout` or `stderr` keys on command results in either table, and all
+supported agents emit the current `CommandExecOutput` schema. Then remove the
+legacy command validator and both migration definitions/pins; keep the
+write-boundary normalization until old executor clients are unsupported.
+
 ## Client APIs
 
 Released desktop/CLI builds that still call retired Convex functions get a

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -100,7 +100,16 @@ describe('executor', () => {
 		}));
 		expect(state.job).toMatchObject({
 			status: 'completed',
-			result: commandResult
+			result: {
+				command: 'echo hi',
+				cwd: '/',
+				exitCode: 0,
+				success: true,
+				running: false,
+				timedOut: false,
+				output: 'hi',
+				truncated: false
+			}
 		});
 		expect(state.job?.completedAt).toBeTypeOf('number');
 		expect(state.run?.status).toBe('running');

--- a/apps/web/src/convex/lib/commandResults.test.ts
+++ b/apps/web/src/convex/lib/commandResults.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { removeLegacyCommandStreams } from './commandResults';
+
+describe('removeLegacyCommandStreams', () => {
+	it('removes only the duplicated command stream fields', () => {
+		expect(
+			removeLegacyCommandStreams('exec_command', {
+				command: 'printf hello',
+				cwd: '/workspace',
+				stdout: 'hello',
+				stderr: '',
+				output: 'hello',
+				exitCode: 0,
+				success: true,
+				running: false,
+				timedOut: false,
+				truncated: false
+			})
+		).toEqual({
+			command: 'printf hello',
+			cwd: '/workspace',
+			output: 'hello',
+			exitCode: 0,
+			success: true,
+			running: false,
+			timedOut: false,
+			truncated: false
+		});
+	});
+
+	it('leaves current and unrelated results untouched', () => {
+		const current = { command: 'true', cwd: '/', output: '', success: true };
+		const unrelated = { stdout: 'value', output: 'value' };
+		expect(removeLegacyCommandStreams('exec_command', current)).toBe(current);
+		expect(removeLegacyCommandStreams('web_search', unrelated)).toBe(unrelated);
+	});
+});

--- a/apps/web/src/convex/lib/commandResults.ts
+++ b/apps/web/src/convex/lib/commandResults.ts
@@ -1,0 +1,24 @@
+import { isJsonObject, isJsonString, type JsonValue } from '@convex/lib/json';
+import type { ExecutorJobResult } from '@convex/lib/validators';
+
+const commandKinds = new Set(['exec_command', 'write_stdin']);
+
+export function removeLegacyCommandStreams(kind: string, result: JsonValue): JsonValue {
+	if (!commandKinds.has(kind) || !isJsonObject(result) || !isJsonString(result.output)) {
+		return result;
+	}
+	if (!Object.hasOwn(result, 'stdout') && !Object.hasOwn(result, 'stderr')) return result;
+
+	const current = { ...result };
+	delete current.stdout;
+	delete current.stderr;
+	return current;
+}
+
+export function normalizeExecutorJobResult(
+	kind: string,
+	result: ExecutorJobResult
+): ExecutorJobResult {
+	// SAFETY: only legacy command-only fields are removed from the command result union member.
+	return removeLegacyCommandStreams(kind, result) as ExecutorJobResult;
+}

--- a/apps/web/src/convex/lib/executorJobs.ts
+++ b/apps/web/src/convex/lib/executorJobs.ts
@@ -3,6 +3,7 @@ import type { MutationCtx } from '@convex/_generated/server';
 import { executorFailureRunPatch } from '@convex/lib/runs';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
 import { recordToolTranscript } from '@convex/lib/transcriptWrites';
+import { normalizeExecutorJobResult } from '@convex/lib/commandResults';
 import { isRunFinalStatus, type ExecutorJobResult } from '@convex/lib/validators';
 
 export async function applyExecutorJobSuccess(
@@ -26,9 +27,10 @@ export async function applyExecutorJobSuccess(
 	if (!ownsActiveRunClaim(args.run, args.claimId, Date.now())) {
 		return false;
 	}
+	const result = normalizeExecutorJobResult(args.job.kind, args.result);
 	await ctx.db.patch('executorJobs', args.job._id, {
 		status: 'completed',
-		result: args.result,
+		result,
 		completedAt: Date.now()
 	});
 	if (args.run.activeJobId === args.job._id) {
@@ -44,7 +46,7 @@ export async function applyExecutorJobSuccess(
 		job: {
 			...args.job,
 			status: 'completed',
-			result: args.result
+			result
 		}
 	});
 	return true;

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -204,7 +204,7 @@ export const vApplyPatchResult = v.object({
 	)
 });
 
-export const vCommandExecResult = v.object({
+const vLegacyCommandExecResult = v.object({
 	command: v.string(),
 	cwd: v.string(),
 	sessionId: v.optional(v.string()),
@@ -215,6 +215,19 @@ export const vCommandExecResult = v.object({
 	stdout: v.string(),
 	stderr: v.string(),
 	output: v.string(),
+	truncated: v.boolean(),
+	error: v.optional(v.string())
+});
+
+export const vCommandExecResult = v.object({
+	command: v.string(),
+	cwd: v.string(),
+	output: v.string(),
+	sessionId: v.optional(v.string()),
+	exitCode: v.optional(v.number()),
+	success: v.boolean(),
+	running: v.boolean(),
+	timedOut: v.boolean(),
 	truncated: v.boolean(),
 	error: v.optional(v.string())
 });
@@ -347,7 +360,7 @@ export const vExecutorJobResult = v.union(
 	v.array(vWorkspaceInstruction),
 	vApplyPatchResult,
 	vAskQuestionResult,
-	vCommandExecResult,
+	v.union(vCommandExecResult, vLegacyCommandExecResult),
 	vReadSkillResult,
 	vScrapeUrlResult,
 	vWebSearchResult,

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -2,6 +2,7 @@ import { Migrations } from '@convex-dev/migrations';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation } from '@convex/_generated/server';
 import schema from '@convex/schema';
+import { normalizeExecutorJobResult, removeLegacyCommandStreams } from '@convex/lib/commandResults';
 
 export const migrations = new Migrations(components.migrations, {
 	schema,
@@ -11,7 +12,31 @@ export const migrations = new Migrations(components.migrations, {
 // `run` targets the currently live migration(s). Each deploy's cron calls it
 // with no args; the runner picks up the pinned migration refs itself. Swap in
 // the next migration when a future cleanup lands.
-export const run = migrations.runner([internal.migrations.clearResponseMessageParts]);
+export const run = migrations.runner([
+	internal.migrations.clearResponseMessageParts,
+	internal.migrations.removeExecutorJobCommandStreams,
+	internal.migrations.removeTranscriptCommandStreams
+]);
+
+export const removeExecutorJobCommandStreams = migrations.define({
+	table: 'executorJobs',
+	migrateOne: (_ctx, job) => {
+		if (job.result === undefined) return;
+		const result = normalizeExecutorJobResult(job.kind, job.result);
+		if (result === job.result) return;
+		return { result };
+	}
+});
+
+export const removeTranscriptCommandStreams = migrations.define({
+	table: 'threadTranscriptParts',
+	migrateOne: (_ctx, part) => {
+		if (part.kind !== 'tool' || !part.tool) return;
+		const output = removeLegacyCommandStreams(part.tool.name, part.tool.output);
+		if (output === part.tool.output) return;
+		return { tool: { ...part.tool, output } };
+	}
+});
 
 /**
  * Clears the response-half payloads (`text`, `parts`) that runs wrote to

--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -340,8 +340,6 @@ impl CommandSession {
             success: completion.success,
             running,
             timed_out: completion.timed_out,
-            stdout,
-            stderr,
             output,
             truncated: stdout_truncated || stderr_truncated || limit_truncated,
             error: completion.error,
@@ -650,8 +648,6 @@ pub struct CommandExecOutput {
     pub success: bool,
     pub running: bool,
     pub timed_out: bool,
-    pub stdout: String,
-    pub stderr: String,
     pub output: String,
     pub truncated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -684,7 +680,7 @@ mod tests {
             .expect("command should succeed");
 
         assert!(output.success);
-        assert!(output.stdout.contains(root.to_string_lossy().as_ref()));
+        assert!(output.output.contains(root.to_string_lossy().as_ref()));
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -742,7 +738,7 @@ mod tests {
 
         assert!(!finished.running);
         assert!(finished.success);
-        assert_eq!(format!("{}{}", started.stdout, finished.stdout), "startend");
+        assert_eq!(format!("{}{}", started.output, finished.output), "startend");
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -775,7 +771,7 @@ mod tests {
             .expect("input should be delivered");
 
         assert!(finished.success);
-        assert_eq!(finished.stdout, "got:hello");
+        assert_eq!(finished.output, "got:hello");
         fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## Summary

- remove duplicated `stdout` and `stderr` fields from the core command result schema while retaining the combined, bounded `output`
- accept and normalize results from released executors that still send the legacy command shape
- migrate existing command results in executor jobs and transcript parts
- document the compatibility shim and its removal gate

## Validation

- `nix develop -c cargo test -p sprocket-workspace`
- `nix develop -c cargo test -p sprocket-agent tools::tests`
- `nix develop -c bun run test src/convex/lib/commandResults.test.ts src/convex/executor.test.ts`
- `nix develop -c bun run check` in `apps/web`
- `nix develop -c bun run lint` in `apps/web`
- `nix develop -c prek run -a`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR compacts command tool results while retaining the combined output, execution status, and error information.
- Removes duplicate `stdout` and `stderr` fields from new Rust command results.
- Normalizes executor-job and transcript writes and migrates stored legacy results.
- Keeps validators compatible with both legacy and current command-result shapes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-workspace/src/tools.rs | Removes separately serialized command streams and retains the bounded combined output and execution metadata. |
| apps/web/src/convex/lib/commandResults.ts | Adds guarded normalization that removes only legacy command stream fields. |
| apps/web/src/convex/lib/executorJobs.ts | Applies command-result normalization consistently to job storage and transcript recording. |
| apps/web/src/convex/lib/validators.ts | Introduces the compact command-result contract while retaining legacy input compatibility. |
| apps/web/src/convex/migrations.ts | Adds online rewrites for legacy command results in executor jobs and transcript parts. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Executor as Local executor
    participant Convex as Convex write boundary
    participant Store as Jobs and transcript
    participant Model as Agent model
    Executor->>Convex: Command result with combined output
    Convex->>Convex: Remove legacy stdout and stderr
    Convex->>Store: Persist compact result
    Store-->>Model: Return compact tool output
    Note over Convex,Store: Migration rewrites existing legacy results
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): avoid duplicate command outp..."](https://github.com/spikonado/sprocket/commit/b82426f7df2bbd10f83479d986452f9516f8ca7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58656356)</sub>

<!-- /greptile_comment -->