### PR TITLE
fix(ui): Keep sidebar run indicators in sync

### DIFF
--- a/apps/web/src/lib/project/threads.test.ts
+++ b/apps/web/src/lib/project/threads.test.ts
@@ -12,6 +12,7 @@ import {
 	mergeUnconfirmedCreatedThread,
 	mergeUnconfirmedCreatedThreads,
 	pickThreadToRestore,
+	overrideThreadActiveRun,
 	resolveExpiredAgentLaunch,
 	resolvePendingAgentLaunch,
 	resolvePendingAgentLaunchesFromThreads,
@@ -129,6 +130,20 @@ describe('project thread helpers', () => {
 		expect(
 			groups.find((group) => group.project.workspacePath === '/workspaces/local')?.threads
 		).toHaveLength(1);
+	});
+
+	it('overrides cached run activity for the selected thread only', () => {
+		const selected = makeThreadSummary({ threadId: threadA, hasActiveRun: false });
+		const other = makeThreadSummary({ threadId: threadB, hasActiveRun: true });
+
+		expect(overrideThreadActiveRun([selected, other], threadA, true)).toEqual([
+			{ ...selected, hasActiveRun: true },
+			other
+		]);
+		expect(overrideThreadActiveRun([selected, other], threadB, false)).toEqual([
+			selected,
+			{ ...other, hasActiveRun: false }
+		]);
 	});
 
 	it('keeps projects in their given order regardless of thread activity', () => {

--- a/apps/web/src/lib/project/threads.ts
+++ b/apps/web/src/lib/project/threads.ts
@@ -86,6 +86,18 @@ export function getProjectThreadGroups(projects: Project[], threads: ThreadSumma
 	);
 }
 
+export function overrideThreadActiveRun(
+	threads: ThreadSummary[],
+	threadId: Id<'threadRecords'>,
+	hasActiveRun: boolean
+): ThreadSummary[] {
+	return threads.map((thread) =>
+		thread.threadId === threadId && thread.hasActiveRun !== hasActiveRun
+			? { ...thread, hasActiveRun }
+			: thread
+	);
+}
+
 function sortThreadsRunningFirst(threads: ThreadSummary[]) {
 	return [...threads].sort((left, right) => {
 		if (left.hasActiveRun !== right.hasActiveRun) {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1884,7 +1884,7 @@
 						error instanceof Error ? error.message : 'Failed to start the local agent run.'
 					);
 				},
-				onStarted: (runId) => {
+				onStarted: () => {
 					if (!isSubmissionCurrent() || !isSubmittedUserCurrent()) return;
 					clearComposerAttachments({ discard: false });
 				},

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -79,6 +79,7 @@
 		isLatestRunReadyForThread,
 		makeUnconfirmedCreatedThread,
 		mergeUnconfirmedCreatedThreads,
+		overrideThreadActiveRun,
 		pickThreadToRestore,
 		retainUnconfirmedCreatedThreads,
 		threadTitleFromPrompt,
@@ -741,10 +742,6 @@
 			.sort((left, right) => right.lastMessageAt - left.lastMessageAt);
 	});
 
-	const groupedProjectThreads = $derived.by<ProjectThreadGroup[]>(() =>
-		getProjectThreadGroups(projects, threads)
-	);
-
 	const runState = $derived(currentLifecycle?.run ?? null);
 	const visibleActions: ExecutorJob[] = [];
 	const threadArtifacts = $derived(
@@ -869,6 +866,13 @@
 	const isRunning = $derived(
 		isRunInProgress && currentLifecycle?.phase !== 'cancellation_requested'
 	);
+	const groupedProjectThreads = $derived.by<ProjectThreadGroup[]>(() => {
+		const sidebarThreads =
+			currentThreadId && currentLifecycle
+				? overrideThreadActiveRun(threads, currentThreadId, isRunInProgress)
+				: threads;
+		return getProjectThreadGroups(projects, sidebarThreads);
+	});
 	const hasPendingAgentLaunch = $derived(
 		isAgentLaunchPending(pendingAgentLaunches, currentThreadId)
 	);
@@ -1882,7 +1886,6 @@
 				},
 				onStarted: (runId) => {
 					if (!isSubmissionCurrent() || !isSubmittedUserCurrent()) return;
-					pendingAgentLaunches = resolvePendingAgentLaunch(pendingAgentLaunches, threadId, runId);
 					clearComposerAttachments({ discard: false });
 				},
 				threadId,
@@ -1983,15 +1986,7 @@
 					pendingAgentLaunches = clearPendingAgentLaunch(pendingAgentLaunches, threadId, launchId);
 					currentError = error.message;
 				},
-				onStarted: (runId) => {
-					pendingAgentLaunches = resolvePendingAgentLaunch(
-						pendingAgentLaunches,
-						threadId,
-						runId,
-						undefined,
-						Date.now()
-					);
-				},
+				onStarted: () => {},
 				threadId,
 				prompt: '',
 				imageUploadIds: [],


### PR DESCRIPTION
## Summary
- keep a pending sidebar indicator until subscribed lifecycle data confirms the run
- reconcile the selected thread’s cached sidebar state with its live lifecycle
- cover stale cached activity overrides with a focused unit test

## Checks
- `bun run --cwd apps/web test -- src/lib/project/threads.test.ts`
- `bun run --cwd apps/web check`
- `bunx prettier --check apps/web/src/routes/+page.svelte apps/web/src/lib/project/threads.ts apps/web/src/lib/project/threads.test.ts`
- `git diff --check`



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps sidebar run indicators synchronized with live lifecycle state while retaining pending launch state until subscription data confirms progress.
- Adds a helper and focused tests for overriding one thread’s cached active-run state.
- Reconciles the selected sidebar thread against its identity-guarded live lifecycle.
- Defers pending-launch resolution from launch callbacks to reactive thread and lifecycle updates.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/+page.svelte | Reconciles selected-thread sidebar activity from matching lifecycle data and leaves pending launches active until subscribed state confirms progress. |
| apps/web/src/lib/project/threads.ts | Adds a narrowly scoped immutable helper for replacing the selected thread’s cached active-run flag. |
| apps/web/src/lib/project/threads.test.ts | Verifies that active-run overrides affect only the specified thread. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): Remove unused launch callback a..."](https://github.com/spikonado/sprocket/commit/2ebc4ad2b230020af3f94f3f744cca544d3798d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59766129)</sub>

**Context used:**

- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)

<!-- /greptile_comment -->