### PR TITLE
fix(server): Refresh auth for Convex calls

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -144,6 +144,17 @@ longer supported.
 
 ## Client APIs
 
+### Local sessions created before account binding
+
+Persisted local sessions created before native WorkOS account binding have no
+`userId`. They continue to deserialize so users receive an explicit sign-in
+error instead of losing the pairing credential, but account-scoped routes
+reject them until the user signs in again. New desktop login callbacks bind
+the authenticated WorkOS user to the local session that started the flow.
+
+Remove `SessionRecord.user_id` optionality after all supported installations
+have completed a native sign-in on a version that writes the binding.
+
 Released desktop/CLI builds that still call retired Convex functions get a
 `ConvexError`: "This Sprocket version is no longer supported. Update to the
 latest Sprocket release." Production does not mask that text.

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -59,7 +59,7 @@ describe('watchLiveCompletion', () => {
 
 		const events: unknown[] = [];
 		await createLocalClient('http://127.0.0.1:7731').watchLiveCompletion(
-			{ authToken: 'token', userId: 'user-1', threadId: threadRecordId('thread-1') },
+			{ userId: 'user-1', threadId: threadRecordId('thread-1') },
 			{
 				signal: new AbortController().signal,
 				onEvent: (event) => {
@@ -170,7 +170,6 @@ describe('run cancellation local API', () => {
 
 		await expect(
 			createLocalClient('http://127.0.0.1:7731').requestRunCancellation({
-				authToken: 'token',
 				runId: runId('run-1')
 			})
 		).resolves.toBeUndefined();

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -170,6 +170,7 @@ describe('run cancellation local API', () => {
 
 		await expect(
 			createLocalClient('http://127.0.0.1:7731').requestRunCancellation({
+				userId: 'user-1',
 				runId: runId('run-1')
 			})
 		).resolves.toBeUndefined();

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -279,7 +279,9 @@ export type DesktopApi = {
 	rekeyRepository: (
 		request: ThreadCacheUserRequest & { from: string; to: string }
 	) => Promise<number>;
-	requestRunCancellation: (request: { runId: Id<'runs'> }) => Promise<void>;
+	requestRunCancellation: (
+		request: ThreadCacheUserRequest & { runId: Id<'runs'> }
+	) => Promise<void>;
 	endAccountSession: (request: ThreadCacheUserRequest) => Promise<void>;
 };
 

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -195,21 +195,15 @@ export type ThreadCacheUserRequest = {
 	userId: string;
 };
 
-export type ThreadCacheRegisterRequest = ThreadCacheUserRequest & {
-	authToken: string;
-};
-
 export type LiveCompletionWatchEvent =
 	{ eventType: 'updated'; live: LiveCompletionOverlay } | { eventType: 'cleared' };
 
 export type TranscriptScopeRequest = {
-	authToken: string;
 	userId: string;
 	threadId: Id<'threadRecords'>;
 };
 
 export type TranscriptPageRequest = {
-	authToken?: string;
 	userId: string;
 	threadId: Id<'threadRecords'>;
 	before?: number;
@@ -269,7 +263,7 @@ export type DesktopApi = {
 	fetchTranscriptAttachment: (
 		request: TranscriptScopeRequest & { imageUploadId: Id<'imageUploads'> }
 	) => Promise<Blob | null>;
-	registerThreadCache: (request: ThreadCacheRegisterRequest) => Promise<ThreadCacheWatchEvent>;
+	registerThreadCache: (request: ThreadCacheUserRequest) => Promise<ThreadCacheWatchEvent>;
 	fetchThreadSnapshot: (request: ThreadCacheUserRequest) => Promise<ThreadCacheSnapshot>;
 	syncArchivedThreads: (request: ThreadCacheUserRequest) => Promise<ThreadCacheWatchEvent>;
 	watchThreadCache: (
@@ -283,13 +277,13 @@ export type DesktopApi = {
 	archiveThread: (request: ThreadCommandRequest) => Promise<boolean>;
 	restoreThread: (request: ThreadCommandRequest) => Promise<boolean>;
 	rekeyRepository: (
-		request: ThreadCacheRegisterRequest & { from: string; to: string }
+		request: ThreadCacheUserRequest & { from: string; to: string }
 	) => Promise<number>;
-	requestRunCancellation: (request: { authToken: string; runId: Id<'runs'> }) => Promise<void>;
+	requestRunCancellation: (request: { runId: Id<'runs'> }) => Promise<void>;
 	endAccountSession: (request: ThreadCacheUserRequest) => Promise<void>;
 };
 
-export type ThreadCommandRequest = ThreadCacheRegisterRequest & {
+export type ThreadCommandRequest = ThreadCacheUserRequest & {
 	threadId: Id<'threadRecords'>;
 };
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -12,7 +12,6 @@
 		cancelDesktopSignIn,
 		clearDesktopSignInOpenError,
 		convexAuthRetryPending,
-		getAccessToken,
 		reconcileNativeAuthentication,
 		retryConvexAuthentication,
 		signIn,
@@ -599,12 +598,11 @@
 				}
 			}
 			try {
-				const authToken = await getAccessToken();
-				if (!authToken || ac.signal.aborted || currentThreadId !== watchedThreadId) {
+				if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
 					return;
 				}
 				await api.watchTranscript(
-					{ authToken, userId, threadId: watchedThreadId },
+					{ userId, threadId: watchedThreadId },
 					{
 						signal: ac.signal,
 						onEvent: (event) => {
@@ -642,28 +640,22 @@
 		void (async () => {
 			while (!ac.signal.aborted) {
 				try {
-					const authToken = await getAccessToken();
-					if (ac.signal.aborted) {
-						return;
-					}
-					if (authToken) {
-						await api.watchLiveCompletion(
-							{ authToken, userId, threadId: watchedThreadId },
-							{
-								signal: ac.signal,
-								onEvent: (event) => {
-									if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
-										return;
-									}
-									if (event.eventType === 'updated') {
-										liveCompletion = event.live;
-									} else {
-										liveCompletion = null;
-									}
+					await api.watchLiveCompletion(
+						{ userId, threadId: watchedThreadId },
+						{
+							signal: ac.signal,
+							onEvent: (event) => {
+								if (ac.signal.aborted || currentThreadId !== watchedThreadId) {
+									return;
+								}
+								if (event.eventType === 'updated') {
+									liveCompletion = event.live;
+								} else {
+									liveCompletion = null;
 								}
 							}
-						);
-					}
+						}
+					);
 				} catch {
 					if (ac.signal.aborted) {
 						return;
@@ -965,14 +957,13 @@
 		}
 	}
 
-	async function localThreadCommandContext() {
+	function localThreadCommandContext() {
 		const api = desktopApi;
 		const userId = getCurrentUserId();
-		const authToken = await getAccessToken();
-		if (!api || !userId || !authToken) {
+		if (!api || !userId) {
 			throw new Error('The local Sprocket service is not ready.');
 		}
-		return { api, userId, authToken };
+		return { api, userId };
 	}
 
 	async function signOut() {
@@ -985,8 +976,8 @@
 	}
 
 	async function rekeyLocalRepository(from: string, to: string) {
-		const { api, userId, authToken } = await localThreadCommandContext();
-		await api.rekeyRepository({ userId, authToken, from, to });
+		const { api, userId } = localThreadCommandContext();
+		await api.rekeyRepository({ userId, from, to });
 		await pullThreadSnapshot(userId);
 	}
 
@@ -1024,11 +1015,10 @@
 		if (!api || !userId) {
 			return;
 		}
-		const authToken = await getAccessToken();
-		if (!authToken || getCurrentUserId() !== userId) {
+		if (getCurrentUserId() !== userId) {
 			return;
 		}
-		const event = await api.registerThreadCache({ userId, authToken });
+		const event = await api.registerThreadCache({ userId });
 		if (getCurrentUserId() !== userId) {
 			return;
 		}
@@ -1402,8 +1392,8 @@
 
 	async function renameThread(threadId: Id<'threadRecords'>, title: string) {
 		try {
-			const { api, userId, authToken } = await localThreadCommandContext();
-			const cacheSynchronized = await api.renameThread({ userId, authToken, threadId, title });
+			const { api, userId } = localThreadCommandContext();
+			const cacheSynchronized = await api.renameThread({ userId, threadId, title });
 			if (!cacheSynchronized) threadCacheStatus = 'reconnecting';
 			unconfirmedCreatedThreads = unconfirmedCreatedThreads.map((thread) =>
 				thread.threadId === threadId ? { ...thread, title } : thread
@@ -1450,12 +1440,10 @@
 		}
 		loadingOlderTranscriptGeneration = generation;
 		try {
-			const authToken = await getAccessToken();
-			if (!authToken || currentThreadId !== threadId || replicaGeneration !== generation) {
+			if (currentThreadId !== threadId || replicaGeneration !== generation) {
 				return;
 			}
 			const page = await api.fetchTranscriptPage({
-				authToken,
 				userId,
 				threadId,
 				before,
@@ -1485,12 +1473,7 @@
 		if (!api || !threadId || !userId) {
 			return null;
 		}
-		const authToken = await getAccessToken();
-		if (!authToken) {
-			return null;
-		}
 		const blob = await api.fetchTranscriptAttachment({
-			authToken,
 			userId,
 			threadId,
 			imageUploadId
@@ -1501,17 +1484,15 @@
 	async function archiveThread(threadId: Id<'threadRecords'>) {
 		const archiveUserId = getCurrentUserId();
 		try {
-			const { api, userId, authToken } = await localThreadCommandContext();
-			const cacheSynchronized = await api.archiveThread({ userId, authToken, threadId });
+			const { api, userId } = localThreadCommandContext();
+			const cacheSynchronized = await api.archiveThread({ userId, threadId });
 			if (!cacheSynchronized) threadCacheStatus = 'reconnecting';
 			await pullThreadSnapshot(userId);
 			if (archiveUserId) {
 				clearComposerRecovery(archiveUserId, `thread:${threadId}`);
 				const api = desktopApi;
-				const authToken = await getAccessToken();
-				if (api && authToken) {
+				if (api) {
 					await api.clearTranscriptReplica({
-						authToken,
 						userId: archiveUserId,
 						threadId
 					});
@@ -1538,8 +1519,8 @@
 
 	async function restoreThread(threadId: Id<'threadRecords'>) {
 		try {
-			const { api, userId, authToken } = await localThreadCommandContext();
-			const cacheSynchronized = await api.restoreThread({ userId, authToken, threadId });
+			const { api, userId } = localThreadCommandContext();
+			const cacheSynchronized = await api.restoreThread({ userId, threadId });
 			if (!cacheSynchronized) threadCacheStatus = 'reconnecting';
 			await pullThreadSnapshot(userId);
 		} catch (error) {
@@ -1929,9 +1910,8 @@
 		}
 
 		try {
-			const { api, authToken } = await localThreadCommandContext();
+			const { api } = localThreadCommandContext();
 			await api.requestRunCancellation({
-				authToken,
 				runId: runState.runId
 			});
 		} catch (error) {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1910,8 +1910,9 @@
 		}
 
 		try {
-			const { api } = localThreadCommandContext();
+			const { api, userId } = localThreadCommandContext();
 			await api.requestRunCancellation({
+				userId,
 				runId: runState.runId
 			});
 		} catch (error) {

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -75,6 +75,8 @@ pub fn peer_may_complete_desktop_login_callback(peer: std::net::SocketAddr) -> b
 struct SessionRecord {
     role: String,
     created_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    user_id: Option<String>,
 }
 
 impl AuthState {
@@ -178,6 +180,7 @@ impl AuthState {
             SessionRecord {
                 role: "owner".to_string(),
                 created_at: crate::now_ms(),
+                user_id: None,
             },
         );
         self.persist_sessions().await?;
@@ -198,6 +201,50 @@ impl AuthState {
             .same_site(SameSite::Lax)
             .max_age(cookie::time::Duration::seconds(SESSION_MAX_AGE_SECS))
             .build()
+    }
+
+    pub async fn bind_session_user(
+        &self,
+        session_token: &str,
+        user_id: &str,
+    ) -> anyhow::Result<()> {
+        let snapshot = {
+            let mut sessions = self.sessions.write().await;
+            let session = sessions
+                .get_mut(session_token)
+                .ok_or_else(|| anyhow::anyhow!("authentication required"))?;
+            if session_is_expired(session) {
+                anyhow::bail!("authentication required");
+            }
+            session.user_id = Some(user_id.to_string());
+            sessions_snapshot(&sessions)
+        };
+        self.save_sessions(snapshot).await
+    }
+
+    pub async fn require_session_user(
+        &self,
+        session_token: &str,
+        expected_user_id: &str,
+    ) -> anyhow::Result<()> {
+        let sessions = self.sessions.read().await;
+        let session = sessions
+            .get(session_token)
+            .filter(|session| !session_is_expired(session))
+            .ok_or_else(|| anyhow::anyhow!("authentication required"))?;
+        match session.user_id.as_deref() {
+            Some(user_id) if user_id == expected_user_id => Ok(()),
+            Some(_) => anyhow::bail!("local session belongs to a different user"),
+            None => anyhow::bail!("local session is not bound to a user; sign in again"),
+        }
+    }
+
+    pub async fn session_has_user(&self, session_token: &str) -> bool {
+        self.sessions
+            .read()
+            .await
+            .get(session_token)
+            .is_some_and(|session| !session_is_expired(session) && session.user_id.is_some())
     }
 
     async fn persist_sessions(&self) -> anyhow::Result<()> {
@@ -259,6 +306,17 @@ pub async fn require_session(
     if !session.authenticated {
         anyhow::bail!("authentication required");
     }
+    Ok(session_token)
+}
+
+pub async fn require_session_user(
+    auth: &AuthState,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+    user_id: &str,
+) -> anyhow::Result<String> {
+    let session_token = require_session(auth, headers, jar).await?;
+    auth.require_session_user(&session_token, user_id).await?;
     Ok(session_token)
 }
 
@@ -348,6 +406,44 @@ mod tests {
         let session = reloaded.session_state(Some(&session_token)).await;
         assert!(session.authenticated);
 
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn account_scoped_access_requires_the_bound_session_user() {
+        let temp_dir = std::env::temp_dir().join(format!("sprocket-auth-test-{}", Uuid::new_v4()));
+        let auth = AuthState::load(&temp_dir).expect("auth state");
+        let (_, session_token) = auth
+            .bootstrap(auth.pairing_credential())
+            .await
+            .expect("bootstrap should succeed");
+
+        assert!(
+            auth.require_session_user(&session_token, "user-1")
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("sign in again")
+        );
+        auth.bind_session_user(&session_token, "user-1")
+            .await
+            .unwrap();
+        auth.require_session_user(&session_token, "user-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            auth.require_session_user(&session_token, "user-2")
+                .await
+                .unwrap_err()
+                .to_string(),
+            "local session belongs to a different user"
+        );
+
+        let reloaded = AuthState::load(&temp_dir).expect("reloaded auth state");
+        reloaded
+            .require_session_user(&session_token, "user-1")
+            .await
+            .unwrap();
         let _ = fs::remove_dir_all(temp_dir);
     }
 

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -135,12 +135,16 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     let pairing_credential = auth.pairing_credential().to_string();
     let project_attachments = project_attachments::ProjectAttachmentStore::new(data_dir.clone());
     let transcript = TranscriptStore::new(data_dir.join("transcripts"));
-    let transcript_watchers =
-        TranscriptWatchers::new(convex_deployment_url.clone(), Arc::clone(&transcript));
+    let transcript_watchers = TranscriptWatchers::new(
+        convex_deployment_url.clone(),
+        Arc::clone(&transcript),
+        native_auth.auth_token_fetcher(),
+    );
     let thread_cache = thread_sync::ThreadCacheSync::new(
         convex_deployment_url.clone(),
         thread_cache::ThreadSnapshotStore::new(data_dir.clone()),
         Arc::clone(&project_attachments),
+        native_auth.auth_token_fetcher(),
     );
     let http_base_url = config.listen_url();
     let web_ui_enabled = config

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -129,7 +129,7 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     let machine_identity = Arc::new(machine_identity::MachineIdentity::load(&data_dir)?);
     let machines = machines::MachineManager::new(
         convex_deployment_url.clone(),
-        native_auth.auth_token_fetcher(),
+        Arc::clone(&native_auth),
         Arc::clone(&machine_identity),
     );
     let pairing_credential = auth.pairing_credential().to_string();
@@ -138,13 +138,13 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
     let transcript_watchers = TranscriptWatchers::new(
         convex_deployment_url.clone(),
         Arc::clone(&transcript),
-        native_auth.auth_token_fetcher(),
+        Arc::clone(&native_auth),
     );
     let thread_cache = thread_sync::ThreadCacheSync::new(
         convex_deployment_url.clone(),
         thread_cache::ThreadSnapshotStore::new(data_dir.clone()),
         Arc::clone(&project_attachments),
-        native_auth.auth_token_fetcher(),
+        Arc::clone(&native_auth),
     );
     let http_base_url = config.listen_url();
     let web_ui_enabled = config

--- a/crates/sprocket-server/src/machines.rs
+++ b/crates/sprocket-server/src/machines.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use convex::Value;
-use sprocket_convex::AuthTokenFetcher;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 
 use crate::machine_identity::MachineIdentity;
+use crate::native_auth::NativeAuthManager;
 use crate::transcript_client::UserConvexClient;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
@@ -27,7 +27,7 @@ struct AccountPresence {
 
 pub struct MachineManager {
     deployment_url: String,
-    auth_token_fetcher: AuthTokenFetcher,
+    native_auth: Arc<NativeAuthManager>,
     identity: Arc<MachineIdentity>,
     accounts: Mutex<HashMap<String, AccountPresence>>,
     registration: Mutex<()>,
@@ -43,12 +43,12 @@ struct LifecycleState {
 impl MachineManager {
     pub(crate) fn new(
         deployment_url: String,
-        auth_token_fetcher: AuthTokenFetcher,
+        native_auth: Arc<NativeAuthManager>,
         identity: Arc<MachineIdentity>,
     ) -> Arc<Self> {
         Arc::new(Self {
             deployment_url,
-            auth_token_fetcher,
+            native_auth,
             identity,
             accounts: Mutex::new(HashMap::new()),
             registration: Mutex::new(()),
@@ -59,7 +59,7 @@ impl MachineManager {
     pub async fn register(self: &Arc<Self>, expected_user_id: &str) -> anyhow::Result<()> {
         let _registration = self.registration.lock().await;
         self.ensure_running().await?;
-        let registered = self.register_remote().await?;
+        let registered = self.register_remote(expected_user_id).await?;
         if registered.machine_id != self.identity.installation_id {
             anyhow::bail!("machine registration returned a different installation");
         }
@@ -172,11 +172,12 @@ impl MachineManager {
         Err(error)
     }
 
-    async fn register_remote(&self) -> anyhow::Result<RegisteredMachine> {
+    async fn register_remote(&self, expected_user_id: &str) -> anyhow::Result<RegisteredMachine> {
         timeout(RPC_TIMEOUT, async {
             let client = UserConvexClient::connect_with_fetcher(
                 &self.deployment_url,
-                Arc::clone(&self.auth_token_fetcher),
+                self.native_auth
+                    .auth_token_fetcher_for_user(expected_user_id.to_string()),
             )
             .await?;
             client
@@ -250,11 +251,15 @@ mod tests {
     fn manager_for_test() -> (std::path::PathBuf, Arc<MachineManager>) {
         let dir = std::env::temp_dir().join(format!("sprocket-machine-{}", uuid::Uuid::new_v4()));
         let identity = Arc::new(MachineIdentity::load(&dir).expect("identity"));
-        let fetcher: AuthTokenFetcher =
-            Arc::new(|_| Box::pin(async { anyhow::bail!("unexpected authentication request") }));
+        let native_auth = NativeAuthManager::configured_for_test(
+            crate::native_auth::NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            "http://127.0.0.1/callback".to_string(),
+        );
         (
             dir,
-            MachineManager::new("not a valid URL".into(), fetcher, identity),
+            MachineManager::new("not a valid URL".into(), native_auth, identity),
         )
     }
 

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -446,6 +446,19 @@ impl NativeAuthManager {
         })
     }
 
+    pub async fn require_user(&self, expected_user_id: &str) -> anyhow::Result<()> {
+        self.access_token(false).await?;
+        let session = self.session.lock().await;
+        let user = session
+            .user
+            .as_ref()
+            .context("native WorkOS session has no user")?;
+        if user.id != expected_user_id {
+            anyhow::bail!("native and browser sessions belong to different users");
+        }
+        Ok(())
+    }
+
     async fn access_token(&self, force_refresh: bool) -> anyhow::Result<String> {
         let _credential_operation = self.credential_operation.lock().await;
         let refresh_before = unix_time_secs().saturating_add(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
@@ -918,6 +931,30 @@ mod tests {
             expected_access_token
         );
         assert_eq!(store.token().as_deref(), Some("refresh-new"));
+    }
+
+    #[tokio::test]
+    async fn require_user_rejects_a_different_native_identity() {
+        let manager = manager_with_response(
+            MemoryRefreshTokenStore::with_token("refresh-old"),
+            StatusCode::OK,
+            serde_json::to_value(authentication_response(
+                access_token(unix_time_secs() + 3_600),
+                "refresh-new",
+            ))
+            .unwrap(),
+        )
+        .await;
+
+        manager.require_user("user_123").await.unwrap();
+        assert_eq!(
+            manager
+                .require_user("user_456")
+                .await
+                .unwrap_err()
+                .to_string(),
+            "native and browser sessions belong to different users"
+        );
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -438,16 +438,39 @@ impl NativeAuthManager {
         self.clear_refresh_token().await
     }
 
-    pub fn auth_token_fetcher(self: &Arc<Self>) -> AuthTokenFetcher {
+    pub fn auth_token_fetcher_for_user(
+        self: &Arc<Self>,
+        expected_user_id: String,
+    ) -> AuthTokenFetcher {
         let manager = Arc::clone(self);
         Arc::new(move |force_refresh| {
             let manager = Arc::clone(&manager);
-            Box::pin(async move { manager.access_token(force_refresh).await })
+            let expected_user_id = expected_user_id.clone();
+            Box::pin(async move {
+                manager
+                    .access_token_for_user(force_refresh, &expected_user_id)
+                    .await
+            })
         })
     }
 
     pub async fn require_user(&self, expected_user_id: &str) -> anyhow::Result<()> {
-        self.access_token(false).await?;
+        self.access_token_for_user(false, expected_user_id).await?;
+        Ok(())
+    }
+
+    async fn access_token(&self, force_refresh: bool) -> anyhow::Result<String> {
+        let _credential_operation = self.credential_operation.lock().await;
+        self.access_token_locked(force_refresh).await
+    }
+
+    async fn access_token_for_user(
+        &self,
+        force_refresh: bool,
+        expected_user_id: &str,
+    ) -> anyhow::Result<String> {
+        let _credential_operation = self.credential_operation.lock().await;
+        let token = self.access_token_locked(force_refresh).await?;
         let session = self.session.lock().await;
         let user = session
             .user
@@ -456,11 +479,10 @@ impl NativeAuthManager {
         if user.id != expected_user_id {
             anyhow::bail!("native and browser sessions belong to different users");
         }
-        Ok(())
+        Ok(token)
     }
 
-    async fn access_token(&self, force_refresh: bool) -> anyhow::Result<String> {
-        let _credential_operation = self.credential_operation.lock().await;
+    async fn access_token_locked(&self, force_refresh: bool) -> anyhow::Result<String> {
         let refresh_before = unix_time_secs().saturating_add(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
         if !force_refresh {
             let session = self.session.lock().await;
@@ -953,6 +975,31 @@ mod tests {
                 .await
                 .unwrap_err()
                 .to_string(),
+            "native and browser sessions belong to different users"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_bound_fetcher_rejects_an_account_transition() {
+        let manager = Arc::new(
+            manager_with_response(
+                MemoryRefreshTokenStore::with_token("refresh-old"),
+                StatusCode::OK,
+                serde_json::to_value(authentication_response(
+                    access_token(unix_time_secs() + 3_600),
+                    "refresh-new",
+                ))
+                .unwrap(),
+            )
+            .await,
+        );
+        let fetcher = manager.auth_token_fetcher_for_user("user_123".to_string());
+
+        fetcher(false).await.unwrap();
+        manager.session.lock().await.user.as_mut().unwrap().id = "user_456".to_string();
+
+        assert_eq!(
+            fetcher(false).await.unwrap_err().to_string(),
             "native and browser sessions belong to different users"
         );
     }

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -298,7 +298,11 @@ impl NativeAuthManager {
         })
     }
 
-    pub async fn complete_login(&self, code: &str, state: &str) -> anyhow::Result<NativeUser> {
+    pub async fn complete_login(
+        &self,
+        code: &str,
+        state: &str,
+    ) -> anyhow::Result<(NativeUser, String)> {
         let code = required_callback_value(code, "authorization code")?;
         let state = required_callback_value(state, "desktop login state")?;
         let (code_verifier, pending_session_token, sign_out_generation) = {
@@ -330,7 +334,10 @@ impl NativeAuthManager {
             .authenticate_with_code(params)
             .await
         {
-            Ok(response) => self.accept_authentication(response).await,
+            Ok(response) => self
+                .accept_authentication(response)
+                .await
+                .map(|user| (user, pending_session_token)),
             Err(error) => {
                 self.session
                     .lock()
@@ -1023,12 +1030,13 @@ mod tests {
             .await
             .unwrap();
 
-        let user = manager
+        let (user, session_token) = manager
             .complete_login("authorization-code", &login.login_id)
             .await
             .unwrap();
 
         assert_eq!(user.id, "user_123");
+        assert_eq!(session_token, "paired-session");
         assert_eq!(store.token().as_deref(), Some("refresh-new"));
         assert_eq!(
             manager.access_token(false).await.unwrap(),

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -23,14 +23,14 @@ use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::AppState;
-use crate::auth::require_session;
+use crate::auth::require_session_user;
 use crate::routes::api_error::ApiError;
 
 const AGENT_START_TIMEOUT: Duration = Duration::from_secs(20);
 const AGENT_START_CLEANUP_TIMEOUT: Duration = Duration::from_secs(12);
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RunAgentApiRequest {
     user_id: String,
     submission_id: String,
@@ -63,7 +63,12 @@ async fn run_agent_handler(
     jar: CookieJar,
     Json(payload): Json<RunAgentApiRequest>,
 ) -> Result<(StatusCode, Json<RunAgentStartResponse>), ApiError> {
-    require_session(&state.auth, &headers, &jar)
+    require_session_user(&state.auth, &headers, &jar, &payload.user_id)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    state
+        .native_auth
+        .require_user(&payload.user_id)
         .await
         .map_err(ApiError::unauthorized)?;
 
@@ -174,8 +179,9 @@ async fn run_agent_handler(
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LiveCompletionWatchRequest {
+    user_id: String,
     thread_id: String,
 }
 
@@ -191,7 +197,7 @@ async fn live_handler(
     jar: CookieJar,
     Json(payload): Json<LiveCompletionWatchRequest>,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
+    require_session_user(&state.auth, &headers, &jar, &payload.user_id)
         .await
         .map_err(ApiError::unauthorized)?;
     let hub = Arc::clone(&state.live_completions);

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -78,7 +78,9 @@ async fn run_agent_handler(
         .register(&payload.user_id)
         .await
         .map_err(ApiError::bad_request)?;
-    let auth_token_fetcher = state.native_auth.auth_token_fetcher();
+    let auth_token_fetcher = state
+        .native_auth
+        .auth_token_fetcher_for_user(payload.user_id.clone());
     let request = RunAgentRequest {
         deployment_url: state.convex_deployment_url.clone(),
         auth_token_fetcher: auth_token_fetcher.clone(),

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -377,24 +377,26 @@ mod tests {
 
         let project_attachments = ProjectAttachmentStore::new(temp_dir.clone());
         let transcript = sprocket_agent::TranscriptStore::new(temp_dir.join("transcripts"));
-        let transcript_watchers = crate::transcript_watch::TranscriptWatchers::new(
-            "https://example.convex.cloud".to_string(),
-            transcript.clone(),
-        );
-        let thread_cache = crate::thread_sync::ThreadCacheSync::new(
-            "https://example.convex.cloud".to_string(),
-            crate::thread_cache::ThreadSnapshotStore::new(temp_dir.clone()),
-            project_attachments.clone(),
-        );
-
-        let machine_identity = Arc::new(
-            crate::machine_identity::MachineIdentity::load(&temp_dir).expect("machine identity"),
-        );
         let native_auth = crate::native_auth::NativeAuthManager::configured_for_test(
             crate::native_auth::NativeAuthConfig {
                 workos_client_id: "client_test".to_string(),
             },
             auth::desktop_login_callback_url(7731),
+        );
+        let transcript_watchers = crate::transcript_watch::TranscriptWatchers::new(
+            "https://example.convex.cloud".to_string(),
+            transcript.clone(),
+            native_auth.auth_token_fetcher(),
+        );
+        let thread_cache = crate::thread_sync::ThreadCacheSync::new(
+            "https://example.convex.cloud".to_string(),
+            crate::thread_cache::ThreadSnapshotStore::new(temp_dir.clone()),
+            project_attachments.clone(),
+            native_auth.auth_token_fetcher(),
+        );
+
+        let machine_identity = Arc::new(
+            crate::machine_identity::MachineIdentity::load(&temp_dir).expect("machine identity"),
         );
         let state = AppState {
             auth,

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -233,11 +233,20 @@ async fn desktop_login_callback(
     };
 
     match state.native_auth.complete_login(code, callback_state).await {
-        Ok(_) => desktop_login_html_response(
-            StatusCode::OK,
-            "Signed in",
-            "Return to Sprocket. You can close this tab.",
-        ),
+        Ok((user, session_token)) => {
+            if let Err(error) = state.auth.bind_session_user(&session_token, &user.id).await {
+                return desktop_login_html_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Sign-in failed",
+                    &error.to_string(),
+                );
+            }
+            desktop_login_html_response(
+                StatusCode::OK,
+                "Signed in",
+                "Return to Sprocket. You can close this tab.",
+            )
+        }
         Err(error) => desktop_login_html_response(
             StatusCode::BAD_REQUEST,
             "Sign-in failed",
@@ -255,7 +264,13 @@ async fn desktop_login_result(
         .await
         .map_err(|_| ApiError::authentication_required())?;
 
-    Ok(Json(state.native_auth.status(&session_token).await))
+    let status = state.native_auth.status(&session_token).await;
+    if matches!(status, NativeLoginStatus::Authenticated { .. })
+        && !state.auth.session_has_user(&session_token).await
+    {
+        return Ok(Json(NativeLoginStatus::SignedOut));
+    }
+    Ok(Json(status))
 }
 
 async fn desktop_login_cancel(

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -386,13 +386,13 @@ mod tests {
         let transcript_watchers = crate::transcript_watch::TranscriptWatchers::new(
             "https://example.convex.cloud".to_string(),
             transcript.clone(),
-            native_auth.auth_token_fetcher(),
+            Arc::clone(&native_auth),
         );
         let thread_cache = crate::thread_sync::ThreadCacheSync::new(
             "https://example.convex.cloud".to_string(),
             crate::thread_cache::ThreadSnapshotStore::new(temp_dir.clone()),
             project_attachments.clone(),
-            native_auth.auth_token_fetcher(),
+            Arc::clone(&native_auth),
         );
 
         let machine_identity = Arc::new(
@@ -407,7 +407,7 @@ mod tests {
             thread_cache,
             machines: crate::machines::MachineManager::new(
                 "https://example.convex.cloud".to_string(),
-                native_auth.auth_token_fetcher(),
+                Arc::clone(&native_auth),
                 Arc::clone(&machine_identity),
             ),
             live_completions: Arc::new(sprocket_agent::LiveCompletionHub::new()),

--- a/crates/sprocket-server/src/routes/threads.rs
+++ b/crates/sprocket-server/src/routes/threads.rs
@@ -45,12 +45,14 @@ struct RekeyRequest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct CancelRequest {
+    user_id: String,
     run_id: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LifecycleRequest {
+    user_id: String,
     thread_id: String,
 }
 
@@ -107,6 +109,14 @@ async fn client(state: &AppState) -> Result<UserConvexClient, ApiError> {
     .map_err(ApiError::bad_request)
 }
 
+async fn require_user(state: &AppState, user_id: &str) -> Result<(), ApiError> {
+    state
+        .native_auth
+        .require_user(user_id)
+        .await
+        .map_err(ApiError::unauthorized)
+}
+
 fn thread_args(thread_id: String) -> BTreeMap<String, Value> {
     BTreeMap::from([("threadId".into(), Value::String(thread_id))])
 }
@@ -117,6 +127,7 @@ async fn run_thread_command(
     function: &str,
     categories: &[ThreadSnapshotCategory],
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    require_user(state, &payload.user_id).await?;
     let mut args = thread_args(payload.thread_id);
     if let Some(title) = payload.title {
         args.insert("title".into(), Value::String(title));
@@ -221,6 +232,7 @@ async fn rekey_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let args = BTreeMap::from([
         ("from".into(), Value::String(payload.from)),
         ("to".into(), Value::String(payload.to)),
@@ -273,6 +285,7 @@ async fn lifecycle_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let result = client(&state)
         .await?
         .query(
@@ -292,6 +305,7 @@ async fn cancel_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let args = BTreeMap::from([("runId".into(), Value::String(payload.run_id))]);
     let result = client(&state)
         .await?
@@ -310,6 +324,7 @@ async fn end_account_session_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     state
         .machines
         .end(&payload.user_id)
@@ -327,6 +342,7 @@ async fn register_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     state
         .machines
         .register(&payload.user_id)
@@ -349,6 +365,7 @@ async fn snapshot_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let user_id = payload.user_id.trim();
     if user_id.is_empty() {
         return Err(ApiError::bad_request(anyhow!("user id is required")));
@@ -374,6 +391,7 @@ async fn archive_sync_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     state
         .thread_cache
         .sync_archived(&payload.user_id)
@@ -391,6 +409,7 @@ async fn watch_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let user_id = payload.user_id.trim();
     if user_id.is_empty() {
         return Err(ApiError::bad_request(anyhow!("user id is required")));

--- a/crates/sprocket-server/src/routes/threads.rs
+++ b/crates/sprocket-server/src/routes/threads.rs
@@ -21,47 +21,36 @@ use crate::thread_sync::{ThreadCacheEvent, ThreadCacheStatus};
 use crate::transcript_client::UserConvexClient;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ThreadCacheRegisterRequest {
-    user_id: String,
-    auth_token: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ThreadCacheUserRequest {
     user_id: String,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ThreadCommandRequest {
     user_id: String,
-    auth_token: String,
     thread_id: String,
     title: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct RekeyRequest {
     user_id: String,
-    auth_token: String,
     from: String,
     to: String,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct CancelRequest {
-    auth_token: String,
     run_id: String,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LifecycleRequest {
-    auth_token: String,
     thread_id: String,
 }
 
@@ -109,10 +98,13 @@ pub fn routes() -> axum::Router<AppState> {
         )
 }
 
-async fn client(state: &AppState, token: String) -> Result<UserConvexClient, ApiError> {
-    UserConvexClient::connect(&state.convex_deployment_url, token)
-        .await
-        .map_err(ApiError::bad_request)
+async fn client(state: &AppState) -> Result<UserConvexClient, ApiError> {
+    UserConvexClient::connect_with_fetcher(
+        &state.convex_deployment_url,
+        state.native_auth.auth_token_fetcher(),
+    )
+    .await
+    .map_err(ApiError::bad_request)
 }
 
 fn thread_args(thread_id: String) -> BTreeMap<String, Value> {
@@ -129,7 +121,7 @@ async fn run_thread_command(
     if let Some(title) = payload.title {
         args.insert("title".into(), Value::String(title));
     }
-    let result: ThreadCommandResult = client(state, payload.auth_token.clone())
+    let result: ThreadCommandResult = client(state)
         .await?
         .mutate(function, args)
         .await
@@ -145,12 +137,7 @@ async fn run_thread_command(
         .map_or(categories, std::slice::from_ref);
     let cache_synchronized = match state
         .thread_cache
-        .refresh_repository(
-            &payload.user_id,
-            payload.auth_token,
-            &result.repository_key,
-            refresh_categories,
-        )
+        .refresh_repository(&payload.user_id, &result.repository_key, refresh_categories)
         .await
     {
         Ok(()) => true,
@@ -238,7 +225,7 @@ async fn rekey_handler(
         ("from".into(), Value::String(payload.from)),
         ("to".into(), Value::String(payload.to)),
     ]);
-    let result: RekeyResult = client(&state, payload.auth_token.clone())
+    let result: RekeyResult = client(&state)
         .await?
         .mutate("threads:rekeyRepositoryForLocalCache", args)
         .await
@@ -253,7 +240,6 @@ async fn rekey_handler(
             .thread_cache
             .refresh_repository(
                 &payload.user_id,
-                payload.auth_token,
                 &result.to,
                 &[
                     ThreadSnapshotCategory::Active,
@@ -287,7 +273,7 @@ async fn lifecycle_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
-    let result = client(&state, payload.auth_token)
+    let result = client(&state)
         .await?
         .query(
             "chat:selectedThreadLifecycle",
@@ -307,7 +293,7 @@ async fn cancel_handler(
         .await
         .map_err(ApiError::unauthorized)?;
     let args = BTreeMap::from([("runId".into(), Value::String(payload.run_id))]);
-    let result = client(&state, payload.auth_token)
+    let result = client(&state)
         .await?
         .mutate("agentRuntime:requestCancellation", args)
         .await
@@ -336,7 +322,7 @@ async fn register_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     jar: CookieJar,
-    Json(payload): Json<ThreadCacheRegisterRequest>,
+    Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Json<ThreadCacheEvent>, ApiError> {
     require_session(&state.auth, &headers, &jar)
         .await
@@ -348,7 +334,7 @@ async fn register_handler(
         .map_err(ApiError::bad_request)?;
     state
         .thread_cache
-        .register(&payload.user_id, payload.auth_token)
+        .register(&payload.user_id)
         .await
         .map_err(ApiError::bad_request)?;
     Ok(Json(state.thread_cache.current_event().await))

--- a/crates/sprocket-server/src/routes/threads.rs
+++ b/crates/sprocket-server/src/routes/threads.rs
@@ -100,10 +100,12 @@ pub fn routes() -> axum::Router<AppState> {
         )
 }
 
-async fn client(state: &AppState) -> Result<UserConvexClient, ApiError> {
+async fn client(state: &AppState, user_id: &str) -> Result<UserConvexClient, ApiError> {
     UserConvexClient::connect_with_fetcher(
         &state.convex_deployment_url,
-        state.native_auth.auth_token_fetcher(),
+        state
+            .native_auth
+            .auth_token_fetcher_for_user(user_id.to_string()),
     )
     .await
     .map_err(ApiError::bad_request)
@@ -132,7 +134,7 @@ async fn run_thread_command(
     if let Some(title) = payload.title {
         args.insert("title".into(), Value::String(title));
     }
-    let result: ThreadCommandResult = client(state)
+    let result: ThreadCommandResult = client(state, &payload.user_id)
         .await?
         .mutate(function, args)
         .await
@@ -237,7 +239,7 @@ async fn rekey_handler(
         ("from".into(), Value::String(payload.from)),
         ("to".into(), Value::String(payload.to)),
     ]);
-    let result: RekeyResult = client(&state)
+    let result: RekeyResult = client(&state, &payload.user_id)
         .await?
         .mutate("threads:rekeyRepositoryForLocalCache", args)
         .await
@@ -286,7 +288,7 @@ async fn lifecycle_handler(
         .await
         .map_err(ApiError::unauthorized)?;
     require_user(&state, &payload.user_id).await?;
-    let result = client(&state)
+    let result = client(&state, &payload.user_id)
         .await?
         .query(
             "chat:selectedThreadLifecycle",
@@ -307,7 +309,7 @@ async fn cancel_handler(
         .map_err(ApiError::unauthorized)?;
     require_user(&state, &payload.user_id).await?;
     let args = BTreeMap::from([("runId".into(), Value::String(payload.run_id))]);
-    let result = client(&state)
+    let result = client(&state, &payload.user_id)
         .await?
         .mutate("agentRuntime:requestCancellation", args)
         .await

--- a/crates/sprocket-server/src/routes/threads.rs
+++ b/crates/sprocket-server/src/routes/threads.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use tokio::sync::broadcast;
 
 use crate::AppState;
-use crate::auth::require_session;
 use crate::routes::api_error::ApiError;
 use crate::thread_cache::{CachedThreadSummary, ThreadSnapshotCategory};
 use crate::thread_sync::{ThreadCacheEvent, ThreadCacheStatus};
@@ -119,6 +118,18 @@ async fn require_user(state: &AppState, user_id: &str) -> Result<(), ApiError> {
         .map_err(ApiError::unauthorized)
 }
 
+async fn require_session_user(
+    state: &AppState,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+    user_id: &str,
+) -> Result<(), ApiError> {
+    crate::auth::require_session_user(&state.auth, headers, jar, user_id)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    require_user(state, user_id).await
+}
+
 fn thread_args(thread_id: String) -> BTreeMap<String, Value> {
     BTreeMap::from([("threadId".into(), Value::String(thread_id))])
 }
@@ -129,7 +140,6 @@ async fn run_thread_command(
     function: &str,
     categories: &[ThreadSnapshotCategory],
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_user(state, &payload.user_id).await?;
     let mut args = thread_args(payload.thread_id);
     if let Some(title) = payload.title {
         args.insert("title".into(), Value::String(title));
@@ -171,9 +181,7 @@ async fn rename_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCommandRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     run_thread_command(
         &state,
         payload,
@@ -191,9 +199,7 @@ async fn archive_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCommandRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     run_thread_command(
         &state,
         payload,
@@ -211,9 +217,7 @@ async fn restore_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCommandRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     run_thread_command(
         &state,
         payload,
@@ -231,10 +235,7 @@ async fn rekey_handler(
     jar: CookieJar,
     Json(payload): Json<RekeyRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let args = BTreeMap::from([
         ("from".into(), Value::String(payload.from)),
         ("to".into(), Value::String(payload.to)),
@@ -284,10 +285,7 @@ async fn lifecycle_handler(
     jar: CookieJar,
     Json(payload): Json<LifecycleRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let result = client(&state, &payload.user_id)
         .await?
         .query(
@@ -304,10 +302,7 @@ async fn cancel_handler(
     jar: CookieJar,
     Json(payload): Json<CancelRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let args = BTreeMap::from([("runId".into(), Value::String(payload.run_id))]);
     let result = client(&state, &payload.user_id)
         .await?
@@ -323,10 +318,7 @@ async fn end_account_session_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     state
         .machines
         .end(&payload.user_id)
@@ -341,10 +333,7 @@ async fn register_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Json<ThreadCacheEvent>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     state
         .machines
         .register(&payload.user_id)
@@ -364,10 +353,7 @@ async fn snapshot_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Json<ThreadCacheSnapshotResponse>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let user_id = payload.user_id.trim();
     if user_id.is_empty() {
         return Err(ApiError::bad_request(anyhow!("user id is required")));
@@ -390,10 +376,7 @@ async fn archive_sync_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Json<ThreadCacheEvent>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     state
         .thread_cache
         .sync_archived(&payload.user_id)
@@ -408,10 +391,7 @@ async fn watch_handler(
     jar: CookieJar,
     Json(payload): Json<ThreadCacheUserRequest>,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let user_id = payload.user_id.trim();
     if user_id.is_empty() {
         return Err(ApiError::bad_request(anyhow!("user id is required")));

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -73,7 +73,9 @@ async fn page_handler(
     if payload.before.is_some() {
         let client = UserConvexClient::connect_with_fetcher(
             &state.convex_deployment_url,
-            state.native_auth.auth_token_fetcher(),
+            state
+                .native_auth
+                .auth_token_fetcher_for_user(payload.user_id.clone()),
         )
         .await
         .map_err(|error| {
@@ -210,7 +212,9 @@ async fn attachment_handler(
 
     let client = UserConvexClient::connect_with_fetcher(
         &state.convex_deployment_url,
-        state.native_auth.auth_token_fetcher(),
+        state
+            .native_auth
+            .auth_token_fetcher_for_user(payload.user_id.clone()),
     )
     .await
     .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -15,7 +15,6 @@ use sprocket_agent::{TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE};
 use tokio::sync::broadcast;
 
 use crate::AppState;
-use crate::auth::require_session;
 use crate::routes::api_error::ApiError;
 use crate::transcript_client::{UserConvexClient, download_attachment_bytes};
 use crate::transcript_watch::TranscriptWatchEvent;
@@ -60,16 +59,25 @@ async fn require_user(state: &AppState, user_id: &str) -> Result<(), ApiError> {
         .map_err(ApiError::unauthorized)
 }
 
+async fn require_session_user(
+    state: &AppState,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+    user_id: &str,
+) -> Result<(), ApiError> {
+    crate::auth::require_session_user(&state.auth, headers, jar, user_id)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    require_user(state, user_id).await
+}
+
 async fn page_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     jar: CookieJar,
     Json(payload): Json<TranscriptPageRequest>,
 ) -> Result<Json<sprocket_agent::TranscriptPage>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     if payload.before.is_some() {
         let client = UserConvexClient::connect_with_fetcher(
             &state.convex_deployment_url,
@@ -128,10 +136,7 @@ async fn watch_handler(
     jar: CookieJar,
     Json(payload): Json<TranscriptScope>,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     let session = state
         .transcript_watchers
         .open(&payload.user_id, &payload.thread_id)
@@ -167,10 +172,7 @@ async fn clear_handler(
     jar: CookieJar,
     Json(payload): Json<TranscriptScope>,
 ) -> Result<StatusCode, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     state
         .transcript_watchers
         .abort_thread(&payload.user_id, &payload.thread_id)
@@ -189,10 +191,7 @@ async fn attachment_handler(
     jar: CookieJar,
     Json(payload): Json<TranscriptAttachmentRequest>,
 ) -> Result<Response, ApiError> {
-    require_session(&state.auth, &headers, &jar)
-        .await
-        .map_err(ApiError::unauthorized)?;
-    require_user(&state, &payload.user_id).await?;
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
     if let Some(blob) = state
         .transcript
         .blob_for_upload(&payload.user_id, &payload.image_upload_id)

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -52,6 +52,14 @@ pub fn routes() -> axum::Router<AppState> {
         .route("/transcript/attachment", post(attachment_handler))
 }
 
+async fn require_user(state: &AppState, user_id: &str) -> Result<(), ApiError> {
+    state
+        .native_auth
+        .require_user(user_id)
+        .await
+        .map_err(ApiError::unauthorized)
+}
+
 async fn page_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -61,6 +69,7 @@ async fn page_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     if payload.before.is_some() {
         let client = UserConvexClient::connect_with_fetcher(
             &state.convex_deployment_url,
@@ -120,6 +129,7 @@ async fn watch_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     let session = state
         .transcript_watchers
         .open(&payload.user_id, &payload.thread_id)
@@ -158,6 +168,7 @@ async fn clear_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     state
         .transcript_watchers
         .abort_thread(&payload.user_id, &payload.thread_id)
@@ -179,6 +190,7 @@ async fn attachment_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
+    require_user(&state, &payload.user_id).await?;
     if let Some(blob) = state
         .transcript
         .blob_for_upload(&payload.user_id, &payload.image_upload_id)

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -21,17 +21,15 @@ use crate::transcript_client::{UserConvexClient, download_attachment_bytes};
 use crate::transcript_watch::TranscriptWatchEvent;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TranscriptScope {
-    auth_token: String,
     user_id: String,
     thread_id: String,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TranscriptPageRequest {
-    auth_token: Option<String>,
     user_id: String,
     thread_id: String,
     before: Option<u32>,
@@ -39,9 +37,8 @@ struct TranscriptPageRequest {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TranscriptAttachmentRequest {
-    auth_token: String,
     user_id: String,
     thread_id: String,
     image_upload_id: String,
@@ -64,16 +61,15 @@ async fn page_handler(
     require_session(&state.auth, &headers, &jar)
         .await
         .map_err(ApiError::unauthorized)?;
-    if let Some(auth_token) = payload.auth_token.as_deref() {
-        let client =
-            UserConvexClient::connect(&state.convex_deployment_url, auth_token.to_string())
-                .await
-                .map_err(|error| {
-                    ApiError::internal_with(
-                        "failed to connect while loading transcript history",
-                        error,
-                    )
-                })?;
+    if payload.before.is_some() {
+        let client = UserConvexClient::connect_with_fetcher(
+            &state.convex_deployment_url,
+            state.native_auth.auth_token_fetcher(),
+        )
+        .await
+        .map_err(|error| {
+            ApiError::internal_with("failed to connect while loading transcript history", error)
+        })?;
         let transcript_state = state
             .transcript
             .load_state(&payload.user_id, &payload.thread_id)
@@ -126,7 +122,7 @@ async fn watch_handler(
         .map_err(ApiError::unauthorized)?;
     let session = state
         .transcript_watchers
-        .open(&payload.user_id, &payload.thread_id, payload.auth_token)
+        .open(&payload.user_id, &payload.thread_id)
         .await;
     let stream = unfold(session, |mut session| async move {
         loop {
@@ -200,9 +196,12 @@ async fn attachment_handler(
         return Ok(blob_response(blob.media_type, blob.bytes));
     }
 
-    let client = UserConvexClient::connect(&state.convex_deployment_url, payload.auth_token)
-        .await
-        .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
+    let client = UserConvexClient::connect_with_fetcher(
+        &state.convex_deployment_url,
+        state.native_auth.auth_token_fetcher(),
+    )
+    .await
+    .map_err(|error| ApiError::internal_with("failed to connect to Convex", error))?;
     let Some(remote) = client
         .attachment_download(&payload.image_upload_id)
         .await

--- a/crates/sprocket-server/src/thread_sync.rs
+++ b/crates/sprocket-server/src/thread_sync.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use futures::StreamExt;
+use sprocket_convex::AuthTokenFetcher;
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -45,7 +46,6 @@ struct WatchKey {
 
 struct CacheInner {
     user_id: Option<String>,
-    auth_token: Option<String>,
     status: ThreadCacheStatus,
     last_synced_at: Option<u64>,
     tasks: HashMap<WatchKey, JoinHandle<()>>,
@@ -55,6 +55,7 @@ pub struct ThreadCacheSync {
     deployment_url: String,
     store: Arc<ThreadSnapshotStore>,
     attachments: Arc<ProjectAttachmentStore>,
+    auth_token_fetcher: AuthTokenFetcher,
     inner: Mutex<CacheInner>,
     events: broadcast::Sender<ThreadCacheEvent>,
 }
@@ -68,15 +69,16 @@ impl ThreadCacheSync {
         deployment_url: String,
         store: Arc<ThreadSnapshotStore>,
         attachments: Arc<ProjectAttachmentStore>,
+        auth_token_fetcher: AuthTokenFetcher,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(32);
         Arc::new(Self {
             deployment_url,
             store,
             attachments,
+            auth_token_fetcher,
             inner: Mutex::new(CacheInner {
                 user_id: None,
-                auth_token: None,
                 status: ThreadCacheStatus::Loading,
                 last_synced_at: None,
                 tasks: HashMap::new(),
@@ -129,18 +131,10 @@ impl ThreadCacheSync {
         }
     }
 
-    pub async fn register(
-        self: &Arc<Self>,
-        user_id: &str,
-        auth_token: String,
-    ) -> anyhow::Result<()> {
+    pub async fn register(self: &Arc<Self>, user_id: &str) -> anyhow::Result<()> {
         let user_id = user_id.trim();
-        let auth_token = auth_token.trim();
         if user_id.is_empty() {
             anyhow::bail!("user id is required");
-        }
-        if auth_token.is_empty() {
-            anyhow::bail!("auth token is required");
         }
         let last_synced_at = self.store.latest_synced_at(user_id).await?;
         let mut emit_loading = false;
@@ -152,7 +146,6 @@ impl ThreadCacheSync {
                 emit_loading = true;
             }
             inner.user_id = Some(user_id.to_string());
-            inner.auth_token = Some(auth_token.to_string());
             inner.last_synced_at = last_synced_at.or(inner.last_synced_at);
         }
         if emit_loading {
@@ -173,9 +166,6 @@ impl ThreadCacheSync {
             if inner.user_id.as_deref() != Some(user_id) {
                 anyhow::bail!("thread cache is registered to a different account");
             }
-            if inner.auth_token.as_deref().unwrap_or("").is_empty() {
-                anyhow::bail!("thread cache is not registered");
-            }
         }
         self.reconcile_watches(ThreadSnapshotCategory::Archived)
             .await?;
@@ -185,17 +175,20 @@ impl ThreadCacheSync {
     pub async fn refresh_repository(
         self: &Arc<Self>,
         user_id: &str,
-        auth_token: String,
         repository_key: &str,
         categories: &[ThreadSnapshotCategory],
     ) -> anyhow::Result<()> {
-        self.register(user_id, auth_token.clone()).await?;
+        self.register(user_id).await?;
         if repository_key.is_empty() {
             return Ok(());
         }
-        self.ensure_repository_watches(user_id, repository_key, categories, &auth_token)
+        self.ensure_repository_watches(user_id, repository_key, categories)
             .await;
-        let client = UserConvexClient::connect(&self.deployment_url, auth_token).await?;
+        let client = UserConvexClient::connect_with_fetcher(
+            &self.deployment_url,
+            Arc::clone(&self.auth_token_fetcher),
+        )
+        .await?;
         for &category in categories {
             let start = WatchStart {
                 deployment_url: self.deployment_url.clone(),
@@ -204,7 +197,7 @@ impl ThreadCacheSync {
                 user_id: user_id.to_string(),
                 repository_key: repository_key.to_string(),
                 category,
-                auth_token: String::new(),
+                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
             };
             download_consistent_snapshot(&start, &client).await?;
         }
@@ -216,7 +209,6 @@ impl ThreadCacheSync {
         user_id: &str,
         repository_key: &str,
         categories: &[ThreadSnapshotCategory],
-        auth_token: &str,
     ) {
         let mut inner = self.inner.lock().await;
         if inner.user_id.as_deref() != Some(user_id) {
@@ -238,7 +230,7 @@ impl ThreadCacheSync {
                 user_id: key.user_id.clone(),
                 repository_key: key.repository_key.clone(),
                 category: key.category,
-                auth_token: auth_token.to_string(),
+                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
             }));
             inner.tasks.insert(key, task);
         }
@@ -248,18 +240,12 @@ impl ThreadCacheSync {
         self: &Arc<Self>,
         category: ThreadSnapshotCategory,
     ) -> anyhow::Result<()> {
-        let (user_id, auth_token) = {
+        let user_id = {
             let inner = self.inner.lock().await;
-            (
-                inner
-                    .user_id
-                    .clone()
-                    .ok_or_else(|| anyhow!("thread cache is not registered"))?,
-                inner
-                    .auth_token
-                    .clone()
-                    .ok_or_else(|| anyhow!("thread cache is not registered"))?,
-            )
+            inner
+                .user_id
+                .clone()
+                .ok_or_else(|| anyhow!("thread cache is not registered"))?
         };
         let repository_keys = attached_repository_keys(&self.attachments).await?;
         let wanted: HashSet<WatchKey> = repository_keys
@@ -293,7 +279,7 @@ impl ThreadCacheSync {
                 user_id: key.user_id.clone(),
                 repository_key: key.repository_key.clone(),
                 category: key.category,
-                auth_token: auth_token.clone(),
+                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
             }));
             inner.tasks.insert(key, task);
         }
@@ -345,7 +331,7 @@ struct WatchStart {
     user_id: String,
     repository_key: String,
     category: ThreadSnapshotCategory,
-    auth_token: String,
+    auth_token_fetcher: AuthTokenFetcher,
 }
 
 fn abort_tasks(inner: &mut CacheInner) {
@@ -409,7 +395,11 @@ fn classify_watch_error(error: &anyhow::Error) -> ThreadCacheStatus {
 }
 
 async fn run_watch(start: &WatchStart) -> anyhow::Result<()> {
-    let client = UserConvexClient::connect(&start.deployment_url, start.auth_token.clone()).await?;
+    let client = UserConvexClient::connect_with_fetcher(
+        &start.deployment_url,
+        Arc::clone(&start.auth_token_fetcher),
+    )
+    .await?;
     let mut subscription = client
         .subscribe_snapshot_revision(&start.repository_key, start.category.as_str())
         .await?;

--- a/crates/sprocket-server/src/thread_sync.rs
+++ b/crates/sprocket-server/src/thread_sync.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use futures::StreamExt;
-use sprocket_convex::AuthTokenFetcher;
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
+use crate::native_auth::NativeAuthManager;
 use crate::now_ms;
 use crate::project_attachments::{ProjectAttachmentStore, WorkspaceAvailability};
 use crate::thread_cache::{
@@ -55,7 +55,7 @@ pub struct ThreadCacheSync {
     deployment_url: String,
     store: Arc<ThreadSnapshotStore>,
     attachments: Arc<ProjectAttachmentStore>,
-    auth_token_fetcher: AuthTokenFetcher,
+    native_auth: Arc<NativeAuthManager>,
     inner: Mutex<CacheInner>,
     events: broadcast::Sender<ThreadCacheEvent>,
 }
@@ -65,18 +65,18 @@ pub struct ThreadCacheWatchSession {
 }
 
 impl ThreadCacheSync {
-    pub fn new(
+    pub(crate) fn new(
         deployment_url: String,
         store: Arc<ThreadSnapshotStore>,
         attachments: Arc<ProjectAttachmentStore>,
-        auth_token_fetcher: AuthTokenFetcher,
+        native_auth: Arc<NativeAuthManager>,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(32);
         Arc::new(Self {
             deployment_url,
             store,
             attachments,
-            auth_token_fetcher,
+            native_auth,
             inner: Mutex::new(CacheInner {
                 user_id: None,
                 status: ThreadCacheStatus::Loading,
@@ -186,7 +186,8 @@ impl ThreadCacheSync {
             .await;
         let client = UserConvexClient::connect_with_fetcher(
             &self.deployment_url,
-            Arc::clone(&self.auth_token_fetcher),
+            self.native_auth
+                .auth_token_fetcher_for_user(user_id.to_string()),
         )
         .await?;
         for &category in categories {
@@ -197,7 +198,7 @@ impl ThreadCacheSync {
                 user_id: user_id.to_string(),
                 repository_key: repository_key.to_string(),
                 category,
-                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
+                native_auth: Arc::clone(&self.native_auth),
             };
             download_consistent_snapshot(&start, &client).await?;
         }
@@ -230,7 +231,7 @@ impl ThreadCacheSync {
                 user_id: key.user_id.clone(),
                 repository_key: key.repository_key.clone(),
                 category: key.category,
-                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
+                native_auth: Arc::clone(&self.native_auth),
             }));
             inner.tasks.insert(key, task);
         }
@@ -279,7 +280,7 @@ impl ThreadCacheSync {
                 user_id: key.user_id.clone(),
                 repository_key: key.repository_key.clone(),
                 category: key.category,
-                auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
+                native_auth: Arc::clone(&self.native_auth),
             }));
             inner.tasks.insert(key, task);
         }
@@ -331,7 +332,7 @@ struct WatchStart {
     user_id: String,
     repository_key: String,
     category: ThreadSnapshotCategory,
-    auth_token_fetcher: AuthTokenFetcher,
+    native_auth: Arc<NativeAuthManager>,
 }
 
 fn abort_tasks(inner: &mut CacheInner) {
@@ -397,7 +398,9 @@ fn classify_watch_error(error: &anyhow::Error) -> ThreadCacheStatus {
 async fn run_watch(start: &WatchStart) -> anyhow::Result<()> {
     let client = UserConvexClient::connect_with_fetcher(
         &start.deployment_url,
-        Arc::clone(&start.auth_token_fetcher),
+        start
+            .native_auth
+            .auth_token_fetcher_for_user(start.user_id.clone()),
     )
     .await?;
     let mut subscription = client

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
@@ -16,13 +15,6 @@ pub struct UserConvexClient {
 }
 
 impl UserConvexClient {
-    pub async fn connect(deployment_url: &str, auth_token: String) -> anyhow::Result<Self> {
-        let client = ConvexClient::new(deployment_url).await?;
-        let fetcher = static_token_fetcher(auth_token);
-        client.set_auth_token_fetcher(fetcher).await;
-        Ok(Self { client })
-    }
-
     pub async fn connect_with_fetcher(
         deployment_url: &str,
         fetcher: AuthTokenFetcher,
@@ -168,18 +160,6 @@ pub struct RemoteAttachmentDownload {
     pub media_type: String,
     pub storage_id: String,
     pub url: String,
-}
-
-fn static_token_fetcher(token: String) -> AuthTokenFetcher {
-    Arc::new(move |_force_refresh| {
-        let token = token.clone();
-        Box::pin(async move {
-            if token.trim().is_empty() {
-                return Err(anyhow!("transcript auth token is empty"));
-            }
-            Ok(token)
-        })
-    })
 }
 
 fn thread_id_args(thread_id: &str) -> BTreeMap<String, Value> {

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
 use sprocket_agent::{TRANSCRIPT_PAGE_SIZE, TranscriptStore, apply_remote_state};
+use sprocket_convex::AuthTokenFetcher;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
@@ -36,15 +37,16 @@ type WatchStarter = Arc<dyn Fn(WatchStart) -> JoinHandle<()> + Send + Sync>;
 struct WatchStart {
     deployment_url: String,
     store: Arc<TranscriptStore>,
+    auth_token_fetcher: AuthTokenFetcher,
     user_id: String,
     thread_id: String,
-    auth_token: String,
     events: broadcast::Sender<TranscriptWatchEvent>,
 }
 
 pub struct TranscriptWatchers {
     deployment_url: String,
     store: Arc<TranscriptStore>,
+    auth_token_fetcher: AuthTokenFetcher,
     inner: Mutex<HashMap<WatchKey, WatchSlot>>,
     start: WatchStarter,
 }
@@ -56,18 +58,29 @@ pub struct TranscriptWatchSession {
 }
 
 impl TranscriptWatchers {
-    pub fn new(deployment_url: String, store: Arc<TranscriptStore>) -> Arc<Self> {
-        Self::with_starter(deployment_url, store, Arc::new(spawn_convex_watch))
+    pub fn new(
+        deployment_url: String,
+        store: Arc<TranscriptStore>,
+        auth_token_fetcher: AuthTokenFetcher,
+    ) -> Arc<Self> {
+        Self::with_starter(
+            deployment_url,
+            store,
+            auth_token_fetcher,
+            Arc::new(spawn_convex_watch),
+        )
     }
 
     fn with_starter(
         deployment_url: String,
         store: Arc<TranscriptStore>,
+        auth_token_fetcher: AuthTokenFetcher,
         start: WatchStarter,
     ) -> Arc<Self> {
         Arc::new(Self {
             deployment_url,
             store,
+            auth_token_fetcher,
             inner: Mutex::new(HashMap::new()),
             start,
         })
@@ -109,12 +122,7 @@ impl TranscriptWatchers {
         }
     }
 
-    pub async fn open(
-        self: &Arc<Self>,
-        user_id: &str,
-        thread_id: &str,
-        auth_token: String,
-    ) -> TranscriptWatchSession {
+    pub async fn open(self: &Arc<Self>, user_id: &str, thread_id: &str) -> TranscriptWatchSession {
         let key = WatchKey {
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
@@ -132,9 +140,9 @@ impl TranscriptWatchers {
         let task = (self.start)(WatchStart {
             deployment_url: self.deployment_url.clone(),
             store: Arc::clone(&self.store),
+            auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
-            auth_token,
             events: events.clone(),
         });
         inner.insert(
@@ -223,7 +231,11 @@ fn spawn_convex_watch(start: WatchStart) -> JoinHandle<()> {
 }
 
 async fn run_watch_loop(start: &WatchStart) -> anyhow::Result<()> {
-    let client = UserConvexClient::connect(&start.deployment_url, start.auth_token.clone()).await?;
+    let client = UserConvexClient::connect_with_fetcher(
+        &start.deployment_url,
+        Arc::clone(&start.auth_token_fetcher),
+    )
+    .await?;
     let remote = client.ensure_migrated(&start.thread_id).await?;
     apply_remote_state(
         &start.store,
@@ -287,6 +299,10 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    fn auth_token_fetcher() -> AuthTokenFetcher {
+        Arc::new(|_| Box::pin(async { Ok("token".to_string()) }))
+    }
+
     #[tokio::test]
     async fn last_close_cancels_the_watch_task() {
         let dir = std::env::temp_dir().join(format!("sprocket-watch-{}", uuid::Uuid::new_v4()));
@@ -296,6 +312,7 @@ mod tests {
         let watchers = TranscriptWatchers::with_starter(
             "https://example.convex.cloud".into(),
             store,
+            auth_token_fetcher(),
             Arc::new(move |_start| {
                 let live_task = live_task.clone();
                 live_task.fetch_add(1, Ordering::SeqCst);
@@ -312,8 +329,8 @@ mod tests {
             }),
         );
 
-        let first = watchers.open("user", "thread", "token".into()).await;
-        let second = watchers.open("user", "thread", "token".into()).await;
+        let first = watchers.open("user", "thread").await;
+        let second = watchers.open("user", "thread").await;
         assert_eq!(watchers.active_count(), 1);
         assert_eq!(live.load(Ordering::SeqCst), 1);
         drop(first);
@@ -333,9 +350,10 @@ mod tests {
         let watchers = TranscriptWatchers::with_starter(
             "https://example.convex.cloud".into(),
             store,
+            auth_token_fetcher(),
             Arc::new(|_start| tokio::spawn(std::future::pending())),
         );
-        let mut session = watchers.open("user", "thread", "token".into()).await;
+        let mut session = watchers.open("user", "thread").await;
 
         watchers
             .notify_local_update("user", "thread", 4, true)

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -3,10 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
 use sprocket_agent::{TRANSCRIPT_PAGE_SIZE, TranscriptStore, apply_remote_state};
-use sprocket_convex::AuthTokenFetcher;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
+use crate::native_auth::NativeAuthManager;
 use crate::transcript_client::{
     UserConvexClient, decode_state_update, retry_after_failure, sync_range,
 };
@@ -37,7 +37,7 @@ type WatchStarter = Arc<dyn Fn(WatchStart) -> JoinHandle<()> + Send + Sync>;
 struct WatchStart {
     deployment_url: String,
     store: Arc<TranscriptStore>,
-    auth_token_fetcher: AuthTokenFetcher,
+    native_auth: Arc<NativeAuthManager>,
     user_id: String,
     thread_id: String,
     events: broadcast::Sender<TranscriptWatchEvent>,
@@ -46,7 +46,7 @@ struct WatchStart {
 pub struct TranscriptWatchers {
     deployment_url: String,
     store: Arc<TranscriptStore>,
-    auth_token_fetcher: AuthTokenFetcher,
+    native_auth: Arc<NativeAuthManager>,
     inner: Mutex<HashMap<WatchKey, WatchSlot>>,
     start: WatchStarter,
 }
@@ -58,15 +58,15 @@ pub struct TranscriptWatchSession {
 }
 
 impl TranscriptWatchers {
-    pub fn new(
+    pub(crate) fn new(
         deployment_url: String,
         store: Arc<TranscriptStore>,
-        auth_token_fetcher: AuthTokenFetcher,
+        native_auth: Arc<NativeAuthManager>,
     ) -> Arc<Self> {
         Self::with_starter(
             deployment_url,
             store,
-            auth_token_fetcher,
+            native_auth,
             Arc::new(spawn_convex_watch),
         )
     }
@@ -74,13 +74,13 @@ impl TranscriptWatchers {
     fn with_starter(
         deployment_url: String,
         store: Arc<TranscriptStore>,
-        auth_token_fetcher: AuthTokenFetcher,
+        native_auth: Arc<NativeAuthManager>,
         start: WatchStarter,
     ) -> Arc<Self> {
         Arc::new(Self {
             deployment_url,
             store,
-            auth_token_fetcher,
+            native_auth,
             inner: Mutex::new(HashMap::new()),
             start,
         })
@@ -140,7 +140,7 @@ impl TranscriptWatchers {
         let task = (self.start)(WatchStart {
             deployment_url: self.deployment_url.clone(),
             store: Arc::clone(&self.store),
-            auth_token_fetcher: Arc::clone(&self.auth_token_fetcher),
+            native_auth: Arc::clone(&self.native_auth),
             user_id: user_id.to_string(),
             thread_id: thread_id.to_string(),
             events: events.clone(),
@@ -233,7 +233,9 @@ fn spawn_convex_watch(start: WatchStart) -> JoinHandle<()> {
 async fn run_watch_loop(start: &WatchStart) -> anyhow::Result<()> {
     let client = UserConvexClient::connect_with_fetcher(
         &start.deployment_url,
-        Arc::clone(&start.auth_token_fetcher),
+        start
+            .native_auth
+            .auth_token_fetcher_for_user(start.user_id.clone()),
     )
     .await?;
     let remote = client.ensure_migrated(&start.thread_id).await?;
@@ -299,8 +301,13 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    fn auth_token_fetcher() -> AuthTokenFetcher {
-        Arc::new(|_| Box::pin(async { Ok("token".to_string()) }))
+    fn native_auth() -> Arc<NativeAuthManager> {
+        NativeAuthManager::configured_for_test(
+            crate::native_auth::NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            "http://127.0.0.1/callback".to_string(),
+        )
     }
 
     #[tokio::test]
@@ -312,7 +319,7 @@ mod tests {
         let watchers = TranscriptWatchers::with_starter(
             "https://example.convex.cloud".into(),
             store,
-            auth_token_fetcher(),
+            native_auth(),
             Arc::new(move |_start| {
                 let live_task = live_task.clone();
                 live_task.fetch_add(1, Ordering::SeqCst);
@@ -350,7 +357,7 @@ mod tests {
         let watchers = TranscriptWatchers::with_starter(
             "https://example.convex.cloud".into(),
             store,
-            auth_token_fetcher(),
+            native_auth(),
             Arc::new(|_start| tokio::spawn(std::future::pending())),
         );
         let mut session = watchers.open("user", "thread").await;


### PR DESCRIPTION
## Summary
- use the native WorkOS token refresh callback for every authenticated server-originated Convex call
- remove browser Convex tokens from local API request types and frontend payloads
- reject stale payload fields and remove the static-token Convex client path

## Testing
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo check -p sprocket-server`
- `nix develop -c cargo test -p sprocket-server`
- `nix develop -c bun run check` (apps/web)
- `nix develop -c bun run test` (apps/web)
- `nix develop -c bun run lint` (apps/web; generated-file warnings only)
- targeted Prettier check
- `git diff --check`









<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces browser-supplied Convex tokens with server-managed, user-bound token refresh callbacks and binds local sessions to the WorkOS account that completed login.
- Persists the authenticated user ID on local session records and rejects unbound or mismatched sessions.
- Revalidates the expected WorkOS identity whenever authenticated Convex clients request tokens.
- Removes browser token fields from local API contracts and rejects obsolete payload fields.
- Applies the combined local-session and native-account checks across thread, transcript, agent, cache, and machine operations.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously reported identity-binding failures are addressed and no blocking failure remains.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/auth.rs | Adds persisted local-session user binding and enforces that account-scoped requests match the bound identity. |
| crates/sprocket-server/src/native_auth.rs | Introduces expected-user token fetchers that serialize credential changes and verify identity on each token request. |
| crates/sprocket-server/src/routes/threads.rs | Replaces caller-supplied tokens with combined local-session and native-user checks for thread operations. |
| crates/sprocket-server/src/routes/transcript.rs | Uses server-managed user-bound authentication for transcript history, watches, clearing, and attachments. |
| crates/sprocket-server/src/routes/auth.rs | Binds the local session that initiated desktop login to the WorkOS user returned by the callback. |
| crates/sprocket-server/src/thread_sync.rs | Replaces stored browser tokens with user-bound native authentication for cache refreshes and watches. |
| apps/web/src/routes/+page.svelte | Removes browser token acquisition and token fields from local-server requests. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Web
    participant Server
    participant LocalSession
    participant WorkOS
    participant Convex
    Web->>Server: Account-scoped request(userId)
    Server->>LocalSession: Validate session bound to userId
    LocalSession-->>Server: Bound identity confirmed
    Server->>WorkOS: Fetch/refresh token for expected userId
    WorkOS-->>Server: Token only if native identity matches
    Server->>Convex: Authenticated operation
    Convex-->>Server: Result
    Server-->>Web: Response
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(server): bind local sessions to acco..."](https://github.com/spikonado/sprocket/commit/2956837a718c543bd767e19e1d697eb64e056788) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60261880)</sub>

<!-- /greptile_comment -->