### PR TITLE
fix(ui): Drive ask-question lifecycle off a ticking now

### DIFF
--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -223,4 +223,45 @@ describe('agentQuestions', () => {
 
 		vi.useRealTimers();
 	});
+
+	it('keeps an overdue-only head answerable until the timeout write lands', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-26T12:00:00.000Z'));
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const overdue = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Still there?',
+			options: [{ id: 'yes', label: 'Yes' }],
+			timeoutMs: 1_000,
+			executionSecret
+		});
+
+		vi.setSystemTime(new Date('2026-07-26T12:00:02.000Z'));
+
+		expect(
+			(
+				await asUser.query(api.agentQuestions.headPendingForThread, {
+					threadId,
+					now: Date.now()
+				})
+			)?.questionId
+		).toBe(overdue.questionId);
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: overdue.questionId,
+				optionId: 'yes'
+			})
+		).resolves.toMatchObject({
+			status: 'answered',
+			answer: { optionId: 'yes', optionLabel: 'Yes' }
+		});
+
+		vi.useRealTimers();
+	});
 });

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -75,32 +75,14 @@ async function headPendingQuestion(
 	return pending[0] ?? null;
 }
 
-/** First pending question that has not yet reached timeoutAt (UI head). */
-async function headLivePendingQuestion(
+/** First live pending question, or the overdue head if nothing is still live. */
+async function headPendingQuestionForUi(
 	ctx: QueryCtx | MutationCtx,
 	threadId: Id<'threadRecords'>,
 	now: number
 ): Promise<Doc<'agentQuestions'> | null> {
 	const pending = await listPendingQuestions(ctx, threadId);
-	return pending.find((question) => question.timeoutAt > now) ?? null;
-}
-
-/** Mark past-due pending questions timedOut so FIFO can advance before the scheduler fires. */
-async function expireOverduePendingQuestions(
-	ctx: MutationCtx,
-	threadId: Id<'threadRecords'>,
-	now: number
-): Promise<void> {
-	const pending = await listPendingQuestions(ctx, threadId);
-	for (const question of pending) {
-		if (question.timeoutAt > now) {
-			continue;
-		}
-		await ctx.db.patch('agentQuestions', question._id, {
-			status: 'timedOut',
-			answeredAt: now
-		});
-	}
+	return pending.find((question) => question.timeoutAt > now) ?? pending[0] ?? null;
 }
 
 export const create = mutation({
@@ -180,7 +162,16 @@ export const answer = mutation({
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
 
 		const now = Date.now();
-		await expireOverduePendingQuestions(ctx, args.threadId, now);
+		const pending = await listPendingQuestions(ctx, args.threadId);
+		const liveHead = pending.find((question) => question.timeoutAt > now) ?? null;
+		for (const question of pending) {
+			if (question.timeoutAt > now) continue;
+			if (!liveHead && question._id === args.questionId) continue;
+			await ctx.db.patch('agentQuestions', question._id, {
+				status: 'timedOut',
+				answeredAt: now
+			});
+		}
 
 		const question = await ctx.db.get('agentQuestions', args.questionId);
 		if (!question || question.threadId !== args.threadId) {
@@ -257,15 +248,15 @@ export const getForExecutor = query({
 export const headPendingForThread = query({
 	args: {
 		threadId: v.id('threadRecords'),
-		// Callers that can refresh should pass wall-clock time; omitted `now`
-		// falls back so older clients and tests keep the overdue-skip behavior.
+		// Callers that can refresh should pass wall-clock time so the head can
+		// skip overdue questions when a later one is still live.
 		now: v.optional(v.number())
 	},
 	returns: v.union(vAgentQuestionSnapshot, v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		const head = await headLivePendingQuestion(ctx, args.threadId, args.now ?? Date.now());
+		const head = await headPendingQuestionForUi(ctx, args.threadId, args.now ?? Date.now());
 		return head ? toSnapshot(head) : null;
 	}
 });

--- a/apps/web/src/convex/chat.lifecycle.test.ts
+++ b/apps/web/src/convex/chat.lifecycle.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api, internal } from '@convex/_generated/api';
 import { CANCELLATION_FORCE_AFTER_MS } from '@convex/lib/runCancellation';
 import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
 
 describe('chat.selectedThreadLifecycle', { timeout: 20_000 }, () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it('shows the latest completed run for a persisted thread', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
@@ -12,6 +16,61 @@ describe('chat.selectedThreadLifecycle', { timeout: 20_000 }, () => {
 			phase: 'completed',
 			run: { runId: expect.any(String) }
 		});
+	});
+
+	it('stops counting overdue ask questions as waiting_for_input when now is passed', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-26T12:00:00.000Z'));
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const executionSecret = 'lifecycle-question-secret';
+		const created = await createQueuedRun(
+			t,
+			asUser,
+			threadId,
+			`lifecycle-q-${Math.random()}`,
+			executionSecret,
+			'Need a choice'
+		);
+		const claimId = 'claim-lifecycle-q';
+		await t.mutation(api.agentRuntime.start, {
+			runId: created.runId,
+			claimId,
+			executionSecret
+		});
+		await t.mutation(api.agentRuntime.beginToolJob, {
+			runId: created.runId,
+			claimId,
+			kind: 'ask_question',
+			payload: {
+				question: 'placeholder',
+				options: [{ id: 'a', label: 'A' }]
+			},
+			executionSecret
+		});
+		await t.mutation(api.agentQuestions.create, {
+			runId: created.runId,
+			claimId,
+			question: 'Overdue?',
+			options: [{ id: 'old', label: 'Old' }],
+			timeoutMs: 1_000,
+			executionSecret
+		});
+
+		expect(
+			await asUser.query(api.chat.selectedThreadLifecycle, {
+				threadId,
+				now: Date.now()
+			})
+		).toMatchObject({ phase: 'waiting_for_input' });
+
+		vi.setSystemTime(new Date('2026-07-26T12:00:02.000Z'));
+		expect(
+			await asUser.query(api.chat.selectedThreadLifecycle, {
+				threadId,
+				now: Date.now()
+			})
+		).toMatchObject({ phase: 'running' });
 	});
 });
 

--- a/apps/web/src/convex/chat.ts
+++ b/apps/web/src/convex/chat.ts
@@ -21,7 +21,10 @@ export const latestRunForThread = query({
 
 export const selectedThreadLifecycle = query({
 	args: {
-		threadId: v.id('threadRecords')
+		threadId: v.id('threadRecords'),
+		// Callers that can refresh should pass wall-clock time so overdue ask
+		// questions stop counting as waiting_for_input without a DB write.
+		now: v.optional(v.number())
 	},
 	returns: vSelectedThreadLifecycle,
 	handler: async (ctx, args) => {
@@ -41,12 +44,14 @@ export const selectedThreadLifecycle = query({
 			});
 		}
 
-		const pendingQuestion = await ctx.db
+		const now = args.now ?? Date.now();
+		const pendingQuestions = await ctx.db
 			.query('agentQuestions')
 			.withIndex('by_threadId_status_sequence', (query) =>
 				query.eq('threadId', args.threadId).eq('status', 'pending')
 			)
-			.first();
+			.collect();
+		const waitingForInput = pendingQuestions.some((question) => question.timeoutAt > now);
 		let executorFriendlyName: string | undefined;
 		const machineId = runMachineId(latestRun);
 		if (machineId) {
@@ -57,7 +62,7 @@ export const selectedThreadLifecycle = query({
 		return projectSelectedThreadLifecycle({
 			threadId: args.threadId,
 			run: latestRun,
-			waitingForInput: pendingQuestion !== null,
+			waitingForInput,
 			executorFriendlyName
 		});
 	}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -451,8 +451,12 @@
 		currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
 			? { threadId: currentThreadId }
 			: 'skip';
+	const authenticatedLifecycleQueryArgs = () =>
+		currentThreadId && getAuthenticatedQueryArgs() !== 'skip'
+			? { threadId: currentThreadId, now: tickingNow() }
+			: 'skip';
 	const activeThreadQuery = useQuery(api.threads.getByThreadId, authenticatedThreadQueryArgs);
-	const lifecycleQuery = useQuery(api.chat.selectedThreadLifecycle, authenticatedThreadQueryArgs);
+	const lifecycleQuery = useQuery(api.chat.selectedThreadLifecycle, authenticatedLifecycleQueryArgs);
 	const artifactsQuery = useQuery(
 		api.artifacts.listArtifactsForThread,
 		authenticatedThreadQueryArgs
@@ -463,7 +467,7 @@
 	);
 	const pendingAgentQuestionQuery = useQuery(
 		api.agentQuestions.headPendingForThread,
-		authenticatedThreadQueryArgs
+		authenticatedLifecycleQueryArgs
 	);
 	const queryError = $derived.by(() => {
 		for (const query of [
@@ -1445,13 +1449,16 @@
 			};
 			await answerAgentQuestion(answer);
 		} catch (error) {
-			if (
-				currentThreadId === threadId &&
-				pendingAgentQuestion?.questionId === question.questionId
-			) {
-				prompt = submittedPrompt;
-				selectedQuestionOptionId = submittedOptionId;
+			// Always surface the error on this thread. Restore the draft only when
+			// the same ask is still showing, or the ask UI cleared (timeout /
+			// advance); never overwrite a different live question's composer.
+			if (currentThreadId === threadId) {
 				currentError = error instanceof Error ? error.message : String(error);
+				const head = pendingAgentQuestion;
+				if (!head || head.questionId === question.questionId) {
+					prompt = submittedPrompt;
+					selectedQuestionOptionId = submittedOptionId;
+				}
 			}
 		} finally {
 			answeringAgentQuestion = false;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -456,7 +456,10 @@
 			? { threadId: currentThreadId, now: tickingNow() }
 			: 'skip';
 	const activeThreadQuery = useQuery(api.threads.getByThreadId, authenticatedThreadQueryArgs);
-	const lifecycleQuery = useQuery(api.chat.selectedThreadLifecycle, authenticatedLifecycleQueryArgs);
+	const lifecycleQuery = useQuery(
+		api.chat.selectedThreadLifecycle,
+		authenticatedLifecycleQueryArgs
+	);
 	const artifactsQuery = useQuery(
 		api.artifacts.listArtifactsForThread,
 		authenticatedThreadQueryArgs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Overdue ask prompts stayed answerable because the lifecycle query did not see wall-clock time. Advancing the conversation head could also swallow answer errors and clobber the draft.

The client passes a ticking `now` into the lifecycle query so timed-out questions stop counting as waiting, and failed answers restore the draft.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>











<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes ask-question lifecycle queries responsive to wall-clock time and restores submitted drafts after failed answers.
- Passes a ticking `now` value into lifecycle and pending-question queries.
- Excludes overdue questions from the waiting-for-input lifecycle state.
- Preserves an overdue-only question until its timeout write lands.
- Restores the draft and selected option when an answer fails without overwriting a different live question.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentQuestions.ts | Updates pending-question selection and answer-time expiration behavior while retaining an overdue-only UI head. |
| apps/web/src/convex/chat.ts | Uses the supplied wall-clock time to exclude overdue questions from the waiting-for-input lifecycle state. |
| apps/web/src/routes/+page.svelte | Supplies ticking query arguments and restores failed answer drafts without retaining the previously broken context-summary wiring. |
| apps/web/src/convex/agentQuestions.test.ts | Covers answering an overdue-only head before its timeout write lands. |
| apps/web/src/convex/chat.lifecycle.test.ts | Covers the lifecycle transition after a pending question becomes overdue. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ui): Keep overdue-only ask questions..."](https://github.com/spikonado/sprocket/commit/76bf622927220f7cf44204f345a4e66ec338cc8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59960079)</sub>

<!-- /greptile_comment -->