### PR TITLE
perf(convex): Stop replaying settled jobs

### DIFF
--- a/apps/web/src/convex/chat.test.ts
+++ b/apps/web/src/convex/chat.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('chat.latestRunForThread', () => {
+	it('returns only the active executor job', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'latest-run-job-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'latest-run-job', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, {
+			claimId: 'latest-run-claim',
+			runId,
+			executionSecret
+		});
+		const { jobId } = await asUser.mutation(api.agentRuntime.beginToolJob, {
+			claimId: 'latest-run-claim',
+			runId,
+			kind: 'exec_command',
+			callId: 'active-call',
+			payload: { cmd: 'sleep 10' },
+			executionSecret
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.insert('executorJobs', {
+				threadId,
+				runId,
+				kind: 'exec_command',
+				callId: 'historical-call',
+				payload: { cmd: 'large historical result' },
+				hidden: false,
+				status: 'completed',
+				enqueuedAt: 1,
+				completedAt: 2,
+				result: {
+					command: 'large historical result',
+					cwd: '/',
+					exitCode: 0,
+					success: true,
+					running: false,
+					timedOut: false,
+					output: 'x'.repeat(10_000),
+					truncated: false
+				},
+				sequence: 1
+			});
+		});
+
+		const latest = await asUser.query(api.chat.latestRunForThread, { threadId });
+		expect(latest.activeJob?._id).toBe(jobId);
+		expect(latest.activeJob?.callId).toBe('active-call');
+	});
+});

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -26,20 +26,16 @@ export const latestRunForThread = query({
 			return {
 				threadId: args.threadId,
 				run: null,
-				jobs: [],
+				activeJob: null,
 				prompt: undefined,
 				imageUploadIds: undefined,
 				serverNow
 			};
 		}
 
-		const jobs = await ctx.db
-			.query('executorJobs')
-			.withIndex('by_runId_hidden_sequence', (query) =>
-				query.eq('runId', latestRun._id).eq('hidden', false)
-			)
-			.order('desc')
-			.take(60);
+		const activeJob = latestRun.activeJobId
+			? await ctx.db.get('executorJobs', latestRun.activeJobId)
+			: null;
 		const promptMessage = latestRun.promptMessageId
 			? await ctx.db.get('threadMessages', latestRun.promptMessageId)
 			: null;
@@ -47,7 +43,7 @@ export const latestRunForThread = query({
 		const latest: Infer<typeof vLatestRunForThread> = {
 			threadId: args.threadId,
 			run: latestRun,
-			jobs: jobs.reverse(),
+			activeJob: activeJob?.hidden ? null : activeJob,
 			serverNow
 		};
 		if (promptMessage?.type === 'prompt') {

--- a/apps/web/src/convex/lib/docs.ts
+++ b/apps/web/src/convex/lib/docs.ts
@@ -119,7 +119,7 @@ export const vCompletionActor = v.object({
 export const vLatestRunForThread = v.object({
 	threadId: v.id('threadRecords'),
 	run: v.union(schema.doc('runs'), v.null()),
-	jobs: v.array(schema.doc('executorJobs')),
+	activeJob: v.union(schema.doc('executorJobs'), v.null()),
 	prompt: v.optional(v.string()),
 	imageUploadIds: v.optional(v.array(v.id('imageUploads'))),
 	serverNow: v.number()

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -80,7 +80,6 @@ export type RunState = {
 	lastError?: string;
 	activeJobId?: Id<'executorJobs'>;
 	promptMessageId?: Id<'threadMessages'>;
-	jobs: ExecutorJob[];
 };
 
 export type MessageAttachment = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -734,15 +734,8 @@
 	);
 
 	const runState = $derived(currentLatestRunData?.run ?? null);
-	const visibleActions = $derived.by(() =>
-		(latestRunResumeKind
-			? (currentLatestRunData?.jobs ?? []).filter(
-					(job) =>
-						!job.hidden &&
-						(job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled')
-				)
-			: (currentLatestRunData?.jobs ?? [])
-		).slice(-60)
+	const visibleActions = $derived(
+		currentLatestRunData?.activeJob ? [currentLatestRunData.activeJob] : []
 	);
 	const threadArtifacts = $derived(
 		(artifactsQuery.data ?? []).map((entry) => ({


### PR DESCRIPTION
## Summary

- replace the latest-run query's 60-document executor job read with one direct `activeJobId` lookup
- rely on the numbered transcript for settled tool history instead of sending the same large results through the reactive Convex query
- keep the currently running tool job available for live status and timing

## Impact

`chat.latestRunForThread` no longer rereads and retransmits up to 60 completed executor job documents whenever a run or job changes. Completed tool output already reaches the UI through the local numbered-transcript replica.

## Stack

- #239 stages the executor call lookup index
- #240 activates that index and targets transcript reconciliation
- this PR is stacked on #240

Do not merge or deploy this PR until #239 has been deployed, its index backfill has completed, and #240 can be merged.

## Validation

- `nix develop -c bash -lc 'cd apps/web && bun run test -- src/convex/chat.test.ts src/lib/chat/assistant-timeline.test.ts'`
- `nix develop -c bash -lc 'cd apps/web && bun run check'`
- `nix develop -c bash -lc 'cd apps/web && bunx convex typecheck'`
- pre-commit hooks, with Mermaid skipped because `mermaid-lint` is unavailable and no Mermaid files changed




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces reactive Convex payloads by replacing the latest run’s settled-job collection with one direct lookup of its active executor job.
- Changes `latestRunForThread` to return `activeJob` instead of up to 60 jobs.
- Updates shared validators, client types, and the Svelte timeline input to use the new response shape.
- Adds a query test confirming that only the active job is returned while historical completed output is excluded.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge after the documented stacked-deployment prerequisites are satisfied.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/chat.ts | Replaces the run-scoped historical job query with a direct lookup of the latest run’s active job. |
| apps/web/src/convex/lib/docs.ts | Updates the public latest-run validator from a jobs array to a nullable active job. |
| apps/web/src/routes/+page.svelte | Supplies only the current active job to the timeline while settled history comes from the transcript replica. |
| apps/web/src/lib/types/sprocket.ts | Removes the obsolete embedded jobs collection from the client-side run shape. |
| apps/web/src/convex/chat.test.ts | Verifies that the latest-run query returns the active job without replaying a large completed job. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Svelte UI
    participant Query as latestRunForThread
    participant Runs as runs
    participant Jobs as executorJobs
    participant Transcript as Local numbered transcript
    UI->>Query: Request latest run for owned thread
    Query->>Runs: Read latest run
    alt activeJobId exists
        Query->>Jobs: Direct lookup by activeJobId
        Jobs-->>Query: Current active job
    end
    Query-->>UI: Run metadata and activeJob
    Transcript-->>UI: Settled tool history
    UI->>UI: Merge transcript history with active job
```
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(convex): Stop replaying settled job..."](https://github.com/spikonado/sprocket/commit/a802f1795d07216dc1a085f54c2dd328f0d52a47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58868473)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
- Knowledge Base — [Roll Back oversized run finalization writes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/reverts/rollback_225-20260830-threadmessages-size-limit-49f2b84.md)
</details>


<!-- /greptile_comment -->