### PR TITLE
fix(ai-gateway): Keep completion tokens alive across a 24h ask_question wait

### DIFF
--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -11,6 +11,7 @@ import { v, type Infer } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import {
 	finalizeQuestionOptions,
+	MAX_QUESTION_TIMEOUT_MS,
 	normalizeQuestionAnswer,
 	validateQuestionText
 } from '@convex/lib/agentQuestions';
@@ -22,7 +23,6 @@ import { vAskQuestionOption } from '@convex/lib/validators';
 
 const DEFAULT_QUESTION_TIMEOUT_MS = 30 * 60 * 1000;
 const MIN_QUESTION_TIMEOUT_MS = 1_000;
-const MAX_QUESTION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 export type AgentQuestionSnapshot = Infer<typeof vAgentQuestionSnapshot>;
 

--- a/apps/web/src/convex/lib/agentQuestions.ts
+++ b/apps/web/src/convex/lib/agentQuestions.ts
@@ -4,6 +4,7 @@ export const AGENT_DECIDE_OPTION_LABEL = 'Let me (the agent) decide';
 export const MAX_QUESTION_CHARS = 2000;
 export const MAX_OPTION_ID_CHARS = 20;
 export const MAX_OPTION_LABEL_CHARS = 200;
+export const MAX_QUESTION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const MIN_AGENT_OPTIONS = 1;
 const MAX_AGENT_OPTIONS = 4;
 

--- a/apps/web/src/convex/lib/gatewayProtocol.ts
+++ b/apps/web/src/convex/lib/gatewayProtocol.ts
@@ -1,6 +1,8 @@
 export const GATEWAY_PROTOCOL_VERSION = 1;
-/** Must outlive ask_question's 24h max wait. The completion client is minted once per agent run. */
-export const GATEWAY_TOKEN_TTL_MS = 25 * 60 * 60 * 1000;
+/** Slack for work before ask_question. The completion client is minted once per agent run. */
+export const GATEWAY_TOKEN_PRIOR_WORK_MS = 12 * 60 * 60 * 1000;
+/** 24h max question wait plus prior-work slack. Kept here so protocol stays independent of agentQuestions. */
+export const GATEWAY_TOKEN_TTL_MS = 24 * 60 * 60 * 1000 + GATEWAY_TOKEN_PRIOR_WORK_MS;
 export const GATEWAY_TOKEN_PREFIX = 'sgt1';
 /** Public OpenAI-compatible routes live under this prefix on the AI gateway origin. */
 export const GATEWAY_API_PREFIX = '/api';

--- a/apps/web/src/convex/lib/gatewayProtocol.ts
+++ b/apps/web/src/convex/lib/gatewayProtocol.ts
@@ -1,6 +1,6 @@
 export const GATEWAY_PROTOCOL_VERSION = 1;
-/** Long enough for a multi-turn agent loop. Claim lease still gates minting. */
-export const GATEWAY_TOKEN_TTL_MS = 12 * 60 * 60 * 1000;
+/** Must outlive ask_question's 24h max wait. The completion client is minted once per agent run. */
+export const GATEWAY_TOKEN_TTL_MS = 25 * 60 * 60 * 1000;
 export const GATEWAY_TOKEN_PREFIX = 'sgt1';
 /** Public OpenAI-compatible routes live under this prefix on the AI gateway origin. */
 export const GATEWAY_API_PREFIX = '/api';

--- a/apps/web/src/convex/lib/gatewayToken.test.ts
+++ b/apps/web/src/convex/lib/gatewayToken.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { GATEWAY_TOKEN_TTL_MS } from '@convex/lib/gatewayProtocol';
+import { MAX_QUESTION_TIMEOUT_MS } from '@convex/lib/agentQuestions';
+import { GATEWAY_TOKEN_PRIOR_WORK_MS, GATEWAY_TOKEN_TTL_MS } from '@convex/lib/gatewayProtocol';
 import { mintGatewayToken, verifyGatewayToken } from '@convex/lib/gatewayToken';
 
 const secret = 'test-gateway-token-secret';
