### PR TITLE
fix(ui): Load older thread messages reliably

### DIFF
--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -211,6 +211,7 @@ export type TranscriptScopeRequest = {
 };
 
 export type TranscriptPageRequest = {
+	authToken?: string;
 	userId: string;
 	threadId: Id<'threadRecords'>;
 	before?: number;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -519,14 +519,17 @@
 	let replicaLoading = $state(false);
 	let replicaContextSummary = $state<string | null>(null);
 	let replicaError = $state<string | null>(null);
-	let loadingOlderTranscript = $state(false);
+	let replicaGeneration = 0;
+	let loadingOlderTranscriptGeneration = $state<number | null>(null);
 	let liveCompletion = $state<LiveCompletionOverlay | null>(null);
+	const loadingOlderTranscript = $derived(loadingOlderTranscriptGeneration === replicaGeneration);
 
 	function applyOlderPageCursor(nextBefore: number | undefined) {
 		replicaNextBefore = nextBefore ?? null;
 	}
 
 	function showReplicaForThread(threadId: Id<'threadRecords'> | null) {
+		replicaGeneration += 1;
 		replicaThreadId = threadId;
 		liveCompletion = null;
 		replicaError = null;
@@ -557,13 +560,18 @@
 		}
 		const ac = new AbortController();
 		const watchedThreadId = threadId;
+		const generation = replicaGeneration;
 		void (async () => {
 			try {
 				const page = await api.fetchTranscriptPage({
 					userId,
 					threadId: watchedThreadId
 				});
-				if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
+				if (
+					ac.signal.aborted ||
+					currentThreadId !== watchedThreadId ||
+					replicaGeneration !== generation
+				) {
 					return;
 				}
 				replicaParts = page.parts;
@@ -573,7 +581,7 @@
 				replicaContextSummary = page.contextSummary ?? null;
 				applyOlderPageCursor(page.nextBefore);
 			} catch {
-				if (!ac.signal.aborted) {
+				if (!ac.signal.aborted && replicaGeneration === generation) {
 					replicaLoading = false;
 					if (replicaParts.length === 0) {
 						replicaError = 'Could not load conversation history.';
@@ -1374,39 +1382,63 @@
 		if (!api || currentThreadId !== threadId) {
 			return;
 		}
+		const generation = replicaGeneration;
 		const page = await api.fetchTranscriptPage({ userId, threadId });
-		if (currentThreadId !== threadId) {
+		if (currentThreadId !== threadId || replicaGeneration !== generation) {
 			return;
 		}
 		replicaParts = mergeTranscriptParts(replicaParts, page.parts);
 		replicaStale = page.stale;
 		replicaContextSummary = page.contextSummary ?? replicaContextSummary;
+		if (replicaParts.length === page.parts.length) {
+			applyOlderPageCursor(page.nextBefore);
+		} else if (replicaNextBefore != null && page.nextBefore != null) {
+			replicaNextBefore = Math.min(replicaNextBefore, page.nextBefore);
+		}
 	}
 
 	async function loadOlderTranscript() {
 		const api = desktopApi;
 		const threadId = currentThreadId;
 		const userId = getCurrentUserId();
-		if (!api || !threadId || !userId || replicaNextBefore == null || loadingOlderTranscript) {
+		const before = replicaNextBefore;
+		const generation = replicaGeneration;
+		if (
+			!api ||
+			!threadId ||
+			!userId ||
+			before == null ||
+			loadingOlderTranscriptGeneration === generation
+		) {
 			return;
 		}
-		loadingOlderTranscript = true;
+		loadingOlderTranscriptGeneration = generation;
 		try {
+			const authToken = await getAccessToken();
+			if (!authToken || currentThreadId !== threadId || replicaGeneration !== generation) {
+				return;
+			}
 			const page = await api.fetchTranscriptPage({
+				authToken,
 				userId,
 				threadId,
-				before: replicaNextBefore
+				before,
+				limit: 100
 			});
-			if (currentThreadId !== threadId) {
+			if (currentThreadId !== threadId || replicaGeneration !== generation) {
 				return;
 			}
 			replicaParts = mergeTranscriptParts(replicaParts, page.parts);
 			replicaStale = page.stale;
 			applyOlderPageCursor(page.nextBefore);
 		} catch {
-			replicaStale = true;
+			if (currentThreadId === threadId && replicaGeneration === generation) {
+				replicaStale = true;
+			}
 		} finally {
-			loadingOlderTranscript = false;
+			if (loadingOlderTranscriptGeneration === generation) {
+				loadingOlderTranscriptGeneration = null;
+			}
 		}
 	}
 
@@ -2400,42 +2432,44 @@
 						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
 					{/if}
 				{:else}
-					<ThreadTranscript
-						currentError={replicaError ??
-							currentError ??
-							$authState.error ??
-							(queryError instanceof Error ? convexClientErrorMessage(queryError) : null) ??
-							(threadCacheStatus === 'error' ? 'Could not sync threads.' : null) ??
-							(threadCacheStatus === 'offline' ? 'Thread sync is offline.' : null) ??
-							null}
-						runError={latestRunResumeKind ? null : (runState?.lastError ?? null)}
-						messages={visibleMessages}
-						actions={visibleActions}
-						activeRunId={isRunning ? (runState?.runId ?? null) : null}
-						project={currentProject}
-						remoteChangeNotice={currentThreadId
-							? (remoteChangeNotices.get(currentThreadId) ?? null)
-							: null}
-						onDismissRemoteChangeNotice={() => {
-							if (currentThreadId) {
-								remoteChangeNotices.delete(currentThreadId);
-							}
-						}}
-						stale={replicaStale}
-						contextSummary={replicaContextSummary}
-						loadingOlder={loadingOlderTranscript}
-						hasOlder={replicaNextBefore != null}
-						emptyStateMessage={currentThreadId &&
-						(replicaLoading || replicaThreadId !== currentThreadId)
-							? 'Loading conversation…'
-							: currentProject
-								? 'Start a thread and ask Sprocket to inspect code, edit files, or run project commands.'
-								: 'Add a project to begin.'}
-						onLoadOlder={() => {
-							void loadOlderTranscript();
-						}}
-						loadAttachment={loadTranscriptAttachment}
-					/>
+					{#key currentThreadId}
+						<ThreadTranscript
+							currentError={replicaError ??
+								currentError ??
+								$authState.error ??
+								(queryError instanceof Error ? convexClientErrorMessage(queryError) : null) ??
+								(threadCacheStatus === 'error' ? 'Could not sync threads.' : null) ??
+								(threadCacheStatus === 'offline' ? 'Thread sync is offline.' : null) ??
+								null}
+							runError={latestRunResumeKind ? null : (runState?.lastError ?? null)}
+							messages={visibleMessages}
+							actions={visibleActions}
+							activeRunId={isRunning ? (runState?.runId ?? null) : null}
+							project={currentProject}
+							remoteChangeNotice={currentThreadId
+								? (remoteChangeNotices.get(currentThreadId) ?? null)
+								: null}
+							onDismissRemoteChangeNotice={() => {
+								if (currentThreadId) {
+									remoteChangeNotices.delete(currentThreadId);
+								}
+							}}
+							stale={replicaStale}
+							contextSummary={replicaContextSummary}
+							loadingOlder={loadingOlderTranscript}
+							hasOlder={replicaNextBefore != null}
+							emptyStateMessage={currentThreadId &&
+							(replicaLoading || replicaThreadId !== currentThreadId)
+								? 'Loading conversation…'
+								: currentProject
+									? 'Start a thread and ask Sprocket to inspect code, edit files, or run project commands.'
+									: 'Add a project to begin.'}
+							onLoadOlder={() => {
+								void loadOlderTranscript();
+							}}
+							loadAttachment={loadTranscriptAttachment}
+						/>
+					{/key}
 
 					{#if catalogError}
 						<div

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -11,6 +11,7 @@ use axum::routing::post;
 use axum_extra::extract::CookieJar;
 use futures::stream::unfold;
 use serde::Deserialize;
+use sprocket_agent::{TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE};
 use tokio::sync::broadcast;
 
 use crate::AppState;
@@ -30,6 +31,7 @@ struct TranscriptScope {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TranscriptPageRequest {
+    auth_token: Option<String>,
     user_id: String,
     thread_id: String,
     before: Option<u32>,
@@ -62,6 +64,44 @@ async fn page_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    if let Some(auth_token) = payload.auth_token.as_deref() {
+        let client =
+            UserConvexClient::connect(&state.convex_deployment_url, auth_token.to_string())
+                .await
+                .map_err(|error| {
+                    ApiError::internal_with(
+                        "failed to connect while loading transcript history",
+                        error,
+                    )
+                })?;
+        let transcript_state = state
+            .transcript
+            .load_state(&payload.user_id, &payload.thread_id)
+            .await
+            .map_err(|error| ApiError::internal_with("failed to read transcript state", error))?;
+        let limit = payload
+            .limit
+            .unwrap_or(TRANSCRIPT_PAGE_SIZE)
+            .min(TRANSCRIPT_CHUNK_SIZE);
+        let end = payload
+            .before
+            .unwrap_or_else(|| transcript_state.visible_end_exclusive())
+            .min(transcript_state.visible_end_exclusive());
+        let start = end
+            .saturating_sub(limit)
+            .max(transcript_state.history_from_number);
+        crate::transcript_client::sync_range(
+            &state.transcript,
+            &client,
+            &payload.user_id,
+            &payload.thread_id,
+            start,
+            end,
+        )
+        .await
+        .map_err(|error| ApiError::internal_with("failed to load transcript history", error))?;
+    }
+
     let page = state
         .transcript
         .page(


### PR DESCRIPTION
## Summary
- fetch missing older transcript ranges into the local replica before returning a page
- load up to 100 older transcript parts per request and preserve the oldest cursor across live refreshes
- isolate transcript and scroll state by thread so stale requests cannot overwrite the selected thread

## Testing
- pre-commit hooks (`prek`): cargo fmt/check, ESLint, Oxlint, Svelte check, Prettier, and related repository checks
- `bun run test -- src/lib/project/transcript.test.ts src/lib/local/client.test.ts` (13 tests)
- `cargo check -p sprocket-server`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes older transcript pagination fetch missing remote parts before reading the local replica and isolates asynchronous transcript state by selected-thread generation.
- Adds an optional account token to transcript page requests so the server can synchronize missing history ranges.
- Requests up to 100 older parts and preserves the oldest pagination cursor across live refreshes.
- Prevents stale asynchronous results and transcript scroll state from crossing thread selections.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed synchronization path fills the requested local range before paging, while generation checks and cursor reconciliation prevent stale thread requests or live refreshes from overwriting the active transcript state.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/types/sprocket.ts | Extends transcript page requests with the optional account token needed for remote range synchronization. |
| apps/web/src/routes/+page.svelte | Adds generation-scoped transcript loading, authenticated older-page requests, cursor preservation, and thread-keyed transcript rendering. |
| crates/sprocket-server/src/routes/transcript.rs | Synchronizes the bounded requested transcript range from Convex into the local replica before serving the page. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Thread UI
  participant Server as Local server
  participant Replica as Local transcript replica
  participant Convex as Convex
  UI->>Server: Page request(authToken, threadId, before, limit)
  Server->>Replica: Read transcript state
  Server->>Convex: Fetch missing parts in requested range
  Convex-->>Server: Authorized transcript parts
  Server->>Replica: Synchronize missing parts
  Server->>Replica: Read completed page
  Replica-->>Server: Parts and nextBefore
  Server-->>UI: Transcript page
  UI->>UI: Validate thread generation and merge parts
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): Load older thread messages reli..."](https://github.com/spikonado/sprocket/commit/750226333b19e814229eae68a2ad6f94296c24b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59569382)</sub>

**Context used:**

- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)

<!-- /greptile_comment -->