### PR TITLE
fix(ui): Apply selected model immediately

### DIFF
--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -428,6 +428,7 @@
 
 	function handleModelChange(modelId: CatalogModelId) {
 		if (!modelCatalog) return;
+		selectedModel = modelId;
 		const model = getCatalogModel(modelCatalog, modelId);
 		if (model) selectedReasoningEffort = model.defaultReasoningEffort;
 		onModelChange?.(modelId);
@@ -775,7 +776,7 @@
 							<div class="bg-hover-fill-strong mx-1 hidden h-4 w-px shrink-0 sm:block"></div>
 
 							<OptionSelector
-								bind:value={selectedModel}
+								value={selectedModel}
 								options={tierModelOptions}
 								ariaLabel="Select model"
 								menuTitle="Model"


### PR DESCRIPTION
## Summary

- make the composer own the model-selection update instead of relying on a nested component binding
- update the selected model before applying its reasoning default and persisting it
- ensure prompt submissions use the model the user just selected rather than the previous value

## Root cause

The option selector updated its own bindable `value`, but the composer callback only updated reasoning effort and persistence. The parent composer state could therefore remain on the previous model, so submissions continued to launch with that old value.

## Validation

- `nix develop -c bun run check` (from `apps/web`)
- `nix develop -c bun run build` (from `apps/web`)
- `nix develop -c bun run test -- src/lib/home/desktop.test.ts src/lib/project/threads.test.ts`
- `nix develop -c bun run test -- src/convex/threads.test.ts`
- targeted ESLint and Prettier checks
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves model-selection ownership into the prompt composer so the selected model is updated before its reasoning default is applied and the choice is persisted.
- Assigns the newly selected model in `handleModelChange`.
- Replaces the nested selector’s two-way binding with callback-driven parent state updates.
- Ensures subsequent submissions observe the newly selected model.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the model selector’s callback and submission state now consistently using the newly selected model.

The selector invokes the composer callback for valid enabled options, and that callback now updates the parent-owned model before applying defaults and persistence; catalog-unavailable interaction is disabled and submission remains guarded by catalog validity.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/prompt-composer.svelte | Updates model selection synchronously in the composer and removes redundant two-way binding; no actionable regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): Apply selected model immediatel..."](https://github.com/spikonado/sprocket/commit/260630e26f0da7f3edda47af569e4e372fd9a1b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59886342)</sub>

<!-- /greptile_comment -->