### PR TITLE
fix(migrations): Page response message clearing past the Convex read limit

### DIFF
--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { internal } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('clearResponseMessageParts', () => {
+	it('clears leftover response payloads and leaves prompts alone', async () => {
+		const t = initConvexTest();
+		const { subject, threadId } = await seedOwnedThread(t);
+		const ids = await t.run(async (ctx) => {
+			const runId = await ctx.db.insert('runs', {
+				threadId,
+				userId: subject,
+				submissionId: 'clear-response-parts',
+				status: 'completed',
+				executionSecretHash: 'hash',
+				completionAttemptSeq: 0,
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				startedAt: 1,
+				completedAt: 2
+			});
+			const promptId = await ctx.db.insert('threadMessages', {
+				threadId,
+				runId,
+				userId: subject,
+				type: 'prompt',
+				text: 'Keep this',
+				parts: []
+			});
+			const responseA = await ctx.db.insert('threadMessages', {
+				threadId,
+				runId,
+				userId: subject,
+				type: 'response',
+				text: 'Drop this',
+				parts: [{ type: 'text', id: 't1', text: 'Drop this' }]
+			});
+			const responseB = await ctx.db.insert('threadMessages', {
+				threadId,
+				runId,
+				userId: subject,
+				type: 'response',
+				text: 'Drop that',
+				parts: [{ type: 'text', id: 't2', text: 'Drop that' }]
+			});
+			return { promptId, responseA, responseB };
+		});
+
+		await t.mutation(internal.migrations.clearResponseMessageParts, {});
+		await t.finishAllScheduledFunctions(() => {});
+
+		const { prompt, responseA, responseB } = await t.run(async (ctx) => ({
+			prompt: await ctx.db.get('threadMessages', ids.promptId),
+			responseA: await ctx.db.get('threadMessages', ids.responseA),
+			responseB: await ctx.db.get('threadMessages', ids.responseB)
+		}));
+		expect(prompt).toMatchObject({ text: 'Keep this', parts: [] });
+		expect(responseA).toMatchObject({ text: '', parts: [] });
+		expect(responseB).toMatchObject({ text: '', parts: [] });
+	});
+});

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -51,17 +51,12 @@ export const removeTranscriptCommandStreams = migrations.define({
 export const clearResponseMessageParts = migrations.define({
 	table: 'threadMessages',
 	customRange: (query) => query.withIndex('by_type_runId', (range) => range.eq('type', 'response')),
-	migrateOne: async (ctx, message) => {
+	// Leftover `parts` can sit near the 1 MiB document cap; the default page of 100 exceeds the 16 MiB read limit.
+	batchSize: 1,
+	migrateOne: (_ctx, message) => {
 		if (message.text === '' && message.parts.length === 0) {
 			return;
 		}
-		// Reads/writes the whole document on purpose: this migration's success
-		// is part of the gate for deleting the oversized `parts` field, which
-		// requires every stored row to survive a patch transaction.
-		const current = await ctx.db.get('threadMessages', message._id);
-		if (!current) {
-			return;
-		}
-		await ctx.db.patch('threadMessages', message._id, { text: '', parts: [] });
+		return { text: '', parts: [] };
 	}
 });


### PR DESCRIPTION
## Summary
- Leftover `threadMessages` response rows can sit near the 1 MiB document cap, so `clearResponseMessageParts` blew Convex's 16 MiB transaction read limit on a 100-row page plus a second `db.get` of the same document.
- Page one document per batch and return the empty `text`/`parts` patch from `migrateOne` so the runner still rewrites every leftover row without double-reading it.

## Test plan
- [ ] `bun run --cwd apps/web test src/convex/migrations.test.ts`
- [ ] After deploy, confirm `migrations:clearResponseMessageParts` resumes from the failed cursor and reaches `success` (cron `migrations:run`, or `npx convex run migrations:clearResponseMessageParts`)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes the legacy response-message cleanup migration to process one document per batch and return its patch directly, avoiding redundant reads of near-limit documents.
- Adds focused coverage that response payloads are cleared while prompt payloads remain intact.
- Keeps the compatibility migration resumable through the existing migration runner.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking gap in regression coverage for production-sized response documents.

The migration behavior is exercised across multiple one-row batches, but the test data remains too small to fail if the read-limit mitigation is later removed.

**Files Needing Attention:** apps/web/src/convex/migrations.test.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/migrations.ts | Reduces cleanup batches to one document and uses the migration framework's returned-patch behavior to avoid the redundant document read. |
| apps/web/src/convex/migrations.test.ts | Verifies multi-batch clearing and prompt preservation, but its small fixtures do not guard against regression of the motivating read-limit failure. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/convex/migrations.test.ts:37
**Fixtures miss read limit**

The response fixtures contain only one short text part each, so this test still passes when the migration uses the previous 100-row, double-read implementation. Add enough near-limit response data to make the test fail when the transaction read-limit mitigation regresses.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): Page response message c..."](https://github.com/spikonado/sprocket/commit/779604b8d13a0662b6213f0944e21c28c0ab94de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59410055)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
- Knowledge Base — [Roll Back oversized run finalization writes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/reverts/rollback_225-20260830-threadmessages-size-limit-49f2b84.md)

<!-- /greptile_comment -->