### PR TITLE
feat(convex): Queue thread token aggregate writes

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -97,15 +97,17 @@ jobs carrying it.
 
 ### 3. Aggregate usage ledger leftovers
 
-Processed-token totals live in `threadUsageEvents` plus a namespaced
-Aggregate. `getThreadUsageValues` reads that sum. `recordThreadUsageEvent`
-still dual-writes `threadUsage.totalTokensProcessed` as a denormalized cache.
+Processed-token totals live on `threadUsage.totalTokensProcessed`.
+`getThreadUsageValues` reads that row. `recordThreadUsageEvent` still
+enqueues a namespaced Aggregate write (`async: true`) so the ledger can
+fill in threads that have no usage row. Those ledger reads are stale.
 
 `usageLedgerMigratedAt` is unused leftover after the backfill. It is not a
 read gate.
 
-Remove the dual-write (and then the required field) after an unset rewrite.
-Drop `usageLedgerMigratedAt` after a separate unset, or in the same rewrite.
+Drop the Aggregate enqueue and the missing-row fallback after a prod check
+shows every thread has a `threadUsage` row. Drop `usageLedgerMigratedAt`
+after a separate unset, or in the same rewrite.
 
 ### 4. Historical `runs.completionTransport`
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
 		"@browserbasehq/stagehand": "^3.7.1",
 		"@context-dot-dev/convex": "^1.0.1",
 		"@convex-dev/action-retrier": "^0.3.1",
-		"@convex-dev/aggregate": "^0.2.2",
+		"@convex-dev/aggregate": "^0.3.0",
 		"@convex-dev/migrations": "^0.3.6",
 		"@convex-dev/rate-limiter": "^0.3.2",
 		"@convex-dev/workflow": "^0.4.6",
