### PR TITLE
fix(ui): Correct live and saved work indicator timing

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -14,7 +14,31 @@ The UI omits durations when section boundaries are unknown rather than inferring
 them from the run start or transcript sequence numbers. New local replicas also
 retain the transcript record creation time for tool-event timing. Existing JSONL
 records remain readable without it; historical reasoning timing cannot be recovered.
-Keep these fields optional until old agents age out and untimed history is retired.
+New completion writes normalize missing timestamps to explicit `null`, including
+writes from older agents. `backfillTranscriptTiming` in `convex/migrations.ts`
+does the same for stored completion items without changing known timestamps.
+It is included in the default migration runner. After deploying the nullable
+validators, write normalization, and null-aware UI, run from `apps/web`:
+
+```sh
+bun convex run migrations:runTranscriptTiming
+```
+
+Pass `'{"dryRun":true}'` to preview one batch without writes.
+Use `--prod` for the production deployment. This is a resumable, idempotent
+backfill; verify its status is complete in the migrations component before
+tightening the stored validators to `v.union(v.number(), v.null())`.
+No historical timing is invented and untimed history need not be deleted.
+Keep optional input validators separate for supported agents that omit timing.
+Removing optional timing from the shared wire validators additionally requires
+all supported producers to emit explicit nulls and old JSONL replicas to be
+normalized at the read boundary. Tool results are projected, not stored as
+completion items, so their wire validator has that separate removal gate.
+Both Convex transcript read endpoints omit null timestamps for released agents
+and UIs; stored records still contain explicit nulls. The local projected-message
+API also omits nulls from replicas populated before that read adapter was deployed.
+Remove these adapters once all supported consumers handle explicit nulls, keeping
+stored and wire validators separate until then.
 The projected `runStartedAt` field remains numeric for released clients, with `0`
 meaning unknown instead of a sequence number. Remove it once supported clients no
 longer read it; the current section timer uses assistant-part timestamps.

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -8,6 +8,17 @@ Current as of 2026-09-03.
 
 ## Transcript projection API
 
+Assistant text, reasoning, and tool calls accept optional `startedAt` and
+`completedAt` timestamps. Released agents and old stored completions lack them.
+The UI omits durations when section boundaries are unknown rather than inferring
+them from the run start or transcript sequence numbers. New local replicas also
+retain the transcript record creation time for tool-event timing. Existing JSONL
+records remain readable without it; historical reasoning timing cannot be recovered.
+Keep these fields optional until old agents age out and untimed history is retired.
+The projected `runStartedAt` field remains numeric for released clients, with `0`
+meaning unknown instead of a sequence number. Remove it once supported clients no
+longer read it; the current section timer uses assistant-part timestamps.
+
 PR #295 keeps `/api/transcript/page` returning raw `parts` for released clients.
 The projected-message client uses `/api/transcript/messages`; the legacy route
 reads the same complete message window and returns its original parts. The

--- a/apps/web/src/convex/lib/transcriptParts.ts
+++ b/apps/web/src/convex/lib/transcriptParts.ts
@@ -8,6 +8,35 @@ import type {
 
 const MAX_TRANSCRIPT_PARTS_PER_QUERY = 100;
 
+export function normalizeCompletionTiming(
+	completion: TranscriptCompletionBody
+): TranscriptCompletionBody {
+	return {
+		...completion,
+		items: completion.items.map((item) => ({
+			...item,
+			startedAt: item.startedAt ?? null,
+			completedAt: item.completedAt ?? null
+		}))
+	};
+}
+
+function transcriptPartForClient(part: Doc<'threadTranscriptParts'>): Doc<'threadTranscriptParts'> {
+	if (!part.completion) return part;
+	return {
+		...part,
+		completion: {
+			...part.completion,
+			items: part.completion.items.map((item) => {
+				const projected = { ...item };
+				if (projected.startedAt == null) delete projected.startedAt;
+				if (projected.completedAt == null) delete projected.completedAt;
+				return projected;
+			})
+		}
+	};
+}
+
 export function promptSourceKey(runId: Id<'runs'>): string {
 	return `prompt:${runId}`;
 }
@@ -134,7 +163,7 @@ export async function appendTranscriptPart(
 		runId: args.runId
 	};
 	if (args.prompt) part.prompt = args.prompt;
-	if (args.completion) part.completion = args.completion;
+	if (args.completion) part.completion = normalizeCompletionTiming(args.completion);
 	if (args.tool) part.tool = args.tool;
 	const partId = await ctx.db.insert('threadTranscriptParts', part);
 	await ctx.db.patch('threadTranscriptStates', state._id, { totalParts: number + 1 });
@@ -170,7 +199,7 @@ export async function loadTranscriptPartsByNumbers(
 	);
 	return numbers.flatMap((number) => {
 		const part = byNumber.get(number);
-		return part ? [part] : [];
+		return part ? [transcriptPartForClient(part)] : [];
 	});
 }
 

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -430,6 +430,8 @@ export const vAssistantTextPart = v.object({
 	type: v.literal('text'),
 	id: v.string(),
 	text: v.string(),
+	startedAt: v.optional(v.number()),
+	completedAt: v.optional(v.number()),
 	turnId: v.optional(v.string()),
 	providerMetadata: v.optional(vJsonValue)
 });
@@ -438,6 +440,8 @@ export const vAssistantReasoningPart = v.object({
 	type: v.literal('reasoning'),
 	id: v.string(),
 	text: v.string(),
+	startedAt: v.optional(v.number()),
+	completedAt: v.optional(v.number()),
 	turnId: v.optional(v.string()),
 	providerMetadata: v.optional(vJsonValue)
 });
@@ -449,6 +453,8 @@ export const vAssistantToolCallPart = v.object({
 	name: v.string(),
 	input: vJsonValue,
 	turnId: v.optional(v.string()),
+	startedAt: v.optional(v.number()),
+	completedAt: v.optional(v.number()),
 	providerMetadata: v.optional(vJsonValue)
 });
 
@@ -468,6 +474,7 @@ export const vAssistantToolResultPart = v.object({
 	type: v.literal('tool-result'),
 	callId: v.string(),
 	name: v.optional(v.string()),
+	completedAt: v.optional(v.number()),
 	output: vJsonValue
 });
 

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -426,12 +426,14 @@ export const MAX_IMAGE_ATTACHMENTS = 4;
 export const MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 export const MAX_IMAGE_ATTACHMENT_LABEL = '10 MiB';
 
+const vAssistantTimestamp = v.optional(v.union(v.number(), v.null()));
+
 export const vAssistantTextPart = v.object({
 	type: v.literal('text'),
 	id: v.string(),
 	text: v.string(),
-	startedAt: v.optional(v.number()),
-	completedAt: v.optional(v.number()),
+	startedAt: vAssistantTimestamp,
+	completedAt: vAssistantTimestamp,
 	turnId: v.optional(v.string()),
 	providerMetadata: v.optional(vJsonValue)
 });
@@ -440,8 +442,8 @@ export const vAssistantReasoningPart = v.object({
 	type: v.literal('reasoning'),
 	id: v.string(),
 	text: v.string(),
-	startedAt: v.optional(v.number()),
-	completedAt: v.optional(v.number()),
+	startedAt: vAssistantTimestamp,
+	completedAt: vAssistantTimestamp,
 	turnId: v.optional(v.string()),
 	providerMetadata: v.optional(vJsonValue)
 });
@@ -453,8 +455,8 @@ export const vAssistantToolCallPart = v.object({
 	name: v.string(),
 	input: vJsonValue,
 	turnId: v.optional(v.string()),
-	startedAt: v.optional(v.number()),
-	completedAt: v.optional(v.number()),
+	startedAt: vAssistantTimestamp,
+	completedAt: vAssistantTimestamp,
 	providerMetadata: v.optional(vJsonValue)
 });
 
@@ -474,7 +476,7 @@ export const vAssistantToolResultPart = v.object({
 	type: v.literal('tool-result'),
 	callId: v.string(),
 	name: v.optional(v.string()),
-	completedAt: v.optional(v.number()),
+	completedAt: vAssistantTimestamp,
 	output: vJsonValue
 });
 

