### PR TITLE
fix(agent): Keep partial text when a stream ends incomplete

### DIFF
--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -360,10 +360,12 @@ where
                         }
                         None => {
                             if let Some(error) = completion_error {
-                                break 'agent_run AgentProviderResult::Failed {
-                                    text: String::new(),
-                                    error,
+                                let text = if final_text.is_empty() {
+                                    streamed_text
+                                } else {
+                                    final_text
                                 };
+                                break 'agent_run AgentProviderResult::Failed { text, error };
                             }
                             if let Err(error) = transcript.finalize_turn().await {
                                 break 'agent_run transcript_error(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a provider stream ended incomplete or failed, the agent discarded whatever text had already arrived and returned an empty failure payload.

Failed runs now keep the streamed or final text that was received before the error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves provider text when a completion stream ends with an incomplete finish reason instead of returning an empty failure payload.
- Uses final response text when available.
- Falls back to accumulated streamed text when the final response is empty.
- Leaves failure classification and error propagation unchanged.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed branch preserves already-received text while retaining the existing incomplete-completion failure result and error, and no changed-code path was found that violates the provider or persistence contracts.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/provider.rs | The incomplete-stream failure branch now follows the existing provider-error text-selection behavior, with no actionable regression identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Keep partial text when a str..."](https://github.com/spikonado/sprocket/commit/db69a8ddfca6f106efff2e2f0aa69cbe0fd5c549) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59959675)</sub>

<!-- /greptile_comment -->