### PR TITLE
build(release): Bump version to v0.3.4

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             source_sha="$TESTED_SHA"
-            version="0.3.2-dev.$source_sha"
+            version="0.3.4-dev.$source_sha"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             source_sha="$GITHUB_SHA"
             version="${GITHUB_REF_NAME#v}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7150,7 +7150,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-agent"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "convex",
@@ -7169,7 +7169,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-cli"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-convex"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "convex",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-server"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -7225,7 +7225,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-workspace"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.4"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -55,7 +55,7 @@ Before tagging, a manual workflow run with publishing disabled can be used to bu
 
 ## Development releases
 
-After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.2.0-dev.<full-commit-sha>` with the npm `dev` dist-tag.
+After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.3.4-dev.<full-commit-sha>` with the npm `dev` dist-tag.
 
 Install the newest development build with:
 

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spikonado/sprocket",
-	"version": "0.3.2",
+	"version": "0.3.4",
 	"description": "Agentic platform for streamlining hardware and software development",
 	"license": "FSL-1.1-ALv2",
 	"type": "module",


### PR DESCRIPTION
## Summary
- bump the Rust workspace and npm package to v0.3.4
- publish development builds with the 0.3.4 prerelease prefix
- update the development release documentation to match the workflow

## Testing
- `nix develop -c cargo test`
- `nix develop -c bun run test`
- `nix develop -c bun run build`
- `nix develop -c prek run -a`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently advances the Rust workspace and npm package to version 0.3.4.
- Updates Rust workspace and lockfile package versions.
- Updates the npm package version.
- Moves development releases to the `0.3.4-dev.<commit-sha>` prefix.
- Aligns the public development-release documentation with the workflow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the release versions and development publication workflow aligned.

The changed development version remains valid under the existing workflow checks and npm tag mapping, while Rust and npm package metadata are consistently updated to 0.3.4.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/npm-release.yml | Updates the development-build version prefix while preserving the validated full-SHA prerelease format and `dev` dist-tag mapping. |
| Cargo.toml | Advances the shared Rust workspace package version from 0.3.2 to 0.3.4. |
| Cargo.lock | Consistently records version 0.3.4 for all five workspace crates inheriting the workspace version. |
| npm/sprocket/package.json | Advances the checked-in npm package version to 0.3.4; release assembly continues to synchronize published package versions. |
| npm/RELEASING.md | Corrects the documented development-release prefix to match the updated workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["build(release): Bump version to v0.3.4"](https://github.com/spikonado/sprocket/commit/ad23d8c165e14a5a852631aa2aec2f7214b34c2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59767203)</sub>

<!-- /greptile_comment -->