### PR TITLE
fix(payments): Gate mandate charge POST on claim generation

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -153,7 +153,16 @@ read gate.
 Remove the dual-write (and then the required field) after an unset rewrite.
 Drop `usageLedgerMigratedAt` after a separate unset, or in the same rewrite.
 
-### 4. Historical `runs.completionTransport`
+### 4. Optional `mandateCharges.claimGeneration`
+
+Added so reserve/reclaim can hand a generation token to
+`markChargeProviderRequested`. Older charge rows omit it; readers treat a
+missing value as `0`.
+
+Remove optionality after a rewrite sets `claimGeneration` on every row, or a
+prod check shows none omit it.
+
+### 5. Historical `runs.completionTransport`
 
 Stored runs may still say `convex-action`. New inserts are `gateway`. The
 field stays optional so those rows validate.
@@ -161,7 +170,7 @@ field stays optional so those rows validate.
 Remove the `convex-action` union member after a rewrite or a prod check shows
 none remain.
 
-### 5. Catalog snapshot fields on `runs`
+### 6. Catalog snapshot fields on `runs`
 
 Earlier gateway work stored `catalogVersion`, `contextWindowTokens`, and
 `autoCompactTokenLimit` on new runs. Current inserts leave those unset. The
@@ -171,14 +180,14 @@ agent reads context budget from `GET /api/v1/models`; `getContext` returns
 Keep the optional fields so rows that still have them validate. Unset them in
 a later rewrite, then drop them from the schema.
 
-### 6. Numbered transcript `migratedAt`
+### 7. Numbered transcript `migratedAt`
 
 `threadTranscriptStates.migratedAt` is leftover after the numbered-transcript
 backfill. Current writes do not set it.
 
 Remove after an unset rewrite, then drop it from the schema.
 
-### 7. Transcript tool `jobId`
+### 8. Transcript tool `jobId`
 
 Sources: append-only tool progress events.
 
@@ -198,7 +207,7 @@ optionality after a production scan finds no jobs without `toolInvocationId`.
 
 Safe when a prod check shows zero transcript tool parts carrying `jobId`.
 
-### 8. Legacy installation identity and machine metadata
+### 9. Legacy installation identity and machine metadata
 
 Local servers now persist a versioned `installation.json`. On first launch
 after upgrade they preserve the UUID from the legacy plain-text
@@ -214,7 +223,7 @@ Delete legacy `installation-id` files only after all supported installations
 have launched a JSON-aware server and rollback to an older release is no
 longer supported.
 
-### 9. Thread-message references
+### 10. Thread-message references
 
 Prompts and attachment metadata now live in `threadTranscriptParts`; current
 code neither reads nor writes `threadMessages`. The table is no longer in the

--- a/apps/web/src/convex/lib/payments/charges.ts
+++ b/apps/web/src/convex/lib/payments/charges.ts
@@ -22,10 +22,10 @@ export const chargeDoc = v.object({
 	reportOutcome: v.optional(vMandateReportOutcome),
 	reportedAt: v.optional(v.number()),
 	reportingStartedAt: v.optional(v.number()),
-		chargingStartedAt: v.optional(v.number()),
-		providerRequestedAt: v.optional(v.number()),
-		claimGeneration: v.optional(v.number()),
-		reportRetrierRunId: v.optional(v.string()),
+	chargingStartedAt: v.optional(v.number()),
+	providerRequestedAt: v.optional(v.number()),
+	claimGeneration: v.optional(v.number()),
+	reportRetrierRunId: v.optional(v.string()),
 	createdAt: v.number(),
 	updatedAt: v.number()
 });

--- a/apps/web/src/convex/lib/payments/charges.ts
+++ b/apps/web/src/convex/lib/payments/charges.ts
@@ -22,9 +22,10 @@ export const chargeDoc = v.object({
 	reportOutcome: v.optional(vMandateReportOutcome),
 	reportedAt: v.optional(v.number()),
 	reportingStartedAt: v.optional(v.number()),
-	chargingStartedAt: v.optional(v.number()),
-	providerRequestedAt: v.optional(v.number()),
-	reportRetrierRunId: v.optional(v.string()),
+		chargingStartedAt: v.optional(v.number()),
+		providerRequestedAt: v.optional(v.number()),
+		claimGeneration: v.optional(v.number()),
+		reportRetrierRunId: v.optional(v.string()),
 	createdAt: v.number(),
 	updatedAt: v.number()
 });

