### PR TITLE
fix(payments): Collapse duplicate billing customer rows

### DIFF
--- a/apps/web/src/convex/billing.ts
+++ b/apps/web/src/convex/billing.ts
@@ -1,6 +1,7 @@
 import { DodoPayments } from '@dodopayments/convex';
 import type { ComponentApi } from '@dodopayments/convex/_generated/component';
 import { components, internal } from '@convex/_generated/api';
+import type { Doc } from '@convex/_generated/dataModel';
 import { v } from 'convex/values';
 import {
 	action,
@@ -8,7 +9,9 @@ import {
 	internalMutation,
 	internalQuery,
 	mutation,
-	query
+	query,
+	type MutationCtx,
+	type QueryCtx
 } from '@convex/_generated/server';
 import { ensureCurrentUser, getUserId } from '@convex/lib/auth';
 import { vCheckoutResponse, vCustomerPortalResponse } from '@convex/lib/docs';
@@ -21,14 +24,34 @@ import {
 import { vSubscriptionStatus, vSubscriptionTier } from '@convex/lib/validators';
 import schema from '@convex/schema';
 
+async function listBillingCustomers(
+	ctx: QueryCtx | MutationCtx,
+	userId: string
+): Promise<Doc<'billingCustomers'>[]> {
+	return await ctx.db
+		.query('billingCustomers')
+		.withIndex('by_userId', (q) => q.eq('userId', userId))
+		.collect();
+}
+
+/** Mutation-only: collapse concurrent identify/upsert races onto one row. */
+async function getBillingCustomerExclusive(
+	ctx: MutationCtx,
+	userId: string
+): Promise<Doc<'billingCustomers'> | null> {
+	const rows = await listBillingCustomers(ctx, userId);
+	const keep = rows[0] ?? null;
+	if (!keep) return null;
+	for (const row of rows) {
+		if (row._id !== keep._id) await ctx.db.delete('billingCustomers', row._id);
+	}
+	return keep;
+}
+
 export const getBillingCustomer = internalQuery({
 	args: { userId: v.string() },
 	returns: v.union(schema.doc('billingCustomers'), v.null()),
-	handler: async (ctx, { userId }) =>
-		ctx.db
-			.query('billingCustomers')
-			.withIndex('by_userId', (q) => q.eq('userId', userId))
-			.unique()
+	handler: async (ctx, { userId }) => (await listBillingCustomers(ctx, userId))[0] ?? null
 });
 
 const dodo: DodoPayments = new DodoPayments(
@@ -111,10 +134,7 @@ export const upsertSubscription = internalMutation({
 		const existing = await getSubscriptionDocExclusive(ctx, args.userId);
 
 		const syncBillingCustomer = async () => {
-			const customer = await ctx.db
-				.query('billingCustomers')
-				.withIndex('by_userId', (q) => q.eq('userId', args.userId))
-				.unique();
+			const customer = await getBillingCustomerExclusive(ctx, args.userId);
 			if (customer)
 				await ctx.db.patch('billingCustomers', customer._id, {
 					dodoCustomerId: args.dodoCustomerId

--- a/apps/web/src/convex/subscriptionUsage.test.ts
+++ b/apps/web/src/convex/subscriptionUsage.test.ts
@@ -240,4 +240,34 @@ describe('subscription and usage backend', () => {
 		expect(rows).toHaveLength(1);
 		expect(rows[0]).toMatchObject({ subject: userId });
 	});
+
+	it('collapses duplicate billing customers without throwing', async () => {
+		const t = initConvexTest();
+		const userId = 'user_dup_customer';
+		await t.run(async (ctx) => {
+			await ctx.db.insert('billingCustomers', { userId, dodoCustomerId: 'old' });
+			await ctx.db.insert('billingCustomers', { userId, dodoCustomerId: 'stale' });
+		});
+		expect((await t.query(internal.billing.getBillingCustomer, { userId }))?.dodoCustomerId).toBe(
+			'old'
+		);
+
+		await t.mutation(internal.billing.upsertSubscription, {
+			userId,
+			tier: 'pro',
+			dodoSubscriptionId: 'sub_dup',
+			dodoProductId: 'prod_dup',
+			dodoCustomerId: 'fresh',
+			status: 'active',
+			eventAt: 1
+		});
+		const customers = await t.run(async (ctx) =>
+			ctx.db
+				.query('billingCustomers')
+				.withIndex('by_userId', (query) => query.eq('userId', userId))
+				.collect()
+		);
+		expect(customers).toHaveLength(1);
+		expect(customers[0]?.dodoCustomerId).toBe('fresh');
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Concurrent Dodo identify and webhook upserts could insert two billingCustomers rows for the same user. Later `.unique()` calls then threw, so checkout and the customer portal failed.

Reads now take the earliest row. Mutations delete the extras before patching the Dodo customer id.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ac522f5-75df-4786-be34-16aee6035bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ac522f5-75df-4786-be34-16aee6035bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents duplicate billing-customer records from breaking payment flows.
- Billing-customer reads now deterministically select the earliest matching record instead of requiring uniqueness.
- Subscription mutations delete duplicate customer records before updating the retained mapping.
- A regression test covers duplicate reads, cleanup, and customer-id refresh.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The changed query avoids duplicate-row exceptions, while the mutation atomically retains the earliest record, removes extras, and updates the surviving customer mapping; the regression test covers the intended behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/billing.ts | Adds deterministic billing-customer lookup and mutation-time duplicate cleanup without an identified actionable regression. |
| apps/web/src/convex/subscriptionUsage.test.ts | Adds focused coverage proving earliest-row reads and mutation-time collapse to one refreshed customer record. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(payments): Collapse duplicate billin..."](https://github.com/spikonado/sprocket/commit/b4259fe1ffe21ebf7a7dfd3223ef8af20620f230) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60399405)</sub>

<!-- /greptile_comment -->