### PR TITLE
perf(cli): Open the browser without waiting for the launcher

### DIFF
--- a/crates/sprocket-cli/Cargo.toml
+++ b/crates/sprocket-cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.5.60", features = ["derive", "env"] }
-open = "5.3.3"
+open = "5.4.2"
 reqwest = { version = "0.13.4", default-features = false, features = ["json"] }
 sprocket-server = { path = "../sprocket-server" }
 sprocket-workspace = { path = "../sprocket-workspace" }

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -220,7 +220,7 @@ async fn open_running_web_app(
 
     let target = browser_launch_url(&expected_base_url, &credential, workspace_path);
     eprintln!("Sprocket is already running. Opening it in your browser…");
-    open::that(&target)
+    open::that_detached(&target)
         .with_context(|| format!("failed to open the browser; open {target} manually"))?;
     Ok(true)
 }

--- a/crates/sprocket-server/Cargo.toml
+++ b/crates/sprocket-server/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5.60", features = ["derive", "env"] }
 cookie = { version = "0.18.1", features = ["percent-encode"] }
 hmac = "0.13.0"
 keyring = "4.2.0"
-open = "5.3.3"
+open = "5.4.2"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -266,7 +266,7 @@ async fn open_browser_when_ready(health_base_url: String, open_target: String) {
             .await
             .is_ok_and(|response| response.status().is_success())
         {
-            if let Err(error) = open::that(&open_target) {
+            if let Err(error) = open::that_detached(&open_target) {
                 tracing::warn!("failed to open browser: {error}");
             }
             return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renovate already moved `open` to 5.4.2 in the lockfile. The crate added `that_detached` so the OS launcher can return without leaving us waiting on the child.

The CLI exits right after opening an already-running instance, and the server opens the browser from an async readiness loop. Both still used blocking `that()`.

This switches those two call sites to `that_detached` and pins the manifests to 5.4.2 so they match the lockfile.

Does not close the lockfile-maintenance Renovate PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b7f70a-c1f4-4df1-9a66-08ffa89d5205?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b7f70a-c1f4-4df1-9a66-08ffa89d5205&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the CLI and server to launch browsers through `open::that_detached`, allowing startup and existing-instance handoff paths to continue without waiting for the OS launcher.
- Pins both direct `open` dependencies to 5.4.2, matching the existing lockfile resolution.
- Detaches browser launch when the CLI connects to an already-running Sprocket instance.
- Detaches browser launch after the local server becomes healthy.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended non-blocking browser-launch behavior applied consistently at both call sites.

The manifests match the committed lockfile, both browser launch targets and readiness checks remain unchanged, and the new API detaches the OS launcher while continuing to report immediate spawn failures.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-cli/Cargo.toml | Pins `open` to 5.4.2, consistent with the version already resolved in the lockfile. |
| crates/sprocket-cli/src/main.rs | Uses the detached launcher for the existing-server browser handoff so the CLI can exit immediately. |
| crates/sprocket-server/Cargo.toml | Pins the server's direct `open` dependency to the version providing the detached API. |
| crates/sprocket-server/src/lib.rs | Uses the detached launcher after readiness succeeds while retaining spawn-error warning behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): Open the browser without wait..."](https://github.com/spikonado/sprocket/commit/e306c0a4ecf41205a185c9353bf87dec3b0fe916) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60280301)</sub>

**Context used:**

- Knowledge Base — [Command-line interface](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/command-line-interface.md)
- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)

<!-- /greptile_comment -->