### PR TITLE
test(convex): Enforce convex-test transaction limits

### DIFF
--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -48,7 +48,8 @@ type GatewayRunTestRequest = {
 
 /** Fresh mock backend with our schema, functions, and registered components. */
 export function initConvexTest(): ConvexTestInstance {
-	const t = convexTest(schema, modules);
+	// Match deployed Convex read/write limits so oversized transactions fail here.
+	const t = convexTest({ schema, modules, transactionLimits: true });
 	// SAFETY: each component test helper types registerComponent against its own
 	// TestConvex variance; the convex-test backend object is the same instance.
 	const backend = t as never;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`convex-test` 0.0.56 (already on main) can enforce production transaction bandwidth. The harness still uses the two-arg `convexTest(schema, modules)` form, which leaves limits off.

This PR only adopts that option:

- Switch `initConvexTest` to `convexTest({ schema, modules, transactionLimits: true })`
- Tests now fail on oversized reads/writes the same way a deployed Convex backend would

No production code changes.

## Checks

- `bun run --cwd apps/web test src/convex`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b2cc64-4eab-4dc8-83df-fff42cfc4c57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables production-like transaction bandwidth limits in the shared Convex test harness.
- Replaces the positional `convexTest` initialization with configuration containing the schema, modules, and enabled transaction limits.
- Applies the stricter transaction behavior to tests using `initConvexTest`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/test.setup.ts | Updates the shared test-backend initialization to enable transaction-limit enforcement; no follow-up-eligible issue was established. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(convex): Enforce convex-test transa..."](https://github.com/spikonado/sprocket/commit/51bfa9288e7df4441f875fbdf28f3234f42742a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59359979)</sub>

<!-- /greptile_comment -->