### PR TITLE
fix(web): Stop Convex auth and query subscription churn

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -35,14 +35,7 @@ Deploy this compatibility schema and code, run the migration to completion,
 verify every thread has a status, then make the field required and remove the
 optional cache handling in a follow-up deployment.
 
-### 1. Legacy fields on `uiPreferences`
-
-Source: #187, plus later catalog/payments work.
-
-Optional fields kept so existing rows validate. Nothing current writes them:
-
-- `uiPreferences.lastThreadId` — restore uses `pickThreadToRestore`
-- `uiPreferences.paymentsEmail` — mandate setup uses the WorkOS identity email
+### 1. Legacy project tables and references
 
 The `projects` and `projectConnections` tables stay in the schema so existing
 rows and leftover `projectId` fields validate. Threads store `repositoryKey`
@@ -56,11 +49,6 @@ error.
 The repository-key backfill and `projectId` unset passes are done. Remove the
 leftover tables and `projectId` fields after a later unset rewrite, then drop
 `repositoryKey` optionality.
-
-Remove the remaining `uiPreferences` fields by unsetting each in a one-off
-backfill, then dropping them from `convex/schema.ts`.
-
-Safe when a prod check shows zero rows carrying the field.
 
 ### 2. Mandate job payloads still accept `userEmail`
 

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -64,13 +64,7 @@ export default defineSchema({
 	}).index('by_userId', ['userId']),
 	uiPreferences: defineTable({
 		userId: v.string(),
-		// Deprecated: only present on rows written by older clients. New clients
-		// resume the latest active thread instead.
-		lastThreadId: v.optional(v.id('threadRecords')),
-		theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
-		// Deprecated: mandate setup uses the WorkOS identity email. Kept so
-		// rows written by older clients still validate.
-		paymentsEmail: v.optional(v.string())
+		theme: v.union(v.literal('light'), v.literal('dark'))
 	}).index('by_userId', ['userId']),
 	// Stored-only. New clients do not write these tables. Kept so existing
 	// documents and leftover `projectId` fields validate until the rewrite

