### PR TITLE
fix(ui): Persist thread model selection

### DIFF
--- a/apps/web/src/convex/threads.test.ts
+++ b/apps/web/src/convex/threads.test.ts
@@ -3,6 +3,26 @@ import { api } from '@convex/_generated/api';
 import { initConvexTest, seedOwnedThread } from './test.setup';
 
 describe('threads local-cache commands', () => {
+	it('stores the selected model on its thread and advances the cache revision', async () => {
+		const t = initConvexTest();
+		const { asUser, repositoryKey, threadId } = await seedOwnedThread(t);
+
+		await asUser.mutation(api.threads.setSelectedModel, {
+			threadId,
+			selectedModel: 'grok-4.5'
+		});
+
+		expect((await asUser.query(api.threads.getByThreadId, { threadId })).selectedModel).toBe(
+			'grok-4.5'
+		);
+		expect(
+			await asUser.query(api.threads.getSnapshotRevision, {
+				repositoryKey,
+				category: 'active'
+			})
+		).toBe(2);
+	});
+
 	it('returns authenticated cache-refresh metadata', async () => {
 		const t = initConvexTest();
 		const { asUser, subject, repositoryKey, threadId } = await seedOwnedThread(t);

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -184,6 +184,25 @@ export const create = mutation({
 	}
 });
 
+export const setSelectedModel = mutation({
+	args: {
+		threadId: v.id('threadRecords'),
+		selectedModel: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const userId = await getUserId(ctx);
+		const thread = await getOwnedThreadRecord(ctx.db, userId, args.threadId);
+		if (thread.selectedModel === args.selectedModel) {
+			return null;
+		}
+
+		await ctx.db.patch('threadRecords', thread._id, { selectedModel: args.selectedModel });
+		await bumpThreadSnapshotForRecord(ctx, thread);
+		return null;
+	}
+});
+
 /** Retired UI listing. Current clients read the local summary cache. */
 export const listMine = query({
 	args: {},

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -44,6 +44,7 @@
 		onRemoveAttachment: (localId: string) => void;
 		modelCatalog?: ModelCatalog;
 		selectedModel?: CatalogModelId;
+		onModelChange?: (modelId: CatalogModelId) => void;
 		selectedReasoningEffort?: string;
 		selectedServiceTier?: string;
 		pendingQuestion?: PendingAgentQuestion | null;
@@ -77,6 +78,7 @@
 		onRemoveAttachment,
 		modelCatalog,
 		selectedModel = $bindable(defaultModelId),
+		onModelChange,
 		selectedReasoningEffort = $bindable<string>(defaultReasoningEffort),
 		selectedServiceTier = $bindable<string>(defaultServiceTier),
 		pendingQuestion = null,
@@ -428,6 +430,7 @@
 		if (!modelCatalog) return;
 		const model = getCatalogModel(modelCatalog, modelId);
 		if (model) selectedReasoningEffort = model.defaultReasoningEffort;
+		onModelChange?.(modelId);
 	}
 
 	function formatTokens(value: number): string {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -147,6 +147,7 @@
 		}
 	});
 	const createThreadMutation = useMutation(api.threads.create);
+	const setThreadSelectedModel = useMutation(api.threads.setSelectedModel);
 	const answerAgentQuestion = useMutation(api.agentQuestions.answer);
 	const setThemePreference = useMutation(api.uiPreferences.setTheme);
 	const generateImageUploadUrl = useMutation(api.imageUploads.generateUploadUrl);
@@ -1347,6 +1348,29 @@
 		return result;
 	}
 
+	async function persistSelectedModel(modelId: CatalogModelId) {
+		const threadId = currentThreadId;
+		const userId = getCurrentUserId();
+		if (!threadId || !userId) {
+			return;
+		}
+
+		unconfirmedCreatedThreads = unconfirmedCreatedThreads.map((thread) =>
+			thread.threadId === threadId ? { ...thread, selectedModel: modelId } : thread
+		);
+		try {
+			await setThreadSelectedModel({ threadId, selectedModel: modelId });
+			if (getCurrentUserId() === userId) {
+				void pullThreadSnapshot(userId);
+			}
+		} catch (error) {
+			if (currentThreadId === threadId && getCurrentUserId() === userId) {
+				currentError =
+					error instanceof Error ? error.message : 'Failed to save the selected model.';
+			}
+		}
+	}
+
 	function startThreadDraftForProject(workspacePath: string) {
 		openProject(workspacePath, { draft: true });
 	}
@@ -2465,6 +2489,9 @@
 						onRemoveAttachment={removeComposerAttachment}
 						{modelCatalog}
 						bind:selectedModel
+						onModelChange={(modelId) => {
+							void persistSelectedModel(modelId);
+						}}
 						bind:selectedReasoningEffort
 						bind:selectedServiceTier
 						pendingQuestion={pendingAgentQuestion}


### PR DESCRIPTION
## Summary

- persist explicit model changes immediately on existing thread records
- advance the thread snapshot revision so local caches receive the updated model
- preserve draft-thread behavior while wiring the composer selector to persistence
- verify model storage and snapshot revision advancement in Convex tests

## Validation

- `nix develop -c bun run test`
- `nix develop -c bun run build`
- `nix develop -c bun run check` (from `apps/web`)
- `nix develop -c bunx convex typecheck` (from `apps/web`)
- targeted ESLint and Prettier checks
- targeted `src/convex/threads.test.ts` Vitest suite

`prek run -a` was attempted but blocked on the shared prek cache lock held by concurrent worktrees; its constituent formatting, linting, typechecking, test, and build checks passed independently.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR persists explicit model changes for existing threads while preserving draft-thread behavior.
- Adds an ownership-checked Convex mutation that updates the selected model and advances the thread snapshot revision.
- Connects composer model changes to persistence for existing threads.
- Adds coverage for model storage and snapshot revision advancement.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security defects identified.

The new mutation checks thread ownership, avoids redundant writes, advances the relevant snapshot revision, and the UI continues to carry draft selections through thread creation.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/threads.ts | Adds an ownership-checked selected-model mutation and correctly bumps the affected thread snapshot. |
| apps/web/src/routes/+page.svelte | Persists model changes only for existing authenticated threads while retaining the selected model in draft creation and run submission flows. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Adds an optional callback for explicit model-selection changes without altering bindable draft state. |
| apps/web/src/convex/threads.test.ts | Verifies both durable model storage and snapshot revision advancement. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Composer
  participant Page
  participant Convex
  participant Cache
  User->>Composer: Select model
  Composer->>Page: onModelChange(modelId)
  alt Existing thread
    Page->>Convex: setSelectedModel(threadId, modelId)
    Convex->>Convex: Verify ownership and patch thread
    Convex->>Cache: Advance snapshot revision
    Page->>Cache: Pull refreshed snapshot
  else Draft thread
    Page-->>Page: Keep bound model selection
    Page->>Convex: Create thread with selected model on submit
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(models): persist thread model select..."](https://github.com/spikonado/sprocket/commit/8eacfb5d3bbdbc406b1b227e0678c14265297f36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59527632)</sub>

**Context used:**

- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)

<!-- /greptile_comment -->