### PR TITLE
fix(server): Create pairing credentials without racing first boot

### DIFF
--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
-use std::fs;
-use std::io::ErrorKind;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 use axum::http::HeaderMap;
 use axum_extra::extract::CookieJar;
@@ -83,14 +85,7 @@ impl AuthState {
     pub fn load(data_dir: &Path) -> anyhow::Result<Arc<Self>> {
         fs::create_dir_all(data_dir)?;
 
-        let credential_path = data_dir.join(PAIRING_CREDENTIAL_FILE);
-        let pairing_credential = if let Some(existing) = read_pairing_credential(data_dir)? {
-            existing
-        } else {
-            let credential = Uuid::new_v4().to_string();
-            fs::write(&credential_path, format!("{credential}\n"))?;
-            credential
-        };
+        let pairing_credential = load_or_create_pairing_credential(data_dir)?;
 
         let sessions = load_sessions(&data_dir)?;
 
@@ -263,6 +258,45 @@ impl AuthState {
     }
 }
 
+fn load_or_create_pairing_credential(data_dir: &Path) -> anyhow::Result<String> {
+    if let Some(existing) = read_ready_pairing_credential(data_dir)? {
+        return Ok(existing);
+    }
+
+    let path = data_dir.join(PAIRING_CREDENTIAL_FILE);
+    let credential = Uuid::new_v4().to_string();
+    match OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => {
+            file.write_all(format!("{credential}\n").as_bytes())?;
+            file.sync_all()?;
+            Ok(credential)
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            for _ in 0..10 {
+                if let Some(existing) = read_ready_pairing_credential(data_dir)? {
+                    return Ok(existing);
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            anyhow::bail!("pairing credential {} is invalid", path.display())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn read_ready_pairing_credential(data_dir: &Path) -> anyhow::Result<Option<String>> {
+    let credential = match fs::read_to_string(data_dir.join(PAIRING_CREDENTIAL_FILE)) {
+        Ok(credential) => credential,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let credential = credential.trim().to_string();
+    if credential.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(credential))
+}
+
 pub fn read_pairing_credential(data_dir: &Path) -> anyhow::Result<Option<String>> {
     let credential = match fs::read_to_string(data_dir.join(PAIRING_CREDENTIAL_FILE)) {
         Ok(credential) => credential,
@@ -370,6 +404,33 @@ mod tests {
 
         assert_eq!(read_pairing_credential(&temp_dir).unwrap(), None);
         assert!(!temp_dir.exists());
+    }
+
+    #[test]
+    fn concurrent_first_load_shares_one_pairing_credential() {
+        let temp_dir = std::env::temp_dir().join(format!("sprocket-auth-race-{}", Uuid::new_v4()));
+        let joiners: Vec<_> = (0..8)
+            .map(|_| {
+                let dir = temp_dir.clone();
+                thread::spawn(move || {
+                    AuthState::load(&dir)
+                        .expect("auth state")
+                        .pairing_credential()
+                        .to_string()
+                })
+            })
+            .collect();
+        let credentials: Vec<_> = joiners
+            .into_iter()
+            .map(|worker| worker.join().expect("join"))
+            .collect();
+        let first = credentials[0].as_str();
+        assert!(credentials.iter().all(|credential| credential == first));
+        assert_eq!(
+            read_pairing_credential(&temp_dir).unwrap().as_deref(),
+            Some(first)
+        );
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -3,8 +3,6 @@ use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 
 use axum::http::HeaderMap;
 use axum_extra::extract::CookieJar;
@@ -265,22 +263,48 @@ fn load_or_create_pairing_credential(data_dir: &Path) -> anyhow::Result<String> 
 
     let path = data_dir.join(PAIRING_CREDENTIAL_FILE);
     let credential = Uuid::new_v4().to_string();
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(mut file) => {
-            file.write_all(format!("{credential}\n").as_bytes())?;
-            file.sync_all()?;
-            Ok(credential)
-        }
+    let tmp_path = data_dir.join(format!(
+        "{PAIRING_CREDENTIAL_FILE}.{}.{}.tmp",
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)?;
+    file.write_all(format!("{credential}\n").as_bytes())?;
+    file.sync_all()?;
+    drop(file);
+
+    let published = publish_exclusive_file(&tmp_path, &path);
+    let _ = fs::remove_file(&tmp_path);
+
+    match published {
+        Ok(()) => Ok(credential),
         Err(error) if error.kind() == ErrorKind::AlreadyExists => {
-            for _ in 0..10 {
-                if let Some(existing) = read_ready_pairing_credential(data_dir)? {
-                    return Ok(existing);
-                }
-                thread::sleep(Duration::from_millis(10));
-            }
-            anyhow::bail!("pairing credential {} is invalid", path.display())
+            read_ready_pairing_credential(data_dir)?
+                .ok_or_else(|| anyhow::anyhow!("pairing credential {} is invalid", path.display()))
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Publish `tmp_path` as `dest` only if `dest` does not already exist.
+///
+/// Unix `rename` replaces an existing dest, so first boot uses `hard_link`.
+/// Windows `rename` is exclusive and is the fallback when `hard_link` is unavailable.
+fn publish_exclusive_file(tmp_path: &Path, dest: &Path) -> std::io::Result<()> {
+    match fs::hard_link(tmp_path, dest) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => Err(error),
+        Err(error) => {
+            if cfg!(unix) {
+                Err(error)
+            } else {
+                fs::rename(tmp_path, dest)
+            }
+        }
     }
 }
 
@@ -397,6 +421,7 @@ fn session_is_expired(session: &SessionRecord) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
 
     #[test]
     fn reading_a_missing_pairing_credential_has_no_side_effects() {
@@ -404,6 +429,22 @@ mod tests {
 
         assert_eq!(read_pairing_credential(&temp_dir).unwrap(), None);
         assert!(!temp_dir.exists());
+    }
+
+    #[test]
+    fn exclusive_publish_does_not_replace_an_existing_credential() {
+        let temp_dir = std::env::temp_dir().join(format!("sprocket-auth-link-{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let dest = temp_dir.join(PAIRING_CREDENTIAL_FILE);
+        fs::write(&dest, "winner\n").unwrap();
+        let tmp_path = temp_dir.join(format!("{PAIRING_CREDENTIAL_FILE}.loser.tmp"));
+        fs::write(&tmp_path, "loser\n").unwrap();
+
+        let error = publish_exclusive_file(&tmp_path, &dest).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::AlreadyExists);
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "winner\n");
+
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two processes starting on an empty data dir could each write a different pairing-credential UUID. The one that lost on disk then printed a token that the surviving file would reject.

Write a complete temp file, then hard_link it into place so the dest only appears with content. If another writer already published, read that credential instead of overwriting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ac522f5-75df-4786-be34-16aee6035bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ac522f5-75df-4786-be34-16aee6035bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes concurrent first-boot credential creation by fully writing and syncing a unique temporary file before publishing it exclusively.
- Concurrent loaders now converge on the credential that wins publication.
- The destination is not exposed until its credential contents are complete.
- Tests cover preservation of an existing credential and concurrent first loads.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/auth.rs | Replaces direct credential writes and bounded retries with fully prepared temporary files and exclusive publication, resolving the previously reported partial-file race. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Server process A
    participant B as Server process B
    participant FS as Data directory
    A->>FS: Write and sync unique temp credential A
    B->>FS: Write and sync unique temp credential B
    A->>FS: Exclusively publish credential A
    FS-->>A: Success
    B->>FS: Exclusively publish credential B
    FS-->>B: AlreadyExists
    B->>FS: Read published credential A
    FS-->>B: Credential A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): Publish pairing credentials..."](https://github.com/spikonado/sprocket/commit/ef1e51cd97845ec21419d96e13c752f41051007d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60395483)</sub>

<!-- /greptile_comment -->