### PR TITLE
refactor(web): Use Zod 4 URL and email validators

### DIFF
--- a/apps/web/src/convex/browserAgent.test.ts
+++ b/apps/web/src/convex/browserAgent.test.ts
@@ -190,6 +190,39 @@ describe('browserAgent', () => {
 		expect(stored?.liveViewUrl).toBeUndefined();
 	});
 
+	it('still records the session when the live view URL is not a URL', async () => {
+		process.env.BROWSERBASE_API_KEY = 'bb_key';
+		process.env.BROWSERBASE_PROJECT_ID = 'project-1';
+		process.env.OPENAI_API_KEY = 'openai_key';
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ debuggerFullscreenUrl: 'not-a-url' })
+		});
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const run = await startRun(t, asUser, threadId);
+
+		const out = await t.action(api.browserAgent.act, {
+			instruction: 'browse anyway',
+			runId: run.runId,
+			claimId: run.claimId,
+			executionSecret: run.executionSecret
+		});
+		expect(out.text).toContain('Action performed');
+
+		const stored = await t.run(async (ctx) =>
+			ctx.db
+				.query('browserSessions')
+				.withIndex('by_thread', (query) => query.eq('threadId', threadId))
+				.first()
+		);
+		expect(stored).toMatchObject({
+			browserbaseSessionId: 'bb-session-task',
+			lastUsedRunId: run.runId
+		});
+		expect(stored?.liveViewUrl).toBeUndefined();
+	});
+
 	it('backfills the live view URL for a session row missing it', async () => {
 		process.env.BROWSERBASE_API_KEY = 'bb_key';
 		process.env.BROWSERBASE_PROJECT_ID = 'project-1';

--- a/apps/web/src/convex/browserAgent.ts
+++ b/apps/web/src/convex/browserAgent.ts
@@ -144,7 +144,7 @@ async function fetchLiveViewUrl(apiKey: string, sessionId: string): Promise<stri
 			signal: AbortSignal.timeout(5_000)
 		});
 		if (!response.ok) return null;
-		const parsed = z.object({ debuggerFullscreenUrl: z.string() }).safeParse(await response.json());
+		const parsed = z.object({ debuggerFullscreenUrl: z.url() }).safeParse(await response.json());
 		return parsed.success ? parsed.data.debuggerFullscreenUrl : null;
 	} catch {
 		return null;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -226,7 +226,7 @@ const desktopLoginResultSchema = z.discriminatedUnion('status', [
 	z.object({ status: z.literal('pending') }),
 	z.object({
 		status: z.literal('authenticated'),
-		user: z.object({ id: z.string(), email: z.string() })
+		user: z.object({ id: z.string(), email: z.email() })
 	}),
 	z.object({ status: z.literal('unavailable'), error: z.string() }),
 	z.object({ status: z.literal('failed'), error: z.string() })

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -26,8 +26,8 @@ export type LocalBootstrap = {
 const errorPayloadSchema = z.object({ error: z.string().optional() });
 const sessionSchema = z.object({ authenticated: z.boolean().optional() });
 const localBootstrapSchema = z.object({
-	httpBaseUrl: z.string(),
-	desktopLoginCallbackUrl: z.string().optional(),
+	httpBaseUrl: z.url(),
+	desktopLoginCallbackUrl: z.url().optional(),
 	pairingCredential: z.string()
 });
 const filesystemBrowseResultSchema = z.object({
@@ -63,7 +63,7 @@ const localTranscriptAttachmentSchema = z.object({
 	mediaType: z.string(),
 	size: z.int(),
 	storageId: z.string(),
-	url: z.string().optional()
+	url: z.url().optional()
 });
 const localTranscriptPartSchema = z.object({
 	number: z.int(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Zod 4 already landed, and the int/object cleanup stopped short of a few fields that are always URLs or emails.

This tightens those parsers:

- Local bootstrap `httpBaseUrl` and `desktopLoginCallbackUrl`
- Transcript attachment URLs
- Browserbase live-view URLs
- Native-session user email

Invalid payloads now fail parse instead of passing through as plain strings. No version bump.

Does not close any Renovate PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b7f70a-c1f4-4df1-9a66-08ffa89d5205?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b7f70a-c1f4-4df1-9a66-08ffa89d5205&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens web-client validation for URL and email fields using Zod 4.
- Validates local bootstrap and transcript attachment URLs.
- Validates Browserbase live-view URLs while preserving sessions when validation fails.
- Validates native-session user emails.
- Adds coverage for invalid Browserbase live-view responses.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/browserAgent.ts | Validates Browserbase debugger URLs and safely returns null for malformed responses. |
| apps/web/src/convex/browserAgent.test.ts | Confirms malformed live-view URLs do not prevent browser-session persistence. |
| apps/web/src/lib/auth.ts | Tightens the authenticated desktop-login payload to require a valid email address. |
| apps/web/src/lib/local/client.ts | Tightens URL validation across local bootstrap and transcript attachment payloads. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(browser): Reject non-URL live view ..."](https://github.com/spikonado/sprocket/commit/493518823f3f07429d9c2735a066905235620f8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60280299)</sub>

<!-- /greptile_comment -->