### PR TITLE
refactor(web): Use Zod 4 object and number APIs

### DIFF
--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -36,7 +36,7 @@ export function isUnparseablePageFailure(error: Error): boolean {
 
 const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
 const UNCAUGHT_CONVEX_ERROR_PREFIX = 'Uncaught ConvexError: ';
-const scrapeHttpErrorSchema = z.object({ status: z.number().int().min(400).max(599) });
+const scrapeHttpErrorSchema = z.object({ status: z.int().min(400).max(599) });
 
 export function scrapeHttpErrorStatus(error: Error): number | undefined {
 	let message = error.message.split('\n', 1)[0] ?? '';

--- a/apps/web/src/lib/chat/model-catalog.ts
+++ b/apps/web/src/lib/chat/model-catalog.ts
@@ -139,24 +139,22 @@ export function serviceTierLabel(tier: string): string {
 	}
 }
 
-const gatewayModelSchema = z
-	.object({
-		id: z.string().min(1),
-		label: z.string().min(1),
-		provider: z.string().min(1),
-		supportsImages: z.boolean(),
-		contextWindowTokens: z.number().finite(),
-		autoCompactTokenLimit: z.number().finite(),
-		reasoningEfforts: z.array(z.string()).min(1),
-		defaultReasoningEffort: z.string().min(1),
-		serviceTiers: z.array(z.string()).min(1),
-		usagePolicy: z.literal('unlimited').optional()
-	})
-	.passthrough();
+const gatewayModelSchema = z.looseObject({
+	id: z.string().min(1),
+	label: z.string().min(1),
+	provider: z.string().min(1),
+	supportsImages: z.boolean(),
+	contextWindowTokens: z.number(),
+	autoCompactTokenLimit: z.number(),
+	reasoningEfforts: z.array(z.string()).min(1),
+	defaultReasoningEffort: z.string().min(1),
+	serviceTiers: z.array(z.string()).min(1),
+	usagePolicy: z.literal('unlimited').optional()
+});
 
 const gatewayModelsResponseSchema = z.object({
 	sprocket: z.object({
-		protocolVersion: z.number().finite(),
+		protocolVersion: z.number(),
 		catalogVersion: z.string().min(1),
 		defaultModelId: z.string().min(1),
 		defaultReasoningEffort: z.string().min(1),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Zod 4 is already on main (`^4.1.8`). A few call sites still use v3-era helpers that Zod 4 replaced.

This PR is only that cleanup:

- Gateway model objects: `z.object(...).passthrough()` → `z.looseObject(...)` so extra catalog keys such as `usageWeights` still parse
- Drop redundant `.finite()` — Zod 4 `z.number()` already rejects `±Infinity`
- Scrape HTTP statuses: `z.number().int()` → `z.int()`

No new validation rules and no version bump.

## Checks

- `bun run --cwd apps/web test src/lib/chat/model-catalog.test.ts src/convex/webTools.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR modernizes three model-catalog and scrape-error validators to use Zod 4 APIs without changing their validation behavior.
- Replaces the passthrough gateway model object with `z.looseObject`.
- Removes redundant finite-number checks from catalog fields.
- Uses the top-level integer schema for scrape HTTP statuses.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the updated Zod 4 schemas preserve the existing validation contracts.

The changed integer, loose-object, and number schemas are behaviorally equivalent for their current scrape-error and gateway-catalog inputs, with no accepted failure remaining.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Replaces `z.number().int()` with the behaviorally equivalent Zod 4 `z.int()` API while preserving the HTTP status range. |
| apps/web/src/lib/chat/model-catalog.ts | Adopts Zod 4 loose-object and number APIs while retaining unknown-key preservation and finite-number validation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Use Zod 4 object and numb..."](https://github.com/spikonado/sprocket/commit/36b3a5e5accad53d37411a6cd2d72c6aa8f3c5c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59359980)</sub>

<!-- /greptile_comment -->