### PR TITLE
fix(payments): Skip Dodo upserts for unknown product ids

### DIFF
--- a/apps/web/src/convex/http.ts
+++ b/apps/web/src/convex/http.ts
@@ -36,11 +36,12 @@ async function persistSubscription(
 	}
 	const tier = tierForProductId(data.product_id);
 	if (tier === undefined) {
-		console.warn('Unknown Dodo product; keeping user on free tier.', data.product_id);
+		console.warn('Unknown Dodo product; skipping subscription upsert.', data.product_id);
+		return;
 	}
 	await ctx.runMutation(internal.billing.upsertSubscription, {
 		userId,
-		tier: tier ?? 'free',
+		tier,
 		dodoSubscriptionId: data.subscription_id,
 		dodoProductId: data.product_id,
 		dodoCustomerId: data.customer.customer_id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dodo product ids are not mapped yet (`tierProductIds` is empty), but the webhook still upserted `tier: 'free'`. An active or renewed event could therefore clobber a paid subscription row.

Unknown products now skip the upsert and leave the stored subscription alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ac522f5-75df-4786-be34-16aee6035bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ac522f5-75df-4786-be34-16aee6035bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents Dodo webhook events with unmapped product IDs from overwriting existing subscription records with the free tier.
- Returns before the subscription upsert when product-to-tier lookup fails.
- Removes the fallback that persisted unknown products as free subscriptions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The early return consistently implements the stated policy of ignoring webhook updates for unmapped products and prevents those events from clobbering stored paid subscription state.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/http.ts | Unknown Dodo products now leave existing subscription state unchanged instead of being persisted as free-tier subscriptions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(payments): Skip Dodo upserts for unk..."](https://github.com/spikonado/sprocket/commit/dd0a1306f832635fb495355584a37e57bad9c9ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60395481)</sub>

<!-- /greptile_comment -->