### PR TITLE
perf(convex): Stage executor call lookup index

### DIFF
--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -230,7 +230,11 @@ export default defineSchema({
 	})
 		.index('by_threadId_sequence', ['threadId', 'sequence'])
 		.index('by_runId_sequence', ['runId', 'sequence'])
-		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence']),
+		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence'])
+		.index('by_runId_and_callId_and_hidden', {
+			fields: ['runId', 'callId', 'hidden'],
+			staged: true
+		}),
 	agentQuestions: defineTable({
 		threadId: v.id('threadRecords'),
 		runId: v.id('runs'),


### PR DESCRIPTION
## Summary

- stage a compound executor-job index for exact tool-call lookups
- let Convex backfill the production index without blocking deployment

## Rollout

Merge and deploy this PR first. Wait until Convex reports `by_runId_and_callId_and_hidden` as ready before merging the follow-up PR that activates and queries it.

## Checks

- `bun run check` in `apps/web`
- pre-commit hooks except `mermaid` (the hook binary is missing locally; no Mermaid files changed)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stages a compound executor-job index so Convex can backfill it before a follow-up begins querying it.
- Adds `by_runId_and_callId_and_hidden` over `runId`, `callId`, and `hidden`.
- Marks the index as staged to keep it unavailable to queries during backfill.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only stages an unused index using the repository-supported Convex schema syntax.

The new index is additive, matches the documented staged-index API for the resolved Convex version, and has no current query callers that could access it before activation.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/schema.ts | Adds a correctly formed staged compound index without changing current query behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(convex): Stage executor call lookup..."](https://github.com/spikonado/sprocket/commit/0ee01c4939aaa9fe08c7542f4631bd91160d51d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58862167)</sub>

<!-- /greptile_comment -->