### PR TITLE
perf(convex): Target tool transcript lookups

### DIFF
--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -697,7 +697,8 @@ export const finalizeCompletionCall = mutation({
 		await recordSettledToolTranscripts(ctx, {
 			threadId: run.threadId,
 			userId: run.userId,
-			runId: run._id
+			runId: run._id,
+			items: args.items
 		});
 		return number;
 	}

--- a/apps/web/src/convex/lib/executorJobs.ts
+++ b/apps/web/src/convex/lib/executorJobs.ts
@@ -2,7 +2,6 @@ import type { Doc } from '@convex/_generated/dataModel';
 import type { MutationCtx } from '@convex/_generated/server';
 import { executorFailureRunPatch } from '@convex/lib/runs';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
-import { recordToolTranscript } from '@convex/lib/transcriptWrites';
 import { normalizeExecutorJobResult } from '@convex/lib/commandResults';
 import { isRunFinalStatus, type ExecutorJobResult } from '@convex/lib/validators';
 
@@ -39,16 +38,6 @@ export async function applyExecutorJobSuccess(
 			activeJobId: undefined
 		});
 	}
-	await recordToolTranscript(ctx, {
-		threadId: args.run.threadId,
-		userId: args.run.userId,
-		runId: args.run._id,
-		job: {
-			...args.job,
-			status: 'completed',
-			result
-		}
-	});
 	return true;
 }
 
@@ -85,15 +74,5 @@ export async function applyExecutorJobFailure(
 	if (runPatch) {
 		await ctx.db.patch('runs', args.job.runId, runPatch);
 	}
-	await recordToolTranscript(ctx, {
-		threadId: args.run.threadId,
-		userId: args.run.userId,
-		runId: args.run._id,
-		job: {
-			...args.job,
-			status: 'failed',
-			error: args.error
-		}
-	});
 	return true;
 }

--- a/apps/web/src/convex/lib/runTerminal.ts
+++ b/apps/web/src/convex/lib/runTerminal.ts
@@ -96,8 +96,7 @@ async function recordToolTranscriptsPage(
 			threadId: args.run.threadId,
 			userId: args.run.userId,
 			runId: args.run._id,
-			job,
-			allowWithoutMatchingCompletion: true
+			job
 		});
 	}
 	const last = jobs.at(-1);

--- a/apps/web/src/convex/lib/transcriptWrites.ts
+++ b/apps/web/src/convex/lib/transcriptWrites.ts
@@ -4,34 +4,11 @@ import {
 	appendTranscriptPart,
 	attachmentMetaForUploads,
 	completionSourceKey,
-	getOrCreateTranscriptState,
 	promptSourceKey,
 	toolSourceKey
 } from '@convex/lib/transcriptParts';
 import { isSettledExecutorJobStatus } from '@convex/lib/runs';
 import type { TranscriptCompletionItem, TranscriptToolBody } from '@convex/lib/validators';
