### PR TITLE
fix(server): Close transcript watches synchronously on Drop

### DIFF
--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
 use sprocket_agent::{TRANSCRIPT_PAGE_SIZE, TranscriptStore, apply_remote_state};
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use crate::transcript_client::{
@@ -78,7 +78,7 @@ impl TranscriptWatchers {
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
         };
-        let mut inner = self.inner.lock().await;
+        let mut inner = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         if let Some(slot) = inner.remove(&key) {
             slot.task.abort();
         }
@@ -95,7 +95,12 @@ impl TranscriptWatchers {
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
         };
-        if let Some(slot) = self.inner.lock().await.get(&key) {
+        if let Some(slot) = self
+            .inner
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .get(&key)
+        {
             let _ = slot.events.send(TranscriptWatchEvent {
                 event_type: "updated",
                 total_parts: Some(total_parts),
@@ -114,7 +119,7 @@ impl TranscriptWatchers {
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
         };
-        let mut inner = self.inner.lock().await;
+        let mut inner = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         if let Some(slot) = inner.get_mut(&key) {
             slot.refs += 1;
             return TranscriptWatchSession {
@@ -147,8 +152,8 @@ impl TranscriptWatchers {
         }
     }
 
-    async fn close(&self, key: &WatchKey) {
-        let mut inner = self.inner.lock().await;
+    fn close(&self, key: &WatchKey) {
+        let mut inner = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         let Some(slot) = inner.get_mut(key) else {
             return;
         };
@@ -161,8 +166,11 @@ impl TranscriptWatchers {
     }
 
     #[cfg(test)]
-    pub async fn active_count(&self) -> usize {
-        self.inner.lock().await.len()
+    pub fn active_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .len()
     }
 }
 
@@ -174,11 +182,8 @@ impl TranscriptWatchSession {
 
 impl Drop for TranscriptWatchSession {
     fn drop(&mut self) {
-        let watchers = Arc::clone(&self.watchers);
-        let key = self.key.clone();
-        tokio::spawn(async move {
-            watchers.close(&key).await;
-        });
+        // Sync close so shutdown / no-runtime drops still release the slot.
+        self.watchers.close(&self.key);
     }
 }
 
@@ -309,14 +314,14 @@ mod tests {
 
         let first = watchers.open("user", "thread", "token".into()).await;
         let second = watchers.open("user", "thread", "token".into()).await;
-        assert_eq!(watchers.active_count().await, 1);
+        assert_eq!(watchers.active_count(), 1);
         assert_eq!(live.load(Ordering::SeqCst), 1);
         drop(first);
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        assert_eq!(watchers.active_count().await, 1);
+        assert_eq!(watchers.active_count(), 1);
         drop(second);
         tokio::time::sleep(std::time::Duration::from_millis(40)).await;
-        assert_eq!(watchers.active_count().await, 0);
+        assert_eq!(watchers.active_count(), 0);
         assert_eq!(live.load(Ordering::SeqCst), 0);
         let _ = tokio::fs::remove_dir_all(dir).await;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`TranscriptWatchSession::drop` spawned an async close. If the Tokio runtime was already gone, the watch map entry leaked.

The close path is synchronous now, so shutdown still releases the slot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c8f4e2-a7e6-4fcc-928c-64d6df5b4856&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes transcript-watch session cleanup synchronous so dropping a session can release its shared watch slot even after the Tokio runtime has shut down.
- Replaces the asynchronous mutex protecting transcript-watch slots with a poison-recovering standard mutex.
- Calls watch cleanup directly from `TranscriptWatchSession::drop`.
- Updates the test-only active-watch count helper and its callers to be synchronous.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with synchronous cleanup preserving the shared-watch lifecycle while removing its dependency on a live Tokio runtime.

The changed mutex critical sections contain only short synchronous operations, all async callers remain Send-compatible, and session drops now release watch references immediately without introducing a reachable deadlock or lifecycle regression.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/transcript_watch.rs | Converts watch-slot synchronization and drop cleanup to synchronous operations without holding the mutex across suspension points or changing the established reference-count lifecycle. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): Close transcript watches sy..."](https://github.com/spikonado/sprocket/commit/970eae435c3f4f72a82f5fb6c8509114b1927dbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59960080)</sub>

**Context used:**

- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)

<!-- /greptile_comment -->