### PR TITLE
fix(server): Reject path traversal in SPA static fallback

### DIFF
--- a/crates/sprocket-server/src/static_files.rs
+++ b/crates/sprocket-server/src/static_files.rs
@@ -111,6 +111,9 @@ mod tests {
         assert_eq!(resolve_static_file(&dir, "/../Cargo.toml"), None);
         assert_eq!(resolve_static_file(&dir, "/foo/../../Cargo.toml"), None);
         assert_eq!(resolve_static_file(&dir, "/./pair"), None);
+        // `C:` is a Prefix component only on Windows. On Unix it is a normal
+        // path segment, so drive-style rejection is Windows-only.
+        #[cfg(windows)]
         assert_eq!(resolve_static_file(&dir, "/C:/Windows/win.ini"), None);
     }
 }

--- a/crates/sprocket-server/src/static_files.rs
+++ b/crates/sprocket-server/src/static_files.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use axum::Router;
 use axum::body::Body;
@@ -53,7 +53,16 @@ fn resolve_static_file(dir: &Path, path: &str) -> Option<PathBuf> {
         return Some(dir.join("index.html"));
     }
 
-    let direct = dir.join(clean);
+    // Only Normal components: reject `..`, absolute/prefix segments, and `.`.
+    let relative = Path::new(clean);
+    if !relative
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+
+    let direct = dir.join(relative);
     if direct.is_file() {
         return Some(direct);
     }
@@ -93,5 +102,15 @@ mod tests {
             resolve_static_file(&dir, "/callback"),
             Some(dir.join("callback.html"))
         );
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_absolute_segments() {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../apps/web/dist");
+
+        assert_eq!(resolve_static_file(&dir, "/../Cargo.toml"), None);
+        assert_eq!(resolve_static_file(&dir, "/foo/../../Cargo.toml"), None);
+        assert_eq!(resolve_static_file(&dir, "/./pair"), None);
+        assert_eq!(resolve_static_file(&dir, "/C:/Windows/win.ini"), None);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The SPA static fallback joined request paths onto the web root without rejecting `..` or absolute segments. A crafted URL could resolve outside the bundle directory.

Only `Normal` path components are accepted before joining.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents SPA static fallback paths from escaping the web root by accepting only normal relative path components before joining them.
- Rejects parent-directory, root, current-directory, and platform-specific prefix components.
- Adds traversal and absolute-path regression coverage, with the drive-prefix assertion correctly limited to Windows.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/static_files.rs | Adds component-level validation before static-path resolution and corrects the platform scope of the drive-prefix regression test. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): Gate drive-prefix static te..."](https://github.com/spikonado/sprocket/commit/5fe1556de9b882b69d95492a10f6f2c80d14a485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59959672)</sub>

<!-- /greptile_comment -->