### PR TITLE
fix(workspace): Preserve originals during patch replacement

### DIFF
--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -701,7 +701,9 @@ async fn stage_unique_sibling(
                 let already_exists = error.chain().any(|cause| {
                     cause
                         .downcast_ref::<std::io::Error>()
-                        .is_some_and(|io_error| io_error.kind() == std::io::ErrorKind::AlreadyExists)
+                        .is_some_and(|io_error| {
+                            io_error.kind() == std::io::ErrorKind::AlreadyExists
+                        })
                 });
                 if already_exists {
                     last_error = Some(error);

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -649,7 +649,10 @@ async fn replace_file(path: &Path, contents: &[u8], permissions: Permissions) ->
     let tmp = stage_unique_sibling(path, "tmp", contents, Some(permissions)).await?;
 
     match tokio::fs::rename(&tmp, path).await {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            discard_sprocket_bak_siblings(path).await;
+            Ok(())
+        }
         Err(error) => {
             #[cfg(windows)]
             {
@@ -771,16 +774,27 @@ async fn stage_unique_sibling(
 }
 
 /// Restore `{name}.sprocket-bak.*` when `path` is missing after an interrupted replace.
+///
+/// Unselected generated backups are removed after the chosen file is restored so
+/// a later boot cannot rank a leftover against a new monotonic stamp.
 async fn recover_stranded_sprocket_bak(path: &Path) -> Result<()> {
     if tokio::fs::try_exists(path).await.unwrap_or(false) {
         return Ok(());
     }
-    let Some(bak) = newest_sprocket_bak_sibling(path).await? else {
+    let found = list_sprocket_bak_siblings(path).await?;
+    let Some(bak) =
+        select_newest_sprocket_sibling(found.iter().map(|(key, path)| (*key, path.clone())))
+    else {
         return Ok(());
     };
     tokio::fs::rename(&bak, path)
         .await
         .with_context(|| format!("failed to restore stranded backup for {}", path.display()))?;
+    for (_, leftover) in found {
+        if leftover != bak {
+            let _ = tokio::fs::remove_file(&leftover).await;
+        }
+    }
     Ok(())
 }
 
@@ -830,16 +844,16 @@ fn select_newest_sprocket_sibling<T>(
         .map(|(_, value)| value)
 }
 
-async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
+async fn list_sprocket_bak_siblings(path: &Path) -> Result<Vec<(SprocketSiblingKey, PathBuf)>> {
     let Some(parent) = path.parent() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let mut entries = match tokio::fs::read_dir(parent).await {
         Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => {
             return Err(error).with_context(|| format!("failed to list {}", parent.display()));
         }
@@ -859,7 +873,16 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
         }
         found.push((key, entry.path()));
     }
-    Ok(select_newest_sprocket_sibling(found))
+    Ok(found)
+}
+
+async fn discard_sprocket_bak_siblings(path: &Path) {
+    let Ok(found) = list_sprocket_bak_siblings(path).await else {
+        return;
+    };
+    for (_, bak) in found {
+        let _ = tokio::fs::remove_file(bak).await;
+    }
 }
 
 #[cfg(windows)]
@@ -878,7 +901,7 @@ async fn replace_existing_windows(path: &Path, tmp: &Path) -> Result<()> {
 
     match tokio::fs::rename(tmp, path).await {
         Ok(()) => {
-            let _ = tokio::fs::remove_file(&bak).await;
+            discard_sprocket_bak_siblings(path).await;
             Ok(())
         }
         Err(error) => {
@@ -1117,7 +1140,7 @@ mod tests {
         assert_eq!(fs::read_to_string(&target).unwrap(), "latest original\n");
         assert!(!newest.exists());
         assert_eq!(fs::read_to_string(&user_notes).unwrap(), "user notes\n");
-        assert_eq!(fs::read_to_string(&stale).unwrap(), "stale original\n");
+        assert!(!stale.exists());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1136,7 +1159,7 @@ mod tests {
             .expect("later instance should restore");
         assert_eq!(fs::read_to_string(&target).unwrap(), "latest original\n");
         assert!(!current.exists());
-        assert_eq!(fs::read_to_string(&leftover).unwrap(), "stale original\n");
+        assert!(!leftover.exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -645,6 +645,11 @@ async fn replace_file(path: &Path, contents: &[u8], permissions: Permissions) ->
     // Windows replace moves the original to `*.sprocket-bak.*` before installing
     // the staged file; if that process dies mid-way, restore the backup first.
     recover_stranded_sprocket_bak(path).await?;
+    // Drop leftovers while the target exists. Otherwise a crash after install
+    // but before the success-path sweep can leave an old bak beside the file;
+    // the next replace would then create a second bak and recovery could compare
+    // stamps from different boots.
+    discard_sprocket_bak_siblings(path).await;
 
     let tmp = stage_unique_sibling(path, "tmp", contents, Some(permissions)).await?;
 
@@ -783,7 +788,7 @@ async fn recover_stranded_sprocket_bak(path: &Path) -> Result<()> {
     }
     let found = list_sprocket_bak_siblings(path).await?;
     let Some(bak) =
-        select_newest_sprocket_sibling(found.iter().map(|(key, path)| (*key, path.clone())))
+        select_newest_sprocket_sibling(found.iter().map(|(key, bak)| (*key, bak.clone())))
     else {
         return Ok(());
     };
@@ -1159,6 +1164,26 @@ mod tests {
             .expect("later instance should restore");
         assert_eq!(fs::read_to_string(&target).unwrap(), "latest original\n");
         assert!(!current.exists());
+        assert!(!leftover.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn replace_discards_leftover_bak_while_target_exists() {
+        let root = temp_workspace();
+        let target = root.join("file.txt");
+        let leftover = root.join("file.txt.sprocket-bak.1.0.9");
+        fs::write(&target, "current\n").unwrap();
+        fs::write(&leftover, "old bak\n").unwrap();
+
+        replace_file(
+            &target,
+            b"next\n",
+            fs::metadata(&target).unwrap().permissions(),
+        )
+        .await
+        .expect("replace should ignore leftover bak");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "next\n");
         assert!(!leftover.exists());
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -669,7 +669,7 @@ fn unique_sibling_path(path: &Path, kind: &str) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let instance = sprocket_instance_id();
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let nanos = unix_nanos();
+    let nanos = monotonic_nanos();
     let mut name = path
         .file_name()
         .map(|name| name.to_os_string())
@@ -683,6 +683,44 @@ fn unix_nanos() -> u128 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or(0)
+}
+
+/// Ranking stamp for sibling names. Wall time can step backward, which would
+/// make a later write lose a cross-instance comparison. Monotonic time does not.
+fn monotonic_nanos() -> u128 {
+    #[cfg(unix)]
+    {
+        let mut ts = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // SAFETY: `ts` is a valid timespec out-pointer.
+        if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) } == 0 {
+            let sec = (ts.tv_sec as i128).max(0) as u128;
+            let nsec = (ts.tv_nsec as i128).max(0) as u128;
+            return sec.saturating_mul(1_000_000_000).saturating_add(nsec);
+        }
+    }
+    #[cfg(windows)]
+    {
+        let mut frequency = 0i64;
+        let mut count = 0i64;
+        // SAFETY: both calls write through valid i64 out-pointers.
+        if unsafe { QueryPerformanceFrequency(&mut frequency) } != 0
+            && frequency > 0
+            && unsafe { QueryPerformanceCounter(&mut count) } != 0
+            && count >= 0
+        {
+            return (count as u128).saturating_mul(1_000_000_000) / (frequency as u128);
+        }
+    }
+    unix_nanos()
+}
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn QueryPerformanceCounter(performance_count: *mut i64) -> i32;
+    fn QueryPerformanceFrequency(frequency: *mut i64) -> i32;
 }
 
 /// Stable for one process lifetime. Mixes first-staging wall time with the OS
@@ -772,8 +810,8 @@ fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<Spr
 }
 
 /// Newest sibling is unique even when same-instance seq order and cross-instance
-/// timestamps would not form a pairwise ranking. Keep the latest seq per
-/// process instance, then pick the latest timestamp among those winners.
+/// stamps would not form a pairwise ranking. Keep the latest seq per process
+/// instance, then pick the latest monotonic stamp among those winners.
 fn select_newest_sprocket_sibling<T>(
     items: impl IntoIterator<Item = (SprocketSiblingKey, T)>,
 ) -> Option<T> {

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -750,16 +750,26 @@ fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<(u1
     Some((nanos, seq, pid))
 }
 
-/// Same-process seq is monotonic even if the wall clock jumps backward.
-/// Different processes have no shared counter, so timestamp is the fallback.
-fn sprocket_sibling_is_newer(candidate: (u128, u64, u32), best: (u128, u64, u32)) -> bool {
-    let (candidate_nanos, candidate_seq, candidate_pid) = candidate;
-    let (best_nanos, best_seq, best_pid) = best;
-    if candidate_pid == best_pid {
-        (candidate_seq, candidate_nanos) > (best_seq, best_nanos)
-    } else {
-        (candidate_nanos, candidate_seq, candidate_pid) > (best_nanos, best_seq, best_pid)
+/// Newest sibling is unique even when same-pid seq order and cross-pid
+/// timestamps would not form a pairwise ranking. Keep the latest seq per pid,
+/// then pick the latest timestamp among those per-process winners.
+fn select_newest_sprocket_sibling<T>(
+    items: impl IntoIterator<Item = ((u128, u64, u32), T)>,
+) -> Option<T> {
+    let mut newest_by_pid: HashMap<u32, ((u128, u64, u32), T)> = HashMap::new();
+    for (key, value) in items {
+        let pid = key.2;
+        if newest_by_pid
+            .get(&pid)
+            .is_none_or(|(best, _)| (key.1, key.0) > (best.1, best.0))
+        {
+            newest_by_pid.insert(pid, (key, value));
+        }
     }
+    newest_by_pid
+        .into_values()
+        .max_by(|(left, _), (right, _)| left.cmp(right))
+        .map(|(_, value)| value)
 }
 
 async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
@@ -777,7 +787,7 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
         }
     };
 
-    let mut newest: Option<((u128, u64, u32), PathBuf)> = None;
+    let mut found = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
         let name = entry.file_name();
         let Some(name) = name.to_str() else {
@@ -789,14 +799,9 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
         if !entry.file_type().await?.is_file() {
             continue;
         }
-        if newest
-            .as_ref()
-            .is_none_or(|(best, _)| sprocket_sibling_is_newer(key, *best))
-        {
-            newest = Some((key, entry.path()));
-        }
+        found.push((key, entry.path()));
     }
-    Ok(newest.map(|(_, path)| path))
+    Ok(select_newest_sprocket_sibling(found))
 }
 
 #[cfg(windows)]
@@ -919,7 +924,7 @@ mod tests {
 
     use super::{
         apply_workspace_patch, normalize_unified_diff_hunk_counts, recover_stranded_sprocket_bak,
-        replace_file, sprocket_sibling_is_newer, write_new_file,
+        replace_file, select_newest_sprocket_sibling, write_new_file,
     };
     use crate::commands::{WorkspaceCancellation, WorkspaceOperationCancelled};
     use crate::test_support::temp_workspace;
@@ -930,8 +935,26 @@ mod tests {
     fn same_process_bak_prefers_later_seq_if_clock_jumps_back() {
         let older = (200_u128, 1_u64, 10_u32);
         let newer = (50_u128, 2_u64, 10_u32);
-        assert!(sprocket_sibling_is_newer(newer, older));
-        assert!(!sprocket_sibling_is_newer(older, newer));
+        assert_eq!(
+            select_newest_sprocket_sibling([(older, "old"), (newer, "new")]),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn mixed_pid_bak_selection_is_order_independent() {
+        let a = (10_u128, 2_u64, 1_u32);
+        let b = (20_u128, 1_u64, 1_u32);
+        let c = (15_u128, 0_u64, 2_u32);
+        let keys = [a, b, c];
+        assert_eq!(
+            select_newest_sprocket_sibling(keys.into_iter().map(|key| (key, key))),
+            Some(c)
+        );
+        assert_eq!(
+            select_newest_sprocket_sibling(keys.into_iter().rev().map(|key| (key, key))),
+            Some(c)
+        );
     }
 
     #[tokio::test]

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -667,20 +667,30 @@ async fn replace_file(path: &Path, contents: &[u8], permissions: Permissions) ->
 
 fn unique_sibling_path(path: &Path, kind: &str) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let instance = sprocket_instance_id();
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
+    let nanos = unix_nanos();
     let mut name = path
         .file_name()
         .map(|name| name.to_os_string())
         .unwrap_or_else(|| "file".into());
-    name.push(format!(
-        ".sprocket-{kind}.{}.{seq}.{nanos}",
-        std::process::id()
-    ));
+    name.push(format!(".sprocket-{kind}.{instance}.{seq}.{nanos}"));
     path.with_file_name(name)
+}
+
+fn unix_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+/// Stable for one process lifetime. Mixes first-staging wall time with the OS
+/// pid so a later process that reuses that pid does not share a grouping key
+/// with leftover siblings from the previous occupant.
+fn sprocket_instance_id() -> u128 {
+    static ID: OnceLock<u128> = OnceLock::new();
+    *ID.get_or_init(|| (unix_nanos() << 32) | u128::from(std::process::id()))
 }
 
 async fn stage_unique_sibling(
@@ -736,39 +746,49 @@ async fn recover_stranded_sprocket_bak(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Matches `unique_sibling_path`: `{file_name}.sprocket-{kind}.{pid}.{seq}.{nanos}`.
-fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<(u128, u64, u32)> {
+/// Parsed `{file_name}.sprocket-{kind}.{instance}.{seq}.{nanos}` key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SprocketSiblingKey {
+    nanos: u128,
+    seq: u64,
+    instance: u128,
+}
+
+fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<SprocketSiblingKey> {
     let prefix = format!("{file_name}.sprocket-{kind}.");
     let rest = name.strip_prefix(&prefix)?;
     let mut parts = rest.split('.');
-    let pid: u32 = parts.next()?.parse().ok()?;
-    let seq: u64 = parts.next()?.parse().ok()?;
-    let nanos: u128 = parts.next()?.parse().ok()?;
+    let instance = parts.next()?.parse().ok()?;
+    let seq = parts.next()?.parse().ok()?;
+    let nanos = parts.next()?.parse().ok()?;
     if parts.next().is_some() {
         return None;
     }
-    Some((nanos, seq, pid))
+    Some(SprocketSiblingKey {
+        nanos,
+        seq,
+        instance,
+    })
 }
 
-/// Newest sibling is unique even when same-pid seq order and cross-pid
-/// timestamps would not form a pairwise ranking. Keep the latest seq per pid,
-/// then pick the latest timestamp among those per-process winners.
+/// Newest sibling is unique even when same-instance seq order and cross-instance
+/// timestamps would not form a pairwise ranking. Keep the latest seq per
+/// process instance, then pick the latest timestamp among those winners.
 fn select_newest_sprocket_sibling<T>(
-    items: impl IntoIterator<Item = ((u128, u64, u32), T)>,
+    items: impl IntoIterator<Item = (SprocketSiblingKey, T)>,
 ) -> Option<T> {
-    let mut newest_by_pid: HashMap<u32, ((u128, u64, u32), T)> = HashMap::new();
+    let mut newest_by_instance: HashMap<u128, (SprocketSiblingKey, T)> = HashMap::new();
     for (key, value) in items {
-        let pid = key.2;
-        if newest_by_pid
-            .get(&pid)
-            .is_none_or(|(best, _)| (key.1, key.0) > (best.1, best.0))
+        if newest_by_instance
+            .get(&key.instance)
+            .is_none_or(|(best, _)| (key.seq, key.nanos) > (best.seq, best.nanos))
         {
-            newest_by_pid.insert(pid, (key, value));
+            newest_by_instance.insert(key.instance, (key, value));
         }
     }
-    newest_by_pid
+    newest_by_instance
         .into_values()
-        .max_by(|(left, _), (right, _)| left.cmp(right))
+        .max_by_key(|(key, _)| (key.nanos, key.instance))
         .map(|(_, value)| value)
 }
 
@@ -923,8 +943,8 @@ mod tests {
     use std::sync::Mutex;
 
     use super::{
-        apply_workspace_patch, normalize_unified_diff_hunk_counts, recover_stranded_sprocket_bak,
-        replace_file, select_newest_sprocket_sibling, write_new_file,
+        SprocketSiblingKey, apply_workspace_patch, recover_stranded_sprocket_bak, replace_file,
+        select_newest_sprocket_sibling, write_new_file,
     };
     use crate::commands::{WorkspaceCancellation, WorkspaceOperationCancelled};
     use crate::test_support::temp_workspace;
@@ -933,8 +953,16 @@ mod tests {
 
     #[test]
     fn same_process_bak_prefers_later_seq_if_clock_jumps_back() {
-        let older = (200_u128, 1_u64, 10_u32);
-        let newer = (50_u128, 2_u64, 10_u32);
+        let older = SprocketSiblingKey {
+            nanos: 200,
+            seq: 1,
+            instance: 10,
+        };
+        let newer = SprocketSiblingKey {
+            nanos: 50,
+            seq: 2,
+            instance: 10,
+        };
         assert_eq!(
             select_newest_sprocket_sibling([(older, "old"), (newer, "new")]),
             Some("new")
@@ -942,10 +970,22 @@ mod tests {
     }
 
     #[test]
-    fn mixed_pid_bak_selection_is_order_independent() {
-        let a = (10_u128, 2_u64, 1_u32);
-        let b = (20_u128, 1_u64, 1_u32);
-        let c = (15_u128, 0_u64, 2_u32);
+    fn mixed_instance_bak_selection_is_order_independent() {
+        let a = SprocketSiblingKey {
+            nanos: 10,
+            seq: 2,
+            instance: 1,
+        };
+        let b = SprocketSiblingKey {
+            nanos: 20,
+            seq: 1,
+            instance: 1,
+        };
+        let c = SprocketSiblingKey {
+            nanos: 15,
+            seq: 0,
+            instance: 2,
+        };
         let keys = [a, b, c];
         assert_eq!(
             select_newest_sprocket_sibling(keys.into_iter().map(|key| (key, key))),
@@ -954,6 +994,45 @@ mod tests {
         assert_eq!(
             select_newest_sprocket_sibling(keys.into_iter().rev().map(|key| (key, key))),
             Some(c)
+        );
+    }
+
+    #[test]
+    fn reused_pid_bak_prefers_later_process_timestamp() {
+        // Two process lifetimes can share an OS pid. Their instance ids differ,
+        // so a leftover high-seq backup from the earlier occupant must lose to
+        // a seq-0 backup from the later process.
+        let leftover = SprocketSiblingKey {
+            nanos: 100,
+            seq: 5,
+            instance: 10,
+        };
+        let current = SprocketSiblingKey {
+            nanos: 200,
+            seq: 0,
+            instance: 11,
+        };
+        assert_eq!(
+            select_newest_sprocket_sibling([(leftover, "stale"), (current, "fresh")]),
+            Some("fresh")
+        );
+    }
+
+    #[test]
+    fn equal_timestamp_prefers_later_instance_not_higher_seq() {
+        let leftover = SprocketSiblingKey {
+            nanos: 100,
+            seq: 5,
+            instance: 10,
+        };
+        let current = SprocketSiblingKey {
+            nanos: 100,
+            seq: 0,
+            instance: 11,
+        };
+        assert_eq!(
+            select_newest_sprocket_sibling([(leftover, "stale"), (current, "fresh")]),
+            Some("fresh")
         );
     }
 
@@ -1001,6 +1080,25 @@ mod tests {
         assert!(!newest.exists());
         assert_eq!(fs::read_to_string(&user_notes).unwrap(), "user notes\n");
         assert_eq!(fs::read_to_string(&stale).unwrap(), "stale original\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn recovery_prefers_later_instance_over_leftover_high_seq() {
+        let root = temp_workspace();
+        let target = root.join("file.txt");
+        let leftover = root.join("file.txt.sprocket-bak.10.5.100");
+        let current = root.join("file.txt.sprocket-bak.11.0.200");
+        fs::write(&leftover, "stale original\n").unwrap();
+        fs::write(&current, "latest original\n").unwrap();
+        assert!(!target.exists());
+
+        recover_stranded_sprocket_bak(&target)
+            .await
+            .expect("later instance should restore");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "latest original\n");
+        assert!(!current.exists());
+        assert_eq!(fs::read_to_string(&leftover).unwrap(), "stale original\n");
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -750,6 +750,21 @@ fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<(u1
     Some((nanos, seq, pid))
 }
 
+/// Same-process seq is monotonic even if the wall clock jumps backward.
+/// Different processes have no shared counter, so timestamp is the fallback.
+fn sprocket_sibling_is_newer(
+    candidate: (u128, u64, u32),
+    best: (u128, u64, u32),
+) -> bool {
+    let (candidate_nanos, candidate_seq, candidate_pid) = candidate;
+    let (best_nanos, best_seq, best_pid) = best;
+    if candidate_pid == best_pid {
+        (candidate_seq, candidate_nanos) > (best_seq, best_nanos)
+    } else {
+        (candidate_nanos, candidate_seq, candidate_pid) > (best_nanos, best_seq, best_pid)
+    }
+}
+
 async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
     let Some(parent) = path.parent() else {
         return Ok(None);
@@ -777,7 +792,10 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
         if !entry.file_type().await?.is_file() {
             continue;
         }
-        if newest.as_ref().is_none_or(|(best, _)| key > *best) {
+        if newest
+            .as_ref()
+            .is_none_or(|(best, _)| sprocket_sibling_is_newer(key, *best))
+        {
             newest = Some((key, entry.path()));
         }
     }
@@ -904,12 +922,20 @@ mod tests {
 
     use super::{
         apply_workspace_patch, normalize_unified_diff_hunk_counts, recover_stranded_sprocket_bak,
-        replace_file, write_new_file,
+        replace_file, sprocket_sibling_is_newer, write_new_file,
     };
     use crate::commands::{WorkspaceCancellation, WorkspaceOperationCancelled};
     use crate::test_support::temp_workspace;
 
     static HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn same_process_bak_prefers_later_seq_if_clock_jumps_back() {
+        let older = (200_u128, 1_u64, 10_u32);
+        let newer = (50_u128, 2_u64, 10_u32);
+        assert!(sprocket_sibling_is_newer(newer, older));
+        assert!(!sprocket_sibling_is_newer(older, newer));
+    }
 
     #[tokio::test]
     async fn restores_stranded_sprocket_bak_before_replace() {

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -649,13 +649,13 @@ async fn replace_file(path: &Path, contents: &[u8], permissions: Permissions) ->
     // but before the success-path sweep can leave an old bak beside the file;
     // the next replace would then create a second bak and recovery could compare
     // stamps from different boots.
-    discard_sprocket_bak_siblings(path).await;
+    discard_sprocket_bak_siblings(path).await?;
 
     let tmp = stage_unique_sibling(path, "tmp", contents, Some(permissions)).await?;
 
     match tokio::fs::rename(&tmp, path).await {
         Ok(()) => {
-            discard_sprocket_bak_siblings(path).await;
+            let _ = discard_sprocket_bak_siblings(path).await;
             Ok(())
         }
         Err(error) => {
@@ -881,13 +881,20 @@ async fn list_sprocket_bak_siblings(path: &Path) -> Result<Vec<(SprocketSiblingK
     Ok(found)
 }
 
-async fn discard_sprocket_bak_siblings(path: &Path) {
-    let Ok(found) = list_sprocket_bak_siblings(path).await else {
-        return;
-    };
+async fn discard_sprocket_bak_siblings(path: &Path) -> Result<()> {
+    let found = list_sprocket_bak_siblings(path).await?;
     for (_, bak) in found {
-        let _ = tokio::fs::remove_file(bak).await;
+        match tokio::fs::remove_file(&bak).await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to discard leftover backup {}", bak.display())
+                });
+            }
+        }
     }
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -906,7 +913,7 @@ async fn replace_existing_windows(path: &Path, tmp: &Path) -> Result<()> {
 
     match tokio::fs::rename(tmp, path).await {
         Ok(()) => {
-            discard_sprocket_bak_siblings(path).await;
+            let _ = discard_sprocket_bak_siblings(path).await;
             Ok(())
         }
         Err(error) => {

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::Permissions;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
 use diffy::patch_set::{FileOperation, ParseOptions, PatchKind, PatchSet};
@@ -635,10 +637,168 @@ async fn write_new_file(
 }
 
 async fn replace_file(path: &Path, contents: &[u8], permissions: Permissions) -> Result<()> {
-    tokio::fs::remove_file(path)
+    // Write the full replacement beside the target first. A crash mid-write
+    // must not leave the original deleted with nothing in its place.
+    // Use a unique sibling name so we never delete a user's `*.sprocket-tmp`
+    // (or a recoverable `*.sprocket-bak` from an earlier failed replace).
+    //
+    // Windows replace moves the original to `*.sprocket-bak.*` before installing
+    // the staged file; if that process dies mid-way, restore the backup first.
+    recover_stranded_sprocket_bak(path).await?;
+
+    let tmp = stage_unique_sibling(path, "tmp", contents, Some(permissions)).await?;
+
+    match tokio::fs::rename(&tmp, path).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            #[cfg(windows)]
+            {
+                // Windows rename won't overwrite. Move the original aside first so
+                // a failed install can restore it instead of deleting in place.
+                if error.kind() == std::io::ErrorKind::AlreadyExists {
+                    return replace_existing_windows(path, &tmp).await;
+                }
+            }
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(error).with_context(|| format!("failed to replace {}", path.display()))
+        }
+    }
+}
+
+fn unique_sibling_path(path: &Path, kind: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let mut name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_else(|| "file".into());
+    name.push(format!(
+        ".sprocket-{kind}.{}.{seq}.{nanos}",
+        std::process::id()
+    ));
+    path.with_file_name(name)
+}
+
+async fn stage_unique_sibling(
+    path: &Path,
+    kind: &str,
+    contents: &[u8],
+    permissions: Option<Permissions>,
+) -> Result<PathBuf> {
+    let mut last_error = None;
+    for _ in 0..16 {
+        let candidate = unique_sibling_path(path, kind);
+        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+            continue;
+        }
+        match write_new_file(&candidate, contents, permissions.clone()).await {
+            Ok(()) => return Ok(candidate),
+            Err(error) => {
+                if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+                    last_error = Some(error);
+                    continue;
+                }
+                return Err(error).with_context(|| {
+                    format!("failed to stage replacement for {}", path.display())
+                });
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow!("failed to allocate staging path")))
+        .with_context(|| format!("failed to stage replacement for {}", path.display()))
+}
+
+/// Restore `{name}.sprocket-bak.*` when `path` is missing after an interrupted replace.
+async fn recover_stranded_sprocket_bak(path: &Path) -> Result<()> {
+    if tokio::fs::try_exists(path).await.unwrap_or(false) {
+        return Ok(());
+    }
+    let Some(bak) = newest_sprocket_bak_sibling(path).await? else {
+        return Ok(());
+    };
+    tokio::fs::rename(&bak, path)
         .await
-        .with_context(|| format!("failed to replace {}", path.display()))?;
-    write_new_file(path, contents, Some(permissions)).await
+        .with_context(|| format!("failed to restore stranded backup for {}", path.display()))?;
+    Ok(())
+}
+
+async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
+    let Some(parent) = path.parent() else {
+        return Ok(None);
+    };
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    let prefix = format!("{file_name}.sprocket-bak.");
+    let mut entries = match tokio::fs::read_dir(parent).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to list {}", parent.display()));
+        }
+    };
+
+    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        if !entry.file_type().await?.is_file() {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .await?
+            .modified()
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        match &newest {
+            Some((best, _)) if modified <= *best => {}
+            _ => newest = Some((modified, entry.path())),
+        }
+    }
+    Ok(newest.map(|(_, path)| path))
+}
+
+#[cfg(windows)]
+async fn replace_existing_windows(path: &Path, tmp: &Path) -> Result<()> {
+    // Never clear a pre-existing backup name; allocate a unique sibling instead.
+    let bak = unique_sibling_path(path, "bak");
+
+    match tokio::fs::rename(path, &bak).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            let _ = tokio::fs::remove_file(tmp).await;
+            return Err(error).with_context(|| format!("failed to replace {}", path.display()));
+        }
+    }
+
+    match tokio::fs::rename(tmp, path).await {
+        Ok(()) => {
+            let _ = tokio::fs::remove_file(&bak).await;
+            Ok(())
+        }
+        Err(error) => {
+            match tokio::fs::rename(&bak, path).await {
+                Ok(()) => {
+                    let _ = tokio::fs::remove_file(tmp).await;
+                }
+                Err(_) => {
+                    // Leave bak + tmp so nothing is silently discarded.
+                    // A later replace_file will restore bak if `path` is still missing.
+                }
+            }
+            Err(error).with_context(|| format!("failed to replace {}", path.display()))
+        }
+    }
 }
 
 async fn file_permissions(path: &Path) -> Result<Permissions> {
@@ -658,16 +818,13 @@ async fn restore_snapshot(snapshot: &PatchSnapshot) -> Result<()> {
     let mut errors = Vec::new();
     for (path, file_snapshot) in &snapshot.files {
         let result = match file_snapshot {
-            Some(snapshot) => {
-                async {
-                    match tokio::fs::remove_file(path).await {
-                        Ok(()) => {}
-                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                        Err(error) => return Err(error.into()),
-                    }
-                    write_new_file(path, &snapshot.contents, Some(snapshot.permissions.clone()))
-                        .await
-                }
+            Some(file_snapshot) => {
+                // Same crash-safe replace as apply: never delete then rewrite.
+                replace_file(
+                    path,
+                    &file_snapshot.contents,
+                    file_snapshot.permissions.clone(),
+                )
                 .await
             }
             None => match tokio::fs::remove_file(path).await {
@@ -728,11 +885,39 @@ mod tests {
     use std::fs;
     use std::sync::Mutex;
 
-    use super::{apply_workspace_patch, write_new_file};
+    use super::{
+        apply_workspace_patch, normalize_unified_diff_hunk_counts, recover_stranded_sprocket_bak,
+        replace_file, write_new_file,
+    };
     use crate::commands::{WorkspaceCancellation, WorkspaceOperationCancelled};
     use crate::test_support::temp_workspace;
 
     static HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[tokio::test]
+    async fn restores_stranded_sprocket_bak_before_replace() {
+        let root = temp_workspace();
+        let target = root.join("file.txt");
+        let bak = root.join("file.txt.sprocket-bak.1.2.3");
+        fs::write(&bak, "original\n").unwrap();
+        assert!(!target.exists());
+
+        recover_stranded_sprocket_bak(&target)
+            .await
+            .expect("stranded bak should restore");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "original\n");
+        assert!(!bak.exists());
+
+        replace_file(
+            &target,
+            b"replacement\n",
+            fs::metadata(&target).unwrap().permissions(),
+        )
+        .await
+        .expect("replace after recovery");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "replacement\n");
+        fs::remove_dir_all(root).unwrap();
+    }
 
     #[tokio::test]
     async fn applies_begin_patch_format() {

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -698,10 +698,18 @@ async fn stage_unique_sibling(
         match write_new_file(&candidate, contents, permissions.clone()).await {
             Ok(()) => return Ok(candidate),
             Err(error) => {
-                if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+                let already_exists = error.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io_error| io_error.kind() == std::io::ErrorKind::AlreadyExists)
+                });
+                if already_exists {
                     last_error = Some(error);
                     continue;
                 }
+                // create_new succeeded and a later write step failed. Remove our
+                // partial sibling instead of treating it as a name collision.
+                let _ = tokio::fs::remove_file(&candidate).await;
                 return Err(error).with_context(|| {
                     format!("failed to stage replacement for {}", path.display())
                 });
@@ -726,6 +734,20 @@ async fn recover_stranded_sprocket_bak(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Matches `unique_sibling_path`: `{file_name}.sprocket-{kind}.{pid}.{seq}.{nanos}`.
+fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<(u128, u64, u32)> {
+    let prefix = format!("{file_name}.sprocket-{kind}.");
+    let rest = name.strip_prefix(&prefix)?;
+    let mut parts = rest.split('.');
+    let pid: u32 = parts.next()?.parse().ok()?;
+    let seq: u64 = parts.next()?.parse().ok()?;
+    let nanos: u128 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((nanos, seq, pid))
+}
+
 async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
     let Some(parent) = path.parent() else {
         return Ok(None);
@@ -733,7 +755,6 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return Ok(None);
     };
-    let prefix = format!("{file_name}.sprocket-bak.");
     let mut entries = match tokio::fs::read_dir(parent).await {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -742,26 +763,20 @@ async fn newest_sprocket_bak_sibling(path: &Path) -> Result<Option<PathBuf>> {
         }
     };
 
-    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    let mut newest: Option<((u128, u64, u32), PathBuf)> = None;
     while let Some(entry) = entries.next_entry().await? {
         let name = entry.file_name();
         let Some(name) = name.to_str() else {
             continue;
         };
-        if !name.starts_with(&prefix) {
+        let Some(key) = parse_sprocket_sibling(name, file_name, "bak") else {
             continue;
-        }
+        };
         if !entry.file_type().await?.is_file() {
             continue;
         }
-        let modified = entry
-            .metadata()
-            .await?
-            .modified()
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-        match &newest {
-            Some((best, _)) if modified <= *best => {}
-            _ => newest = Some((modified, entry.path())),
+        if newest.as_ref().is_none_or(|(best, _)| key > *best) {
+            newest = Some((key, entry.path()));
         }
     }
     Ok(newest.map(|(_, path)| path))
@@ -916,6 +931,44 @@ mod tests {
         .await
         .expect("replace after recovery");
         assert_eq!(fs::read_to_string(&target).unwrap(), "replacement\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn recovery_ignores_non_format_sprocket_bak_siblings() {
+        let root = temp_workspace();
+        let target = root.join("file.txt");
+        let user_notes = root.join("file.txt.sprocket-bak.notes");
+        let stale = root.join("file.txt.sprocket-bak.1.1.100");
+        let newest = root.join("file.txt.sprocket-bak.1.2.200");
+        fs::write(&user_notes, "user notes\n").unwrap();
+        fs::write(&stale, "stale original\n").unwrap();
+        fs::write(&newest, "latest original\n").unwrap();
+        assert!(!target.exists());
+
+        recover_stranded_sprocket_bak(&target)
+            .await
+            .expect("valid bak should restore");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "latest original\n");
+        assert!(!newest.exists());
+        assert_eq!(fs::read_to_string(&user_notes).unwrap(), "user notes\n");
+        assert_eq!(fs::read_to_string(&stale).unwrap(), "stale original\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn recovery_does_not_promote_unrelated_prefix_matches() {
+        let root = temp_workspace();
+        let target = root.join("file.txt");
+        let decoy = root.join("file.txt.sprocket-bak.user-notes");
+        fs::write(&decoy, "do not restore me\n").unwrap();
+        assert!(!target.exists());
+
+        recover_stranded_sprocket_bak(&target)
+            .await
+            .expect("unrelated sibling should be ignored");
+        assert!(!target.exists());
+        assert_eq!(fs::read_to_string(&decoy).unwrap(), "do not restore me\n");
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -752,10 +752,7 @@ fn parse_sprocket_sibling(name: &str, file_name: &str, kind: &str) -> Option<(u1
 
 /// Same-process seq is monotonic even if the wall clock jumps backward.
 /// Different processes have no shared counter, so timestamp is the fallback.
-fn sprocket_sibling_is_newer(
-    candidate: (u128, u64, u32),
-    best: (u128, u64, u32),
-) -> bool {
+fn sprocket_sibling_is_newer(candidate: (u128, u64, u32), best: (u128, u64, u32)) -> bool {
     let (candidate_nanos, candidate_seq, candidate_pid) = candidate;
     let (best_nanos, best_seq, best_pid) = best;
     if candidate_pid == best_pid {


### PR DESCRIPTION
## What this fixes

`apply_patch` deleted an existing file before writing its replacement. If the process stopped or a write failed at that point, the original could be lost. The rollback path used the same delete-then-write sequence.

This PR keeps the original in place until the replacement has been fully written and flushed. It then installs the completed file with one same-filesystem rename. Rollback uses the same helper.

## Implementation

- Stage the replacement in a short, exclusively allocated temporary directory beside the target, using the existing `tempfile` dependency.
- Preserve file permissions and reuse the existing write-and-flush helper.
- Use native replacement rename on Unix and Windows. Rust already supports replacing existing files on Windows.
- Remove the Windows move-aside fallback, backup discovery and deletion, timestamp ranking, process-instance IDs, and clock FFI from the earlier PR revision.
- Leave unrelated files alone, including files whose names look like the previous staging or backup format.
- Run the patch tests on Linux, macOS, and Windows in CI instead of only compiling the Windows code.

Short staging names support long target filenames. The helper does not list the target's parent directory, so updates still work in writable, searchable directories without listing permission.

## Tests

Regression coverage includes a forced partial-write failure in an isolated child process, staging allocation failure, long filenames, directory permissions, executable mode preservation, untouched backup-looking files, rollback, Windows replacement, and Windows locked-target failure.

## Scope and limits

This protects individual existing-file replacements from the delete-before-write failure window. It does not make a multi-file patch a crash-atomic transaction or promise durability across power loss. A forcibly terminated process can leave its temporary staging directory behind, but the original remains in place until the replacement rename. There are no public API or stored-data changes.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59960078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details open><summary>Summary</summary>

This PR replaces the Windows backup-and-recovery protocol with same-directory staging followed by native replacement rename, preserving the original until the replacement is complete.
- Uses an exclusively allocated temporary directory beside the target and preserves permissions.
- Reuses the replacement helper during rollback.
- Adds cross-platform CI execution and regression tests for failure cleanup, long names, permissions, rollback, and Windows replacement behavior.
</details>

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Existing target] --> B[Create sibling temporary directory]
    B --> C[Write replacement]
    C --> D[Flush and close staged file]
    D --> E[Rename staged file over target]
    E --> F[Drop temporary directory]
    C -- failure --> G[Preserve original and clean staging]
    E -- failure --> G
```
</details>

<sub>Reviews (11) · Last reviewed commit: ["fix(workspace): Preserve originals durin..."](https://github.com/spikonado/sprocket/commit/1383c0c3e097730d55cd3e6d1881302686b7a0e0)</sub>

<!-- /greptile_comment -->