### PR TITLE
perf(convex): Stage project thread listing index

### DIFF
--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -128,7 +128,11 @@ export default defineSchema({
 	})
 		.index('by_userId_lastMessageAt', ['userId', 'lastMessageAt'])
 		.index('by_userId_submissionId', ['userId', 'submissionId'])
-		.index('by_userId_repositoryKey', ['userId', 'repositoryKey']),
+		.index('by_userId_repositoryKey', ['userId', 'repositoryKey'])
+		.index('by_userId_and_repositoryKey_and_archivedAt_and_lastMessageAt', {
+			fields: ['userId', 'repositoryKey', 'archivedAt', 'lastMessageAt'],
+			staged: true
+		}),
 	threadSnapshotRevisions: defineTable({
 		userId: v.string(),
 		repositoryKey: v.string(),


### PR DESCRIPTION
## Summary

- stage the compound thread index required for bounded per-repository active and archived synchronization
- keep the index unused until Convex finishes backfilling it

## Stack

- Depends on #245
- The follow-up Rust thread-cache PR will remove `staged: true` and consume this index only after its backfill is confirmed

## Validation

- `cd apps/web && bunx convex typecheck`
- `git diff --check`

## Rollout gate

Do not merge the consumer follow-up until `by_userId_and_repositoryKey_and_archivedAt_and_lastMessageAt` has been deployed and fully backfilled.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stages a compound `threadRecords` index so Convex can backfill it before a later consumer begins using it.

- Adds an index ordered by user, repository, archive state, and last-message timestamp.
- Marks the index as staged to keep it unavailable to queries during backfill.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/schema.ts | Adds a correctly staged compound index without changing current query behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["perf(convex): Stage project thread listi..."](https://github.com/spikonado/sprocket/commit/4cb24bd8971f36bad5ce4f11463828f440f4eed9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59031923)</sub>

<!-- /greptile_comment -->