### PR TITLE
build(deps): Update sprocket-agent reqwest to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7155,7 +7155,7 @@ dependencies = [
  "anyhow",
  "convex",
  "futures",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "rig",
  "schemars 1.2.2",
  "serde",

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 anyhow = "1.0.102"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 futures = "0.3.32"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
 rig = { version = "0.42.0", default-features = false, features = ["agent", "reqwest", "rustls"] }
 schemars = "1"
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix the broken reqwest 0.13 bump. Renovate #234 only changed `0.12` → `0.13` and left `features = ["rustls-tls"]`, which 0.13 renamed to `rustls`. CI fails to resolve the crate.

This PR is only that upgrade:

- `sprocket-agent` reqwest `0.13.4` with `rustls`
- lockfile: agent now depends on the existing `reqwest 0.13.4` graph (`sprocket-server` / `sprocket-cli` already use it)

No HTTP client behavior changes. Retry policy adoption is a separate PR.

Does not close #234.

## Checks

- `cargo test -p sprocket-agent -p sprocket-server -p sprocket-cli`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades sprocket-agent's direct reqwest dependency to 0.13.4 and selects the renamed `rustls` feature.
- Repoints sprocket-agent's lockfile dependency from reqwest 0.12.28 to the existing 0.13.4 graph.
- Aligns sprocket-agent with the reqwest version already used by rig, sprocket-server, and sprocket-cli.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable changed-code failures identified.

The direct reqwest callers remain compatible with 0.13.4, the agent and rig share the same reqwest version, and the lockfile change does not introduce the flagged unrelated dependencies.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/Cargo.toml | Upgrades reqwest to 0.13.4 and replaces the removed `rustls-tls` feature with `rustls`; no actionable compatibility defect was found. |
| Cargo.lock | Repoints only sprocket-agent's reqwest dependency edge to the already-resolved 0.13.4 package graph. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build(deps): Update sprocket-agent reqwe..."](https://github.com/spikonado/sprocket/commit/dc249de11610f9a359c12382185cbb3057cd5007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58998404)</sub>

<!-- /greptile_comment -->