### PR TITLE
fix(workspace): Kill leftover Windows process trees after shell exit

### DIFF
--- a/crates/sprocket-workspace/src/tools.rs
+++ b/crates/sprocket-workspace/src/tools.rs
@@ -593,8 +593,10 @@ fn stop_remaining_processes(process_id: Option<u32>) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn stop_processes_after_shell_exit(_process_id: Option<u32>) -> Result<()> {
-    Ok(())
+fn stop_processes_after_shell_exit(process_id: Option<u32>) -> Result<()> {
+    // Match Unix: after the shell exits, kill any leftover process tree so
+    // background children from PowerShell do not outlive the session.
+    stop_remaining_processes(process_id)
 }
 
 pub fn default_command_shell() -> String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unix already tore down the process tree when the shell exited. On Windows, `stop_processes_after_shell_exit` was a no-op, so PowerShell background children could keep running after the session ended.

This calls the same leftover-process cleanup Windows already uses elsewhere once the shell exits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes Windows command-session cleanup to invoke the existing process-tree termination helper after the shell exits.
- Passes the captured shell process ID into post-exit cleanup.
- Aligns the Windows post-exit path with the existing Unix cleanup flow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-workspace/src/tools.rs | Windows shell-exit handling now delegates to the existing remaining-process cleanup function. |

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(workspace): Kill leftover Windows pr..."](https://github.com/spikonado/sprocket/commit/21526e350d526ff006fad976caa3f35e0e6ff5e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59939212)</sub>

<!-- /greptile_comment -->