@@ -38,6 +38,7 @@
 		"zod": "^4.1.8"
 	},
 	"devDependencies": {
+		"@convex-dev/batch-worker": "0.3.0",
 		"@edge-runtime/vm": "^5.0.0",
 		"@sprocket/eslint-config": "workspace:*",
 		"@sprocket/typescript-config": "workspace:*",

--- a/apps/web/src/convex/lib/threadUsage.ts
+++ b/apps/web/src/convex/lib/threadUsage.ts
@@ -19,7 +19,7 @@ type UsageEventInsert = {
 	createdAt: number;
 };
 
-export const threadProcessedTokens = new TableAggregate<{
+const threadProcessedTokens = new TableAggregate<{
 	Namespace: Id<'threadRecords'>;
 	Key: string;
 	DataModel: DataModel;
@@ -63,12 +63,12 @@ async function getUsageRow(
 		.unique();
 }
 
-async function aggregatedProcessedTokens(
+async function staleAggregatedProcessedTokens(
 	ctx: QueryCtx | MutationCtx,
 	threadId: Id<'threadRecords'>
 ): Promise<number | null> {
 	try {
-		return await threadProcessedTokens.sum(ctx, { namespace: threadId });
+		return await threadProcessedTokens.sum(ctx, { namespace: threadId, stale: true });
 	} catch {
 		return null;
 	}
@@ -92,21 +92,25 @@ export async function clearThreadContextTokens(
 	await ctx.db.patch('threadUsage', usageRow._id, { contextTokens: undefined });
 }
 
-/** Current counters for a thread. Reads the Aggregate ledger. */
+/** Live threadUsage counters, or a stale ledger sum if the row is missing. */
 export async function getThreadUsageValues(
 	ctx: QueryCtx | MutationCtx,
 	thread: Doc<'threadRecords'>
 ): Promise<ThreadUsageValues> {
 	const usageRow = await getUsageRow(ctx.db, thread._id);
-	const fieldTotal = usageRow?.totalTokensProcessed ?? 0;
-	const aggregated = await aggregatedProcessedTokens(ctx, thread._id);
+	if (usageRow) {
+		return {
+			contextTokens: usageRow.contextTokens,
+			totalTokensProcessed: usageRow.totalTokensProcessed
+		};
+	}
 	return {
-		contextTokens: usageRow?.contextTokens,
-		totalTokensProcessed: aggregated ?? fieldTotal
+		contextTokens: undefined,
+		totalTokensProcessed: (await staleAggregatedProcessedTokens(ctx, thread._id)) ?? 0
 	};
 }
 
-/** Insert an idempotent usage event and dual-write the additive field. */
+/** Insert an idempotent usage event and update the live threadUsage counters. */
 export async function recordThreadUsageEvent(
 	ctx: MutationCtx,
 	thread: Doc<'threadRecords'>,
@@ -144,7 +148,7 @@ export async function recordThreadUsageEvent(
 	if (!inserted) {
 		throw new Error('Failed to insert usage event.');
 	}
-	await threadProcessedTokens.insertIfDoesNotExist(ctx, inserted);
+	await threadProcessedTokens.insertIfDoesNotExist(ctx, inserted, { async: true });
 
 	const usageRow = await getUsageRow(ctx.db, thread._id);
 	const next: ThreadUsageValues = {

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -127,8 +127,8 @@ export default defineSchema({
 		threadId: v.id('threadRecords'),
 		userId: v.string(),
 		contextTokens: v.optional(v.number()),
-		// Denormalized cache of the Aggregate ledger. See
-		// BACKWARDS_COMPATIBILITY.md (stored schema, usage ledger).
+		// Live processed-token total. See BACKWARDS_COMPATIBILITY.md
+		// (stored schema, usage ledger).
 		totalTokensProcessed: v.number(),
 		// Leftover after the usage-ledger backfill.
 		usageLedgerMigratedAt: v.optional(v.number())

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -5,6 +5,7 @@ import rateLimiterTest from '@convex-dev/rate-limiter/test';
 import exaTest from '@exalabs/convex-exa/test';
 import migrationsTest from '@convex-dev/migrations/test';
 import aggregateTest from '@convex-dev/aggregate/test';
+import batchWorkerTest from '@convex-dev/batch-worker/test';
 import workflowTest from '@convex-dev/workflow/test';
 import actionRetrierTest from '@convex-dev/action-retrier/test';
 import workpoolTest from '@convex-dev/workpool/test';
@@ -43,6 +44,8 @@ export function initConvexTest(): ConvexTestInstance {
 	exaTest.register(backend);
 	migrationsTest.register(backend);
 	aggregateTest.register(backend);
+	// Queued writes use a nested Batch Worker the aggregate test helper omits.
+	batchWorkerTest.register(backend, 'aggregate/batchWorker');
 	workflowTest.register(backend);
 	actionRetrierTest.register(backend);
 	workpoolTest.register(backend, 'webToolWorkpool');

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@browserbasehq/stagehand": "^3.7.1",
         "@context-dot-dev/convex": "^1.0.1",
         "@convex-dev/action-retrier": "^0.3.1",
-        "@convex-dev/aggregate": "^0.2.2",
+        "@convex-dev/aggregate": "^0.3.0",
         "@convex-dev/migrations": "^0.3.6",
         "@convex-dev/rate-limiter": "^0.3.2",
         "@convex-dev/workflow": "^0.4.6",
@@ -52,6 +52,7 @@
         "zod": "^4.1.8",
       },
       "devDependencies": {
+        "@convex-dev/batch-worker": "0.3.0",
         "@edge-runtime/vm": "^5.0.0",
         "@sprocket/eslint-config": "workspace:*",
         "@sprocket/typescript-config": "workspace:*",
@@ -147,9 +148,9 @@
 
     "@convex-dev/action-retrier": ["@convex-dev/action-retrier@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-uji7ZV4GYN24fgnV9FrXABbq2mWCpcMohkEa2ie1zmD5S7ioSxNNBE0lNPB1jlMzICqWCTrbSTr68bgJPag6Ww=="],
 
-    "@convex-dev/aggregate": ["@convex-dev/aggregate@0.2.2", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-9sskfPZdiH0mdc33Obcf2+gQSPDpyHqUDkYmXDsUqhqe5lLwGKYbrxw7LgxHmYm9c1YLbaXqxKiM1CgucfKAAw=="],
+    "@convex-dev/aggregate": ["@convex-dev/aggregate@0.3.0", "", { "dependencies": { "@convex-dev/batch-worker": "0.3.0", "convex-helpers": "0.1.122" }, "peerDependencies": { "convex": "^1.43.0" } }, "sha512-WXLOOkcQ3nUjfXZy3/yYrBcVJz2yFA0rYrcyizbqrp2nC7NdRKDaP24+pm3fyh7JwkaCRo+nJTBTsjE89vyLZQ=="],
 
-    "@convex-dev/batch-worker": ["@convex-dev/batch-worker@0.2.1", "", { "peerDependencies": { "convex": "^1.36.1", "react": "^18.3.1 || ^19.0.0" } }, "sha512-QEDW6XmT+SmBJAmNqyl0QAEmJ4yMKJAIoJ+LntsA8KY5gYP+UhSFvTEMCvo177RZxOR/cfkZ3R+4S/UBaj/JnQ=="],
+    "@convex-dev/batch-worker": ["@convex-dev/batch-worker@0.3.0", "", { "dependencies": { "convex-helpers": "^0.1.119" }, "peerDependencies": { "convex": "^1.43.0", "react": "^18.3.1 || ^19.0.0" } }, "sha512-9CNwrhooFw59vRFEBiibD2/S0VEe6BiPDyJPlvybVkxEzeCKHjGwzaHtez6FuD6wIJ+GglWGqvlu4fOAEh9+pg=="],
 
     "@convex-dev/migrations": ["@convex-dev/migrations@0.3.6", "", { "peerDependencies": { "convex": "^1.42.0", "convex-helpers": "^0.1.115" } }, "sha512-cURYG4uy323MDi55QWNF5HAGemS4QspSgJ4uP+gGPAJdBLBbk2KFO7toFlKhacc1NinJQiG6+D/YEFyFyBS1/A=="],
 
@@ -1814,6 +1815,10 @@
     "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@browserbasehq/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@convex-dev/aggregate/convex-helpers": ["convex-helpers@0.1.122", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.43.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5 || ^6.0.0 || ^7.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-G5b54+RUPyitwEou7VPBxnz5/Tgy8gjtyN0zPgagOjguyBqoh9IjlsVQtWOKY7pxo/IREjF+N1khZmyEuzqbiw=="],
+
+    "@convex-dev/workpool/@convex-dev/batch-worker": ["@convex-dev/batch-worker@0.2.1", "", { "peerDependencies": { "convex": "^1.36.1", "react": "^18.3.1 || ^19.0.0" } }, "sha512-QEDW6XmT+SmBJAmNqyl0QAEmJ4yMKJAIoJ+LntsA8KY5gYP+UhSFvTEMCvo177RZxOR/cfkZ3R+4S/UBaj/JnQ=="],
 
     "@electron/asar/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 


### PR DESCRIPTION
## Summary

Upgrade `@convex-dev/aggregate` to 0.3.1 and use its queued mode for thread token accounting. Usage events no longer update shared aggregate tree nodes inside the request mutation, which removes a source of write conflicts between concurrent runs.

Processed-token reads now use the aggregate's stale snapshot and are eventually consistent. Context-token writes remain synchronous because they live on the per-thread usage row. The Convex test setup registers Aggregate's nested Batch Worker, and the accounting tests drain queued writes before checking settled totals.

This supersedes Renovate PR #233, which contained only the package bump.

## Checks

- `bun run --cwd apps/web test src/convex/agentRuntime.context.test.ts src/convex/threads.test.ts`
- `bun run --cwd apps/web check`
- `bun run --cwd apps/web lint`
- GitHub Actions `build_and_test`
- GitHub Actions `run_prek`