### PR TITLE
fix(agent): Stop cancelled runs promptly

### DIFF
--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -600,7 +600,7 @@ export const isFinished = query({
 	returns: v.boolean(),
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		return isRunFinalStatus(run.status);
+		return isRunFinalStatus(run.status) || run.cancellationRequestedAt !== undefined;
 	}
 });
 

--- a/apps/web/src/convex/chat.lifecycle.test.ts
+++ b/apps/web/src/convex/chat.lifecycle.test.ts
@@ -75,14 +75,14 @@ describe('durable run cancellation', { timeout: 30_000 }, () => {
 		expect(await asUser.query(api.chat.selectedThreadLifecycle, { threadId })).toMatchObject({
 			phase: 'cancellation_requested'
 		});
-		// Cancellation is requested, but execution remains active until cleanup
-		// finishes or the durable deadline expires.
+		// The executor observes the request immediately so it can stop its current
+		// model or tool operation and acknowledge the cancellation.
 		expect(
 			await asUser.query(api.agentRuntime.isFinished, {
 				runId: created.runId,
 				executionSecret
 			})
-		).toBe(false);
+		).toBe(true);
 
 		await expect(
 			asUser.mutation(api.agentRuntime.registerCompletionAttempt, {

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -11,6 +11,11 @@ function threadRecordId(value: string): Id<'threadRecords'> {
 	return value as Id<'threadRecords'>;
 }
 
+function runId(value: string): Id<'runs'> {
+	// SAFETY: fixture strings are only compared as opaque Convex document ids.
+	return value as Id<'runs'>;
+}
+
 afterEach(() => {
 	vi.unstubAllGlobals();
 });
@@ -147,5 +152,27 @@ describe('thread cache local API', () => {
 			}
 		);
 		expect(events).toEqual([{ status: 'live', lastSyncedAt: 20 }]);
+	});
+});
+
+describe('run cancellation local API', () => {
+	it('accepts the boolean returned by the cancellation mutation', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response('true', {
+						status: 200,
+						headers: { 'content-type': 'application/json' }
+					})
+			)
+		);
+
+		await expect(
+			createLocalClient('http://127.0.0.1:7731').requestRunCancellation({
+				authToken: 'token',
+				runId: runId('run-1')
+			})
+		).resolves.toBeUndefined();
 	});
 });

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -693,7 +693,7 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 				body: JSON.stringify(requestBody)
 			}),
 		requestRunCancellation: async (requestBody) => {
-			await request('/api/threads/cancel', z.null(), {
+			await request('/api/threads/cancel', z.boolean(), {
 				method: 'POST',
 				body: JSON.stringify(requestBody)
 			});

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -852,16 +852,19 @@
 	const isRetryableQueuedRun = $derived(
 		currentLifecycle?.phase === 'queued' && currentRecoveredSubmission != null
 	);
-	const isRunning = $derived(
+	const isRunInProgress = $derived(
 		currentLifecycle != null &&
 			isLifecycleInProgress(currentLifecycle.phase) &&
 			!isRetryableQueuedRun
+	);
+	const isRunning = $derived(
+		isRunInProgress && currentLifecycle?.phase !== 'cancellation_requested'
 	);
 	const hasPendingAgentLaunch = $derived(
 		isAgentLaunchPending(pendingAgentLaunches, currentThreadId)
 	);
 	const latestRunResumeKind = $derived(
-		hasPendingAgentLaunch || isRunning
+		hasPendingAgentLaunch || isRunInProgress
 			? null
 			: lifecycleResumeKind(currentLifecycle?.phase ?? 'idle', currentLifecycle?.run?.lastError)
 	);
@@ -882,7 +885,7 @@
 			!isSubmittingPrompt &&
 			!answeringAgentQuestion &&
 			!hasPendingAgentLaunch &&
-			((!isRunning && isLatestRunReady) || pendingAgentQuestion)
+			((!isRunInProgress && isLatestRunReady) || pendingAgentQuestion)
 		)
 	);
 	const recentProjectDirectories = $derived.by(() => {
@@ -1555,7 +1558,7 @@
 
 		if (!canSend) {
 			currentError =
-				isRunning || hasPendingAgentLaunch || isSubmittingPrompt
+				isRunInProgress || hasPendingAgentLaunch || isSubmittingPrompt
 					? 'Wait for the current agent launch or run to finish.'
 					: currentProject?.localAttachmentAvailability === 'available'
 						? 'You need an active project before sending.'
@@ -1865,7 +1868,7 @@
 	}
 
 	async function cancelRun() {
-		if (!runState?.runId || !isRunning) {
+		if (!runState?.runId || !isRunInProgress) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- accept the boolean returned by the local run-cancellation endpoint instead of showing a response-schema error
- notify active model and tool work as soon as cancellation is requested while retaining durable forced cancellation as a fallback
- stop presenting a cancelling run as “Working” without allowing another prompt until the run reaches a terminal state

## Testing
- `nix develop -c bunx vitest --run src/lib/local/client.test.ts src/convex/chat.lifecycle.test.ts src/convex/lib/runCancellation.test.ts` (from `apps/web`)
- `nix develop -c bun run check` (from `apps/web`)
- `nix develop -c prek run prettier --files apps/web/src/convex/agentRuntime.ts apps/web/src/convex/chat.lifecycle.test.ts apps/web/src/lib/local/client.test.ts apps/web/src/lib/local/client.ts apps/web/src/routes/+page.svelte`
- `nix develop -c prek run oxlint --all-files`
- `git diff --check`

Full build and Rust history tests were started but exceeded the local command timeout while compiling dependencies; neither reported a failure before timing out.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes cancellation requests interrupt active model and tool work promptly while retaining durable forced cancellation as a fallback.
- Treats a requested cancellation as a stop signal for the local executor.
- Updates the local-client response validator to accept the cancellation endpoint’s boolean result.
- Separates visible “Working” state from the broader in-progress state so cancelling runs no longer appear active while still blocking new prompts.
- Adds focused lifecycle and local-client coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The cancellation signal is propagated into existing acknowledgement and finalization paths, prompt submission remains blocked until terminal state, and the local response validator now matches the server’s boolean contract.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentRuntime.ts | Expands the executor stop signal to include requested cancellation while preserving terminal acknowledgement and forced-cancellation fallback paths. |
| apps/web/src/routes/+page.svelte | Separates visible running state from lifecycle progress so cancellation changes presentation without unlocking prompt submission. |
| apps/web/src/lib/local/client.ts | Aligns cancellation response validation with the server and Convex boolean contract. |
| apps/web/src/convex/chat.lifecycle.test.ts | Updates lifecycle coverage to verify immediate cancellation observation. |
| apps/web/src/lib/local/client.test.ts | Adds coverage for parsing the cancellation endpoint’s boolean response. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Web UI
  participant Server as Local server
  participant Convex
  participant Agent as Local agent
  UI->>Server: Request cancellation
  Server->>Convex: Record cancellation request
  Convex-->>UI: cancellation_requested
  Agent->>Convex: Poll isFinished
  Convex-->>Agent: true
  Agent->>Agent: Stop model or tool work
  Agent->>Convex: Acknowledge cancelled run
  opt Agent does not acknowledge promptly
    Convex->>Convex: Force cancellation after deadline
  end
  Convex-->>UI: cancelled
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Stop cancelled runs promptly"](https://github.com/spikonado/sprocket/commit/2b78211dad9a034cd911ed30270a9462840a1ab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59528252)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent run lifecycle](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-run-lifecycle.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->