### PR TITLE
fix(http): Retry transient catalog and attachment GETs

### DIFF
--- a/crates/sprocket-agent/src/catalog.rs
+++ b/crates/sprocket-agent/src/catalog.rs
@@ -1,8 +1,35 @@
+use std::time::Duration;
+
 use anyhow::{Context, anyhow};
 
 use crate::types::{ContextBudget, gateway_api_v1_url};
 
 const GATEWAY_PROTOCOL_VERSION: u64 = 1;
+const CATALOG_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn catalog_client(gateway_url: &str) -> anyhow::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().timeout(CATALOG_TIMEOUT);
+    if let Some(host) = reqwest::Url::parse(gateway_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+    {
+        builder = builder.retry(reqwest::retry::for_host(host).classify_fn(|req_rep| {
+            if *req_rep.method() != reqwest::Method::GET {
+                return req_rep.success();
+            }
+            if req_rep.error().is_some() {
+                return req_rep.retryable();
+            }
+            match req_rep.status().map(|status| status.as_u16()) {
+                Some(429 | 502 | 503 | 504) => req_rep.retryable(),
+                _ => req_rep.success(),
+            }
+        }));
+    }
+    builder
+        .build()
+        .context("failed to build AI gateway catalog HTTP client")
+}
 
 #[derive(Debug, serde::Deserialize)]
 struct GatewayModelsResponse {
@@ -29,7 +56,7 @@ pub async fn context_budget_for_model(
     model_id: &str,
 ) -> anyhow::Result<ContextBudget> {
     let url = format!("{}/models", gateway_api_v1_url(gateway_url));
-    let response = reqwest::Client::new()
+    let response = catalog_client(gateway_url)?
         .get(url)
         .header(reqwest::header::ACCEPT, "application/json")
         .send()

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -131,9 +131,24 @@ pub async fn sync_range(
 }
 
 pub async fn download_attachment_bytes(url: &str) -> anyhow::Result<Vec<u8>> {
-    let client = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .no_proxy()
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_secs(60));
+    if let Some(host) = reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_owned))
+    {
+        builder = builder.retry(reqwest::retry::for_host(host).classify_fn(|req_rep| {
+            if *req_rep.method() != reqwest::Method::GET {
+                return req_rep.success();
+            }
+            match req_rep.status().map(|status| status.as_u16()) {
+                Some(429 | 502 | 503 | 504) => req_rep.retryable(),
+                _ => req_rep.success(),
+            }
+        }));
+    }
+    let client = builder
         .build()
         .context("failed to build attachment HTTP client")?;
     let response = client


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopt reqwest's `ClientBuilder::retry` for idempotent GETs.

- AI gateway catalog fetch: retry transport errors and 429/502/503/504, with a 15s timeout so a hung GET can actually retry
- Attachment downloads: retry 429/502/503/504 (not timeouts — a 60s download should not be replayed on a slow body)

Does not change reqwest versions. Compaction POSTs and local probe clients are a separate PR; those must not use this retry policy.

## Checks

- `cargo test -p sprocket-agent -p sprocket-server`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds host-scoped retry policies for transient HTTP failures while preserving GET-only behavior.

- Adds a 15-second timeout and retries transport errors plus 429/502/503/504 responses when fetching the AI gateway catalog.
- Retries 429/502/503/504 responses when downloading transcript attachments without replaying timeout failures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The retry policies remain limited to GET requests and the intended hosts, preserve existing response validation, and bound catalog and attachment requests with explicit timeouts.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/catalog.rs | Adds a bounded, host-scoped retrying client for gateway catalog GET requests. |
| crates/sprocket-server/src/transcript_client.rs | Adds host-scoped status retries to attachment downloads while excluding transport errors. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog or attachment GET] --> B{Result}
  B -->|Success or non-retryable response| C[Return result]
  B -->|Configured transient failure| D[Retry same-host GET]
  D --> B
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(http): Retry transient catalog and a..."](https://github.com/spikonado/sprocket/commit/d6f6ee51ea51d2256c622613364fe0b9f1ebb439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58998663)</sub>

<!-- /greptile_comment -->