### PR TITLE
fix(http): Disable reqwest retries on compaction and local probes

### DIFF
--- a/crates/sprocket-agent/src/compaction.rs
+++ b/crates/sprocket-agent/src/compaction.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::history_json::completion_messages_json;
+use anyhow::Context;
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, ModelTurnAction,
     ModelTurnFinished, RequestPatch, StepEventKind,
@@ -11,10 +11,14 @@ use rig::message::{AssistantContent, UserContent};
 use tokio::time::timeout;
 
 use crate::convex::RuntimeClient;
+use crate::history_json::completion_messages_json;
 use crate::types::{ContextBudget, gateway_api_v1_url};
 
 const CONTEXT_USAGE_TIMEOUT: Duration = Duration::from_secs(5);
 const SUMMARIZE_RETRY_DELAY: Duration = Duration::from_millis(250);
+/// Bound a hung gateway POST. App-level `summarize_with_retry` already
+/// accounts billed tokens; reqwest must not retry this call itself.
+const COMPACTION_HTTP_TIMEOUT: Duration = Duration::from_secs(180);
 /// Keep a small recent tail so the model retains immediate working context.
 const RECENT_TAIL_MESSAGES: usize = 6;
 /// Must match `COMPACTION_MAX_OUTPUT_TOKENS` in
@@ -286,7 +290,11 @@ impl ContextCompactionHook {
             "reasoning": { "effort": self.reasoning_effort },
             "service_tier": if self.service_tier == "fast" { "priority" } else { "standard" }
         });
-        let response = reqwest::Client::new()
+        let response = reqwest::Client::builder()
+            .timeout(COMPACTION_HTTP_TIMEOUT)
+            .retry(reqwest::retry::never())
+            .build()
+            .context("failed to build gateway compaction HTTP client")?
             .post(url)
             .bearer_auth(&credential.token)
             .json(&body)

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -157,6 +157,7 @@ async fn open_running_web_app(
     let client = reqwest::Client::builder()
         .no_proxy()
         .timeout(Duration::from_millis(750))
+        .retry(reqwest::retry::never())
         .build()?;
     let challenge = Uuid::new_v4().to_string();
     let response = match client

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -203,6 +203,7 @@ async fn open_browser_when_ready(health_base_url: String, open_target: String) {
     let client = match reqwest::Client::builder()
         .no_proxy()
         .timeout(Duration::from_millis(250))
+        .retry(reqwest::retry::never())
         .build()
     {
         Ok(client) => client,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reqwest retries protocol NACKs by default. That is wrong for these clients:

- Gateway compaction is a billed POST. `summarize_with_retry` already retries at the app layer and folds billed tokens; a reqwest replay would double-charge. Use `retry(never())` and a 180s timeout so a hung POST fails instead of hanging.
- Local health and pairing-proof checks already poll with their own short timeouts. Default retries would multiply those waits.

Does not change reqwest versions. Idempotent GET retries are a separate PR.

## Checks

- `cargo test -p sprocket-agent -p sprocket-server -p sprocket-cli`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ce704c7-393d-4cdd-99ff-38598ee5bdd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables reqwest’s implicit retries for billed compaction requests and local startup probes, while adding a 180-second bound to gateway compaction.
- Builds the compaction client with retries disabled and a total request timeout.
- Disables retries for CLI pairing-proof checks.
- Disables retries for server health polling.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete changed-code failure remains.

The compaction request retains its explicit application-level retry while avoiding implicit billed replays, and both local probes retain their existing outer fallback or polling behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/compaction.rs | Replaces the default client with a fallible builder that disables transport retries and bounds each compaction request to 180 seconds. |
| crates/sprocket-cli/src/main.rs | Disables implicit retries for the short-lived local pairing-proof request without changing its fallback behavior. |
| crates/sprocket-server/src/lib.rs | Disables implicit retries within the existing bounded health-readiness polling loop. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(http): Disable reqwest retries on co..."](https://github.com/spikonado/sprocket/commit/c701bee22be17da9b985770567fd0fec661cfe9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58998806)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Command-line interface](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/command-line-interface.md)
- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)
</details>


<!-- /greptile_comment -->