### PR TITLE
fix(ui): Keep local created threads on screen

### DIFF
--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -82,6 +82,8 @@ describe('thread cache local API', () => {
 					threadStatus: 'active',
 					latestRunStatus: null,
 					latestRunId: null,
+					latestRunStartedAt: null,
+					latestRunClaimExpiresAt: null,
 					hasActiveRun: false
 				}
 			],
@@ -125,6 +127,8 @@ describe('thread cache local API', () => {
 					threadStatus: 'active',
 					latestRunStatus: null,
 					latestRunId: null,
+					latestRunStartedAt: undefined,
+					latestRunClaimExpiresAt: undefined,
 					hasActiveRun: false
 				}
 			],

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -134,8 +134,8 @@ const threadSummarySchema = z.object({
 		.nullable()
 		.optional(),
 	latestRunId: z.string().nullable().optional(),
-	latestRunStartedAt: z.number().optional(),
-	latestRunClaimExpiresAt: z.number().optional(),
+	latestRunStartedAt: z.number().nullable().optional(),
+	latestRunClaimExpiresAt: z.number().nullable().optional(),
 	hasActiveRun: z.boolean()
 });
 const threadCacheWatchEventSchema = z.object({
@@ -246,8 +246,8 @@ function parseThreadSummary(thread: z.infer<typeof threadSummarySchema>): Thread
 		threadStatus: thread.threadStatus,
 		latestRunStatus: thread.latestRunStatus ?? null,
 		latestRunId: thread.latestRunId ? asConvexId(thread.latestRunId) : null,
-		latestRunStartedAt: thread.latestRunStartedAt,
-		latestRunClaimExpiresAt: thread.latestRunClaimExpiresAt,
+		latestRunStartedAt: thread.latestRunStartedAt ?? undefined,
+		latestRunClaimExpiresAt: thread.latestRunClaimExpiresAt ?? undefined,
 		hasActiveRun: thread.hasActiveRun
 	};
 }

--- a/apps/web/src/lib/project/threads.test.ts
+++ b/apps/web/src/lib/project/threads.test.ts
@@ -8,12 +8,17 @@ import {
 	isActiveThread,
 	isAgentLaunchPending,
 	isLatestRunReadyForThread,
+	makeUnconfirmedCreatedThread,
+	mergeUnconfirmedCreatedThread,
+	mergeUnconfirmedCreatedThreads,
 	pickThreadToRestore,
 	resolveExpiredAgentLaunch,
 	resolvePendingAgentLaunch,
 	resolvePendingAgentLaunchesFromThreads,
 	resolvePendingCreatedThreadId,
 	resolveProjectThreadSelection,
+	retainUnconfirmedCreatedThreads,
+	shouldDropUnconfirmedCreatedThread,
 	toThreadSummary,
 	type PendingAgentLaunch,
 	type PendingAgentLaunches
@@ -393,6 +398,49 @@ describe('project thread helpers', () => {
 				threads: [created, existing]
 			})
 		).toBeNull();
