### PR TITLE
fix(ui): Keep work indicator active across completions

### DIFF
--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -8,6 +8,7 @@ import {
 	buildOpenExecCommandSessions,
 	groupAssistantTimeline,
 	groupAssistantTimelineSections,
+	isAssistantResponseStreaming,
 	isAssistantTimelineToolRunning,
 	partitionWorkSectionTools,
 	resolveCommandSessionLabel,
@@ -59,6 +60,15 @@ function tool(
 ): AssistantTimelineTool {
 	return { type: 'tool', callId, name, input: {}, ...overrides };
 }
+
+describe('assistant response streaming', () => {
+	it('stays active between completion calls until the run itself finishes', () => {
+		const runId = executorRunId('run');
+
+		expect(isAssistantResponseStreaming({ runId, runStatus: 'completed' }, runId)).toBe(true);
+		expect(isAssistantResponseStreaming({ runId, runStatus: 'running' }, null)).toBe(false);
+	});
+});
 
 describe('assistant timeline', () => {
 	it('keeps tool calls between surrounding assistant parts and pairs results', () => {

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -6,7 +6,7 @@ import {
 } from '$convex/lib/assistantParts';
 import { isJsonObject, type JsonValue } from '$convex/lib/json';
 import { jsonBoolean, jsonObjectString } from '$lib/chat/json-fields';
-import type { ExecutorJob } from '$lib/types/sprocket';
+import type { ExecutorJob, ThreadMessage } from '$lib/types/sprocket';
 
 export type AssistantTimelineTool = {
 	type: 'tool';
@@ -39,6 +39,13 @@ export type AssistantTimelineSection =
 	| Extract<AssistantTimelineBlock, { type: 'text' }>;
 
 export type AssistantTimelineToolFailureKind = 'cancelled' | 'failed' | 'interrupted';
+
+export function isAssistantResponseStreaming(
+	message: Pick<ThreadMessage, 'runId' | 'runStatus'>,
+	activeRunId: ThreadMessage['runId'] | null
+): boolean {
+	return message.runId === activeRunId;
+}
 
 /** Tool type used for grouping: prefer streamed call name so groups stay stable as jobs attach. */
 export function assistantTimelineToolKey(tool: AssistantTimelineTool): string {

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -9,6 +9,7 @@
 		buildOpenExecCommandSessions,
 		groupAssistantTimeline,
 		groupAssistantTimelineSections,
+		isAssistantResponseStreaming,
 		partitionWorkSectionTools,
 		workSectionTimingAnchor,
 		workSectionTimingIndexes,
@@ -323,11 +324,7 @@
 							{@const sections = groupAssistantTimelineSections(blocks)}
 							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
 								workSectionTimingIndexes(sections)}
-							{@const isStreaming =
-								message.runId === activeRunId &&
-								message.runStatus !== 'completed' &&
-								message.runStatus !== 'failed' &&
-								message.runStatus !== 'cancelled'}
+							{@const isStreaming = isAssistantResponseStreaming(message, activeRunId)}
 							{@const openSessions = buildOpenExecCommandSessions(timelineTools, isStreaming)}
 							{@const hasPersistedAssistantContent = timeline.some(
 								(part) => part.type === 'text' || part.type === 'reasoning'


### PR DESCRIPTION
## Summary
- derive transcript streaming state from the active run rather than each completion call status
- keep the “Working for” indicator active between tool completion calls
- add regression coverage for completion records marked complete while their run remains active

## Checks
- `bun --cwd apps/web test src/lib/chat/assistant-timeline.test.ts`
- `bun run check` (from `apps/web`)
- Prettier hook
- Oxlint hook

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR derives assistant-response streaming state from active-run identity so the work indicator remains active between completion calls and settles when the run ends.
- Adds a shared helper for active-run streaming state.
- Updates the transcript to use the helper instead of per-completion status.
- Adds regression coverage for completed completion records belonging to an active run.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

Active-run identity is non-null only for in-progress lifecycle phases, transcript messages carry required run IDs, and the new helper therefore remains active across intermediate completions while settling when the run terminates.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/chat/assistant-timeline.ts | Adds a run-identity-based streaming helper consistent with the lifecycle-owned active run. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Replaces completion-status checks with active-run streaming derivation for work disclosure rendering. |
| apps/web/src/lib/chat/assistant-timeline.test.ts | Covers streaming across completed completion records and clearing once the run is no longer active. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): Keep work indicator active acro..."](https://github.com/spikonado/sprocket/commit/ccbf4859a6a8e8b33c0ee75365d6b70bf5d5dd4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59527948)</sub>

**Context used:**

- Knowledge Base — [Chat, timeline, and artifacts UI](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-chat-and-artifacts.md)

<!-- /greptile_comment -->