-
-const SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE = 32;
-
-// Leave enough read budget for the caller's own writes after the sweep.
-const SETTLED_TOOL_READ_RESERVE_DOCS = 64;
-const SETTLED_TOOL_READ_RESERVE_BYTES = 512 * 1024;
-
-function isReadBudgetError(error: Error): boolean {
-	return /too many .{0,40}read/i.test(error.message);
-}
-
-async function transactionNearReadLimit(ctx: MutationCtx): Promise<boolean> {
-	try {
-		const metrics = await ctx.meta.getTransactionMetrics();
-		return (
-			metrics.documentsRead.remaining < SETTLED_TOOL_READ_RESERVE_DOCS ||
-			metrics.bytesRead.remaining < SETTLED_TOOL_READ_RESERVE_BYTES
-		);
-	} catch {
-		return false;
-	}
-}
 
 export async function recordPromptTranscript(
 	ctx: MutationCtx,
@@ -91,20 +68,12 @@ export async function recordToolTranscript(
 			Doc<'executorJobs'>,
 			'_id' | 'hidden' | 'status' | 'callId' | 'kind' | 'result' | 'error'
 		>;
-		allowWithoutMatchingCompletion?: boolean;
 	}
 ): Promise<void> {
 	if (args.job.hidden) {
 		return;
 	}
 	if (!isSettledExecutorJobStatus(args.job.status)) {
-		return;
-	}
-	if (
-		args.job.callId &&
-		!args.allowWithoutMatchingCompletion &&
-		!(await runCompletionContainsToolCall(ctx, args.threadId, args.runId, args.job.callId))
-	) {
 		return;
 	}
 	await appendTranscriptPart(ctx, {
@@ -117,139 +86,34 @@ export async function recordToolTranscript(
 	});
 }
 
-async function runCompletionContainsToolCall(
-	ctx: MutationCtx,
-	threadId: Id<'threadRecords'>,
-	runId: Id<'runs'>,
-	callId: string
-): Promise<boolean> {
-	const parts = ctx.db
-		.query('threadTranscriptParts')
-		.withIndex('by_threadId_and_runId_and_number', (query) =>
-			query.eq('threadId', threadId).eq('runId', runId)
-		);
-	for await (const part of parts) {
-		if (
-			part.kind === 'completion' &&
-			part.completion?.items.some((item) => item.type === 'tool-call' && item.callId === callId)
-		) {
-			return true;
-		}
-	}
-	return false;
-}
-
 export async function recordSettledToolTranscripts(
 	ctx: MutationCtx,
 	args: {
 		threadId: Id<'threadRecords'>;
 		userId: string;
 		runId: Id<'runs'>;
+		items: TranscriptCompletionItem[];
 	}
 ): Promise<void> {
-	// finalizeCompletionCall runs this after every completion, so the scan must
-	// stay cheap: read parts and jobs in bounded chunks, skip jobs whose part
-	// already exists, and insert the rest from one in-memory number counter
-	// instead of per-job lookups. If the run's history is large enough to
-	// exhaust the read budget, bail out — terminal cleanup records any
-	// deferred jobs when the run finishes.
-	const state = await getOrCreateTranscriptState(ctx, {
-		threadId: args.threadId,
-		userId: args.userId
-	});
-	try {
-		await recordSettledToolTranscriptsWithinBudget(ctx, args, state._id, state.totalParts);
-	} catch (error) {
-		if (error instanceof Error && isReadBudgetError(error)) {
-			return;
-		}
-		throw error;
-	}
-}
-
-async function recordSettledToolTranscriptsWithinBudget(
-	ctx: MutationCtx,
-	args: { threadId: Id<'threadRecords'>; userId: string; runId: Id<'runs'> },
-	stateId: Id<'threadTranscriptStates'>,
-	initialNumber: number
-): Promise<void> {
-	let nextNumber = initialNumber;
-
-	const recordedSourceKeys = new Set<string>();
-	const completedCallIds = new Set<string>();
-	// Parts are numbered contiguously per thread, so number is a stable cursor.
-	// (.paginate would be cleaner, but Convex allows only one paginated query
-	// per function execution.)
-	let afterNumber = -1;
-	for (;;) {
-		if (await transactionNearReadLimit(ctx)) {
-			return;
-		}
-		const parts = await ctx.db
-			.query('threadTranscriptParts')
-			.withIndex('by_threadId_and_runId_and_number', (query) =>
-				query.eq('threadId', args.threadId).eq('runId', args.runId).gt('number', afterNumber)
-			)
-			.take(SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE);
-		for (const part of parts) {
-			recordedSourceKeys.add(part.sourceKey);
-			if (part.kind !== 'completion') {
-				continue;
-			}
-			for (const item of part.completion?.items ?? []) {
-				if (item.type === 'tool-call') {
-					completedCallIds.add(item.callId);
-				}
-			}
-		}
-		if (parts.length < SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE) {
-			break;
-		}
-		afterNumber = parts.at(-1)?.number ?? afterNumber;
-	}
-
-	let afterSequence = -1;
-	for (;;) {
-		if (await transactionNearReadLimit(ctx)) {
-			break;
-		}
-		const jobs = await ctx.db
+	const callIds = new Set(
+		args.items.flatMap((item) => (item.type === 'tool-call' ? [item.callId] : []))
+	);
+	for (const callId of callIds) {
+		const job = await ctx.db
 			.query('executorJobs')
-			.withIndex('by_runId_hidden_sequence', (query) =>
-				query.eq('runId', args.runId).eq('hidden', false).gt('sequence', afterSequence)
+			.withIndex('by_runId_and_callId_and_hidden', (query) =>
+				query.eq('runId', args.runId).eq('callId', callId).eq('hidden', false)
 			)
-			.take(SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE);
-		for (const job of jobs) {
-			if (!isSettledExecutorJobStatus(job.status)) {
-				continue;
-			}
-			if (job.callId && !completedCallIds.has(job.callId)) {
-				continue;
-			}
-			const sourceKey = toolSourceKey(job._id);
-			if (recordedSourceKeys.has(sourceKey)) {
-				continue;
-			}
-			await ctx.db.insert('threadTranscriptParts', {
+			.order('desc')
+			.first();
+		if (job) {
+			await recordToolTranscript(ctx, {
 				threadId: args.threadId,
 				userId: args.userId,
-				number: nextNumber,
-				sourceKey,
-				kind: 'tool',
 				runId: args.runId,
-				tool: settledToolBody(job)
+				job
 			});
-			recordedSourceKeys.add(sourceKey);
-			nextNumber += 1;
 		}
-		if (jobs.length < SETTLED_TOOL_TRANSCRIPTS_PAGE_SIZE) {
-			break;
-		}
-		afterSequence = jobs.at(-1)?.sequence ?? afterSequence;
-	}
-
-	if (nextNumber !== initialNumber) {
-		await ctx.db.patch('threadTranscriptStates', stateId, { totalParts: nextNumber });
 	}
 }
 

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -231,10 +231,7 @@ export default defineSchema({
 		.index('by_threadId_sequence', ['threadId', 'sequence'])
 		.index('by_runId_sequence', ['runId', 'sequence'])
 		.index('by_runId_hidden_sequence', ['runId', 'hidden', 'sequence'])
-		.index('by_runId_and_callId_and_hidden', {
-			fields: ['runId', 'callId', 'hidden'],
-			staged: true
-		}),
+		.index('by_runId_and_callId_and_hidden', ['runId', 'callId', 'hidden']),
 	agentQuestions: defineTable({
 		threadId: v.id('threadRecords'),
 		runId: v.id('runs'),

--- a/apps/web/src/convex/transcript.test.ts
+++ b/apps/web/src/convex/transcript.test.ts
@@ -204,6 +204,69 @@ describe('numbered transcript parts', () => {
 		expect(parts.parts[2]?.tool?.callId).toBe('c1');
 	});
 
+	it('only reads jobs named by the current completion call', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'transcript-exact-tool-secret';
+		const { runId } = await createQueuedRun(
+			t,
+			asUser,
+			threadId,
+			'sub-exact-tool',
+			executionSecret,
+			'Use one tool'
+		);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'claim-exact-tool',
+			runId,
+			executionSecret
+		});
+		await asUser.mutation(api.agentRuntime.registerCompletionAttempt, {
+			runId,
+			claimId: 'claim-exact-tool',
+			attemptSeq: 1,
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.insert('executorJobs', {
+				threadId,
+				runId,
+				kind: 'exec_command',
+				callId: 'unrelated',
+				payload: { cmd: 'echo unrelated' },
+				hidden: false,
+				status: 'completed',
+				enqueuedAt: 1,
+				completedAt: 2,
+				result: {
+					command: 'echo unrelated',
+					cwd: '/',
+					exitCode: 0,
+					success: true,
+					running: false,
+					timedOut: false,
+					stdout: 'unrelated',
+					stderr: '',
+					output: 'unrelated',
+					truncated: false
+				},
+				sequence: 0
+			});
+		});
+
+		await asUser.mutation(api.agentRuntime.finalizeCompletionCall, {
+			runId,
+			claimId: 'claim-exact-tool',
+			attemptSeq: 1,
+			streamId: 'stream-without-tool',
+			items: [{ type: 'text', id: 'text', text: 'Done', turnId: 'stream-without-tool' }],
+			executionSecret
+		});
+
+		const parts = await asUser.query(api.transcript.getParts, { threadId, numbers: [0, 1, 2] });
+		expect(parts.parts.map((part) => part.kind)).toEqual(['prompt', 'completion']);
+	});
+
 	it('does not number a failed run partial completion', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);


### PR DESCRIPTION
## Summary

- activate the backfilled executor call lookup index
- reconcile tool transcripts using only call IDs from the completion being finalized
- remove redundant transcript-history scans from executor completion and failure
- retain terminal cleanup as the fallback for unmatched or interrupted jobs

## Rollout dependency

**Do not merge or deploy this PR until #239 has been deployed and Convex reports `by_runId_and_callId_and_hidden` as fully backfilled.** This PR is stacked on #239 and changes that staged index to active before querying it.

## Checks

- `bun run test -- src/convex/transcript.test.ts src/convex/executor.test.ts`
- `bun run check`
- pre-commit hooks except `mermaid` (the hook binary is missing locally; no Mermaid files changed)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR narrows tool-transcript reconciliation to executor jobs referenced by the completion currently being finalized and activates the supporting Convex index.
- Passes completion items into transcript reconciliation and performs indexed lookups by run ID, call ID, and visibility.
- Removes transcript-history scans and settlement-time transcript writes.
- Retains terminal reconciliation as the cleanup path for remaining settled jobs.
- Adds coverage ensuring unrelated executor jobs are not included during completion finalization.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge after the documented prerequisite deployment and index backfill are complete.

No blocking failure remains in the eligible follow-up review findings.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/transcriptWrites.ts | Replaces broad transcript and executor-job scans with targeted indexed reconciliation for call IDs in the current completion. |
| apps/web/src/convex/agentRuntime.ts | Passes finalized completion items into settled-tool transcript reconciliation. |
| apps/web/src/convex/lib/executorJobs.ts | Removes transcript writes from executor success and failure handlers. |
| apps/web/src/convex/lib/runTerminal.ts | Keeps terminal job reconciliation while routing writes through the standard settled-job checks. |
| apps/web/src/convex/schema.ts | Activates the compound executor-job lookup index required by targeted reconciliation. |
| apps/web/src/convex/transcript.test.ts | Adds coverage showing completion finalization does not reconcile unrelated executor jobs. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Model
  participant Finalizer as Completion finalizer
  participant Jobs as Executor jobs
  participant Transcript
  participant Cleanup as Terminal cleanup
  Model->>Finalizer: Finalize completion with items
  Finalizer->>Transcript: Append completion part
  loop Each unique tool-call ID
    Finalizer->>Jobs: "Indexed lookup by run, call ID, hidden=false"
    Jobs-->>Finalizer: Latest matching job
    Finalizer->>Transcript: Append if settled
  end
  Cleanup->>Jobs: Scan terminal run jobs
  Cleanup->>Transcript: Reconcile remaining settled jobs
```
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(convex): Target tool transcript loo..."](https://github.com/spikonado/sprocket/commit/c7c62ef96e768e0b2632a217f5a60e926babdae5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58863848)</sub>

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
- Knowledge Base — [Roll Back oversized run finalization writes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/reverts/rollback_225-20260830-threadmessages-size-limit-49f2b84.md)

<!-- /greptile_comment -->