+	});
+
+	it('prepends an unconfirmed thread and overlays placeholder titles until confirmed', () => {
+		const unconfirmed = makeUnconfirmedCreatedThread({
+			threadId: threadId('thread-record-new'),
+			repositoryKey: 'ws-1',
+			selectedModel: defaultModelId,
+			reasoningEffort: defaultReasoningEffort,
+			serviceTier: defaultServiceTier,
+			title: '  Hello from the first prompt  ',
+			lastMessageAt: 50
+		});
+		const existing = makeThreadSummary({
+			threadId: threadId('thread-record-old')
+		});
+		const placeholder = makeThreadSummary({
+			threadId: unconfirmed.threadId,
+			title: 'New thread'
+		});
+		const confirmed = makeThreadSummary({
+			threadId: unconfirmed.threadId,
+			title: 'Hello from the first prompt'
+		});
+
+		expect(unconfirmed.title).toBe('Hello from the first prompt');
+		expect(mergeUnconfirmedCreatedThread([existing], null)).toEqual([existing]);
+		expect(mergeUnconfirmedCreatedThread([existing], unconfirmed)).toEqual([unconfirmed, existing]);
+		expect(mergeUnconfirmedCreatedThread([placeholder, existing], unconfirmed)).toEqual([
+			{ ...placeholder, title: unconfirmed.title },
+			existing
+		]);
+		expect(mergeUnconfirmedCreatedThread([confirmed, existing], unconfirmed)).toEqual([
+			confirmed,
+			existing
+		]);
+		expect(shouldDropUnconfirmedCreatedThread([existing], unconfirmed)).toBe(false);
+		expect(shouldDropUnconfirmedCreatedThread([placeholder], unconfirmed)).toBe(false);
+		expect(shouldDropUnconfirmedCreatedThread([confirmed], unconfirmed)).toBe(true);
+		expect(mergeUnconfirmedCreatedThreads([existing], [unconfirmed, existing])).toEqual([
+			unconfirmed,
+			existing
+		]);
+		expect(retainUnconfirmedCreatedThreads([confirmed, existing], [unconfirmed])).toEqual([]);
 	});
 
 	it('tracks pending launches independently by thread and clears only progressed ones', () => {

--- a/apps/web/src/lib/project/threads.ts
+++ b/apps/web/src/lib/project/threads.ts
@@ -140,15 +140,98 @@ export function resolvePendingCreatedThreadId(args: {
 	threads: ThreadSummary[];
 }): Id<'threadRecords'> | null {
 	const { pendingCreatedThreadId, threads } = args;
-	if (!pendingCreatedThreadId) {
-		return null;
-	}
-
-	if (threads.some((thread) => thread.threadId === pendingCreatedThreadId)) {
+	if (!pendingCreatedThreadId || findThreadById(threads, pendingCreatedThreadId)) {
 		return null;
 	}
 
 	return pendingCreatedThreadId;
+}
+
+const PLACEHOLDER_THREAD_TITLE = 'New thread';
+const MAX_THREAD_TITLE_LENGTH = 72;
+
+export function threadTitleFromPrompt(prompt: string) {
+	return prompt.trim().slice(0, MAX_THREAD_TITLE_LENGTH) || PLACEHOLDER_THREAD_TITLE;
+}
+
+export function isPlaceholderThreadTitle(title: string) {
+	const trimmed = title.trim();
+	return trimmed === '' || trimmed === PLACEHOLDER_THREAD_TITLE;
+}
+
+export function makeUnconfirmedCreatedThread(args: {
+	threadId: ThreadSummary['threadId'];
+	repositoryKey: string;
+	selectedModel: ThreadSummary['selectedModel'];
+	reasoningEffort: ThreadSummary['reasoningEffort'];
+	serviceTier: ThreadSummary['serviceTier'];
+	title?: string;
+	lastMessageAt?: number;
+}): ThreadSummary {
+	return toThreadSummary({
+		threadId: args.threadId,
+		repositoryKey: args.repositoryKey,
+		title: threadTitleFromPrompt(args.title ?? ''),
+		selectedModel: args.selectedModel,
+		reasoningEffort: args.reasoningEffort,
+		serviceTier: args.serviceTier,
+		lastMessageAt: args.lastMessageAt ?? Date.now(),
+		threadStatus: 'active',
+		latestRunStatus: null,
+		latestRunId: null,
+		hasActiveRun: false
+	});
+}
+
+function needsUnconfirmedTitleOverlay(existing: ThreadSummary, unconfirmed: ThreadSummary) {
+	return isPlaceholderThreadTitle(existing.title) && !isPlaceholderThreadTitle(unconfirmed.title);
+}
+
+export function mergeUnconfirmedCreatedThread(
+	threads: ThreadSummary[],
+	unconfirmed: ThreadSummary | null
+): ThreadSummary[] {
+	if (!unconfirmed) {
+		return threads;
+	}
+	const existing = findThreadById(threads, unconfirmed.threadId);
+	if (!existing) {
+		return [unconfirmed, ...threads];
+	}
+	if (needsUnconfirmedTitleOverlay(existing, unconfirmed)) {
+		return threads.map((thread) =>
+			thread.threadId === existing.threadId ? { ...thread, title: unconfirmed.title } : thread
+		);
+	}
+	return threads;
+}
+
+export function shouldDropUnconfirmedCreatedThread(
+	threads: ThreadSummary[],
+	unconfirmed: ThreadSummary | null
+) {
+	if (!unconfirmed) {
+		return false;
+	}
+	const existing = findThreadById(threads, unconfirmed.threadId);
+	if (!existing) {
+		return false;
+	}
+	return !needsUnconfirmedTitleOverlay(existing, unconfirmed);
+}
+
+export function retainUnconfirmedCreatedThreads(
+	threads: ThreadSummary[],
+	unconfirmed: ThreadSummary[]
+) {
+	return unconfirmed.filter((row) => !shouldDropUnconfirmedCreatedThread(threads, row));
+}
+
+export function mergeUnconfirmedCreatedThreads(
+	threads: ThreadSummary[],
+	unconfirmed: ThreadSummary[]
+) {
+	return unconfirmed.reduce((list, row) => mergeUnconfirmedCreatedThread(list, row), threads);
 }
 
 export function isLatestRunReadyForThread(args: {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -77,7 +77,11 @@
 		isActiveThread,
 		isAgentLaunchPending,
 		isLatestRunReadyForThread,
+		makeUnconfirmedCreatedThread,
+		mergeUnconfirmedCreatedThreads,
 		pickThreadToRestore,
+		retainUnconfirmedCreatedThreads,
+		threadTitleFromPrompt,
 		resolveExpiredAgentLaunch,
 		resolvePendingAgentLaunch,
 		resolvePendingAgentLaunchesFromThreads,
@@ -110,6 +114,7 @@
 	const convexAuth = useAuth();
 	let sawAuthLoadingDuringRetry = $state(false);
 	const isSignedIn = $derived(Boolean($authState.user));
+	const signedInUserId = $derived($authState.user?.id ?? null);
 	const retryPending = $derived($convexAuthRetryPending);
 	const authReady = $derived(
 		$authState.isReady &&
@@ -229,6 +234,7 @@
 	let lastSyncedComposerThreadId: Id<'threadRecords'> | null = null;
 	let projectSelectionGeneration = $state(0);
 	let pendingCreatedThreadId = $state<Id<'threadRecords'> | null>(null);
+	let unconfirmedCreatedThreads = $state<ThreadSummary[]>([]);
 	let desktopProjectAttachmentsByPath = $state<Record<string, ProjectAttachment>>({});
 	let hasLoadedDesktopProjectAttachments = $state(false);
 	let desktopProjectAttachmentsGeneration = 0;
@@ -236,6 +242,7 @@
 	let threadCacheStatus = $state<ThreadCacheStatus>('loading');
 	let threadSnapshotThreads = $state<ThreadSummary[]>([]);
 	let threadCacheGeneration = 0;
+	let threadSnapshotPullGeneration = 0;
 	let archivedSyncGeneration = 0;
 	let selectionUserId = $state<string | null>(null);
 	let projectPickerOpen = $state(false);
@@ -252,7 +259,7 @@
 	const REMOTE_CHANGE_NOTICE =
 		'This directory’s git remote changed. Existing threads now follow the new repository.';
 	function getCurrentUserId() {
-		return $authState.user?.id ?? null;
+		return signedInUserId;
 	}
 
 	function updateComposerAttachment(localId: string, patch: Partial<ComposerAttachment>) {
@@ -482,7 +489,12 @@
 			.sort((left, right) => right.lastUsedAt - left.lastUsedAt)
 			.map(projectFromAttachment)
 	);
-	const threads = $derived(threadSnapshotThreads.map(toThreadSummary));
+	const threads = $derived(
+		mergeUnconfirmedCreatedThreads(
+			threadSnapshotThreads.map(toThreadSummary),
+			unconfirmedCreatedThreads
+		)
+	);
 	const currentActiveThread = $derived(dataForThread(activeThreadQuery.data, currentThreadId));
 	const contextUsage = $derived.by(() => {
 		const model = modelCatalog
@@ -539,7 +551,7 @@
 		if (!threadId || !api || !isSignedIn) {
 			return;
 		}
-		const userId = untrack(() => $authState.user?.id ?? null);
+		const userId = untrack(() => getCurrentUserId());
 		if (!userId) {
 			return;
 		}
@@ -605,7 +617,7 @@
 		if (!threadId || !api || !isSignedIn) {
 			return;
 		}
-		const userId = untrack(() => $authState.user?.id ?? null);
+		const userId = untrack(() => getCurrentUserId());
 		if (!userId) {
 			return;
 		}
@@ -971,18 +983,23 @@
 		if (!api) {
 			return;
 		}
+		const generation = ++threadSnapshotPullGeneration;
 		const snapshot = await api.fetchThreadSnapshot({ userId });
-		if (getCurrentUserId() !== userId) {
+		if (generation !== threadSnapshotPullGeneration || getCurrentUserId() !== userId) {
 			return;
 		}
 		threadSnapshotThreads = snapshot.threads;
+		unconfirmedCreatedThreads = retainUnconfirmedCreatedThreads(
+			snapshot.threads,
+			unconfirmedCreatedThreads
+		);
 		applyThreadCacheEvent(snapshot);
 	}
 
 	async function registerThreadCacheForCurrentUser() {
 		const api = desktopApi;
 		const userId = getCurrentUserId();
-		if (!api || !userId || !authReady) {
+		if (!api || !userId) {
 			return;
 		}
 		const authToken = await getAccessToken();
@@ -999,15 +1016,19 @@
 
 	$effect(() => {
 		const api = desktopApi;
-		const userId = getCurrentUserId();
-		if (!api || !userId || !authReady) {
+		const userId = signedInUserId;
+		if (!api || !userId) {
 			return;
 		}
 		const generation = ++threadCacheGeneration;
 		const ac = new AbortController();
 		void (async () => {
 			try {
-				await registerThreadCacheForCurrentUser();
+				try {
+					await registerThreadCacheForCurrentUser();
+				} catch {
+					await pullThreadSnapshot(userId);
+				}
 				if (generation !== threadCacheGeneration || ac.signal.aborted) {
 					return;
 				}
@@ -1038,6 +1059,15 @@
 		return () => {
 			ac.abort();
 		};
+	});
+
+	$effect(() => {
+		const api = desktopApi;
+		const userId = signedInUserId;
+		if (!api || !userId || !authReady) {
+			return;
+		}
+		void registerThreadCacheForCurrentUser().catch(() => {});
 	});
 
 	$effect(() => {
@@ -1269,53 +1299,9 @@
 		openProjectPicker('reconnect', workspacePath);
 	}
 
-	function schedulePendingCreatedThreadExpiration(args: {
-		prompt: string;
-		attachments: ComposerAttachment[];
-		imageUploadIds: Id<'imageUploads'>[];
-		reasoningEffort: string;
-		serviceTier: string;
-		selectedModel: CatalogModelId;
-		submissionId: string;
-		threadId: Id<'threadRecords'>;
-		userId: string;
-		repositoryKey: string;
-		workspacePath: string;
-	}) {
-		window.setTimeout(() => {
-			if (
-				getCurrentUserId() !== args.userId ||
-				pendingCreatedThreadId !== args.threadId ||
-				currentThreadId !== args.threadId ||
-				currentWorkspacePath !== args.workspacePath ||
-				threads.some((thread) => thread.threadId === args.threadId)
-			) {
-				return;
-			}
-
-			pendingCreatedThreadId = null;
-			setProjectSelection(args.workspacePath, null, true);
-			const recoveryScope = getComposerScope(null, args.workspacePath);
-			if (recoveryScope) {
-				storeComposerRecovery(args.userId, recoveryScope, {
-					message: 'The new thread did not appear. Review your prompt and try sending it again.',
-					prompt: args.prompt,
-					attachments: args.attachments,
-					imageUploadIds: args.imageUploadIds,
-					reasoningEffort: args.reasoningEffort,
-					serviceTier: args.serviceTier,
-					selectedModel: args.selectedModel,
-					submissionId: args.submissionId
-				});
-			}
-		}, agentLaunchTimeoutMs);
-	}
-
 	async function createThread(args: {
 		isSubmissionCurrent: () => boolean;
 		prompt: string;
-		attachments: ComposerAttachment[];
-		imageUploadIds: Id<'imageUploads'>[];
 		selectionGeneration: number;
 		selectedModel: CatalogModelId;
 		selectedReasoningEffort: string;
@@ -1323,7 +1309,6 @@
 		submissionId: string;
 		userId: string;
 		repositoryKey: string;
-		workspacePath: string;
 	}) {
 		const result = await createThreadMutation({
 			submissionId: args.submissionId,
@@ -1338,27 +1323,25 @@
 			return null;
 		}
 
-		if (
-			args.userId === getCurrentUserId() &&
-			args.selectionGeneration === projectSelectionGeneration
-		) {
-			pendingCreatedThreadId = result.threadId;
-			projectSelectionGeneration += 1;
-			currentThreadId = result.threadId;
-			draftWorkspacePath = null;
-			schedulePendingCreatedThreadExpiration({
-				prompt: args.prompt,
-				attachments: args.attachments,
-				imageUploadIds: args.imageUploadIds,
-				reasoningEffort: args.selectedReasoningEffort,
-				serviceTier: args.selectedServiceTier,
-				selectedModel: args.selectedModel,
-				submissionId: args.submissionId,
-				threadId: result.threadId,
-				userId: args.userId,
-				repositoryKey: args.repositoryKey,
-				workspacePath: args.workspacePath
-			});
+		if (args.userId === getCurrentUserId()) {
+			unconfirmedCreatedThreads = [
+				...unconfirmedCreatedThreads.filter((thread) => thread.threadId !== result.threadId),
+				makeUnconfirmedCreatedThread({
+					threadId: result.threadId,
+					repositoryKey: args.repositoryKey,
+					selectedModel: args.selectedModel,
+					reasoningEffort: args.selectedReasoningEffort,
+					serviceTier: args.selectedServiceTier,
+					title: threadTitleFromPrompt(args.prompt)
+				})
+			];
+			void pullThreadSnapshot(args.userId);
+			if (args.selectionGeneration === projectSelectionGeneration) {
+				pendingCreatedThreadId = result.threadId;
+				projectSelectionGeneration += 1;
+				currentThreadId = result.threadId;
+				draftWorkspacePath = null;
+			}
 		}
 
 		return result;
@@ -1377,6 +1360,9 @@
 			const { api, userId, authToken } = await localThreadCommandContext();
 			const cacheSynchronized = await api.renameThread({ userId, authToken, threadId, title });
 			if (!cacheSynchronized) threadCacheStatus = 'reconnecting';
+			unconfirmedCreatedThreads = unconfirmedCreatedThreads.map((thread) =>
+				thread.threadId === threadId ? { ...thread, title } : thread
+			);
 			await pullThreadSnapshot(userId);
 		} catch (error) {
 			currentError = error instanceof Error ? error.message : 'Failed to rename thread.';
@@ -1467,6 +1453,9 @@
 				if (currentThreadId === threadId) {
 					currentThreadId = null;
 					pendingCreatedThreadId = null;
+					unconfirmedCreatedThreads = unconfirmedCreatedThreads.filter(
+						(thread) => thread.threadId !== threadId
+					);
 					projectSelectionGeneration += 1;
 				}
 				currentError = null;
@@ -1714,16 +1703,13 @@
 				: await createThread({
 						isSubmissionCurrent,
 						prompt: submittedPrompt,
-						attachments: submittedAttachments,
-						imageUploadIds: submittedImageUploadIds,
 						selectionGeneration,
 						selectedModel: submittedModel,
 						selectedReasoningEffort: submittedReasoningEffort,
 						selectedServiceTier: submittedServiceTier,
 						submissionId: threadSubmissionId,
 						userId: submittedUserId,
-						repositoryKey: submittedRepositoryKey,
-						workspacePath
+						repositoryKey: submittedRepositoryKey
 					});
 			const threadId = selectedThreadId ?? threadCreation?.threadId ?? null;
 			if (!threadId || !isSubmissionCurrent()) {
@@ -1759,9 +1745,8 @@
 					remoteChangeNotices.set(threadId, REMOTE_CHANGE_NOTICE);
 				}
 			}
-			// The browser is no longer involved after Convex binds the run-scoped
-			// executor capability. Start with a fresh token so closing the tab during
-			// the detached launch cannot strand it on an expiring browser token.
+			// Refresh so a detached launch is not left on a token about to expire.
+			// The thread-cache watch keys off user id, so this does not tear it down.
 			const authToken = await getAccessToken({ forceRefreshToken: true });
 			if (!authToken) {
 				recoverSubmission('Your session ended before the agent started. Sign in again.');
@@ -1977,6 +1962,7 @@
 		currentThreadId = null;
 		draftWorkspacePath = null;
 		pendingCreatedThreadId = null;
+		unconfirmedCreatedThreads = [];
 		pendingAgentLaunches = {};
 		restoredWorkspacePathToAttach = null;
 		ensureSubscriptionAttemptedFor = null;
@@ -1984,7 +1970,7 @@
 		threadSnapshotReady = false;
 		threadCacheStatus = 'loading';
 		threadSnapshotThreads = [];
-		threadCacheGeneration += 1;
+		threadSnapshotPullGeneration += 1;
 		projectSelectionGeneration += 1;
 		prompt = '';
 		clearComposerAttachments({ discard: true });
@@ -2102,7 +2088,7 @@
 
 		const nextPendingCreatedThreadId = resolvePendingCreatedThreadId({
 			pendingCreatedThreadId,
-			threads
+			threads: threadSnapshotThreads
 		});
 		if (nextPendingCreatedThreadId !== pendingCreatedThreadId) {
 			pendingCreatedThreadId = nextPendingCreatedThreadId;

--- a/crates/sprocket-server/src/machine_sessions.rs
+++ b/crates/sprocket-server/src/machine_sessions.rs
@@ -93,6 +93,7 @@ impl MachineSessionManager {
                 sleep(HEARTBEAT_INTERVAL).await;
                 if manager.heartbeat(&heartbeat_user_id).await.is_err() {
                     tracing::warn!("machine session heartbeat failed");
+                    break;
                 }
             }
         });
@@ -188,7 +189,7 @@ impl MachineSessionManager {
             };
             (session.auth_token.clone(), session.session_id.clone())
         };
-        timeout(SESSION_RPC_TIMEOUT, async {
+        let error = match timeout(SESSION_RPC_TIMEOUT, async {
             let client = UserConvexClient::connect(&self.deployment_url, auth_token).await?;
             let _: serde_json::Value = client
                 .mutate("machineSessions:heartbeat", self.session_args(session_id))
@@ -196,8 +197,15 @@ impl MachineSessionManager {
             anyhow::Ok(())
         })
         .await
-        .map_err(|_| anyhow::anyhow!("machine session heartbeat timed out"))??;
-        Ok(())
+        {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(error)) => error,
+            Err(_) => anyhow::anyhow!("machine session heartbeat timed out"),
+        };
+        if let Some(session) = self.sessions.lock().await.remove(user_id) {
+            session.heartbeat.abort();
+        }
+        Err(error)
     }
 
     async fn end_remote(&self, session: &AccountSession) -> anyhow::Result<()> {
@@ -315,6 +323,34 @@ mod tests {
             );
             session.heartbeat.abort();
         }
+
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[tokio::test]
+    async fn failed_heartbeat_drops_the_cached_session() {
+        let (dir, manager) = manager_for_test();
+        {
+            let mut sessions = manager.sessions.lock().await;
+            sessions.insert(
+                "user-a".into(),
+                AccountSession {
+                    auth_token: "old-token".into(),
+                    session_id: "session-1".into(),
+                    heartbeat: tokio::spawn(std::future::pending()),
+                },
+            );
+        }
+
+        manager
+            .heartbeat("user-a")
+            .await
+            .expect_err("invalid deployment must fail heartbeat");
+        assert!(manager.sessions.lock().await.get("user-a").is_none());
+        manager
+            .register("user-a", "new-token".into())
+            .await
+            .expect_err("cleared session must register with Convex");
 
         let _ = tokio::fs::remove_dir_all(dir).await;
     }

--- a/crates/sprocket-server/src/machine_sessions.rs
+++ b/crates/sprocket-server/src/machine_sessions.rs
@@ -13,6 +13,12 @@ use crate::transcript_client::UserConvexClient;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const SESSION_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
+fn process_identity_is_inactive(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("Machine session is not active")
+        || message.contains("Process session is no longer active")
+}
+
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RegisteredSession {
@@ -62,25 +68,23 @@ impl MachineSessionManager {
         if let Some(session_id) = self.reuse_live_session(user_id, &auth_token).await {
             return Ok(session_id);
         }
-        let process_session_id = self
-            .process_session_ids
-            .lock()
+        let registered = match self
+            .register_remote(
+                auth_token.clone(),
+                self.process_session_id_for(user_id).await,
+            )
             .await
-            .entry(user_id.to_string())
-            .or_insert_with(|| self.identity.process_session_id.clone())
-            .clone();
-        let registered: RegisteredSession = timeout(SESSION_RPC_TIMEOUT, async {
-            let client =
-                UserConvexClient::connect(&self.deployment_url, auth_token.clone()).await?;
-            client
-                .mutate(
-                    "machineSessions:register",
-                    self.registration_args(process_session_id),
+        {
+            Ok(registered) => registered,
+            Err(error) if process_identity_is_inactive(&error) => {
+                self.register_remote(
+                    auth_token.clone(),
+                    self.rotate_process_session_id(user_id).await,
                 )
-                .await
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!("machine session registration timed out"))??;
+                .await?
+            }
+            Err(error) => return Err(error),
+        };
         if registered.user_id != user_id {
             anyhow::bail!("machine session account does not match the requested account");
         }
@@ -118,10 +122,7 @@ impl MachineSessionManager {
             return Ok(());
         };
         session.heartbeat.abort();
-        self.process_session_ids
-            .lock()
-            .await
-            .insert(user_id.to_string(), uuid::Uuid::new_v4().to_string());
+        self.rotate_process_session_id(user_id).await;
         self.end_remote(&session).await
     }
 
@@ -205,7 +206,46 @@ impl MachineSessionManager {
         if let Some(session) = self.sessions.lock().await.remove(user_id) {
             session.heartbeat.abort();
         }
+        if process_identity_is_inactive(&error) {
+            self.rotate_process_session_id(user_id).await;
+        }
         Err(error)
+    }
+
+    async fn process_session_id_for(&self, user_id: &str) -> String {
+        self.process_session_ids
+            .lock()
+            .await
+            .entry(user_id.to_string())
+            .or_insert_with(|| self.identity.process_session_id.clone())
+            .clone()
+    }
+
+    async fn rotate_process_session_id(&self, user_id: &str) -> String {
+        let next = uuid::Uuid::new_v4().to_string();
+        self.process_session_ids
+            .lock()
+            .await
+            .insert(user_id.to_string(), next.clone());
+        next
+    }
+
+    async fn register_remote(
+        &self,
+        auth_token: String,
+        process_session_id: String,
+    ) -> anyhow::Result<RegisteredSession> {
+        timeout(SESSION_RPC_TIMEOUT, async {
+            let client = UserConvexClient::connect(&self.deployment_url, auth_token).await?;
+            client
+                .mutate(
+                    "machineSessions:register",
+                    self.registration_args(process_session_id),
+                )
+                .await
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("machine session registration timed out"))?
     }
 
     async fn end_remote(&self, session: &AccountSession) -> anyhow::Result<()> {
@@ -341,17 +381,40 @@ mod tests {
                 },
             );
         }
+        manager
+            .process_session_ids
+            .lock()
+            .await
+            .insert("user-a".into(), "process-a".into());
 
         manager
             .heartbeat("user-a")
             .await
             .expect_err("invalid deployment must fail heartbeat");
         assert!(manager.sessions.lock().await.get("user-a").is_none());
+        assert_eq!(
+            manager.process_session_id_for("user-a").await,
+            "process-a",
+            "transient heartbeat failures must keep the process identity"
+        );
         manager
             .register("user-a", "new-token".into())
             .await
             .expect_err("cleared session must register with Convex");
 
         let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[test]
+    fn convex_inactive_session_errors_are_recognized() {
+        assert!(process_identity_is_inactive(&anyhow::anyhow!(
+            "Machine session is not active."
+        )));
+        assert!(process_identity_is_inactive(&anyhow::anyhow!(
+            "Process session is no longer active."
+        )));
+        assert!(!process_identity_is_inactive(&anyhow::anyhow!(
+            "machine session heartbeat timed out"
+        )));
     }
 }

--- a/crates/sprocket-server/src/machine_sessions.rs
+++ b/crates/sprocket-server/src/machine_sessions.rs
@@ -13,12 +13,6 @@ use crate::transcript_client::UserConvexClient;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const SESSION_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
-fn process_identity_is_inactive(error: &anyhow::Error) -> bool {
-    let message = error.to_string();
-    message.contains("Machine session is not active")
-        || message.contains("Process session is no longer active")
-}
-
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RegisteredSession {
@@ -68,23 +62,12 @@ impl MachineSessionManager {
         if let Some(session_id) = self.reuse_live_session(user_id, &auth_token).await {
             return Ok(session_id);
         }
-        let registered = match self
+        let registered = self
             .register_remote(
                 auth_token.clone(),
                 self.process_session_id_for(user_id).await,
             )
-            .await
-        {
-            Ok(registered) => registered,
-            Err(error) if process_identity_is_inactive(&error) => {
-                self.register_remote(
-                    auth_token.clone(),
-                    self.rotate_process_session_id(user_id).await,
-                )
-                .await?
-            }
-            Err(error) => return Err(error),
-        };
+            .await?;
         if registered.user_id != user_id {
             anyhow::bail!("machine session account does not match the requested account");
         }
@@ -205,9 +188,6 @@ impl MachineSessionManager {
         };
         if let Some(session) = self.sessions.lock().await.remove(user_id) {
             session.heartbeat.abort();
-        }
-        if process_identity_is_inactive(&error) {
-            self.rotate_process_session_id(user_id).await;
         }
         Err(error)
     }
@@ -403,18 +383,5 @@ mod tests {
             .expect_err("cleared session must register with Convex");
 
         let _ = tokio::fs::remove_dir_all(dir).await;
-    }
-
-    #[test]
-    fn convex_inactive_session_errors_are_recognized() {
-        assert!(process_identity_is_inactive(&anyhow::anyhow!(
-            "Machine session is not active."
-        )));
-        assert!(process_identity_is_inactive(&anyhow::anyhow!(
-            "Process session is no longer active."
-        )));
-        assert!(!process_identity_is_inactive(&anyhow::anyhow!(
-            "machine session heartbeat timed out"
-        )));
     }
 }

--- a/crates/sprocket-server/src/machine_sessions.rs
+++ b/crates/sprocket-server/src/machine_sessions.rs
@@ -59,6 +59,9 @@ impl MachineSessionManager {
         let account = self.account_lock(user_id, false).await?;
         let _account = account.lock().await;
         self.ensure_running().await?;
+        if let Some(session_id) = self.reuse_live_session(user_id, &auth_token).await {
+            return Ok(session_id);
+        }
         let process_session_id = self
             .process_session_ids
             .lock()
@@ -168,6 +171,13 @@ impl MachineSessionManager {
         Ok(())
     }
 
+    async fn reuse_live_session(&self, user_id: &str, auth_token: &str) -> Option<String> {
+        let mut sessions = self.sessions.lock().await;
+        let session = sessions.get_mut(user_id)?;
+        session.auth_token = auth_token.to_string();
+        Some(session.session_id.clone())
+    }
+
     async fn heartbeat(&self, user_id: &str) -> anyhow::Result<()> {
         let account = self.account_lock(user_id, true).await?;
         let _account = account.lock().await;
@@ -251,14 +261,19 @@ impl MachineSessionManager {
 mod tests {
     use super::*;
 
+    fn manager_for_test() -> (std::path::PathBuf, Arc<MachineSessionManager>) {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-machine-session-{}", uuid::Uuid::new_v4()));
+        let identity = Arc::new(MachineIdentity::load(&dir).expect("identity"));
+        (
+            dir,
+            MachineSessionManager::new("not a valid URL".into(), identity),
+        )
+    }
+
     #[tokio::test]
     async fn shutdown_rejects_late_registration_before_network_io() {
-        let dir = std::env::temp_dir().join(format!(
-            "sprocket-machine-session-manager-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let identity = Arc::new(MachineIdentity::load(&dir).expect("identity"));
-        let manager = MachineSessionManager::new("not a valid URL".into(), identity);
+        let (dir, manager) = manager_for_test();
 
         manager.shutdown().await;
         let error = manager
@@ -266,6 +281,40 @@ mod tests {
             .await
             .expect_err("registration after shutdown must fail");
         assert!(error.to_string().contains("shutting down"));
+
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[tokio::test]
+    async fn live_session_is_reused_without_another_convex_call() {
+        let (dir, manager) = manager_for_test();
+        {
+            let mut sessions = manager.sessions.lock().await;
+            sessions.insert(
+                "user-a".into(),
+                AccountSession {
+                    auth_token: "old-token".into(),
+                    session_id: "session-1".into(),
+                    heartbeat: tokio::spawn(std::future::pending()),
+                },
+            );
+        }
+
+        let session_id = manager
+            .register("user-a", "new-token".into())
+            .await
+            .expect("reuse live session");
+        assert_eq!(session_id, "session-1");
+        {
+            let sessions = manager.sessions.lock().await;
+            let session = sessions.get("user-a").expect("session");
+            assert_eq!(session.auth_token, "new-token");
+            assert!(
+                !session.heartbeat.is_finished(),
+                "reuse must keep the existing heartbeat"
+            );
+            session.heartbeat.abort();
+        }
 
         let _ = tokio::fs::remove_dir_all(dir).await;
     }


### PR DESCRIPTION
## Summary
- Reuse a live in-memory machine session instead of calling Convex `machineSessions.register` on every thread-cache/register and agent-run path.
- Accept JSON `null` for idle-run timestamps in the local snapshot parser so rust cache rows are not thrown away.
- Keep newly created threads in the sidebar (prompt title overlay) until the local snapshot confirms them, and stop the 30s timeout that yanked a live thread back to a draft.

## Test plan
- [ ] `sprocket --web` from this checkout, hard-refresh
- [ ] Send a prompt on a new thread: sidebar name comes from the prompt, row stays after switching away
- [ ] Confirm `machineSessions` does not update in a tight loop while sending
- [ ] Existing threads still list from `~/.sprocket/thread-cache`







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reuses in-memory machine sessions, accepts nullable idle-run timestamps in local snapshots, and retains newly created threads in the sidebar until the local cache confirms them.
- Adds optimistic thread-summary overlays and removes the fixed creation-expiration timeout.
- Makes snapshot pulls generation-aware and retries cache registration as authentication becomes ready.
- Evicts cached machine sessions after heartbeat failures while preserving superseded process identities.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because a superseded machine session can still be reused before heartbeat cleanup, causing agent-run creation to fail.

Amronos stated that failed heartbeats now prevent stale session reuse, but the cached session is returned without remote validation until the periodic heartbeat observes supersession, leaving the previously reported run-creation failure reachable during that interval.

**Files Needing Attention:** crates/sprocket-server/src/machine_sessions.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/machine_sessions.rs | Reuses cached sessions and evicts them after heartbeat failure, but a superseded cached session remains reusable until heartbeat detection. |
| apps/web/src/routes/+page.svelte | Adds optimistic created-thread retention, generation-aware snapshot pulls, and revised cache-registration effects. |
| apps/web/src/lib/project/threads.ts | Adds helpers for prompt-derived titles and merging or retiring unconfirmed thread summaries. |
| apps/web/src/lib/local/client.ts | Accepts JSON null for optional run timestamps and normalizes it to undefined. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Web
  participant Server
  participant Convex
  Web->>Server: Register or launch agent
  alt Cached machine session exists
    Server-->>Web: Reuse cached session ID
  else No cached session
    Server->>Convex: Register process session
    Convex-->>Server: Machine session ID
  end
  loop Periodic heartbeat
    Server->>Convex: Heartbeat cached session
    alt Heartbeat rejected
      Server->>Server: Evict cached session and stop loop
    end
  end
  Web->>Server: Fetch local thread snapshot
  Server-->>Web: Cached thread summaries
  Web->>Web: Merge unconfirmed created threads
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(local): Keep superseded process iden..."](https://github.com/spikonado/sprocket/commit/06d591e7df38bf98a33f9041d6302e3f3da5fbe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59398207)</sub>

**Context used:**

- Knowledge Base — [Machine session coordination](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/machine-session-coordination.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)

<!-- /greptile_comment -->