### PR TITLE
fix(desktop): Adopt Electron 44 console-message event fields

### DIFF
--- a/apps/desktop/main.mjs
+++ b/apps/desktop/main.mjs
@@ -439,10 +439,8 @@ function createMainWindow() {
 		console.error('Renderer process gone', details);
 	});
 	mainWindow.webContents.on('did-finish-load', notifyWorkspaceLaunch);
-	mainWindow.webContents.on('console-message', (_event, level, message, line, sourceId) => {
-		const levels = ['debug', 'info', 'warn', 'error'];
-		const label = levels[level] ?? 'log';
-		console.log(`[renderer:${label}] ${sourceId}:${line} ${message}`);
+	mainWindow.webContents.on('console-message', ({ level, message, lineNumber, sourceId }) => {
+		console.log(`[renderer:${level}] ${sourceId}:${lineNumber} ${message}`);
 	});
 
 	void loadRendererWhenReady(mainWindow, rendererUrl).catch((error) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Electron 44 deprecates the positional `console-message` arguments. The current handler still maps an integer 0–3 onto `debug/info/warn/error`, which will mis-label renderer logs once those args go away.

This PR only adopts the event object:

- Read `level`, `message`, `lineNumber`, and `sourceId` from the event
- Log Electron's string severity (`debug`, `info`, `warning`, `error`) instead of a local integer table

Log labels change `warn` → `warning` to match Electron. Nothing in-repo parses that prefix.

Does not bump Electron (already on ^44 via #231).

## Checks

- Review of `apps/desktop/main.mjs` against the Electron 44 `console-message` contract

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates desktop renderer-console forwarding to use Electron 44’s event-object fields and native string severity labels.

- Replaces deprecated positional `console-message` arguments with event-property destructuring.
- Removes the integer-to-label severity mapping.
- Preserves the existing renderer log format while changing `warn` to Electron’s `warning`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The desktop package targets Electron 44, and the sole console-message handler now consistently consumes that runtime’s event-object fields without leaving a mixed positional-callback path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/desktop/main.mjs | Migrates the renderer console listener to Electron 44’s event-object contract without introducing an actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): Adopt Electron 44 console-..."](https://github.com/spikonado/sprocket/commit/18e32b8d10ce04ba89c9f40211799a2d04076e96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59359978)</sub>

<!-- /greptile_comment -->