--- a/apps/web/src/convex/payments.test.ts
+++ b/apps/web/src/convex/payments.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { api } from '@convex/_generated/api';
+import { api, internal } from '@convex/_generated/api';
 import type { JsonObject, JsonValue } from '@convex/lib/json';
 import {
 	createQueuedRun,
@@ -307,12 +307,68 @@ describe('payments mandates', () => {
 			userId: 'user_alice',
 			pravaTransactionId: 'txn_9',
 			amount: 4_000,
-			status: 'awaiting_result'
+			status: 'awaiting_result',
+			claimGeneration: 1
 		});
 		expect(stored).not.toHaveProperty('token');
 		expect(stored).not.toHaveProperty('dynamicCvv');
 		expect(stored).not.toHaveProperty('expiryMonth');
 		expect(stored).not.toHaveProperty('expiryYear');
+	});
+
+	it('rejects markChargeProviderRequested after a stale reclaim bumps claimGeneration', async () => {
+		process.env.PRAVA_SECRET_KEY = 'sk_test_secret';
+		const t = initConvexTest();
+		const run = await startRun(t, 'user_alice');
+		const { setup } = await createApprovedMandate(t, run);
+
+		const first = await t.mutation(internal.payments.reserveCharge, {
+			mandateId: setup.mandateId,
+			runId: run.runId,
+			userId: 'user_alice',
+			amount: '40.00',
+			currency: 'USD',
+			description: 'Order 8842',
+			reference: 'order-gen'
+		});
+		expect(first).toMatchObject({ kind: 'reserved', claimGeneration: 1 });
+
+		await t.run(async (ctx) => {
+			if (first.kind !== 'reserved') throw new Error('expected reserved');
+			await ctx.db.patch('mandateCharges', first.chargeId, {
+				chargingStartedAt: Date.now() - 120_000
+			});
+		});
+
+		const reclaimed = await t.mutation(internal.payments.reserveCharge, {
+			mandateId: setup.mandateId,
+			runId: run.runId,
+			userId: 'user_alice',
+			amount: '40.00',
+			currency: 'USD',
+			description: 'Order 8842 retry',
+			reference: 'order-gen'
+		});
+		expect(reclaimed).toMatchObject({ kind: 'reserved', claimGeneration: 2 });
+		if (reclaimed.kind !== 'reserved' || first.kind !== 'reserved') {
+			throw new Error('expected reserved generations');
+		}
+
+		await expect(
+			t.mutation(internal.payments.markChargeProviderRequested, {
+				chargeId: first.chargeId,
+				userId: 'user_alice',
+				claimGeneration: first.claimGeneration
+			})
+		).rejects.toThrow(/taken over by another attempt/);
+
+		await expect(
+			t.mutation(internal.payments.markChargeProviderRequested, {
+				chargeId: reclaimed.chargeId,
+				userId: 'user_alice',
+				claimGeneration: reclaimed.claimGeneration
+			})
+		).resolves.toBeNull();
 	});
 
 	it('reuses a completed charge handle without replaying credentials', async () => {

--- a/apps/web/src/convex/payments.ts
+++ b/apps/web/src/convex/payments.ts
@@ -198,7 +198,8 @@ export const syncMandate = internalMutation({
 const reserveChargeResult = v.union(
 	v.object({
 		kind: v.literal('reserved'),
-		chargeId: v.id('mandateCharges')
+		chargeId: v.id('mandateCharges'),
+		claimGeneration: v.number()
 	}),
 	v.object({
 		kind: v.literal('existing'),
@@ -265,6 +266,7 @@ export const reserveCharge = internalMutation({
 						);
 					}
 					if (existing.status === 'failed') {
+						const claimGeneration = (existing.claimGeneration ?? 0) + 1;
 						await ctx.db.patch('mandateCharges', existing._id, {
 							runId: args.runId,
 							description: args.description,
@@ -272,9 +274,14 @@ export const reserveCharge = internalMutation({
 							pravaTransactionId: undefined,
 							providerRequestedAt: undefined,
 							chargingStartedAt: now,
+							claimGeneration,
 							updatedAt: now
 						});
-						return { kind: 'reserved' as const, chargeId: existing._id };
+						return {
+							kind: 'reserved' as const,
+							chargeId: existing._id,
+							claimGeneration
+						};
 					}
 					if (
 						existing.chargingStartedAt !== undefined &&
@@ -283,14 +290,20 @@ export const reserveCharge = internalMutation({
 						return { kind: 'inFlight' as const };
 					}
 					// Abandoned reservation that never reached Prava: reclaim.
+					const claimGeneration = (existing.claimGeneration ?? 0) + 1;
 					await ctx.db.patch('mandateCharges', existing._id, {
 						runId: args.runId,
 						description: args.description,
 						status: 'awaiting_result',
 						chargingStartedAt: now,
+						claimGeneration,
 						updatedAt: now
 					});
-					return { kind: 'reserved' as const, chargeId: existing._id };
+					return {
+						kind: 'reserved' as const,
+						chargeId: existing._id,
+						claimGeneration
+					};
 				}
 			}
 
@@ -304,10 +317,11 @@ export const reserveCharge = internalMutation({
 				reference,
 				status: 'awaiting_result',
 				chargingStartedAt: now,
+				claimGeneration: 1,
 				createdAt: now,
 				updatedAt: now
 			});
-			return { kind: 'reserved' as const, chargeId };
+			return { kind: 'reserved' as const, chargeId, claimGeneration: 1 };
 		} catch (error) {
 			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}
@@ -315,10 +329,24 @@ export const reserveCharge = internalMutation({
 });
 
 export const markChargeProviderRequested = internalMutation({
-	args: { chargeId: v.id('mandateCharges'), userId: v.string() },
+	args: {
+		chargeId: v.id('mandateCharges'),
+		userId: v.string(),
+		claimGeneration: v.number()
+	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		await ownedCharge(ctx, args.chargeId, args.userId);
+		const charge = await ownedCharge(ctx, args.chargeId, args.userId);
+		if ((charge.claimGeneration ?? 0) !== args.claimGeneration) {
+			throw new Error(
+				'Charge reservation was taken over by another attempt; refusing to charge again.'
+			);
+		}
+		if (charge.providerRequestedAt !== undefined) {
+			throw new Error(
+				'A previous charge attempt for this reference may have already been submitted to Prava; refusing to charge again.'
+			);
+		}
 		await ctx.db.patch('mandateCharges', args.chargeId, {
 			providerRequestedAt: Date.now(),
 			updatedAt: Date.now()
@@ -844,10 +872,13 @@ export const mandateCharge = action({
 				errorMessage?: string;
 			};
 			// Mark before the network call so a lost response cannot be mistaken
-			// for an abandoned reservation that is safe to reclaim.
+			// for an abandoned reservation that is safe to reclaim. claimGeneration
+			// stops a concurrent reclaim (e.g. during a slow resolve above) from
+			// also reaching POST /charge.
 			await ctx.runMutation(internal.payments.markChargeProviderRequested, {
 				chargeId: reservation.chargeId,
-				userId: actor.userId
+				userId: actor.userId,
+				claimGeneration: reservation.claimGeneration
 			});
 			try {
 				result = await pravaRequest(`/v1/mandates/${encodeURIComponent(prava.id)}/charge`, {

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -348,6 +348,9 @@ export default defineSchema({
 		// may have committed, so a row with this set and no transaction id must
 		// not be reclaimed for another provider request.
 		providerRequestedAt: v.optional(v.number()),
+		// Bumped on every reserve/reclaim. markChargeProviderRequested must see
+		// the same generation or a concurrent reclaim won the row.
+		claimGeneration: v.optional(v.number()),
 		reportRetrierRunId: v.optional(v.string()),
 		createdAt: v.number(),
 		updatedAt: v.number()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A slow Prava resolve could let reclaim hand the same mandate charge to a second provider request after the first POST was already in flight.

Reserve and reclaim now bump `claimGeneration`, and `markChargeProviderRequested` only proceeds when it still sees that generation. Older charge rows without the field still read as generation 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>













<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59959670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details open><summary>Summary</summary>

This PR fences mandate charge submission with a reservation generation so a superseded action cannot POST after another action reclaims the charge.
- Adds an optional, legacy-compatible `claimGeneration` field to mandate charge records and validators.
- Increments the generation whenever a charge is created or reclaimed.
- Requires the current generation and an unset provider-request marker immediately before submitting the charge.
- Adds coverage for a stale action racing with a reclaimed reservation.
</details>

<details open><summary>Diagram</summary>

```mermaid
sequenceDiagram
  participant A as First charge action
  participant C as Convex charge row
  participant B as Reclaiming action
  participant P as Prava
  A->>C: Reserve generation 1
  Note over A: Mandate resolution is delayed
  B->>C: Reclaim and set generation 2
  B->>C: Mark provider requested (generation 2)
  B->>P: POST charge
  A->>C: Mark provider requested (generation 1)
  C-->>A: Reject superseded generation
```
</details>

<sub>Reviews (6) · Last reviewed commit: ["style(payments): Align charge document v..."](https://github.com/spikonado/sprocket/commit/e3ecfdbec568682a7c30fd3adba989ab0708a820)</sub>

<!-- /greptile_comment -->