### PR TITLE
refactor(web): Use Zod 4 ints for remaining counters

### DIFF
--- a/apps/web/src/convex/lib/gatewayToken.ts
+++ b/apps/web/src/convex/lib/gatewayToken.ts
@@ -4,7 +4,7 @@ import { GATEWAY_TOKEN_PREFIX, GATEWAY_TOKEN_TTL_MS } from '@convex/lib/gatewayP
 const gatewayTokenPayloadSchema = z.object({
 	v: z.literal(1),
 	userId: z.string(),
-	exp: z.number()
+	exp: z.int()
 });
 
 export type GatewayTokenPayload = z.infer<typeof gatewayTokenPayloadSchema>;

--- a/apps/web/src/lib/chat/model-catalog.ts
+++ b/apps/web/src/lib/chat/model-catalog.ts
@@ -144,8 +144,8 @@ const gatewayModelSchema = z.looseObject({
 	label: z.string().min(1),
 	provider: z.string().min(1),
 	supportsImages: z.boolean(),
-	contextWindowTokens: z.number(),
-	autoCompactTokenLimit: z.number(),
+	contextWindowTokens: z.int(),
+	autoCompactTokenLimit: z.int(),
 	reasoningEfforts: z.array(z.string()).min(1),
 	defaultReasoningEffort: z.string().min(1),
 	serviceTiers: z.array(z.string()).min(1),
@@ -154,7 +154,7 @@ const gatewayModelSchema = z.looseObject({
 
 const gatewayModelsResponseSchema = z.object({
 	sprocket: z.object({
-		protocolVersion: z.number(),
+		protocolVersion: z.int(),
 		catalogVersion: z.string().min(1),
 		defaultModelId: z.string().min(1),
 		defaultReasoningEffort: z.string().min(1),

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -49,8 +49,8 @@ const projectAttachmentSchema = z.object({
 	repositoryKey: z.string(),
 	displayName: z.string(),
 	availability: z.enum(['available', 'unavailable']),
-	lastValidatedAt: z.number(),
-	lastUsedAt: z.number(),
+	lastValidatedAt: z.int(),
+	lastUsedAt: z.int(),
 	unavailableReason: z.string().optional(),
 	previousRepositoryKey: z.string().optional()
 });
@@ -61,12 +61,12 @@ const localTranscriptAttachmentSchema = z.object({
 	imageUploadId: z.string(),
 	name: z.string(),
 	mediaType: z.string(),
-	size: z.number(),
+	size: z.int(),
 	storageId: z.string(),
 	url: z.string().optional()
 });
 const localTranscriptPartSchema = z.object({
-	number: z.number(),
+	number: z.int(),
 	sourceKey: z.string(),
 	kind: z.enum(['prompt', 'completion', 'tool']),
 	runId: z.string(),
@@ -95,16 +95,16 @@ const localTranscriptPartSchema = z.object({
 });
 const localTranscriptPageSchema = z.object({
 	threadId: z.string(),
-	totalParts: z.number(),
-	historyFromNumber: z.number(),
+	totalParts: z.int(),
+	historyFromNumber: z.int(),
 	stale: z.boolean(),
 	parts: z.array(localTranscriptPartSchema),
-	nextBefore: z.number().optional(),
+	nextBefore: z.int().optional(),
 	contextSummary: z.string().optional()
 });
 const transcriptWatchEventSchema = z.object({
 	eventType: z.string(),
-	totalParts: z.number().optional(),
+	totalParts: z.int().optional(),
 	stale: z.boolean()
 });
 const liveCompletionOverlaySchema = z.object({
@@ -114,7 +114,7 @@ const liveCompletionOverlaySchema = z.object({
 	streamId: z.string().optional(),
 	text: z.string(),
 	parts: z.array(z.unknown()),
-	runStartedAt: z.number()
+	runStartedAt: z.int()
 });
 const liveCompletionWatchEventSchema = z.discriminatedUnion('eventType', [
 	z.object({ eventType: z.literal('updated'), live: liveCompletionOverlaySchema }),
@@ -127,20 +127,20 @@ const threadSummarySchema = z.object({
 	selectedModel: z.string(),
 	reasoningEffort: z.string(),
 	serviceTier: z.string(),
-	lastMessageAt: z.number(),
+	lastMessageAt: z.int(),
 	threadStatus: z.enum(['active', 'archived']),
 	latestRunStatus: z
 		.enum(['queued', 'running', 'awaiting_executor', 'completed', 'failed', 'cancelled'])
 		.nullable()
 		.optional(),
 	latestRunId: z.string().nullable().optional(),
-	latestRunStartedAt: z.number().nullable().optional(),
-	latestRunClaimExpiresAt: z.number().nullable().optional(),
+	latestRunStartedAt: z.int().nullable().optional(),
+	latestRunClaimExpiresAt: z.int().nullable().optional(),
 	hasActiveRun: z.boolean()
 });
 const threadCacheWatchEventSchema = z.object({
 	status: z.enum(['loading', 'live', 'reconnecting', 'offline', 'error']),
-	lastSyncedAt: z.number().nullable()
+	lastSyncedAt: z.int().nullable()
 });
 const threadCacheSnapshotSchema = threadCacheWatchEventSchema.extend({
 	threads: z.array(threadSummarySchema)
@@ -688,7 +688,7 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 				body: JSON.stringify(requestBody)
 			}),
 		rekeyRepository: async (requestBody) =>
-			await request('/api/threads/rekey', z.number(), {
+			await request('/api/threads/rekey', z.int(), {
 				method: 'POST',
 				body: JSON.stringify(requestBody)
 			}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#255 switched some schemas to `z.int()` and `z.looseObject()`. Integer fields in the local API client, gateway token payload, and model catalog were still `z.number()`.

Those fields are counters, timestamps, and protocol versions. `z.int()` rejects floats the way the old chained `.int()` API did.

## Checks

- `bun run --cwd apps/web test src/lib/local/client.test.ts src/convex/lib/gatewayToken.test.ts src/lib/chat/model-catalog.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-881a6f54-8857-4542-9099-33b710421e55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-881a6f54-8857-4542-9099-33b710421e55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens validation of counters, timestamps, protocol versions, and token limits by replacing permissive numeric schemas with Zod 4 integer schemas.
- Validates gateway-token expiration as an integer.
- Validates model-catalog protocol and token-limit fields as integers.
- Validates local API timestamps, counters, sequence numbers, attachment sizes, and rekey counts as integers.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable regressions identified.

The tightened schemas align with the current integer-valued token, catalog, and local API producers, so no reachable response or credential path was found that the new validation rejects.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/gatewayToken.ts | Tightens gateway-token expiration validation; the production issuer always supplies an integer millisecond timestamp. |
| apps/web/src/lib/chat/model-catalog.ts | Tightens protocol and model token-limit validation consistently with the integer-valued gateway contract. |
| apps/web/src/lib/local/client.ts | Tightens local API numeric contracts for counters and timestamps, whose current producers supply integer-valued data. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Use Zod 4 ints for remain..."](https://github.com/spikonado/sprocket/commit/f0b6e49ad395adbd6967a1ef5b5fa67d4a475927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59829286)</sub>

<!-- /greptile_comment -->