### PR TITLE
perf(convex): Stage active run listing index

### DIFF
--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -153,6 +153,10 @@ export default defineSchema({
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
 		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])
+		.index('by_userId_and_status_and_startedAt', {
+			fields: ['userId', 'status', 'startedAt'],
+			staged: true
+		})
 		.index('by_executionSecretHash', ['executionSecretHash'])
 		.index('by_userId_submissionId', ['userId', 'submissionId']),
 	threadMessages: defineTable({


### PR DESCRIPTION
## Summary

Stage `runs.by_userId_and_status_and_startedAt` so Convex can backfill it without blocking deployment.

A follow-up will use this index to remove the `threads.listMine` N+1 latest-run queries. It will query the small set of active runs by status and keep inactive threads on the existing `threadRecords.by_userId_lastMessageAt` index.

## Rollout

This PR only starts the asynchronous index backfill. Deploy it and wait for Convex to report `by_userId_and_status_and_startedAt` as fully backfilled before activating or querying the index in the follow-up.

## Stack

- #239 stages the executor call lookup index
- #240 activates that index and targets transcript reconciliation
- #242 stops the latest-run subscription from replaying settled jobs
- this PR is stacked on #242

The earlier #239 deployment and backfill gate still applies to the stack.

## Validation

Pre-commit hooks passed, with Mermaid skipped because `mermaid-lint` is unavailable and no Mermaid files changed.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stages a new composite index for listing runs by user, status, and start time, allowing Convex to backfill it before a follow-up activates it.
- Adds `runs.by_userId_and_status_and_startedAt`.
- Marks the index as staged so current query behavior remains unchanged.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/schema.ts | Adds a supported, currently unqueried staged index without changing the run schema or runtime query behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(convex): Stage active run listing i..."](https://github.com/spikonado/sprocket/commit/160446e6fc8d114a336d4722fc673cd60e391879) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58870241)</sub>

<!-- /greptile_comment -->