-/** Keep in sync with MAX_QUESTION_TIMEOUT_MS in agentQuestions.ts. */
-const MAX_QUESTION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 describe('gateway token', () => {
 	it('round-trips a valid token and rejects expiry and tampering', async () => {
@@ -23,7 +22,9 @@ describe('gateway token', () => {
 		);
 	});
 
-	it('outlives the maximum ask-question wait', () => {
-		expect(GATEWAY_TOKEN_TTL_MS).toBeGreaterThan(MAX_QUESTION_TIMEOUT_MS);
+	it('outlives a max-length ask wait after prior work', () => {
+		expect(GATEWAY_TOKEN_TTL_MS).toBeGreaterThanOrEqual(
+			MAX_QUESTION_TIMEOUT_MS + GATEWAY_TOKEN_PRIOR_WORK_MS
+		);
 	});
 });

--- a/apps/web/src/convex/lib/gatewayToken.test.ts
+++ b/apps/web/src/convex/lib/gatewayToken.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { GATEWAY_TOKEN_TTL_MS } from '@convex/lib/gatewayProtocol';
 import { mintGatewayToken, verifyGatewayToken } from '@convex/lib/gatewayToken';
 
 const secret = 'test-gateway-token-secret';
+/** Keep in sync with MAX_QUESTION_TIMEOUT_MS in agentQuestions.ts. */
+const MAX_QUESTION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 describe('gateway token', () => {
 	it('round-trips a valid token and rejects expiry and tampering', async () => {
@@ -18,5 +21,9 @@ describe('gateway token', () => {
 		await expect(verifyGatewayToken(secret, token, payload.exp + 1)).rejects.toThrow(
 			'Gateway token expired.'
 		);
+	});
+
+	it('outlives the maximum ask-question wait', () => {
+		expect(GATEWAY_TOKEN_TTL_MS).toBeGreaterThan(MAX_QUESTION_TIMEOUT_MS);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
ask_question can block the same minted completion client for up to 24 hours, and the client is created once at run start. A 12h token died during that wait. 25h only left one hour of slack for work before the question.

TTL is now 24h plus 12h of prior work. The test uses the production question timeout so those values cannot drift apart. Claim leases still gate minting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ac522f5-75df-4786-be34-16aee6035bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ac522f5-75df-4786-be34-16aee6035bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends gateway-token validity to cover the maximum supported question wait plus the existing prior-work allowance and centralizes the production question-timeout constant.
- Defines a named 12-hour prior-work allowance and raises the gateway-token lifetime to 36 hours.
- Moves the 24-hour maximum question timeout into the shared agent-question helper.
- Adds a regression assertion coupling token lifetime to the production timeout and allowance.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/agentQuestions.ts | Replaces the local maximum-timeout declaration with the shared production constant without changing timeout enforcement. |
| apps/web/src/convex/lib/agentQuestions.ts | Exports the existing 24-hour question-timeout limit for production and test reuse. |
| apps/web/src/convex/lib/gatewayProtocol.ts | Extends gateway-token validity to the supported 24-hour question wait plus the documented 12-hour prior-work allowance. |
| apps/web/src/convex/lib/gatewayToken.test.ts | Adds a regression assertion tying gateway-token lifetime to the shared question timeout and prior-work allowance. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Agent
  participant Convex
  participant User
  participant Gateway
  Agent->>Convex: Mint gateway token at run start (36h TTL)
  Agent->>Convex: ask_question (up to 24h)
  Convex->>User: Wait for answer
  User-->>Convex: Submit answer
  Convex-->>Agent: Resume run
  Agent->>Gateway: Continue using retained token
  Gateway-->>Agent: Accept completion request within TTL
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(gateway): Keep tokens alive through ..."](https://github.com/spikonado/sprocket/commit/9bb0e94ef8a58b542e69051d99273624124d6928) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60395482)</sub>

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)

<!-- /greptile_comment -->