### PR TITLE
perf(convex): Query active thread runs in bulk

### DIFF
--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -153,10 +153,7 @@ export default defineSchema({
 	})
 		.index('by_threadId_startedAt', ['threadId', 'startedAt'])
 		.index('by_threadId_status_startedAt', ['threadId', 'status', 'startedAt'])
-		.index('by_userId_and_status_and_startedAt', {
-			fields: ['userId', 'status', 'startedAt'],
-			staged: true
-		})
+		.index('by_userId_and_status_and_startedAt', ['userId', 'status', 'startedAt'])
 		.index('by_executionSecretHash', ['executionSecretHash'])
 		.index('by_userId_submissionId', ['userId', 'submissionId']),
 	threadMessages: defineTable({

--- a/apps/web/src/convex/threads.test.ts
+++ b/apps/web/src/convex/threads.test.ts
@@ -60,6 +60,25 @@ describe('threads.listMine ordering', () => {
 		const runningIds = threads.filter((thread) => thread.hasActiveRun).map((t) => t.threadId);
 		expect(runningIds).toEqual([runningNewer, runningOlder]);
 	});
+
+	it('does not load the latest settled run for an inactive thread', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const created = await createQueuedRun(t, asUser, threadId, 'settled-run', 'settled-run-secret');
+		await t.run(async (ctx) => {
+			await ctx.db.patch('runs', created.runId, {
+				status: 'completed',
+				completedAt: Date.now()
+			});
+		});
+
+		const threads = await asUser.query(api.threads.listMine, {});
+		expect(threads.find((thread) => thread.threadId === threadId)).toMatchObject({
+			latestRunId: null,
+			latestRunStatus: null,
+			hasActiveRun: false
+		});
+	});
 });
 
 describe('threads.rekeyRepository', () => {

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -4,13 +4,9 @@ import { v } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
 import { vThreadSummary, vThreadWithUsageDoc } from '@convex/lib/docs';
+import { compareRunStartedAt } from '@convex/lib/runs';
 import { getThreadUsageValues } from '@convex/lib/threadUsage';
-import {
-	isRunFinalStatus,
-	vReasoningEffort,
-	vRunStatus,
-	vServiceTier
-} from '@convex/lib/validators';
+import { vReasoningEffort, vRunStatus, vServiceTier } from '@convex/lib/validators';
 
 async function patchOwnedThread(
 	ctx: MutationCtx,
@@ -101,33 +97,43 @@ export const listMine = query({
 	returns: v.array(vThreadSummary),
 	handler: async (ctx) => {
 		const userId = await getUserId(ctx);
-		const records = await ctx.db
-			.query('threadRecords')
-			.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
-			.order('desc')
-			.collect();
-		const summaries = await Promise.all(
-			records.map(async (record) => {
-				const latestRun = await ctx.db
+		const [records, ...activeRunGroups] = await Promise.all([
+			ctx.db
+				.query('threadRecords')
+				.withIndex('by_userId_lastMessageAt', (query) => query.eq('userId', userId))
+				.order('desc')
+				.collect(),
+			...(['queued', 'running', 'awaiting_executor'] as const).map((status) =>
+				ctx.db
 					.query('runs')
-					.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', record._id))
-					.order('desc')
-					.first();
-				return {
-					...record,
-					threadId: record._id,
-					repositoryKey: record.repositoryKey ?? '',
-					title: record.title?.trim() || 'New thread',
-					threadStatus:
-						record.archivedAt !== undefined ? ('archived' as const) : ('active' as const),
-					latestRunStatus: latestRun?.status ?? null,
-					latestRunId: latestRun?._id ?? null,
-					latestRunStartedAt: latestRun?.startedAt,
-					latestRunClaimExpiresAt: latestRun?.claimExpiresAt,
-					hasActiveRun: latestRun ? !isRunFinalStatus(latestRun.status) : false
-				};
-			})
-		);
+					.withIndex('by_userId_and_status_and_startedAt', (query) =>
+						query.eq('userId', userId).eq('status', status)
+					)
+					.collect()
+			)
+		]);
+		const activeRunByThread = new Map<Id<'threadRecords'>, Doc<'runs'>>();
+		for (const run of activeRunGroups.flat()) {
+			const current = activeRunByThread.get(run.threadId);
+			if (!current || compareRunStartedAt(run, current) > 0) {
+				activeRunByThread.set(run.threadId, run);
+			}
+		}
+		const summaries = records.map((record) => {
+			const activeRun = activeRunByThread.get(record._id);
+			return {
+				...record,
+				threadId: record._id,
+				repositoryKey: record.repositoryKey ?? '',
+				title: record.title?.trim() || 'New thread',
+				threadStatus: record.archivedAt !== undefined ? ('archived' as const) : ('active' as const),
+				latestRunStatus: activeRun?.status ?? null,
+				latestRunId: activeRun?._id ?? null,
+				latestRunStartedAt: activeRun?.startedAt,
+				latestRunClaimExpiresAt: activeRun?.claimExpiresAt,
+				hasActiveRun: activeRun !== undefined
+			};
+		});
 		// Running threads first, then most recently active. The index already
 		// returns lastMessageAt-desc, so the comparator only needs to promote
 		// active runs while staying stable for the rest.


### PR DESCRIPTION
## Summary

- replace one latest-run query per thread with indexed bulk reads for `queued`, `running`, and `awaiting_executor` runs
- retain the newest active run if inconsistent data contains multiple active runs for a thread
- intentionally omit settled-run metadata from inactive thread summaries

## Rollout

**Do not merge or deploy this PR until #243 has been deployed and Convex reports `by_userId_and_status_and_startedAt` as fully backfilled.**

The existing stack gate also remains mandatory: deploy #239 and wait for `by_runId_and_callId_and_hidden` to finish backfilling before merging/deploying #240 or any descendants.

## Validation

- `nix develop -c bash -lc 'cd apps/web && bun run test -- src/convex/threads.test.ts src/lib/project/threads.test.ts'`
- `nix develop -c bash -lc 'cd apps/web && bun run check'`
- `nix develop -c bash -lc 'cd apps/web && bunx convex typecheck'`
- pre-commit hooks (`SKIP=mermaid`; Mermaid is unavailable and no Mermaid files changed)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces per-thread latest-run lookups with three user-scoped indexed reads and derives summaries from the newest active run, intentionally omitting settled-run metadata.
- Promotes the active-run index after its staged backfill.
- Groups active runs by thread and selects the newest using the existing run comparator.
- Adds coverage confirming inactive summaries omit settled-run metadata.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge after the explicitly documented index-backfill rollout prerequisite is satisfied.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/schema.ts | Promotes the user/status/start-time run index from staged to queryable, subject to the documented prerequisite backfill. |
| apps/web/src/convex/threads.ts | Replaces per-thread run queries with bulk active-status reads and deterministic newest-run selection. |
| apps/web/src/convex/threads.test.ts | Verifies inactive thread summaries no longer expose metadata from settled runs. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q[listMine] --> T[Load owned thread records]
  Q --> QR[Load queued runs]
  Q --> RR[Load running runs]
  Q --> AR[Load awaiting-executor runs]
  QR --> G[Group runs by thread]
  RR --> G
  AR --> G
  G --> N[Select newest active run]
  T --> S[Build thread summaries]
  N --> S
  S --> O[Promote active threads]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(convex): Query active thread runs i..."](https://github.com/spikonado/sprocket/commit/535d50f061cfddb0a1fc9773345ab34bb72769be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58871672)</sub>

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)

<!-- /greptile_comment -->