--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { internal } from '@convex/_generated/api';
-import { initConvexTest } from './test.setup';
+import { initConvexTest, type ConvexTestInstance } from './test.setup';
+
+const oneBatch = {
+	cursor: null,
+	dryRun: false,
+	oneBatchOnly: true
+} as const;
 
 describe('thread status migration', () => {
 	it('backfills status from the latest run', async () => {
@@ -35,11 +41,7 @@ describe('thread status migration', () => {
 			return threadId;
 		});
 
-		await t.mutation(internal.migrations.backfillThreadStatus, {
-			cursor: null,
-			dryRun: false,
-			oneBatchOnly: true
-		});
+		await t.mutation(internal.migrations.backfillThreadStatus, oneBatch);
 
 		expect(await t.run(async (ctx) => await ctx.db.get('threadRecords', threadId))).toMatchObject({
 			status: 'running'
@@ -66,11 +68,7 @@ describe('thread status migration', () => {
 			return { threadId, usageId };
 		});
 
-		await t.mutation(internal.migrations.backfillThreadStatus, {
-			cursor: null,
-			dryRun: false,
-			oneBatchOnly: true
-		});
+		await t.mutation(internal.migrations.backfillThreadStatus, oneBatch);
 
 		const migrated = await t.run(async (ctx) => ({
 			thread: await ctx.db.get('threadRecords', threadId),
@@ -78,5 +76,181 @@ describe('thread status migration', () => {
 		}));
 		expect(migrated.thread).toBeNull();
 		expect(migrated.usage).toBeNull();
+	});
+});
+
+async function seedTranscriptTimingParts(t: ConvexTestInstance) {
+	return await t.run(async (ctx) => {
+		const threadId = await ctx.db.insert('threadRecords', {
+			userId: 'user_alice',
+			submissionId: 'timing-thread',
+			repositoryKey: 'alpha',
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard',
+			lastMessageAt: 1
+		});
+		const runId = await ctx.db.insert('runs', {
+			threadId,
+			userId: 'user_alice',
+			submissionId: 'timing-run',
+			status: 'completed',
+			executionSecretHash: 'fixture',
+			completionAttemptSeq: 0,
+			selectedModel: 'gpt-5.6-sol',
+			reasoningEffort: 'medium',
+			serviceTier: 'standard',
+			startedAt: 1
+		});
+		const completionId = await ctx.db.insert('threadTranscriptParts', {
+			threadId,
+			userId: 'user_alice',
+			number: 0,
+			sourceKey: 'completion:legacy',
+			kind: 'completion',
+			runId,
+			completion: {
+				streamId: 'stream-1',
+				items: [
+					{ type: 'text', id: 'missing', text: 'untimed', turnId: 'stream-1' },
+					{ type: 'text', id: 'zero', text: 'zero', startedAt: 0, completedAt: 0 },
+					{ type: 'text', id: 'nulls', text: 'already null', startedAt: null, completedAt: null },
+					{
+						type: 'text',
+						id: 'known',
+						text: 'known',
+						startedAt: 1_000,
+						completedAt: 2_000,
+						providerMetadata: { model: 'gpt' }
+					},
+					{ type: 'reasoning', id: 'partial', text: 'think', completedAt: 5 },
+					{
+						type: 'tool-call',
+						partId: 'p1',
+						callId: 'c1',
+						name: 'exec_command',
+						input: { cmd: 'ls' },
+						turnId: 'stream-1',
+						startedAt: 3
+					}
+				]
+			}
+		});
+		const timedId = await ctx.db.insert('threadTranscriptParts', {
+			threadId,
+			userId: 'user_alice',
+			number: 1,
+			sourceKey: 'completion:timed',
+			kind: 'completion',
+			runId,
+			completion: {
+				streamId: 'stream-2',
+				items: [{ type: 'text', id: 'timed', text: 'done', startedAt: 10, completedAt: 20 }]
+			}
+		});
+		const promptId = await ctx.db.insert('threadTranscriptParts', {
+			threadId,
+			userId: 'user_alice',
+			number: 2,
+			sourceKey: 'prompt:legacy',
+			kind: 'prompt',
+			runId,
+			prompt: { text: 'Hello', imageUploads: [] }
+		});
+		const toolId = await ctx.db.insert('threadTranscriptParts', {
+			threadId,
+			userId: 'user_alice',
+			number: 3,
+			sourceKey: 'tool:legacy',
+			kind: 'tool',
+			runId,
+			tool: {
+				toolInvocationId: 'inv-1',
+				callId: 'c1',
+				name: 'exec_command',
+				status: 'started'
+			}
+		});
+		return { completionId, timedId, promptId, toolId };
+	});
+}
+
+async function loadTranscriptTimingParts(
+	t: ConvexTestInstance,
+	ids: Awaited<ReturnType<typeof seedTranscriptTimingParts>>
+) {
+	return await t.run(async (ctx) => ({
+		completion: await ctx.db.get('threadTranscriptParts', ids.completionId),
+		timed: await ctx.db.get('threadTranscriptParts', ids.timedId),
+		prompt: await ctx.db.get('threadTranscriptParts', ids.promptId),
+		tool: await ctx.db.get('threadTranscriptParts', ids.toolId)
+	}));
+}
+
+const normalizedLegacyItems = [
+	{
+		type: 'text',
+		id: 'missing',
+		text: 'untimed',
+		turnId: 'stream-1',
+		startedAt: null,
+		completedAt: null
+	},
+	{ type: 'text', id: 'zero', text: 'zero', startedAt: 0, completedAt: 0 },
+	{ type: 'text', id: 'nulls', text: 'already null', startedAt: null, completedAt: null },
+	{
+		type: 'text',
+		id: 'known',
+		text: 'known',
+		startedAt: 1_000,
+		completedAt: 2_000,
+		providerMetadata: { model: 'gpt' }
+	},
+	{ type: 'reasoning', id: 'partial', text: 'think', startedAt: null, completedAt: 5 },
+	{
+		type: 'tool-call',
+		partId: 'p1',
+		callId: 'c1',
+		name: 'exec_command',
+		input: { cmd: 'ls' },
+		turnId: 'stream-1',
+		startedAt: 3,
+		completedAt: null
+	}
+];
+
+describe('transcript timing migration', () => {
+	it('nulls missing completion timestamps and leaves other fields alone', async () => {
+		const t = initConvexTest();
+		const ids = await seedTranscriptTimingParts(t);
+		const before = await loadTranscriptTimingParts(t, ids);
+
+		await t.mutation(internal.migrations.backfillTranscriptTiming, oneBatch);
+
+		const after = await loadTranscriptTimingParts(t, ids);
+		expect(after.completion?.completion).toEqual({
+			streamId: 'stream-1',
+			items: normalizedLegacyItems
+		});
+		expect(after.completion).toMatchObject({
+			kind: 'completion',
+			number: 0,
+			sourceKey: 'completion:legacy',
+			userId: 'user_alice'
+		});
+		expect(after.timed).toEqual(before.timed);
+		expect(after.prompt).toEqual(before.prompt);
+		expect(after.tool).toEqual(before.tool);
+	});
+
+	it('does not change documents on a second run', async () => {
+		const t = initConvexTest();
+		const ids = await seedTranscriptTimingParts(t);
+
+		await t.mutation(internal.migrations.backfillTranscriptTiming, oneBatch);
+		const first = await loadTranscriptTimingParts(t, ids);
+		await t.mutation(internal.migrations.backfillTranscriptTiming, oneBatch);
+
+		expect(await loadTranscriptTimingParts(t, ids)).toEqual(first);
 	});
 });

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -2,6 +2,7 @@ import { Migrations } from '@convex-dev/migrations';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation } from '@convex/_generated/server';
 import schema from '@convex/schema';
+import { normalizeCompletionTiming } from '@convex/lib/transcriptParts';
 
 export const migrations = new Migrations(components.migrations, {
 	schema,
@@ -10,8 +11,24 @@ export const migrations = new Migrations(components.migrations, {
 
 export const run = migrations.runner([
 	internal.migrations.removeRunPromptMessageIds,
-	internal.migrations.removeImageUploadMessageIds
+	internal.migrations.removeImageUploadMessageIds,
+	internal.migrations.backfillTranscriptTiming
 ]);
+
+export const runTranscriptTiming = migrations.runner(internal.migrations.backfillTranscriptTiming);
+
+export const backfillTranscriptTiming = migrations.define({
+	table: 'threadTranscriptParts',
+	migrateOne: (_ctx, part) => {
+		if (
+			!part.completion?.items.some(
+				(item) => item.startedAt === undefined || item.completedAt === undefined
+			)
+		)
+			return;
+		return { completion: normalizeCompletionTiming(part.completion) };
+	}
+});
 
 export const removeRunPromptMessageIds = migrations.define({
 	table: 'runs',

--- a/apps/web/src/convex/transcript.test.ts
+++ b/apps/web/src/convex/transcript.test.ts
@@ -111,7 +111,7 @@ describe('numbered transcript parts', () => {
 		expect(parts.parts[1]?.completion?.items).toEqual(items);
 	});
 
-	it('records a completion', async () => {
+	it('normalizes missing timing from older agents on new completion writes', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const executionSecret = 'transcript-no-begin-secret';
@@ -145,6 +145,21 @@ describe('numbered transcript parts', () => {
 		expect(number).toBe(1);
 		const parts = await asUser.query(api.transcript.getParts, { threadId, numbers: [0, 1] });
 		expect(parts.parts.map((part) => part.kind)).toEqual(['prompt', 'completion']);
+		const stored = await t.run(
+			async (ctx) => await ctx.db.get('threadTranscriptParts', parts.parts[1]!._id)
+		);
+		expect(stored?.completion?.items).toEqual([
+			{ type: 'text', id: 't', text: 'Hi', turnId: 'stream-1', startedAt: null, completedAt: null }
+		]);
+		expect(parts.parts[1]?.completion?.items).toEqual([
+			{ type: 'text', id: 't', text: 'Hi', turnId: 'stream-1' }
+		]);
+		const agentParts = await t.query(api.transcript.getPartsForRun, {
+			runId,
+			executionSecret,
+			numbers: [1]
+		});
+		expect(agentParts.parts[0]?.completion?.items).toEqual(parts.parts[1]?.completion?.items);
 	});
 
 	it('appends started and finished tool events paired by invocation id', async () => {

--- a/apps/web/src/convex/transcript.test.ts
+++ b/apps/web/src/convex/transcript.test.ts
@@ -59,14 +59,31 @@ describe('numbered transcript parts', () => {
 			executionSecret
 		});
 		const items = [
-			{ type: 'text' as const, id: 'stream-1:text:a', text: 'Working', turnId: 'stream-1' },
+			{
+				type: 'reasoning' as const,
+				id: 'stream-1:reasoning:a',
+				text: 'Thinking',
+				turnId: 'stream-1',
+				startedAt: 1_000,
+				completedAt: 2_000
+			},
+			{
+				type: 'text' as const,
+				id: 'stream-1:text:a',
+				text: 'Working',
+				turnId: 'stream-1',
+				startedAt: 2_000,
+				completedAt: 3_000
+			},
 			{
 				type: 'tool-call' as const,
 				partId: 'stream-1:tool:c1',
 				callId: 'c1',
 				name: 'exec_command',
 				input: { cmd: 'ls' },
-				turnId: 'stream-1'
+				turnId: 'stream-1',
+				startedAt: 3_000,
+				completedAt: 3_100
 			}
 		];
 		const number = await asUser.mutation(api.agentRuntime.finalizeCompletionCall, {
@@ -91,7 +108,7 @@ describe('numbered transcript parts', () => {
 		expect(state.totalParts).toBe(2);
 		const parts = await asUser.query(api.transcript.getParts, { threadId, numbers: [0, 1] });
 		expect(parts.parts.map((part) => part.kind)).toEqual(['prompt', 'completion']);
-		expect(parts.parts[1]?.completion?.items).toHaveLength(2);
+		expect(parts.parts[1]?.completion?.items).toEqual(items);
 	});
 
 	it('records a completion', async () => {

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -15,7 +15,6 @@ import {
 	partitionWorkSectionTools,
 	resolveCommandSessionLabel,
 	workSectionTimingAnchor,
-	workSectionTimingIndexes,
 	type AssistantTimelineTool,
 	type AssistantTimelineWorkBlock
 } from '$lib/chat/assistant-timeline';
@@ -649,65 +648,41 @@ describe('command session labels', () => {
 	});
 });
 
-describe('workSectionTimingIndexes', () => {
-	it('maps section indexes to work indexes and prior completion anchors', () => {
-		const sections = groupAssistantTimelineSections(
-			groupAssistantTimeline([
-				{ type: 'reasoning', id: 'r1', text: 'plan' },
-				tool('c1', 'exec_command', {
-					job: executorJob('job-1', 1, {
-						status: 'completed',
-						completedAt: 5_000,
-						kind: 'exec_command'
-					})
-				}),
-				{ type: 'text', id: 't1', text: 'mid' },
-				{ type: 'reasoning', id: 'r2', text: 'more' }
-			])
-		);
-
-		expect(workSectionTimingIndexes(sections)).toEqual({
-			workIndexBySectionIndex: [0, undefined, 1],
-			priorCompletedAtByWorkIndex: [undefined, 5_000]
-		});
-	});
-});
-
 describe('workSectionTimingAnchor', () => {
-	it('starts the first section at run start and ends at job completion', () => {
+	it('uses recorded reasoning and tool boundaries without a job subscription', () => {
 		const section = {
 			type: 'work' as const,
 			key: 'c1',
 			blocks: [
+				{ type: 'reasoning' as const, id: 'r1', text: 'plan', startedAt: 500, completedAt: 900 },
 				{
 					type: 'tool-group' as const,
 					toolKey: 'exec_command',
 					tools: [
 						tool('c1', 'exec_command', {
-							job: executorJob('job-1', 1, {
-								kind: 'exec_command',
-								status: 'completed',
-								enqueuedAt: 1_000,
-								claimedAt: 1_200,
-								completedAt: 5_000
-							})
+							startedAt: 1_000,
+							completedAt: 5_000
 						})
 					]
+				},
+				{
+					type: 'reasoning' as const,
+					id: 'r2',
+					text: 'review result',
+					startedAt: 5_200,
+					completedAt: 7_000
 				}
 			]
 		};
 
 		expect(
 			workSectionTimingAnchor(section, {
-				inProgress: false,
-				workSectionIndex: 0,
-				runStartedAt: 500,
-				runCompletedAt: 9_000
+				inProgress: false
 			})
-		).toEqual({ startedAtMs: 500, completedAtMs: 5_000 });
+		).toEqual({ startedAtMs: 500, completedAtMs: 7_000 });
 	});
 
-	it('falls back to run start while the first section is in progress without jobs', () => {
+	it('does not invent a duration for old reasoning without timestamps', () => {
 		const section = {
 			type: 'work' as const,
 			key: 'r1',
@@ -716,27 +691,58 @@ describe('workSectionTimingAnchor', () => {
 
 		expect(
 			workSectionTimingAnchor(section, {
-				inProgress: true,
-				workSectionIndex: 0,
-				runStartedAt: 4_000
+				inProgress: true
 			})
-		).toEqual({ startedAtMs: 4_000 });
+		).toEqual({});
+		expect(workSectionTimingAnchor(section, { inProgress: false, endedAt: 9_000 })).toEqual({});
 	});
 
-	it('uses prior work completion for later sections without jobs', () => {
+	it('keeps later reasoning on its own start and freezes at the next text boundary', () => {
 		const section = {
 			type: 'work' as const,
 			key: 'r2',
-			blocks: [{ type: 'reasoning' as const, id: 'r2', text: 'more' }]
+			blocks: [
+				{
+					type: 'reasoning' as const,
+					id: 'r2',
+					text: 'more',
+					startedAt: 8_000,
+					completedAt: 10_000
+				}
+			]
 		};
 
 		expect(
 			workSectionTimingAnchor(section, {
-				inProgress: true,
-				workSectionIndex: 1,
-				runStartedAt: 1_000,
-				priorWorkCompletedAtMs: 8_000
+				inProgress: true
 			})
 		).toEqual({ startedAtMs: 8_000 });
+		expect(workSectionTimingAnchor(section, { inProgress: false, endedAt: 11_000 })).toEqual({
+			startedAtMs: 8_000,
+			completedAtMs: 11_000
+		});
+	});
+
+	it('uses result completion rather than tool-call generation time', () => {
+		const parts = buildAssistantTimeline(
+			[
+				{
+					type: 'tool-call',
+					callId: 'c1',
+					name: 'exec_command',
+					input: {},
+					startedAt: 1_000,
+					completedAt: 1_100
+				},
+				{ type: 'tool-result', callId: 'c1', output: 'done', completedAt: 5_000 }
+			],
+			[]
+		);
+		const [section] = groupAssistantTimelineSections(groupAssistantTimeline(parts));
+		if (section.type !== 'work') throw new Error('Expected work');
+		expect(workSectionTimingAnchor(section, { inProgress: false })).toEqual({
+			startedAtMs: 1_000,
+			completedAtMs: 5_000
+		});
 	});
 });

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -649,6 +649,17 @@ describe('command session labels', () => {
 });
 
 describe('workSectionTimingAnchor', () => {
+	it('treats migrated null timing as unknown rather than epoch zero', () => {
+		const section = {
+			type: 'work' as const,
+			key: 'r1',
+			blocks: [
+				{ type: 'reasoning' as const, id: 'r1', text: '', startedAt: null, completedAt: null }
+			]
+		};
+		expect(workSectionTimingAnchor(section, { inProgress: true })).toEqual({});
+		expect(workSectionTimingAnchor(section, { inProgress: false, endedAt: 9_000 })).toEqual({});
+	});
 	it('uses recorded reasoning and tool boundaries without a job subscription', () => {
 		const section = {
 			type: 'work' as const,

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -143,7 +143,7 @@ export function workSectionTimingAnchor(
 		const items = block.type === 'tool-group' ? block.tools : [block];
 		for (const item of items) {
 			// Older transcripts did not record boundaries. A partial duration is misleading.
-			if (item.startedAt === undefined) return {};
+			if (item.startedAt == null) return {};
 			startedAtMs = Math.min(startedAtMs ?? item.startedAt, item.startedAt);
 			if (!options.inProgress) {
 				const end = item.completedAt ?? options.endedAt;

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -15,6 +15,8 @@ export type AssistantTimelineTool = {
 	input: JsonValue;
 	output?: JsonValue;
 	job?: ExecutorJob;
+	startedAt?: number;
+	completedAt?: number;
 };
 
 export type AssistantTimelineItem =
@@ -123,112 +125,34 @@ export function groupAssistantTimelineSections(
 	return sections;
 }
 
-function forEachWorkSectionJob(
-	blocks: AssistantTimelineWorkBlock[],
-	visit: (job: NonNullable<AssistantTimelineTool['job']>) => void
-) {
-	for (const block of blocks) {
-		if (block.type !== 'tool-group') continue;
-		for (const tool of block.tools) {
-			if (tool.job) visit(tool.job);
-		}
-	}
-}
-
-/** Earliest durable job start in a work section, if any. */
-export function workSectionJobStartedAtMs(
-	blocks: AssistantTimelineWorkBlock[]
-): number | undefined {
-	let startMs: number | undefined;
-	forEachWorkSectionJob(blocks, (job) => {
-		const jobStart = job.claimedAt ?? job.enqueuedAt;
-		startMs = startMs === undefined ? jobStart : Math.min(startMs, jobStart);
-	});
-	return startMs;
-}
-
-/** Latest durable job completion in a work section, if any. */
-export function workSectionJobCompletedAtMs(
-	blocks: AssistantTimelineWorkBlock[]
-): number | undefined {
-	let endMs: number | undefined;
-	forEachWorkSectionJob(blocks, (job) => {
-		if (job.completedAt === undefined) return;
-		endMs = endMs === undefined ? job.completedAt : Math.max(endMs, job.completedAt);
-	});
-	return endMs;
-}
-
-/**
- * Precompute work-section indexes and prior-completion anchors so the transcript
- * can resolve timing without O(n²) slice/filter per section.
- */
-export type WorkSectionTimingIndexes = {
-	workIndexBySectionIndex: Array<number | undefined>;
-	priorCompletedAtByWorkIndex: Array<number | undefined>;
-};
-
-export function workSectionTimingIndexes(
-	sections: AssistantTimelineSection[]
-): WorkSectionTimingIndexes {
-	const workIndexBySectionIndex: Array<number | undefined> = [];
-	const priorCompletedAtByWorkIndex: Array<number | undefined> = [];
-	let workIndex = 0;
-	let priorEnd: number | undefined;
-
-	for (const section of sections) {
-		if (section.type !== 'work') {
-			workIndexBySectionIndex.push(undefined);
-			continue;
-		}
-
-		workIndexBySectionIndex.push(workIndex);
-		priorCompletedAtByWorkIndex.push(priorEnd);
-		const sectionEnd = workSectionJobCompletedAtMs(section.blocks);
-		if (sectionEnd !== undefined) {
-			priorEnd = priorEnd === undefined ? sectionEnd : Math.max(priorEnd, sectionEnd);
-		}
-		workIndex += 1;
-	}
-
-	return { workIndexBySectionIndex, priorCompletedAtByWorkIndex };
-}
-
 export type WorkSectionTimingAnchor = {
-	startedAtMs: number;
+	startedAtMs?: number;
 	completedAtMs?: number;
 };
 
-/**
- * Durable wall-clock anchors for a work section from Convex job/run timestamps.
- * First section starts at run start; later sections prefer job start / prior work end.
- */
 export function workSectionTimingAnchor(
 	section: Extract<AssistantTimelineSection, { type: 'work' }>,
 	options: {
 		inProgress: boolean;
-		/** 0-based index among work sections in this assistant message. */
-		workSectionIndex: number;
-		runStartedAt: number;
-		runCompletedAt?: number;
-		/** Latest job completion among earlier work sections in this message. */
-		priorWorkCompletedAtMs?: number;
+		endedAt?: number;
 	}
 ): WorkSectionTimingAnchor {
-	const jobStartedAtMs = workSectionJobStartedAtMs(section.blocks);
-	const startedAtMs =
-		options.workSectionIndex === 0
-			? options.runStartedAt
-			: (jobStartedAtMs ?? options.priorWorkCompletedAtMs ?? options.runStartedAt);
-
-	if (options.inProgress) {
-		return { startedAtMs };
+	let startedAtMs: number | undefined;
+	let completedAtMs = options.endedAt;
+	for (const block of section.blocks) {
+		const items = block.type === 'tool-group' ? block.tools : [block];
+		for (const item of items) {
+			// Older transcripts did not record boundaries. A partial duration is misleading.
+			if (item.startedAt === undefined) return {};
+			startedAtMs = Math.min(startedAtMs ?? item.startedAt, item.startedAt);
+			if (!options.inProgress) {
+				const end = item.completedAt ?? options.endedAt;
+				if (end === undefined) return {};
+				completedAtMs = Math.max(completedAtMs ?? end, end);
+			}
+		}
 	}
-
-	const completedAtMs =
-		workSectionJobCompletedAtMs(section.blocks) ?? options.runCompletedAt ?? startedAtMs;
-
-	return { startedAtMs, completedAtMs };
+	return options.inProgress ? { startedAtMs } : { startedAtMs, completedAtMs };
 }
 
 /** Whether a tool call never reached a durable result (no output and no finished job). */
@@ -484,7 +408,10 @@ export function buildAssistantTimeline(
 			type: 'tool',
 			callId: part.callId,
 			name: part.name,
-			input: part.input
+			input: part.input,
+			startedAt: part.startedAt ?? job?.enqueuedAt,
+			// The call's completedAt ends argument generation, not tool execution.
+			completedAt: result?.completedAt ?? job?.completedAt
 		};
 		if (result) {
 			item.output = result.output;
@@ -504,6 +431,8 @@ export function buildAssistantTimeline(
 			callId: job.callId ?? `executor-job:${job._id}`,
 			name: job.kind,
 			input: job.payload,
+			startedAt: job.enqueuedAt,
+			completedAt: job.completedAt,
 			job
 		};
 		if (job.result !== undefined) {

--- a/apps/web/src/lib/chat/elapsed-time.test.ts
+++ b/apps/web/src/lib/chat/elapsed-time.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { elapsedSeconds } from './elapsed-time';
+
+describe('elapsedSeconds', () => {
+	it('uses wall-clock differences so delayed ticks catch up', () => {
+		expect(elapsedSeconds(1_000, 2_999)).toBe(1);
+		expect(elapsedSeconds(1_000, 65_000)).toBe(64);
+	});
+	it('does not turn missing or invalid timestamps into a duration', () => {
+		expect(elapsedSeconds(undefined, 5_000)).toBeUndefined();
+		expect(elapsedSeconds(0, 5_000)).toBeUndefined();
+		expect(elapsedSeconds(1_000, undefined)).toBeUndefined();
+		expect(elapsedSeconds(NaN, 5_000)).toBeUndefined();
+		expect(elapsedSeconds(5_000, 4_000)).toBe(0);
+	});
+});

--- a/apps/web/src/lib/chat/elapsed-time.ts
+++ b/apps/web/src/lib/chat/elapsed-time.ts
@@ -1,0 +1,26 @@
+import { createSubscriber } from 'svelte/reactivity';
+
+const subscribe = createSubscriber((update) => {
+	const interval = setInterval(update, 1_000);
+	return () => clearInterval(interval);
+});
+
+export function tickingNow(): number {
+	subscribe();
+	return Date.now();
+}
+
+export function elapsedSeconds(
+	startedAt: number | undefined,
+	endedAt: number | undefined
+): number | undefined {
+	if (
+		startedAt === undefined ||
+		startedAt <= 0 ||
+		endedAt === undefined ||
+		!Number.isFinite(startedAt) ||
+		!Number.isFinite(endedAt)
+	)
+		return undefined;
+	return Math.max(0, Math.floor((endedAt - startedAt) / 1_000));
+}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -367,7 +367,10 @@
 											{@const nextSection = sections[sectionIndex + 1]}
 											{@const timing = workSectionTimingAnchor(section, {
 												inProgress: workInProgress,
-												endedAt: nextSection?.type === 'text' ? nextSection.startedAt : undefined
+												endedAt:
+													nextSection?.type === 'text'
+														? (nextSection.startedAt ?? undefined)
+														: undefined
 											})}
 											{#if visibleBlocks.length > 0 || workInProgress || runningTools.length > 0}
 												<WorkDisclosure

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -12,7 +12,6 @@
 		isAssistantResponseStreaming,
 		partitionWorkSectionTools,
 		workSectionTimingAnchor,
-		workSectionTimingIndexes,
 		type AssistantTimelineTool,
 		type AssistantTimelineWorkBlock
 	} from '$lib/chat/assistant-timeline';
@@ -332,8 +331,6 @@
 							{@const sessionCommands = buildCommandSessionCommandMap(timelineTools)}
 							{@const blocks = groupAssistantTimeline(timeline)}
 							{@const sections = groupAssistantTimelineSections(blocks)}
-							{@const { workIndexBySectionIndex, priorCompletedAtByWorkIndex } =
-								workSectionTimingIndexes(sections)}
 							{@const isStreaming = isAssistantResponseStreaming(message, activeRunId)}
 							{@const openSessions = buildOpenExecCommandSessions(timelineTools, isStreaming)}
 							{@const hasPersistedAssistantContent = timeline.some(
@@ -367,13 +364,10 @@
 											{@const workInProgress =
 												isStreaming &&
 												(sectionIndex === sections.length - 1 || runningTools.length > 0)}
-											{@const workSectionOrder = workIndexBySectionIndex[sectionIndex] ?? 0}
+											{@const nextSection = sections[sectionIndex + 1]}
 											{@const timing = workSectionTimingAnchor(section, {
 												inProgress: workInProgress,
-												workSectionIndex: workSectionOrder,
-												runStartedAt: message.runStartedAt,
-												runCompletedAt: message.runCompletedAt,
-												priorWorkCompletedAtMs: priorCompletedAtByWorkIndex[workSectionOrder]
+												endedAt: nextSection?.type === 'text' ? nextSection.startedAt : undefined
 											})}
 											{#if visibleBlocks.length > 0 || workInProgress || runningTools.length > 0}
 												<WorkDisclosure
@@ -477,7 +471,7 @@
 											{/if}
 										{/if}
 									{/each}
-									{#if !isStreaming && message.runCompletedAt !== undefined}
+									{#if !isStreaming && message.runStartedAt > 0 && message.runCompletedAt !== undefined}
 										<p class="text-muted-foreground text-sm">
 											Worked for {formatElapsedDuration(
 												Math.max(

--- a/apps/web/src/lib/components/home/work-disclosure.svelte
+++ b/apps/web/src/lib/components/home/work-disclosure.svelte
@@ -3,11 +3,11 @@
 	import { untrack, type Snippet } from 'svelte';
 	import { createInProgressDisclosure } from '$lib/components/home/in-progress-disclosure.svelte';
 	import { formatElapsedDuration } from '$lib/format';
+	import { elapsedSeconds, tickingNow } from '$lib/chat/elapsed-time';
 
 	type Props = {
 		inProgress: boolean;
-		/** Durable Convex/job/run wall-clock start for this work section. */
-		startedAtMs: number;
+		startedAtMs?: number;
 		/** Durable end when the section is finished; omit while in progress. */
 		completedAtMs?: number;
 		children: Snippet;
@@ -22,7 +22,7 @@
 		disclosure.toggle();
 	}
 
-	let elapsedSeconds = $state(0);
+	const duration = $derived(elapsedSeconds(startedAtMs, inProgress ? tickingNow() : completedAtMs));
 	const disclosure = createInProgressDisclosure(() => inProgress);
 
 	$effect(() => {
@@ -38,28 +38,8 @@
 		};
 	});
 
-	$effect(() => {
-		const start = startedAtMs;
-
-		if (inProgress) {
-			const tick = () => {
-				elapsedSeconds = Math.max(0, Math.floor((Date.now() - start) / 1000));
-			};
-			tick();
-			const intervalId = window.setInterval(tick, 1000);
-			return () => {
-				window.clearInterval(intervalId);
-			};
-		}
-
-		const end = completedAtMs ?? Date.now();
-		elapsedSeconds = Math.max(0, Math.floor((end - start) / 1000));
-	});
-
 	const label = $derived(
-		inProgress
-			? `Working for ${formatElapsedDuration(elapsedSeconds)}`
-			: `Worked for ${formatElapsedDuration(elapsedSeconds)}`
+		`${inProgress ? 'Working' : 'Worked'}${duration === undefined ? '' : ` for ${formatElapsedDuration(duration)}`}`
 	);
 </script>
 

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -71,21 +71,32 @@ describe('mergePagedTranscriptWithLive', () => {
 	});
 
 	it('keeps durable tool results attached to their streamed calls', () => {
-		const call = { type: 'tool-call' as const, callId: 'call', name: 'exec_command', input: null };
+		const call = {
+			type: 'tool-call' as const,
+			callId: 'call',
+			name: 'exec_command',
+			input: null,
+			startedAt: 1_000
+		};
 		const result = {
 			type: 'tool-result' as const,
 			callId: 'call',
 			name: 'exec_command',
-			output: 'done'
+			output: 'done',
+			completedAt: 5_000
 		};
 		const messages = mergePagedTranscriptWithLive({
 			messages: [message({ streamIds: [], parts: [call, result], sourceNumbers: [1, 2] })],
-			live: { ...live(), parts: [{ ...call, input: { cmd: 'pwd' } }] },
+			live: { ...live(), parts: [{ ...call, input: { cmd: 'pwd' }, startedAt: undefined }] },
 			userId: 'user-1',
 			threadId
 		});
 		expect(messages[0].parts.map((part) => part.type)).toEqual(['tool-call', 'tool-result']);
 		expect(messages[0].sourceNumbers).toEqual([1, 2]);
+		expect(buildAssistantTimeline(messages[0].parts, [])[0]).toMatchObject({
+			startedAt: 1_000,
+			completedAt: 5_000
+		});
 	});
 
 	it('keeps reasoning before its tools when tool events arrive before the completion', () => {

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -64,7 +64,13 @@ export function mergePagedTranscriptWithLive(args: {
 				parts.push(part);
 			}
 		}
-		const turnParts = live.parts.flatMap((part) => {
+		const previousParts = new Map(existing?.parts.map((part) => [partKey(part), part]));
+		const turnParts = live.parts.flatMap((incoming) => {
+			const previous = previousParts.get(partKey(incoming));
+			const part =
+				previous?.type === 'tool-call' && incoming.type === 'tool-call'
+					? { ...incoming, startedAt: incoming.startedAt ?? previous.startedAt }
+					: incoming;
 			const result = part.type === 'tool-call' ? results.get(part.callId) : undefined;
 			return result && !liveKeys.has(partKey(result)) ? [part, result] : [part];
 		});

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
+	import { elapsedSeconds, tickingNow } from '$lib/chat/elapsed-time';
 	import { page } from '$app/state';
 	import { PanelRight } from '@lucide/svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
@@ -206,7 +207,6 @@
 	let answeringAgentQuestion = $state(false);
 	let composerAttachments = $state<ComposerAttachment[]>([]);
 	let currentError = $state<string | null>(null);
-	let elapsedSeconds = $state(0);
 	const submittingPromptScopes = new SvelteMap<string, number>();
 	const composerRecoveries = new SvelteMap<string, ComposerRecovery>();
 	const recoveredSubmissionIds = new SvelteMap<
@@ -844,6 +844,9 @@
 	);
 	const isRunning = $derived(
 		isRunInProgress && currentLifecycle?.phase !== 'cancellation_requested'
+	);
+	const runElapsedSeconds = $derived(
+		isRunInProgress ? elapsedSeconds(runState?.startedAt, tickingNow()) : undefined
 	);
 	const groupedProjectThreads = $derived(getProjectThreadGroups(projects, threads));
 	const hasPendingAgentLaunch = $derived(
@@ -1485,8 +1488,6 @@
 			return;
 		}
 
-		elapsedSeconds = 0;
-
 		const selectedThreadId = currentThreadId;
 		let submittedRepositoryKey = currentRepositoryKey;
 		if (!submittedRepositoryKey) {
@@ -1847,7 +1848,6 @@
 		prompt = '';
 		clearComposerAttachments({ discard: true });
 		currentError = null;
-		elapsedSeconds = 0;
 		selectedModel = modelCatalog?.defaultModelId ?? defaultModelId;
 		selectedReasoningEffort = modelCatalog?.defaultReasoningEffort ?? defaultReasoningEffort;
 		selectedServiceTier = modelCatalog?.defaultServiceTier ?? defaultServiceTier;
@@ -2073,25 +2073,6 @@
 		}
 	});
 
-	$effect(() => {
-		const startedAt = runState?.startedAt;
-		if (!isRunning || !startedAt) {
-			elapsedSeconds = 0;
-			return;
-		}
-
-		const updateElapsed = () => {
-			elapsedSeconds = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
-		};
-
-		updateElapsed();
-		const intervalId = window.setInterval(updateElapsed, 1000);
-
-		return () => {
-			window.clearInterval(intervalId);
-		};
-	});
-
 	onMount(() => {
 		void loadModelCatalog();
 		const bridge = window.sprocketDesktopBridge;
@@ -2279,7 +2260,7 @@
 							runError={latestRunResumeKind ? null : (runState?.lastError ?? null)}
 							messages={visibleMessages}
 							actions={visibleActions}
-							activeRunId={isRunning ? (runState?.runId ?? null) : null}
+							activeRunId={isRunInProgress ? (runState?.runId ?? null) : null}
 							project={currentProject}
 							remoteChangeNotice={currentThreadId
 								? (remoteChangeNotices.get(currentThreadId) ?? null)
@@ -2349,7 +2330,9 @@
 						isSubmitting={isSubmittingPrompt || hasPendingAgentLaunch || answeringAgentQuestion}
 						isStarting={hasPendingAgentLaunch}
 						{isRunning}
-						elapsedLabel={isRunning ? formatElapsedDuration(elapsedSeconds) : null}
+						elapsedLabel={runElapsedSeconds === undefined
+							? null
+							: formatElapsedDuration(runElapsedSeconds)}
 						{contextUsage}
 						projectSkills={composerProjectSkills}
 						onSubmit={() => {

--- a/crates/sprocket-agent/src/live.rs
+++ b/crates/sprocket-agent/src/live.rs
@@ -1,10 +1,18 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 const CHANNEL_CAPACITY: usize = 64;
+
+pub(crate) fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type")]
@@ -13,6 +21,14 @@ pub enum LiveAssistantPart {
     Text {
         id: String,
         text: String,
+        #[serde(rename = "startedAt", default, skip_serializing_if = "Option::is_none")]
+        started_at: Option<u64>,
+        #[serde(
+            rename = "completedAt",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        completed_at: Option<u64>,
         #[serde(rename = "turnId", skip_serializing_if = "Option::is_none")]
         turn_id: Option<String>,
     },
@@ -20,6 +36,14 @@ pub enum LiveAssistantPart {
     Reasoning {
         id: String,
         text: String,
+        #[serde(rename = "startedAt", default, skip_serializing_if = "Option::is_none")]
+        started_at: Option<u64>,
+        #[serde(
+            rename = "completedAt",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        completed_at: Option<u64>,
         #[serde(rename = "turnId", skip_serializing_if = "Option::is_none")]
         turn_id: Option<String>,
     },
@@ -31,9 +55,142 @@ pub enum LiveAssistantPart {
         call_id: String,
         name: String,
         input: serde_json::Value,
+        #[serde(rename = "startedAt", default, skip_serializing_if = "Option::is_none")]
+        started_at: Option<u64>,
+        #[serde(
+            rename = "completedAt",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        completed_at: Option<u64>,
         #[serde(rename = "turnId", skip_serializing_if = "Option::is_none")]
         turn_id: Option<String>,
     },
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct LiveAssistantParts {
+    pub parts: Vec<LiveAssistantPart>,
+    text_index: HashMap<String, usize>,
+    tool_index: HashMap<String, usize>,
+}
+
+impl LiveAssistantParts {
+    pub fn clear(&mut self) {
+        self.parts.clear();
+        self.text_index.clear();
+        self.tool_index.clear();
+    }
+
+    pub fn items_json(&self) -> Vec<serde_json::Value> {
+        self.parts
+            .iter()
+            .map(|part| serde_json::to_value(part).expect("live assistant parts always serialize"))
+            .collect()
+    }
+
+    pub fn apply_text_delta(
+        &mut self,
+        event_type: &str,
+        id: String,
+        delta: &str,
+        turn_id: Option<String>,
+        now_ms: u64,
+    ) {
+        let key = format!("{event_type}:{id}");
+        if let Some(&index) = self.text_index.get(&key) {
+            match &mut self.parts[index] {
+                LiveAssistantPart::Text {
+                    text,
+                    started_at,
+                    completed_at,
+                    turn_id: existing,
+                    ..
+                } if event_type == "text" => {
+                    text.push_str(delta);
+                    if started_at.is_none() {
+                        *started_at = Some(now_ms);
+                    }
+                    *completed_at = Some(now_ms);
+                    if turn_id.is_some() {
+                        *existing = turn_id;
+                    }
+                }
+                LiveAssistantPart::Reasoning {
+                    text,
+                    started_at,
+                    completed_at,
+                    turn_id: existing,
+                    ..
+                } if event_type == "reasoning" => {
+                    text.push_str(delta);
+                    if started_at.is_none() {
+                        *started_at = Some(now_ms);
+                    }
+                    *completed_at = Some(now_ms);
+                    if turn_id.is_some() {
+                        *existing = turn_id;
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+        let part = if event_type == "reasoning" {
+            LiveAssistantPart::Reasoning {
+                id,
+                text: delta.to_string(),
+                started_at: Some(now_ms),
+                completed_at: Some(now_ms),
+                turn_id,
+            }
+        } else {
+            LiveAssistantPart::Text {
+                id,
+                text: delta.to_string(),
+                started_at: Some(now_ms),
+                completed_at: Some(now_ms),
+                turn_id,
+            }
+        };
+        self.text_index.insert(key, self.parts.len());
+        self.parts.push(part);
+    }
+
+    pub fn apply_tool_call(
+        &mut self,
+        part_id: Option<String>,
+        call_id: String,
+        name: String,
+        input: serde_json::Value,
+        turn_id: Option<String>,
+        now_ms: u64,
+    ) {
+        let key = part_id.clone().unwrap_or_else(|| call_id.clone());
+        let started_at = self
+            .tool_index
+            .get(&key)
+            .and_then(|&index| match &self.parts[index] {
+                LiveAssistantPart::ToolCall { started_at, .. } => *started_at,
+                _ => None,
+            })
+            .or(Some(now_ms));
+        let part = LiveAssistantPart::ToolCall {
+            part_id,
+            call_id,
+            name,
+            input,
+            started_at,
+            completed_at: Some(now_ms),
+            turn_id,
+        };
+        if let Some(&index) = self.tool_index.get(&key) {
+            self.parts[index] = part;
+        } else {
+            self.tool_index.insert(key, self.parts.len());
+            self.parts.push(part);
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -185,10 +342,97 @@ mod tests {
             parts: vec![LiveAssistantPart::Text {
                 id: "t".to_string(),
                 text: text.to_string(),
+                started_at: None,
+                completed_at: None,
                 turn_id: Some("stream-1".to_string()),
             }],
             run_started_at: 1,
         }
+    }
+
+    #[test]
+    fn live_parts_keep_old_json_without_timing() {
+        let part: LiveAssistantPart = serde_json::from_value(serde_json::json!({
+            "type": "text",
+            "id": "t",
+            "text": "hello",
+            "turnId": "stream-1"
+        }))
+        .unwrap();
+        assert_eq!(
+            part,
+            LiveAssistantPart::Text {
+                id: "t".into(),
+                text: "hello".into(),
+                started_at: None,
+                completed_at: None,
+                turn_id: Some("stream-1".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn text_and_reasoning_record_start_once_and_update_end() {
+        let mut parts = LiveAssistantParts::default();
+        parts.apply_text_delta("text", "t".into(), "Hello", Some("turn".into()), 10);
+        parts.apply_text_delta("text", "t".into(), "!", Some("turn".into()), 25);
+        parts.apply_text_delta("reasoning", "r".into(), "think", Some("turn".into()), 11);
+        parts.apply_text_delta("reasoning", "r".into(), " more", Some("turn".into()), 40);
+
+        assert_eq!(
+            parts.parts,
+            vec![
+                LiveAssistantPart::Text {
+                    id: "t".into(),
+                    text: "Hello!".into(),
+                    started_at: Some(10),
+                    completed_at: Some(25),
+                    turn_id: Some("turn".into()),
+                },
+                LiveAssistantPart::Reasoning {
+                    id: "r".into(),
+                    text: "think more".into(),
+                    started_at: Some(11),
+                    completed_at: Some(40),
+                    turn_id: Some("turn".into()),
+                }
+            ]
+        );
+        assert_eq!(parts.items_json()[0]["startedAt"], serde_json::json!(10));
+    }
+
+    #[test]
+    fn tool_replacement_keeps_the_original_start() {
+        let mut parts = LiveAssistantParts::default();
+        parts.apply_tool_call(
+            Some("p1".into()),
+            "c1".into(),
+            "exec_command".into(),
+            serde_json::json!({"cmd": "echo"}),
+            Some("turn".into()),
+            50,
+        );
+        parts.apply_tool_call(
+            Some("p1".into()),
+            "c1".into(),
+            "exec_command".into(),
+            serde_json::json!({"cmd": "ls"}),
+            Some("turn".into()),
+            80,
+        );
+
+        assert_eq!(
+            parts.parts,
+            vec![LiveAssistantPart::ToolCall {
+                part_id: Some("p1".into()),
+                call_id: "c1".into(),
+                name: "exec_command".into(),
+                input: serde_json::json!({"cmd": "ls"}),
+                started_at: Some(50),
+                completed_at: Some(80),
+                turn_id: Some("turn".into()),
+            }]
+        );
     }
 
     #[tokio::test]

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -16,7 +15,7 @@ use crate::compaction::ContextCompactionHook;
 use crate::convex::RuntimeClient;
 use crate::hooks::{AgentPromptHook, GatewayRequestHook, ToolCallTracker};
 use crate::live::{
-    LiveAssistantPart, LiveCompletionHub, LiveCompletionOverlay, join_assistant_text_parts,
+    LiveAssistantParts, LiveCompletionHub, LiveCompletionOverlay, join_assistant_text_parts, now_ms,
 };
 use crate::tools::agent_tools;
 use crate::types::{ContextBudget, RunContextResponse, gateway_api_v1_url};
@@ -415,9 +414,7 @@ struct TranscriptSink {
     run_started_at: u64,
     stream_id: String,
     attempt_seq: u64,
-    parts: Vec<LiveAssistantPart>,
-    text_index: HashMap<String, usize>,
-    tool_index: HashMap<String, usize>,
+    parts: LiveAssistantParts,
     last_publish: Instant,
     unpublished: usize,
     streamed: bool,
@@ -444,9 +441,7 @@ impl TranscriptSink {
             thread_id,
             run_started_at,
             attempt_seq: 1,
-            parts: Vec::new(),
-            text_index: HashMap::new(),
-            tool_index: HashMap::new(),
+            parts: LiveAssistantParts::default(),
             last_publish: Instant::now(),
             unpublished: 0,
             streamed: false,
@@ -481,8 +476,6 @@ impl TranscriptSink {
 
     fn reset_parts(&mut self) {
         self.parts.clear();
-        self.text_index.clear();
-        self.tool_index.clear();
         self.unpublished = 0;
         self.streamed = false;
     }
@@ -523,10 +516,7 @@ impl TranscriptSink {
     }
 
     fn items_json(&self) -> Vec<serde_json::Value> {
-        self.parts
-            .iter()
-            .map(|part| serde_json::to_value(part).expect("live assistant parts always serialize"))
-            .collect()
+        self.parts.items_json()
     }
 
     fn has_unpublished(&self) -> bool {
@@ -558,8 +548,8 @@ impl TranscriptSink {
             run_id: self.run_id.clone(),
             run_status: "running".to_string(),
             stream_id: Some(self.stream_id.clone()),
-            text: join_assistant_text_parts(&self.parts),
-            parts: self.parts.clone(),
+            text: join_assistant_text_parts(&self.parts.parts),
+            parts: self.parts.parts.clone(),
             run_started_at: self.run_started_at,
         });
     }
@@ -573,48 +563,8 @@ impl TranscriptSink {
     ) {
         self.streamed = true;
         self.unpublished += 1;
-        let key = format!("{event_type}:{id}");
-        if let Some(&index) = self.text_index.get(&key) {
-            match &mut self.parts[index] {
-                LiveAssistantPart::Text {
-                    text,
-                    turn_id: existing,
-                    ..
-                } if event_type == "text" => {
-                    text.push_str(delta);
-                    if turn_id.is_some() {
-                        *existing = turn_id;
-                    }
-                }
-                LiveAssistantPart::Reasoning {
-                    text,
-                    turn_id: existing,
-                    ..
-                } if event_type == "reasoning" => {
-                    text.push_str(delta);
-                    if turn_id.is_some() {
-                        *existing = turn_id;
-                    }
-                }
-                _ => {}
-            }
-            return;
-        }
-        let part = if event_type == "reasoning" {
-            LiveAssistantPart::Reasoning {
-                id,
-                text: delta.to_string(),
-                turn_id,
-            }
-        } else {
-            LiveAssistantPart::Text {
-                id,
-                text: delta.to_string(),
-                turn_id,
-            }
-        };
-        self.text_index.insert(key, self.parts.len());
-        self.parts.push(part);
+        self.parts
+            .apply_text_delta(event_type, id, delta, turn_id, now_ms());
     }
 
     fn apply_tool_call(
@@ -627,20 +577,8 @@ impl TranscriptSink {
     ) {
         self.streamed = true;
         self.unpublished += 1;
-        let key = part_id.clone().unwrap_or_else(|| call_id.clone());
-        let part = LiveAssistantPart::ToolCall {
-            part_id,
-            call_id,
-            name,
-            input,
-            turn_id,
-        };
-        if let Some(&index) = self.tool_index.get(&key) {
-            self.parts[index] = part;
-        } else {
-            self.tool_index.insert(key, self.parts.len());
-            self.parts.push(part);
-        }
+        self.parts
+            .apply_tool_call(part_id, call_id, name, input, turn_id, now_ms());
     }
 }
 

--- a/crates/sprocket-agent/src/transcript/history.rs
+++ b/crates/sprocket-agent/src/transcript/history.rs
@@ -285,6 +285,7 @@ mod tests {
             source_key: format!("prompt:{number}"),
             kind: TranscriptPartKind::Prompt,
             run_id: run_id.to_string(),
+            created_at: None,
             prompt: Some(TranscriptPromptBody {
                 text: text.to_string(),
                 image_uploads: Vec::new(),
@@ -308,6 +309,7 @@ mod tests {
             source_key: source_key.into(),
             kind: TranscriptPartKind::Tool,
             run_id: "run".into(),
+            created_at: None,
             prompt: None,
             completion: None,
             tool: Some(TranscriptToolBody {
@@ -327,6 +329,7 @@ mod tests {
             source_key: format!("completion:{number}"),
             kind: TranscriptPartKind::Completion,
             run_id: "run".into(),
+            created_at: None,
             prompt: None,
             completion: Some(TranscriptCompletionBody {
                 stream_id: Some("s".into()),
@@ -372,6 +375,7 @@ mod tests {
                     source_key: "completion:current".into(),
                     kind: TranscriptPartKind::Completion,
                     run_id: "current".into(),
+                    created_at: None,
                     prompt: None,
                     completion: Some(TranscriptCompletionBody {
                         stream_id: Some("s".into()),
@@ -400,6 +404,7 @@ mod tests {
                     source_key: "completion:parent".into(),
                     kind: TranscriptPartKind::Completion,
                     run_id: "parent".into(),
+                    created_at: None,
                     prompt: None,
                     completion: Some(TranscriptCompletionBody {
                         stream_id: Some("s".into()),
@@ -431,6 +436,7 @@ mod tests {
                     source_key: "tool:orphan".into(),
                     kind: TranscriptPartKind::Tool,
                     run_id: "run".into(),
+                    created_at: None,
                     prompt: None,
                     completion: None,
                     tool: Some(TranscriptToolBody {
@@ -447,6 +453,7 @@ mod tests {
                     source_key: "completion:run".into(),
                     kind: TranscriptPartKind::Completion,
                     run_id: "run".into(),
+                    created_at: None,
                     prompt: None,
                     completion: Some(TranscriptCompletionBody {
                         stream_id: Some("s".into()),
@@ -464,6 +471,7 @@ mod tests {
                     source_key: "tool:keep".into(),
                     kind: TranscriptPartKind::Tool,
                     run_id: "run".into(),
+                    created_at: None,
                     prompt: None,
                     completion: None,
                     tool: Some(TranscriptToolBody {
@@ -592,6 +600,7 @@ mod tests {
                     source_key: "prompt:0".into(),
                     kind: TranscriptPartKind::Prompt,
                     run_id: "run".into(),
+                    created_at: None,
                     prompt: Some(TranscriptPromptBody {
                         text: "see this".into(),
                         image_uploads: vec![TranscriptAttachmentMeta {
@@ -611,6 +620,7 @@ mod tests {
                     source_key: "completion:1".into(),
                     kind: TranscriptPartKind::Completion,
                     run_id: "run".into(),
+                    created_at: None,
                     prompt: None,
                     completion: Some(TranscriptCompletionBody {
                         stream_id: Some("s".into()),

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -670,6 +670,14 @@ fn project_messages(
                         }
                     }
                     for mut item in completion.items {
+                        // Released UIs understand omitted timestamps, but not explicit nulls.
+                        if let Some(object) = item.as_object_mut() {
+                            for key in ["startedAt", "completedAt"] {
+                                if object.get(key).is_some_and(JsonValue::is_null) {
+                                    object.remove(key);
+                                }
+                            }
+                        }
                         match json_type(&item) {
                             Some("text") => {
                                 if let Some(text) = item.get("text").and_then(JsonValue::as_str) {
@@ -1040,7 +1048,7 @@ mod tests {
             serde_json::json!({"type": "reasoning", "id": "r", "text": "plan"}),
             serde_json::json!({"type": "text", "id": "t", "text": "checking"}),
             serde_json::json!({"type": "tool-call", "callId": "a", "name": "exec_command", "input": {}}),
-            serde_json::json!({"type": "tool-call", "callId": "b", "name": "exec_command", "input": {}}),
+            serde_json::json!({"type": "tool-call", "callId": "b", "name": "exec_command", "input": {}, "startedAt": null, "completedAt": null}),
         ];
         for include_details in [false, true] {
             let messages = project_messages(
@@ -1127,6 +1135,22 @@ mod tests {
         assert!(messages[0].parts[0].get("startedAt").is_none());
         assert!(messages[0].parts[0].get("completedAt").is_none());
         assert_eq!(messages[0].run_started_at, UNKNOWN_RUN_STARTED_AT);
+    }
+
+    #[test]
+    fn migrated_null_timing_projects_as_missing_for_released_clients() {
+        let mut part = completion(4);
+        for item in &mut part.completion.as_mut().unwrap().items {
+            item["startedAt"] = JsonValue::Null;
+            item["completedAt"] = JsonValue::Null;
+        }
+        for include_details in [false, true] {
+            let messages = project_messages("user", "thread", vec![part.clone()], include_details);
+            for item in &messages[0].parts {
+                assert!(item.get("startedAt").is_none());
+                assert!(item.get("completedAt").is_none());
+            }
+        }
     }
 
     #[test]

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 
 use super::types::{
     TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE, TranscriptMessage, TranscriptPage, TranscriptPart,
-    TranscriptPartKind, TranscriptState,
+    TranscriptPartKind, TranscriptState, UNKNOWN_RUN_STARTED_AT,
 };
 
 fn safe_segment(value: &str) -> String {
@@ -597,7 +597,7 @@ fn project_messages(
                         attachments: prompt.image_uploads,
                         parts: Vec::new(),
                         run_status: "completed".to_string(),
-                        run_started_at: u64::from(part.number),
+                        run_started_at: UNKNOWN_RUN_STARTED_AT,
                         source_numbers: vec![part.number],
                         stream_ids: Vec::new(),
                         details_loaded: true,
@@ -619,7 +619,7 @@ fn project_messages(
                             attachments: Vec::new(),
                             parts: Vec::new(),
                             run_status: "completed".to_string(),
-                            run_started_at: u64::from(part.number),
+                            run_started_at: UNKNOWN_RUN_STARTED_AT,
                             source_numbers: Vec::new(),
                             stream_ids: Vec::new(),
                             details_loaded: include_details,
@@ -637,21 +637,24 @@ fn project_messages(
                         .items
                         .iter()
                         .filter_map(|item| {
-                            (item.get("type").and_then(JsonValue::as_str) == Some("tool-call"))
-                                .then(|| item.get("callId").and_then(JsonValue::as_str))
-                                .flatten()
+                            (json_type(item) == Some("tool-call")).then(|| json_call_id(item))
                         })
+                        .flatten()
                         .collect::<HashSet<_>>();
                     let mut results = HashMap::new();
+                    let mut placeholder_calls = HashMap::new();
                     response.parts.retain(|item| {
-                        let Some(call_id) = item.get("callId").and_then(JsonValue::as_str) else {
+                        let Some(call_id) = json_call_id(item) else {
                             return true;
                         };
                         if !call_ids.contains(call_id) {
                             return true;
                         }
-                        match item.get("type").and_then(JsonValue::as_str) {
-                            Some("tool-call") => false,
+                        match json_type(item) {
+                            Some("tool-call") => {
+                                placeholder_calls.insert(call_id.to_string(), item.clone());
+                                false
+                            }
                             Some("tool-result") => {
                                 results.insert(call_id.to_string(), item.clone());
                                 false
@@ -660,14 +663,14 @@ fn project_messages(
                         }
                     });
                     for item in &completion.items {
-                        if item.get("type").and_then(JsonValue::as_str) == Some("tool-result") {
-                            if let Some(call_id) = item.get("callId").and_then(JsonValue::as_str) {
+                        if json_type(item) == Some("tool-result") {
+                            if let Some(call_id) = json_call_id(item) {
                                 results.remove(call_id);
                             }
                         }
                     }
                     for mut item in completion.items {
-                        match item.get("type").and_then(JsonValue::as_str) {
+                        match json_type(&item) {
                             Some("text") => {
                                 if let Some(text) = item.get("text").and_then(JsonValue::as_str) {
                                     response.text.push_str(text);
@@ -698,27 +701,45 @@ fn project_messages(
                             }
                             _ => {}
                         }
-                        let result = item
-                            .get("callId")
-                            .and_then(JsonValue::as_str)
-                            .and_then(|call_id| results.remove(call_id));
+                        if json_type(&item) == Some("tool-call") {
+                            if let Some(call_id) = json_call_id(&item) {
+                                if let Some(placeholder) = placeholder_calls.get(call_id) {
+                                    copy_missing_timing(&mut item, placeholder);
+                                }
+                            }
+                        }
+                        let result =
+                            json_call_id(&item).and_then(|call_id| results.remove(call_id));
                         response.parts.push(item);
                         if let Some(result) = result {
                             response.parts.push(result);
                         }
                     }
                 }
+                let created_at = part.created_at;
                 if let Some(tool) = part.tool {
-                    let call_exists = response.parts.iter().any(|item| {
-                        item.get("type").and_then(JsonValue::as_str) == Some("tool-call")
-                            && item.get("callId").and_then(JsonValue::as_str)
-                                == Some(tool.call_id.as_str())
-                    });
-                    if !call_exists {
-                        response.parts.push(serde_json::json!({
-                            "type": "tool-call", "callId": tool.call_id,
-                            "name": tool.name, "input": if include_details { serde_json::json!({}) } else { JsonValue::Null }
-                        }));
+                    let existing_call = response
+                        .parts
+                        .iter_mut()
+                        .find(|item| is_typed_call(item, "tool-call", &tool.call_id));
+                    let started_at = created_at.filter(|_| tool.status == "started");
+                    if let Some(call) = existing_call {
+                        if call.get("startedAt").is_none() {
+                            if let Some(object) = call.as_object_mut() {
+                                insert_ms(object, "startedAt", started_at);
+                            }
+                        }
+                    } else {
+                        response.parts.push(tool_call_placeholder(
+                            &tool.call_id,
+                            &tool.name,
+                            if include_details {
+                                serde_json::json!({})
+                            } else {
+                                JsonValue::Null
+                            },
+                            started_at,
+                        ));
                     }
                     let terminal_key = tool
                         .tool_invocation_id
@@ -731,8 +752,9 @@ fn project_messages(
                         let mut result = serde_json::json!({
                             "type": "tool-result", "callId": tool.call_id, "name": tool.name
                         });
+                        let object = result.as_object_mut().expect("object");
                         let output = tool.output.unwrap_or(JsonValue::Null);
-                        result.as_object_mut().expect("object").insert(
+                        object.insert(
                             "output".to_string(),
                             if include_details {
                                 output
@@ -740,17 +762,18 @@ fn project_messages(
                                 tool_output_summary(output)
                             },
                         );
-                        if let Some(index) = response.parts.iter().position(|item| {
-                            item.get("type").and_then(JsonValue::as_str) == Some("tool-result")
-                                && item.get("callId").and_then(JsonValue::as_str)
-                                    == Some(tool.call_id.as_str())
-                        }) {
+                        insert_ms(object, "completedAt", created_at);
+                        if let Some(index) = response
+                            .parts
+                            .iter()
+                            .position(|item| is_typed_call(item, "tool-result", &tool.call_id))
+                        {
                             response.parts[index] = result;
-                        } else if let Some(index) = response.parts.iter().position(|item| {
-                            item.get("type").and_then(JsonValue::as_str) == Some("tool-call")
-                                && item.get("callId").and_then(JsonValue::as_str)
-                                    == Some(tool.call_id.as_str())
-                        }) {
+                        } else if let Some(index) = response
+                            .parts
+                            .iter()
+                            .position(|item| is_typed_call(item, "tool-call", &tool.call_id))
+                        {
                             response.parts.insert(index + 1, result);
                         } else {
                             response.parts.push(result);
@@ -761,6 +784,59 @@ fn project_messages(
         }
     }
     messages
+}
+
+fn json_str<'a>(item: &'a JsonValue, key: &str) -> Option<&'a str> {
+    item.get(key).and_then(JsonValue::as_str)
+}
+
+fn json_type(item: &JsonValue) -> Option<&str> {
+    json_str(item, "type")
+}
+
+fn json_call_id(item: &JsonValue) -> Option<&str> {
+    json_str(item, "callId")
+}
+
+fn is_typed_call(item: &JsonValue, type_name: &str, call_id: &str) -> bool {
+    json_type(item) == Some(type_name) && json_call_id(item) == Some(call_id)
+}
+
+fn insert_ms(object: &mut serde_json::Map<String, JsonValue>, key: &str, value: Option<u64>) {
+    if let Some(ms) = value {
+        object.insert(key.to_string(), JsonValue::from(ms));
+    }
+}
+
+fn copy_missing_timing(target: &mut JsonValue, source: &JsonValue) {
+    let Some(object) = target.as_object_mut() else {
+        return;
+    };
+    for key in ["startedAt", "completedAt"] {
+        if object.get(key).is_none() {
+            if let Some(value) = source.get(key) {
+                object.insert(key.to_string(), value.clone());
+            }
+        }
+    }
+}
+
+fn tool_call_placeholder(
+    call_id: &str,
+    name: &str,
+    input: JsonValue,
+    started_at: Option<u64>,
+) -> JsonValue {
+    let mut call = serde_json::json!({
+        "type": "tool-call",
+        "callId": call_id,
+        "name": name,
+        "input": input
+    });
+    if let Some(object) = call.as_object_mut() {
+        insert_ms(object, "startedAt", started_at);
+    }
+    call
 }
 
 fn tool_output_summary(output: JsonValue) -> JsonValue {
@@ -858,7 +934,7 @@ async fn recover_and_read_chunk(path: &Path) -> anyhow::Result<Vec<TranscriptPar
 mod tests {
     use super::*;
     use crate::transcript::types::{
-        TranscriptCompletionBody, TranscriptPartKind, TranscriptPromptBody,
+        TranscriptCompletionBody, TranscriptPartKind, TranscriptPromptBody, UNKNOWN_RUN_STARTED_AT,
     };
 
     fn prompt(number: u32, text: &str) -> TranscriptPart {
@@ -867,6 +943,7 @@ mod tests {
             source_key: format!("prompt:{number}"),
             kind: TranscriptPartKind::Prompt,
             run_id: format!("run-{number}"),
+            created_at: None,
             prompt: Some(TranscriptPromptBody {
                 text: text.to_string(),
                 image_uploads: Vec::new(),
@@ -882,6 +959,7 @@ mod tests {
             source_key: format!("completion:{number}"),
             kind: TranscriptPartKind::Completion,
             run_id: "run-1".to_string(),
+            created_at: None,
             prompt: None,
             completion: Some(TranscriptCompletionBody {
                 stream_id: Some("stream-1".to_string()),
@@ -902,6 +980,7 @@ mod tests {
             source_key: format!("completion:{number}"),
             kind: TranscriptPartKind::Completion,
             run_id: run_id.to_string(),
+            created_at: None,
             prompt: None,
             completion: Some(TranscriptCompletionBody {
                 stream_id: Some(format!("stream-{number}")),
@@ -915,16 +994,23 @@ mod tests {
 
     #[test]
     fn projection_omits_disclosure_payloads_until_requested() {
-        let part = completion(0);
+        let mut part = completion(0);
+        let reasoning = &mut part.completion.as_mut().unwrap().items[0];
+        reasoning["startedAt"] = serde_json::json!(1_000);
+        reasoning["completedAt"] = serde_json::json!(2_000);
         let summary = project_messages("user", "thread", vec![part.clone()], false);
         assert_eq!(summary[0].text, "answer");
         assert_eq!(summary[0].parts[0]["text"], "");
+        assert_eq!(summary[0].parts[0]["startedAt"], 1_000);
+        assert_eq!(summary[0].parts[0]["completedAt"], 2_000);
         assert!(summary[0].parts[1]["input"].is_null());
         assert!(summary[0].parts[2]["output"].is_null());
         assert!(!summary[0].details_loaded);
 
         let details = project_messages("user", "thread", vec![part], true);
         assert_eq!(details[0].parts[0]["text"], "secret");
+        assert_eq!(details[0].parts[0]["startedAt"], 1_000);
+        assert_eq!(details[0].parts[0]["completedAt"], 2_000);
         assert_eq!(details[0].parts[1]["input"]["cmd"], "pwd");
         assert_eq!(details[0].parts[2]["output"], "secret output");
         assert!(details[0].details_loaded);
@@ -932,11 +1018,12 @@ mod tests {
 
     #[test]
     fn completion_order_replaces_early_tool_placeholders() {
-        let tool = |number, call_id: &str, status: &str| TranscriptPart {
+        let tool = |number, call_id: &str, status: &str, created_at: Option<u64>| TranscriptPart {
             number,
             source_key: format!("tool:{number}"),
             kind: TranscriptPartKind::Tool,
             run_id: "run-1".to_string(),
+            created_at,
             prompt: None,
             completion: None,
             tool: Some(crate::transcript::types::TranscriptToolBody {
@@ -961,11 +1048,11 @@ mod tests {
                 "thread",
                 vec![
                     completion_for_run(0, "run-1", "previous turn"),
-                    tool(1, "b", "started"),
-                    tool(2, "a", "started"),
-                    tool(3, "a", "completed"),
+                    tool(1, "b", "started", Some(1_100)),
+                    tool(2, "a", "started", Some(1_200)),
+                    tool(3, "a", "completed", Some(1_800)),
                     turn.clone(),
-                    tool(5, "b", "completed"),
+                    tool(5, "b", "completed", Some(2_400)),
                     completion_for_run(6, "run-1", "answer"),
                 ],
                 include_details,
@@ -993,7 +1080,95 @@ mod tests {
             assert_eq!(parts[6]["callId"], "b");
             assert_eq!(parts[4]["output"]["status"], "completed");
             assert_eq!(parts[1]["text"], if include_details { "plan" } else { "" });
+            assert_eq!(parts[1].get("startedAt"), None);
+            assert_eq!(parts[3]["startedAt"], 1_200);
+            assert_eq!(parts[4]["completedAt"], 1_800);
+            assert_eq!(parts[5]["startedAt"], 1_100);
+            assert_eq!(parts[6]["completedAt"], 2_400);
         }
+    }
+
+    #[test]
+    fn projected_messages_use_unknown_run_start_instead_of_sequence() {
+        let messages = project_messages("user", "thread", vec![prompt(7, "hi")], true);
+        assert_eq!(messages[0].run_started_at, UNKNOWN_RUN_STARTED_AT);
+        assert_eq!(messages[0].source_numbers, vec![7]);
+    }
+
+    #[test]
+    fn finished_tool_without_start_does_not_invent_zero_duration() {
+        let part = TranscriptPart {
+            number: 1,
+            source_key: "tool:finished".into(),
+            kind: TranscriptPartKind::Tool,
+            run_id: "run-1".into(),
+            created_at: Some(5_000),
+            prompt: None,
+            completion: None,
+            tool: Some(crate::transcript::types::TranscriptToolBody {
+                job_id: None,
+                tool_invocation_id: None,
+                call_id: "c1".into(),
+                name: "exec_command".into(),
+                output: None,
+                status: "completed".into(),
+            }),
+        };
+        let messages = project_messages("user", "thread", vec![part], false);
+        assert!(messages[0].parts[0].get("startedAt").is_none());
+        assert_eq!(messages[0].parts[1]["completedAt"], 5_000);
+    }
+
+    #[test]
+    fn does_not_fabricate_reasoning_timing_from_part_created_at() {
+        let mut part = completion(4);
+        part.created_at = Some(9_000);
+        let messages = project_messages("user", "thread", vec![part], true);
+        assert!(messages[0].parts[0].get("startedAt").is_none());
+        assert!(messages[0].parts[0].get("completedAt").is_none());
+        assert_eq!(messages[0].run_started_at, UNKNOWN_RUN_STARTED_AT);
+    }
+
+    #[test]
+    fn completion_tool_call_keeps_its_own_start_over_placeholder() {
+        let tool = TranscriptPart {
+            number: 1,
+            source_key: "tool:1".into(),
+            kind: TranscriptPartKind::Tool,
+            run_id: "run-1".into(),
+            created_at: Some(500),
+            prompt: None,
+            completion: None,
+            tool: Some(crate::transcript::types::TranscriptToolBody {
+                job_id: None,
+                tool_invocation_id: None,
+                call_id: "c1".into(),
+                name: "exec_command".into(),
+                output: None,
+                status: "started".into(),
+            }),
+        };
+        let turn = TranscriptPart {
+            number: 2,
+            source_key: "completion:2".into(),
+            kind: TranscriptPartKind::Completion,
+            run_id: "run-1".into(),
+            created_at: Some(900),
+            prompt: None,
+            completion: Some(TranscriptCompletionBody {
+                stream_id: Some("s".into()),
+                items: vec![serde_json::json!({
+                    "type": "tool-call",
+                    "callId": "c1",
+                    "name": "exec_command",
+                    "input": {},
+                    "startedAt": 700
+                })],
+            }),
+            tool: None,
+        };
+        let messages = project_messages("user", "thread", vec![tool, turn], true);
+        assert_eq!(messages[0].parts[0]["startedAt"], 700);
     }
 
     #[test]
@@ -1052,6 +1227,28 @@ mod tests {
         assert_eq!(older.next_before, Some(2));
 
         tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn preserves_created_at_on_disk() {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-created-at-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        let mut part = prompt(0, "hello");
+        part.created_at = Some(1_700_000_000_000);
+        store.append_parts("user", "thread", &[part]).await.unwrap();
+        let read = store.read_parts("user", "thread", &[0]).await.unwrap();
+        assert_eq!(read[0].created_at, Some(1_700_000_000_000));
+        let chunk = tokio::fs::read_to_string(
+            store
+                .thread_dir("user", "thread")
+                .join("parts")
+                .join("00000000.jsonl"),
+        )
+        .await
+        .unwrap();
+        assert!(chunk.contains("\"createdAt\":1700000000000"));
+        let _ = tokio::fs::remove_dir_all(dir).await;
     }
 
     #[tokio::test]

--- a/crates/sprocket-agent/src/transcript/sync.rs
+++ b/crates/sprocket-agent/src/transcript/sync.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use serde::Deserialize;
+use serde::Deserializer;
 use sprocket_convex::{deserialize_convex_u32, deserialize_convex_u64};
 
 use super::store::TranscriptStore;
@@ -34,6 +35,12 @@ struct RemoteTranscriptPart {
     source_key: String,
     kind: String,
     run_id: String,
+    #[serde(
+        rename = "_creationTime",
+        default,
+        deserialize_with = "deserialize_creation_time"
+    )]
+    created_at: Option<u64>,
     prompt: Option<RemotePrompt>,
     completion: Option<RemoteCompletion>,
     tool: Option<RemoteTool>,
@@ -82,6 +89,21 @@ struct RemoteTool {
     status: String,
 }
 
+fn deserialize_creation_time<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<f64>::deserialize(deserializer)?
+        .map(|value| {
+            if !value.is_finite() || value < 0.0 || value >= u64::MAX as f64 {
+                return Err(serde::de::Error::custom("invalid transcript creation time"));
+            }
+            // Convex creation times can include fractional milliseconds.
+            Ok(value as u64)
+        })
+        .transpose()
+}
+
 fn to_local_part(part: RemoteTranscriptPart) -> anyhow::Result<TranscriptPart> {
     let kind = match part.kind.as_str() {
         "prompt" => TranscriptPartKind::Prompt,
@@ -94,6 +116,7 @@ fn to_local_part(part: RemoteTranscriptPart) -> anyhow::Result<TranscriptPart> {
         source_key: part.source_key,
         kind,
         run_id: part.run_id,
+        created_at: part.created_at,
         prompt: part.prompt.map(|prompt| TranscriptPromptBody {
             text: prompt.text,
             image_uploads: prompt
@@ -201,6 +224,7 @@ mod tests {
             source_key: format!("prompt:{number}"),
             kind: TranscriptPartKind::Prompt,
             run_id: format!("run-{number}"),
+            created_at: None,
             prompt: Some(TranscriptPromptBody {
                 text: format!("{number}"),
                 image_uploads: Vec::new(),
@@ -238,5 +262,42 @@ mod tests {
             vec![0, 1, 2]
         );
         let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[test]
+    fn remote_parts_read_convex_creation_time() {
+        let parts = parse_remote_parts(serde_json::json!({
+            "parts": [{
+                "number": 2.0,
+                "sourceKey": "tool:inv:started",
+                "kind": "tool",
+                "runId": "run",
+                "_creationTime": 1_700_000_000_000.125,
+                "tool": {
+                    "callId": "c1",
+                    "name": "exec_command",
+                    "status": "started"
+                }
+            }]
+        }))
+        .unwrap();
+        assert_eq!(parts[0].created_at, Some(1_700_000_000_000));
+        assert_eq!(parts[0].tool.as_ref().unwrap().call_id, "c1");
+    }
+
+    #[test]
+    fn remote_parts_keep_working_without_creation_time() {
+        let parts = parse_remote_parts(serde_json::json!({
+            "parts": [{
+                "number": 0.0,
+                "sourceKey": "prompt:0",
+                "kind": "prompt",
+                "runId": "run",
+                "prompt": { "text": "hi", "imageUploads": [] }
+            }]
+        }))
+        .unwrap();
+        assert_eq!(parts[0].created_at, None);
+        assert_eq!(parts[0].prompt.as_ref().unwrap().text, "hi");
     }
 }

--- a/crates/sprocket-agent/src/transcript/types.rs
+++ b/crates/sprocket-agent/src/transcript/types.rs
@@ -4,6 +4,8 @@ use serde_json::Value as JsonValue;
 pub const TRANSCRIPT_CHUNK_SIZE: u32 = 100;
 pub const TRANSCRIPT_PAGE_SIZE: u32 = 40;
 pub const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+/// Projected when no real run start timestamp exists. Never a sequence number.
+pub const UNKNOWN_RUN_STARTED_AT: u64 = 0;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -106,6 +108,8 @@ pub struct TranscriptPart {
     pub kind: TranscriptPartKind,
     pub run_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<TranscriptPromptBody>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion: Option<TranscriptCompletionBody>,
@@ -188,6 +192,7 @@ pub struct TranscriptMessage {
     pub attachments: Vec<TranscriptAttachmentMeta>,
     pub parts: Vec<JsonValue>,
     pub run_status: String,
+    /// Unix milliseconds. `0` means the run start was never recorded.
     pub run_started_at: u64,
     pub source_numbers: Vec<u32>,
     pub stream_ids: Vec<String>,
@@ -224,5 +229,23 @@ mod tests {
         assert_eq!(state.missing_in(0, 7), vec![3, 6]);
         state.remote_total_parts = 1;
         assert_eq!(state.visible_end_exclusive(), 6);
+    }
+
+    #[test]
+    fn transcript_part_keeps_old_json_without_created_at() {
+        let part: TranscriptPart = serde_json::from_value(serde_json::json!({
+            "number": 3,
+            "sourceKey": "prompt:3",
+            "kind": "prompt",
+            "runId": "run",
+            "prompt": { "text": "hi", "imageUploads": [] }
+        }))
+        .unwrap();
+        assert_eq!(part.number, 3);
+        assert_eq!(part.created_at, None);
+        assert_eq!(
+            part.prompt.as_ref().map(|prompt| prompt.text.as_str()),
+            Some("hi")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Record per-part timestamps while assistant text, reasoning and tool calls stream, and retain them through transcript storage and lazy projection.
- Calculate work-section durations from recorded boundaries instead of transcript sequence numbers, run-wide guesses or missing job subscriptions.
- Share the live clock between indicators, continue timing during cancellation, and omit durations when old history has no reliable boundaries.
- Preserve timing through live/durable merges and document optional metadata compatibility.
- Backfill missing completion timing to explicit nulls, normalize legacy writes, and retain omitted timestamps on existing APIs. Document the migration commands and gates for removing optional validators.

## Validation
- Web test suite: 318 passed. Targeted timing, transcript and migration regression tests passed.
- `cargo test -p sprocket-agent`: 86 passed.
- Web production build and Convex codegen passed.
- Commit hooks passed: cargo fmt/check, ESLint/Convex typecheck, Oxlint, Svelte check, Prettier and hygiene checks.

## Migration rollout
Deploy the nullable validators and normalization before running `bun convex run migrations:runTranscriptTiming --prod` from `apps/web`. The backfill is resumable and idempotent. It has not been run in production. A development dry-run attempt was blocked because the deployment does not yet expose the new runner. Keep stored fields optional until the backfill completes; keep separate optional wire validators while released clients need them. See `BACKWARDS_COMPATIBILITY.md`.

## Compatibility
Old JSONL and completion records remain readable. Historical reasoning without timestamps shows “Worked” without an invented duration. Tool event timestamps are retained when available; existing cached records are not fabricated or destructively rewritten.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR records assistant-part timing across live and durable transcript paths, derives work-disclosure durations from those boundaries, and preserves compatibility for legacy untimed records.
- Adds timestamps to streamed text, reasoning, and tool-call parts.
- Preserves timing through Convex storage, local transcript synchronization, and live/history merging.
- Adds a resumable migration that normalizes missing stored timestamps to explicit nulls while legacy client projections continue omitting them.
- Updates work and run indicators to use a shared wall-clock calculation and avoid inventing durations for old history.
- Adds regression coverage for migration idempotency, projection compatibility, timing boundaries, and persisted transcript metadata.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding correctness, compatibility, security, or repository-rule issue identified.

Timing metadata remains optional at wire boundaries, normalized storage is compatible with the nullable schema, legacy projections omit explicit nulls, and live/durable transcript merging preserves the boundaries needed by the updated indicators.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/live.rs | Adds timestamp-aware accumulation for streamed assistant text, reasoning, and tool calls while retaining compatibility with old JSON. |
| crates/sprocket-agent/src/provider.rs | Routes provider stream events through the timestamp-aware live-part accumulator. |
| crates/sprocket-agent/src/transcript/store.rs | Preserves transcript creation metadata and projects tool timing without exposing migrated null timestamps to released clients. |
| crates/sprocket-agent/src/transcript/sync.rs | Imports Convex transcript creation times into the local durable replica with validated numeric conversion. |
| apps/web/src/convex/lib/transcriptParts.ts | Normalizes missing completion boundaries for storage and omits null boundaries from compatibility-facing reads. |
| apps/web/src/convex/migrations.ts | Adds an idempotent transcript timing backfill and dedicated migration runner. |
| apps/web/src/lib/chat/assistant-timeline.ts | Calculates work-section boundaries from recorded assistant and tool timestamps rather than run-wide or sequence-derived estimates. |
| apps/web/src/lib/project/transcript.ts | Retains durable tool-call start timing when matching live data omits it. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Supplies recorded section boundaries to work disclosures and suppresses total durations when the run start is unknown. |
| apps/web/src/lib/components/home/work-disclosure.svelte | Uses the shared ticking clock and gracefully renders disclosures with unknown timing. |
| apps/web/src/routes/+page.svelte | Shares wall-clock elapsed-time behavior across run indicators and keeps cancellation-visible runs attached to the transcript. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Provider[Provider stream] --> Live[Live assistant parts with timestamps]
    Provider --> Convex[Numbered Convex transcript]
    Convex --> Normalize[Nullable timing normalization]
    Normalize --> ClientProjection[Legacy-compatible client projection]
    Convex --> Sync[Local transcript synchronization]
    Sync --> LocalStore[Local durable replica]
    Live --> Merge[Live and durable message merge]
    ClientProjection --> Merge
    LocalStore --> Merge
    Merge --> Timeline[Assistant timeline grouping]
    Timeline --> Indicators[Work and run duration indicators]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(transcript): Backfill unknown timing..."](https://github.com/spikonado/sprocket/commit/cfec2176ef1fda781b8751e496223782d434bbb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60763308)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Agent run lifecycle](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-run-lifecycle.md)
- Knowledge Base — [Chat, timeline, and artifacts UI](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-chat-and-artifacts.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->