### PR TITLE
fix(ui): Remove thread compaction summaries

### DIFF
--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -46,7 +46,6 @@
 		onDismissRemoteChangeNotice?: () => void;
 		emptyStateMessage?: string;
 		stale?: boolean;
-		contextSummary?: string | null;
 		loadingOlder?: boolean;
 		hasOlder?: boolean;
 		onLoadOlder?: () => void;
@@ -66,7 +65,6 @@
 			? 'Start a thread and ask Sprocket to inspect code, edit files, or run project commands.'
 			: 'Add a project to begin.',
 		stale = false,
-		contextSummary = null,
 		loadingOlder = false,
 		hasOlder = false,
 		onLoadOlder,
@@ -228,15 +226,6 @@
 				>
 					Showing a local copy while Sprocket reconnects to history.
 				</div>
-			{/if}
-
-			{#if contextSummary}
-				<details class="text-muted-foreground mb-6 rounded-2xl border px-4 py-3 text-sm">
-					<summary class="text-foreground cursor-pointer"
-						>Earlier conversation was summarized</summary
-					>
-					<p class="mt-2 whitespace-pre-wrap">{contextSummary}</p>
-				</details>
 			{/if}
 
 			{#if loadingOlder}

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -99,8 +99,7 @@ const localTranscriptPageSchema = z.object({
 	historyFromNumber: z.int(),
 	stale: z.boolean(),
 	parts: z.array(localTranscriptPartSchema),
-	nextBefore: z.int().optional(),
-	contextSummary: z.string().optional()
+	nextBefore: z.int().optional()
 });
 const transcriptWatchEventSchema = z.object({
 	eventType: z.string(),
@@ -168,7 +167,6 @@ function parseLocalTranscriptPage(
 		historyFromNumber: page.historyFromNumber,
 		stale: page.stale,
 		nextBefore: page.nextBefore,
-		contextSummary: page.contextSummary,
 		parts: page.parts.map(parseLocalTranscriptPart)
 	};
 }

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -163,7 +163,6 @@ export type LocalTranscriptPage = {
 	stale: boolean;
 	parts: LocalTranscriptPart[];
 	nextBefore?: number;
-	contextSummary?: string;
 };
 
 export type LiveCompletionOverlay = {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -519,7 +519,6 @@
 	let replicaStale = $state(false);
 	let replicaThreadId = $state<Id<'threadRecords'> | null>(null);
 	let replicaLoading = $state(false);
-	let replicaContextSummary = $state<string | null>(null);
 	let replicaError = $state<string | null>(null);
 	let replicaGeneration = 0;
 	let loadingOlderTranscriptGeneration = $state<number | null>(null);
@@ -539,7 +538,6 @@
 		replicaNextBefore = null;
 		replicaStale = false;
 		replicaLoading = threadId !== null;
-		replicaContextSummary = null;
 	}
 
 	$effect.pre(() => {
@@ -580,7 +578,6 @@
 				replicaStale = page.stale;
 				replicaLoading = false;
 				replicaError = null;
-				replicaContextSummary = page.contextSummary ?? null;
 				applyOlderPageCursor(page.nextBefore);
 			} catch {
 				if (!ac.signal.aborted && replicaGeneration === generation) {
@@ -1420,7 +1417,6 @@
 		}
 		replicaParts = mergeTranscriptParts(replicaParts, page.parts);
 		replicaStale = page.stale;
-		replicaContextSummary = page.contextSummary ?? replicaContextSummary;
 		if (replicaParts.length === page.parts.length) {
 			applyOlderPageCursor(page.nextBefore);
 		} else if (replicaNextBefore != null && page.nextBefore != null) {
@@ -2477,7 +2473,6 @@
 								}
 							}}
 							stale={replicaStale}
-							contextSummary={replicaContextSummary}
 							loadingOlder={loadingOlderTranscript}
 							hasOlder={replicaNextBefore != null}
 							emptyStateMessage={currentThreadId &&

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -219,7 +219,6 @@ impl TranscriptStore {
                 stale: state.stale,
                 parts: Vec::new(),
                 next_before: None,
-                context_summary: state.context_summary.clone(),
             });
         }
         let start = end_exclusive.saturating_sub(limit).max(history_from);
@@ -236,7 +235,6 @@ impl TranscriptStore {
             } else {
                 None
             },
-            context_summary: state.context_summary.clone(),
         })
     }
 

--- a/crates/sprocket-agent/src/transcript/types.rs
+++ b/crates/sprocket-agent/src/transcript/types.rs
@@ -173,8 +173,6 @@ pub struct TranscriptPage {
     pub parts: Vec<TranscriptPart>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_before: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub context_summary: Option<String>,
 }
 
 impl TranscriptPart {


### PR DESCRIPTION
## Summary
- remove the conversation compaction summary disclosure from the transcript UI
- remove now-unused summary state and component plumbing
- stop exposing compaction summaries in local transcript page responses while preserving them for agent context

## Checks
- `nix develop -c bun run check` (apps/web)
- `nix develop -c cargo test -p sprocket-agent transcript::`
- `nix develop -c cargo fmt --check`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hides conversation-compaction summaries from the transcript UI and removes the corresponding field throughout the UI-facing transcript-page contract while preserving summaries in agent context.
- Removes summary disclosure rendering and associated Svelte state and props.
- Removes `contextSummary` from the web client schema and shared transcript-page type.
- Stops serializing the summary from Rust transcript-page responses without changing stored transcript state or model-history reconstruction.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the UI-facing contract updated consistently and agent compaction context preserved.

The removed field has no remaining transcript-page consumers, and future agent runs continue loading compaction summaries directly from retained transcript state.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/components/home/thread-transcript.svelte | Removes the compaction-summary prop and disclosure while leaving transcript rendering and pagination behavior unchanged. |
| apps/web/src/lib/local/client.ts | Removes the summary field from transcript-page validation and parsing in alignment with the server response. |
| apps/web/src/lib/types/sprocket.ts | Updates the shared UI-facing transcript-page type to match the narrowed response contract. |
| apps/web/src/routes/+page.svelte | Removes unused summary state, response handling, and component plumbing without affecting transcript paging or live updates. |
| crates/sprocket-agent/src/transcript/store.rs | Stops exposing the stored context summary through UI-facing transcript pages while retaining it in transcript state. |
| crates/sprocket-agent/src/transcript/types.rs | Removes the summary from the serialized `TranscriptPage` wire type without changing `TranscriptState` or agent-history data. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ui): Hide conversation compacti..."](https://github.com/spikonado/sprocket/commit/ba72fd1aed49476a887cc75293a86c186b5eb0f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59951028)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Chat, timeline, and artifacts UI](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-chat-and-artifacts.md)
</details>


<!-- /greptile_comment -->