### PR TITLE
fix(agent-tools): Simplify HTTP errors from scrape_url

### DIFF
--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { isUnparseablePageFailure, scrapeHttpErrorMessage } from '@convex/webTools';
+import { isUnparseablePageFailure, scrapeHttpErrorStatus } from '@convex/webTools';
 
 describe('scrape HTTP failures', () => {
 	it('turns a Context.dev HTTP error into a readable message', () => {
 		const error = new Error(
 			'Uncaught ConvexError: Uncaught ConvexError: {"message":"Target page returned a 404","status":404,"response":{"error_code":"NOT_FOUND"}}\n    at contextRequest (http.js:24:12)'
 		);
-		expect(scrapeHttpErrorMessage(error)).toBe('This webpage returned a 404 error.');
+		expect(scrapeHttpErrorStatus(error)).toBe(404);
 	});
 
 	it('ignores non-HTTP and malformed errors', () => {
-		expect(scrapeHttpErrorMessage(new Error('{"status":200}'))).toBeUndefined();
-		expect(scrapeHttpErrorMessage(new Error('Context.dev scrape failed.'))).toBeUndefined();
+		expect(scrapeHttpErrorStatus(new Error('{"status":200}'))).toBeUndefined();
+		expect(scrapeHttpErrorStatus(new Error('Context.dev scrape failed.'))).toBeUndefined();
 	});
 });
 

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { isUnparseablePageFailure } from '@convex/webTools';
+import { isUnparseablePageFailure, scrapeHttpErrorMessage } from '@convex/webTools';
+
+describe('scrape HTTP failures', () => {
+	it('turns a Context.dev HTTP error into a readable message', () => {
+		const error = new Error(
+			'Uncaught ConvexError: Uncaught ConvexError: {"message":"Target page returned a 404","status":404,"response":{"error_code":"NOT_FOUND"}}\n    at contextRequest (http.js:24:12)'
+		);
+		expect(scrapeHttpErrorMessage(error)).toBe('This webpage returned a 404 error.');
+	});
+
+	it('ignores non-HTTP and malformed errors', () => {
+		expect(scrapeHttpErrorMessage(new Error('{"status":200}'))).toBeUndefined();
+		expect(scrapeHttpErrorMessage(new Error('Context.dev scrape failed.'))).toBeUndefined();
+	});
+});
 
 describe('unparseable page failures', () => {
 	it('recognizes component return-validation failures', () => {

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -34,6 +34,33 @@ export function isUnparseablePageFailure(error: Error): boolean {
 }
 
 const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
+const UNCAUGHT_CONVEX_ERROR_PREFIX = 'Uncaught ConvexError: ';
+
+export function scrapeHttpErrorMessage(error: Error): string | undefined {
+	let message = error.message.split('\n', 1)[0] ?? '';
+	while (message.startsWith(UNCAUGHT_CONVEX_ERROR_PREFIX)) {
+		message = message.slice(UNCAUGHT_CONVEX_ERROR_PREFIX.length);
+	}
+
+	let payload: unknown;
+	try {
+		payload = JSON.parse(message);
+	} catch {
+		return undefined;
+	}
+	if (
+		typeof payload !== 'object' ||
+		payload === null ||
+		!('status' in payload) ||
+		typeof payload.status !== 'number' ||
+		!Number.isInteger(payload.status) ||
+		payload.status < 400 ||
+		payload.status > 599
+	) {
+		return undefined;
+	}
+	return `This webpage returned a ${payload.status} error.`;
+}
 
 async function withTimeout<T>(label: string, timeoutMs: number, promise: Promise<T>): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
@@ -97,8 +124,14 @@ async function runScrape(
 			})
 		);
 	} catch (error) {
-		if (error instanceof Error && isUnparseablePageFailure(error)) {
-			throw new NonRetryableError(UNPARSEABLE_PAGE_ERROR, { cause: error });
+		if (error instanceof Error) {
+			const httpErrorMessage = scrapeHttpErrorMessage(error);
+			if (httpErrorMessage) {
+				throw new NonRetryableError(httpErrorMessage, { cause: error });
+			}
+			if (isUnparseablePageFailure(error)) {
+				throw new NonRetryableError(UNPARSEABLE_PAGE_ERROR, { cause: error });
+			}
 		}
 		throw error;
 	}

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -1,6 +1,7 @@
 'use node';
 
-import { v, type Infer } from 'convex/values';
+import { ConvexError, v, type Infer } from 'convex/values';
+import { z } from 'zod';
 import { ContextDev } from '@context-dot-dev/convex';
 import { ExaClient } from '@exalabs/convex-exa';
 import { action, internalAction, type ActionCtx } from '@convex/_generated/server';
@@ -35,8 +36,9 @@ export function isUnparseablePageFailure(error: Error): boolean {
 
 const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
 const UNCAUGHT_CONVEX_ERROR_PREFIX = 'Uncaught ConvexError: ';
+const scrapeHttpErrorSchema = z.object({ status: z.number().int().min(400).max(599) });
 
-export function scrapeHttpErrorMessage(error: Error): string | undefined {
+export function scrapeHttpErrorStatus(error: Error): number | undefined {
 	let message = error.message.split('\n', 1)[0] ?? '';
 	while (message.startsWith(UNCAUGHT_CONVEX_ERROR_PREFIX)) {
 		message = message.slice(UNCAUGHT_CONVEX_ERROR_PREFIX.length);
@@ -48,18 +50,8 @@ export function scrapeHttpErrorMessage(error: Error): string | undefined {
 	} catch {
 		return undefined;
 	}
-	if (
-		typeof payload !== 'object' ||
-		payload === null ||
-		!('status' in payload) ||
-		typeof payload.status !== 'number' ||
-		!Number.isInteger(payload.status) ||
-		payload.status < 400 ||
-		payload.status > 599
-	) {
-		return undefined;
-	}
-	return `This webpage returned a ${payload.status} error.`;
+	const result = scrapeHttpErrorSchema.safeParse(payload);
+	return result.success ? result.data.status : undefined;
 }
 
 async function withTimeout<T>(label: string, timeoutMs: number, promise: Promise<T>): Promise<T> {
@@ -125,9 +117,13 @@ async function runScrape(
 		);
 	} catch (error) {
 		if (error instanceof Error) {
-			const httpErrorMessage = scrapeHttpErrorMessage(error);
-			if (httpErrorMessage) {
-				throw new NonRetryableError(httpErrorMessage, { cause: error });
+			const status = scrapeHttpErrorStatus(error);
+			if (status !== undefined) {
+				const message = `This webpage returned a ${status} error.`;
+				if (status === 408 || status === 429 || status >= 500) {
+					throw new ConvexError(message);
+				}
+				throw new NonRetryableError(message, { cause: error });
 			}
 			if (isUnparseablePageFailure(error)) {
 				throw new NonRetryableError(UNPARSEABLE_PAGE_ERROR, { cause: error });


### PR DESCRIPTION
## Summary

- parse HTTP statuses from Context.dev scrape failures
- show scrape failures as `This webpage returned a <status> error.` in agent results and the UI
- cover nested ConvexError payloads and malformed/non-error responses

## Checks

- `bun run --cwd apps/web test src/convex/webTools.test.ts`
- `bun run --cwd apps/web check`
- Prettier and ESLint on changed files
- `git diff --check`



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR parses HTTP statuses from Context.dev scrape failures and converts them into concise user-facing messages while preserving retries for transient responses.
- Adds bounded status extraction for nested Convex error messages.
- Treats 408, 429, and 5xx responses as retryable while keeping other HTTP failures non-retryable.
- Adds focused coverage for recognized, non-HTTP, and malformed error messages.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; transient HTTP statuses now avoid the non-retryable path while retaining concise terminal error messages.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Parses scrape HTTP statuses, emits readable errors, and preserves workpool retries for transient statuses. |
| apps/web/src/convex/webTools.test.ts | Covers the observed nested Convex error format and rejects non-HTTP or malformed messages. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): preserve transient scrape retr..."](https://github.com/spikonado/sprocket/commit/c6fa3041fd6963e5d1b6ae82d970a6b0521e3d40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58676869)</sub>

**Context used:**

- Knowledge Base — [Restore readable agent tool failures](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/reverts/rollback_206-20260825-failed-tool-errors-e0e2ec7.md)

<!-- /greptile_comment -->