--- a/apps/web/src/convex/uiPreferences.test.ts
+++ b/apps/web/src/convex/uiPreferences.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { initConvexTest } from './test.setup';
+
+describe('theme preferences', () => {
+	it('syncs themes between sessions while isolating accounts', async () => {
+		const t = initConvexTest();
+		const alice = t.withIdentity({ subject: 'alice' });
+		const otherAliceSession = t.withIdentity({ subject: 'alice' });
+		const bob = t.withIdentity({ subject: 'bob' });
+		expect(await alice.query(api.uiPreferences.getMine, {})).toBeNull();
+
+		const saved = await alice.mutation(api.uiPreferences.setTheme, { theme: 'dark' });
+		expect(await otherAliceSession.query(api.uiPreferences.getMine, {})).toEqual(saved);
+		expect(await bob.query(api.uiPreferences.getMine, {})).toBeNull();
+
+		const updated = await otherAliceSession.mutation(api.uiPreferences.setTheme, {
+			theme: 'light'
+		});
+		expect(updated?._id).toBe(saved?._id);
+		expect(await alice.query(api.uiPreferences.getMine, {})).toMatchObject({ theme: 'light' });
+		await expect(t.query(api.uiPreferences.getMine, {})).rejects.toThrow('Authentication required');
+	});
+});

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { User } from '@workos-inc/authkit-js';
+import { get } from 'svelte/store';
+import { authState, convexAuthLoading, convexAuthUserId } from './auth';
+
+const initialState = get(authState);
+const user: User = {
+	object: 'user',
+	id: 'user-a',
+	email: 'a@example.com',
+	firstName: null,
+	lastName: null,
+	profilePictureUrl: null,
+	lastSignInAt: null,
+	externalId: undefined,
+	emailVerified: true,
+	createdAt: '',
+	updatedAt: ''
+};
+
+afterEach(() => authState.set(initialState));
+
+describe('Convex auth dependencies', () => {
+	it('ignores token refreshes and unrelated UI state without hiding account changes', () => {
+		authState.set({ ...initialState, isReady: true, isLoading: false, user });
+		const identityChanged = vi.fn();
+		const loadingChanged = vi.fn();
+		const stopIdentity = convexAuthUserId.subscribe(identityChanged);
+		const stopLoading = convexAuthLoading.subscribe(loadingChanged);
+		try {
+			for (let refresh = 0; refresh < 5; refresh += 1) {
+				authState.update((state) => ({ ...state, user: { ...user }, error: null }));
+			}
+			authState.update((state) => ({ ...state, nativeSession: 'ready', error: 'UI error' }));
+			expect(identityChanged.mock.calls).toEqual([['user-a']]);
+			expect(loadingChanged.mock.calls).toEqual([[false]]);
+
+			authState.update((state) => ({ ...state, user: { ...user, id: 'user-b' } }));
+			authState.update((state) => ({ ...state, user: null }));
+			expect(identityChanged.mock.calls).toEqual([['user-a'], ['user-b'], [null]]);
+		} finally {
+			stopIdentity();
+			stopLoading();
+		}
+	});
+
+	it('still notifies Convex when a manual retry enters and leaves loading', () => {
+		authState.set({ ...initialState, isReady: true, isLoading: false, user });
+		const changed = vi.fn();
+		const stop = convexAuthLoading.subscribe(changed);
+		try {
+			authState.update((state) => ({ ...state, isLoading: true }));
+			authState.update((state) => ({ ...state, isLoading: false }));
+			expect(changed.mock.calls).toEqual([[false], [true], [false]]);
+		} finally {
+			stop();
+		}
+	});
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -3,7 +3,7 @@ import { createClient, type User } from '@workos-inc/authkit-js';
 import { z } from 'zod';
 import { api } from '$convex/_generated/api';
 import { usesLoopbackBrowserAuth } from '../../../desktop/local-config.mjs';
-import { get, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 
 type AuthStatus = {
 	isLoading: boolean;
@@ -28,6 +28,9 @@ const initialState: AuthStatus = {
 };
 
 export const authState = writable<AuthStatus>(initialState);
+// Primitive stores suppress same-user refresh notifications before setupAuth's effect.
+export const convexAuthUserId = derived(authState, (state) => state.user?.id ?? null);
+export const convexAuthLoading = derived(authState, (state) => !state.isReady || state.isLoading);
 export const convexAuthRetryVersion = writable(0);
 /** UI-only: stays true until Convex confirms or rejects the post-retry token. */
 export const convexAuthRetryPending = writable(false);

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -97,14 +97,11 @@
 	}: Props = $props();
 
 	const convexAuth = useAuth();
-	const subscriptionQuery = useQuery(api.billing.getMySubscription, () =>
-		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
-	);
 	const usageQuery = useQuery(api.usage.getMyUsage, () =>
 		convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip'
 	);
-	const subscriptionTier = $derived(subscriptionQuery.data?.tier);
-	const subscriptionFailed = $derived(Boolean(subscriptionQuery.error));
+	const subscriptionTier = $derived(usageQuery.data?.tier);
+	const subscriptionFailed = $derived(Boolean(usageQuery.error));
 	// Until the tier is known, render the free allowlist so locked models are never selectable.
 	const tierModelOptions = $derived(
 		modelCatalog ? modelOptionsForTier(modelCatalog, subscriptionTier ?? 'free') : []
@@ -121,7 +118,7 @@
 				)
 			: undefined
 	);
-	// Block send until a catalog model is selected. If the subscription query fails, keep send
+	// Block send until a catalog model is selected. If the usage query fails, keep send
 	// enabled for a known selection and let the backend enforce entitlements.
 	const canSubmitWithModel = $derived(
 		selectedCatalogModel !== undefined &&

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -2,7 +2,13 @@
 	import '../app.css';
 	import { browser } from '$app/environment';
 	import { setupAuth, setupConvex } from 'convex-svelte';
-	import { authState, convexAuthRetryVersion, getAccessToken, initializeAuth } from '$lib/auth';
+	import {
+		convexAuthLoading,
+		convexAuthUserId,
+		convexAuthRetryVersion,
+		getAccessToken,
+		initializeAuth
+	} from '$lib/auth';
 	import type { RuntimeConfig } from './+layout';
 
 	const { children, data }: { children: import('svelte').Snippet; data: RuntimeConfig } = $props();
@@ -19,8 +25,8 @@
 		// a fresh Convex auth configuration and waits for backend confirmation.
 		void $convexAuthRetryVersion;
 		return {
-			isLoading: !$authState.isReady || $authState.isLoading,
-			isAuthenticated: Boolean($authState.user),
+			isLoading: $convexAuthLoading,
+			isAuthenticated: Boolean($convexAuthUserId),
 			fetchAccessToken: getAccessToken
 		};
 	});

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -12,6 +12,7 @@
 		cancelDesktopSignIn,
 		clearDesktopSignInOpenError,
 		convexAuthRetryPending,
+		convexAuthUserId,
 		reconcileNativeAuthentication,
 		retryConvexAuthentication,
 		signIn,
@@ -99,8 +100,8 @@
 
 	const convexAuth = useAuth();
 	let sawAuthLoadingDuringRetry = $state(false);
-	const isSignedIn = $derived(Boolean($authState.user));
-	const signedInUserId = $derived($authState.user?.id ?? null);
+	const signedInUserId = $derived($convexAuthUserId);
+	const isSignedIn = $derived(Boolean(signedInUserId));
 	const retryPending = $derived($convexAuthRetryPending);
 	const nativeAuthLoading = $derived($authState.nativeSession === 'loading');
 	const nativeAuthBlocked = $derived(
@@ -374,7 +375,7 @@
 	}
 
 	function getAuthenticatedQueryArgs() {
-		return $authState.user && convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip';
+		return signedInUserId && convexAuth.isAuthenticated && !convexAuth.isLoading ? {} : 'skip';
 	}
 
 	const uiPreferencesQuery = useQuery(api.uiPreferences.getMine, getAuthenticatedQueryArgs);


### PR DESCRIPTION
## Summary

- Break the WorkOS/Convex auth refresh feedback loop. WorkOS refresh updates the whole auth store; the old setupAuth getter subscribed to that store, so every refresh tore down and reinstalled Convex authentication. Convex then forced another token refresh. Primitive user-ID and loading stores now suppress unchanged updates while preserving account switches, sign-out, and explicit retry.
- Keep query subscriptions stable across same-user refreshes by using the same user-ID store rather than the whole auth state in page query arguments.
- Remove the composer's redundant billing subscription. The existing usage query already returns the same subscription tier.
- Keep cross-device theme sync as requested. Remove uiPreferences.lastThreadId and paymentsEmail; only userId and required theme remain. Retired setter endpoints still return the update-required error.

Convex already caches reactive queries. Repeated auth resets and unsubscribe/resubscribe cycles were preventing stable subscriptions; adding a TTL cache would hide the problem and stale live data. Real database changes will still rerun the affected queries.

## Schema rollout

The owner confirmed that production uiPreferences data was cleared before this schema change. No production migration or deployment was performed by this PR. Other deployments with legacy preference rows must clean those rows before deploying the reduced schema.

## Testing

- Full web/frontend and Convex test suite: 313 tests passed.
- Targeted auth, theme preference, and retired-client tests passed.
- Web production build passed.
- Svelte check: zero errors and warnings.
- All pre-commit checks passed, including cargo check, ESLint/Convex typecheck, Oxlint, formatting, and Mermaid lint.
- Two pre-PR reviews completed.

Production call-rate reduction still needs verification after deployment and client updates.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes Convex authentication and reactive query subscriptions by narrowing frontend dependencies to primitive authentication state, consolidates composer billing information into the existing usage query, and reduces the `uiPreferences` schema after the documented data cleanup.

- Same-user WorkOS refreshes no longer reinstall Convex authentication.
- Account changes, sign-out, loading transitions, and explicit authentication retries remain reactive.
- Page queries avoid resubscribing when unrelated authentication-store fields change.
- The composer reads subscription tier from the existing usage response.
- Theme preferences retain cross-session synchronization with a smaller required schema.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

The narrowed authentication dependencies preserve all established meaningful transitions, the consolidated query returns the same subscription-tier semantics, and current preference writers satisfy the reduced schema.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/auth.ts | Introduces primitive derived stores that suppress unchanged authentication notifications while preserving identity and loading transitions. |
| apps/web/src/routes/+layout.svelte | Configures Convex authentication from stable primitive dependencies plus an explicit retry signal. |
| apps/web/src/routes/+page.svelte | Uses the stable user-ID store for signed-in state and authenticated query arguments. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Removes the redundant billing subscription and consumes the equivalent tier returned by the usage query. |
| apps/web/src/convex/schema.ts | Narrows `uiPreferences` to required user and theme fields following the documented cleanup prerequisite. |
| apps/web/src/lib/auth.test.ts | Verifies suppression of same-user refresh churn and preservation of account, sign-out, and retry-loading transitions. |
| apps/web/src/convex/uiPreferences.test.ts | Covers cross-session theme synchronization, account isolation, updates, and authentication enforcement. |
| BACKWARDS_COMPATIBILITY.md | Removes the retired preference-field compatibility entry after the schema reduction. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[WorkOS auth state] --> B[Derived user ID]
  A --> C[Derived loading flag]
  D[Explicit retry version] --> E[Convex setupAuth]
  B --> E
  C --> E
  E --> F[Stable Convex authentication]
  B --> G[Authenticated page query arguments]
  F --> G
  G --> H[Stable reactive subscriptions]
  H --> I[Usage query]
  I --> J[Usage limits and subscription tier]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Stop Convex auth and query sub..."](https://github.com/spikonado/sprocket/commit/3670ebeb5b9e5c972ddc34ea328ba8dd55c2c927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60714587)</sub>

<!-- /greptile_comment -->