### PR TITLE
feat(agent): Load user AGENTS instructions

### DIFF
--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -2,8 +2,9 @@ use anyhow::anyhow;
 use rig::completion::Message;
 use rig::message::{ImageMediaType, UserContent};
 use sprocket_workspace::{
-    BUILTIN_SKILLS, WorkspaceInstruction, WorkspaceSkill, default_user_skills_dirs,
-    load_workspace_instructions, load_workspace_skills, resolve_workspace_root,
+    BUILTIN_SKILLS, WorkspaceInstruction, WorkspaceInstructionSource, WorkspaceSkill,
+    default_user_skills_dirs, load_workspace_instructions, load_workspace_skills,
+    resolve_workspace_root,
 };
 use std::future::Future;
 use std::sync::Arc;
@@ -94,17 +95,33 @@ fn build_workspace_preamble(
     workspace_instructions: &[WorkspaceInstruction],
     skills: &[WorkspaceSkill],
 ) -> String {
-    let instruction_block = if workspace_instructions.is_empty() {
+    let user_instructions = workspace_instructions
+        .iter()
+        .filter(|instruction| instruction.source == WorkspaceInstructionSource::User)
+        .map(|instruction| instruction.contents.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let project_instructions = workspace_instructions
+        .iter()
+        .filter(|instruction| instruction.source == WorkspaceInstructionSource::Workspace)
+        .map(|instruction| instruction.contents.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let instruction_block = if user_instructions.is_empty() && project_instructions.is_empty() {
         "No AGENTS.md instructions were preloaded for the current workspace.".to_string()
     } else {
-        format!(
-            "# AGENTS.md instructions for {workspace_path}:\n<INSTRUCTIONS>\n{}\n</INSTRUCTIONS>",
-            workspace_instructions
-                .iter()
-                .map(|instruction| instruction.contents.as_str())
-                .collect::<Vec<_>>()
-                .join("\n\n")
-        )
+        let mut blocks = Vec::new();
+        if !user_instructions.is_empty() {
+            blocks.push(format!(
+                "# AGENTS.md specific to the user:\n<INSTRUCTIONS>\n{user_instructions}\n</INSTRUCTIONS>"
+            ));
+        }
+        if !project_instructions.is_empty() {
+            blocks.push(format!(
+                "# AGENTS.md instructions for {workspace_path}:\n<INSTRUCTIONS>\n{project_instructions}\n</INSTRUCTIONS>"
+            ));
+        }
+        blocks.join("\n\n")
     };
 
     let skills_block = if skills.is_empty() {
@@ -184,6 +201,7 @@ fn build_workspace_preamble(
         "",
         "## AGENTS.md Spec",
         "",
+        "The user's `~/.agents/AGENTS.md` applies to every workspace and appears before repository instructions.",
         "AGENTS.md files can appear anywhere in the repository tree.",
         "Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
         "Follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
@@ -915,7 +933,9 @@ fn image_media_type(media_type: &str) -> anyhow::Result<ImageMediaType> {
 
 #[cfg(test)]
 mod tests {
-    use sprocket_workspace::{SkillSource, WorkspaceSkill};
+    use sprocket_workspace::{
+        SkillSource, WorkspaceInstruction, WorkspaceInstructionSource, WorkspaceSkill,
+    };
 
     use super::{build_workspace_preamble, submission_owned_by_another_executor};
 
@@ -972,6 +992,37 @@ mod tests {
         let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
         assert!(preamble.contains("description: Line one line two"));
         assert!(!preamble.contains("description: Line one\n"));
+    }
+
+    #[test]
+    fn preamble_renders_user_instructions_before_workspace_instructions() {
+        let instructions = [
+            WorkspaceInstruction {
+                path: "/home/user/.agents/AGENTS.md".to_string(),
+                directory: "/home/user/.agents".to_string(),
+                contents: "user instructions".to_string(),
+                truncated: false,
+                source: WorkspaceInstructionSource::User,
+            },
+            WorkspaceInstruction {
+                path: "/tmp/project/AGENTS.md".to_string(),
+                directory: "/tmp/project".to_string(),
+                contents: "workspace instructions".to_string(),
+                truncated: false,
+                source: WorkspaceInstructionSource::Workspace,
+            },
+        ];
+
+        let preamble = build_workspace_preamble("/tmp/project", &instructions, &[]);
+
+        let user_heading = "# AGENTS.md specific to the user:";
+        let workspace_heading = "# AGENTS.md instructions for /tmp/project:";
+        assert!(preamble.contains(user_heading));
+        assert!(preamble.contains(workspace_heading));
+        assert!(
+            preamble.find(user_heading).expect("user heading")
+                < preamble.find(workspace_heading).expect("workspace heading")
+        );
     }
 }
 

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -113,7 +113,7 @@ fn build_workspace_preamble(
         let mut blocks = Vec::new();
         if !user_instructions.is_empty() {
             blocks.push(format!(
-                "# AGENTS.md specific to the user:\n<INSTRUCTIONS>\n{user_instructions}\n</INSTRUCTIONS>"
+                "# The user's AGENTS.md:\n<INSTRUCTIONS>\n{user_instructions}\n</INSTRUCTIONS>"
             ));
         }
         if !project_instructions.is_empty() {
@@ -201,11 +201,11 @@ fn build_workspace_preamble(
         "",
         "## AGENTS.md Spec",
         "",
-        "The user's `~/.agents/AGENTS.md` applies to every workspace and appears before repository instructions.",
         "AGENTS.md files can appear anywhere in the repository tree.",
         "Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
         "Follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
-        "The AGENTS.md instructions for the current workspace path are already included below and do not need to be re-read.",
+        "The user's `AGENTS.md`, located at `~/.agents/AGENTS.md`, applies to every workspace.",
+        "The user's AGENTS.md and the AGENTS.md for the current workspace path are already included below and do not need to be re-read.",
         "If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
         "",
         &instruction_block,
@@ -1015,7 +1015,7 @@ mod tests {
 
         let preamble = build_workspace_preamble("/tmp/project", &instructions, &[]);
 
-        let user_heading = "# AGENTS.md specific to the user:";
+        let user_heading = "# The user's AGENTS.md:";
         let workspace_heading = "# AGENTS.md instructions for /tmp/project:";
         assert!(preamble.contains(user_heading));
         assert!(preamble.contains(workspace_heading));

--- a/crates/sprocket-workspace/src/agents.rs
+++ b/crates/sprocket-workspace/src/agents.rs
@@ -36,21 +36,22 @@ fn load_workspace_instructions_from(
     let project_root = find_project_root(&canonical_cwd);
     let search_dirs = directories_from_root(&project_root, &canonical_cwd);
     let mut instructions = Vec::new();
-    let mut remaining_bytes = MAX_INSTRUCTION_BYTES;
 
     if let Some(user_home) = user_home {
         let user_agents_path = user_home.join(".agents/AGENTS.md");
+        let mut remaining_user_bytes = MAX_INSTRUCTION_BYTES;
         load_instruction(
             &user_agents_path,
             user_agents_path.parent().unwrap_or(user_home),
             WorkspaceInstructionSource::User,
-            &mut remaining_bytes,
+            &mut remaining_user_bytes,
             &mut instructions,
         )?;
     }
 
+    let mut remaining_workspace_bytes = MAX_INSTRUCTION_BYTES;
     for directory in search_dirs {
-        if remaining_bytes == 0 {
+        if remaining_workspace_bytes == 0 {
             break;
         }
 
@@ -58,7 +59,7 @@ fn load_workspace_instructions_from(
             &directory.join("AGENTS.md"),
             &directory,
             WorkspaceInstructionSource::Workspace,
-            &mut remaining_bytes,
+            &mut remaining_workspace_bytes,
             &mut instructions,
         )?;
     }
@@ -167,6 +168,35 @@ mod tests {
         assert_eq!(instructions.len(), 2);
         assert_eq!(instructions[0].source, WorkspaceInstructionSource::User);
         assert_eq!(instructions[0].contents, "user instructions");
+        assert_eq!(
+            instructions[1].source,
+            WorkspaceInstructionSource::Workspace
+        );
+        assert_eq!(instructions[1].contents, "workspace instructions");
+
+        fs::remove_dir_all(root).expect("temp workspace should be removed");
+        fs::remove_dir_all(user_home).expect("temp user home should be removed");
+    }
+
+    #[test]
+    fn user_instructions_do_not_consume_workspace_instruction_budget() {
+        let root = temp_path("sprocket-user-instruction-budget");
+        let user_home = temp_path("sprocket-user-budget-home");
+        fs::create_dir_all(user_home.join(".agents")).expect("user agents dir");
+        gix::init(&root).expect("git repository should be created");
+        fs::write(
+            user_home.join(".agents/AGENTS.md"),
+            "u".repeat(super::MAX_INSTRUCTION_BYTES),
+        )
+        .expect("user instructions");
+        fs::write(root.join("AGENTS.md"), "workspace instructions")
+            .expect("workspace instructions");
+
+        let instructions = load_workspace_instructions_from(&root, Some(&user_home))
+            .expect("instructions should load");
+
+        assert_eq!(instructions.len(), 2);
+        assert_eq!(instructions[0].source, WorkspaceInstructionSource::User);
         assert_eq!(
             instructions[1].source,
             WorkspaceInstructionSource::Workspace

--- a/crates/sprocket-workspace/src/agents.rs
+++ b/crates/sprocket-workspace/src/agents.rs
@@ -2,10 +2,16 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use crate::paths::home_dir;
 use crate::project_root::find_project_root;
 
 const MAX_INSTRUCTION_BYTES: usize = 32 * 1024;
-const WORKSPACE_INSTRUCTION_FILES: [&str; 2] = ["AGENTS.override.md", "AGENTS.md"];
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum WorkspaceInstructionSource {
+    User,
+    Workspace,
+}
 
 #[derive(Debug, Clone)]
 pub struct WorkspaceInstruction {
@@ -13,9 +19,17 @@ pub struct WorkspaceInstruction {
     pub directory: String,
     pub contents: String,
     pub truncated: bool,
+    pub source: WorkspaceInstructionSource,
 }
 
 pub fn load_workspace_instructions(cwd: &Path) -> Result<Vec<WorkspaceInstruction>> {
+    load_workspace_instructions_from(cwd, home_dir().as_deref())
+}
+
+fn load_workspace_instructions_from(
+    cwd: &Path,
+    user_home: Option<&Path>,
+) -> Result<Vec<WorkspaceInstruction>> {
     let canonical_cwd = cwd
         .canonicalize()
         .with_context(|| format!("failed to resolve {}", cwd.display()))?;
@@ -24,39 +38,67 @@ pub fn load_workspace_instructions(cwd: &Path) -> Result<Vec<WorkspaceInstructio
     let mut instructions = Vec::new();
     let mut remaining_bytes = MAX_INSTRUCTION_BYTES;
 
+    if let Some(user_home) = user_home {
+        let user_agents_path = user_home.join(".agents/AGENTS.md");
+        load_instruction(
+            &user_agents_path,
+            user_agents_path.parent().unwrap_or(user_home),
+            WorkspaceInstructionSource::User,
+            &mut remaining_bytes,
+            &mut instructions,
+        )?;
+    }
+
     for directory in search_dirs {
         if remaining_bytes == 0 {
             break;
         }
 
-        let Some(path) = instruction_file_for_directory(&directory) else {
-            continue;
-        };
-
-        let mut data =
-            std::fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
-        let mut truncated = false;
-        if data.len() > remaining_bytes {
-            data.truncate(remaining_bytes);
-            truncated = true;
-        }
-
-        let contents = String::from_utf8_lossy(&data).to_string();
-        if contents.trim().is_empty() {
-            continue;
-        }
-
-        remaining_bytes = remaining_bytes.saturating_sub(data.len());
-
-        instructions.push(WorkspaceInstruction {
-            path: path.to_string_lossy().to_string(),
-            directory: directory.to_string_lossy().to_string(),
-            contents,
-            truncated,
-        });
+        load_instruction(
+            &directory.join("AGENTS.md"),
+            &directory,
+            WorkspaceInstructionSource::Workspace,
+            &mut remaining_bytes,
+            &mut instructions,
+        )?;
     }
 
     Ok(instructions)
+}
+
+fn load_instruction(
+    path: &Path,
+    directory: &Path,
+    source: WorkspaceInstructionSource,
+    remaining_bytes: &mut usize,
+    instructions: &mut Vec<WorkspaceInstruction>,
+) -> Result<()> {
+    if *remaining_bytes == 0 || !path.is_file() {
+        return Ok(());
+    }
+
+    let mut data =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut truncated = false;
+    if data.len() > *remaining_bytes {
+        data.truncate(*remaining_bytes);
+        truncated = true;
+    }
+
+    let contents = String::from_utf8_lossy(&data).to_string();
+    if contents.trim().is_empty() {
+        return Ok(());
+    }
+
+    *remaining_bytes = remaining_bytes.saturating_sub(data.len());
+    instructions.push(WorkspaceInstruction {
+        path: path.to_string_lossy().to_string(),
+        directory: directory.to_string_lossy().to_string(),
+        contents,
+        truncated,
+        source,
+    });
+    Ok(())
 }
 
 fn directories_from_root(root: &Path, cwd: &Path) -> Vec<PathBuf> {
@@ -79,18 +121,11 @@ fn directories_from_root(root: &Path, cwd: &Path) -> Vec<PathBuf> {
     directories
 }
 
-fn instruction_file_for_directory(directory: &Path) -> Option<PathBuf> {
-    WORKSPACE_INSTRUCTION_FILES
-        .iter()
-        .map(|name| directory.join(name))
-        .find(|candidate| candidate.is_file())
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;
 
-    use super::load_workspace_instructions;
+    use super::{WorkspaceInstructionSource, load_workspace_instructions_from};
 
     fn temp_path(prefix: &str) -> std::path::PathBuf {
         crate::test_support::temp_workspace_labeled(prefix)
@@ -105,7 +140,8 @@ mod tests {
         fs::write(root.join("AGENTS.md"), "root instructions").expect("root instructions");
         fs::write(nested.join("AGENTS.md"), "nested instructions").expect("nested instructions");
 
-        let instructions = load_workspace_instructions(&nested).expect("instructions should load");
+        let instructions =
+            load_workspace_instructions_from(&nested, None).expect("instructions should load");
 
         assert_eq!(instructions.len(), 2);
         assert_eq!(instructions[0].contents, "root instructions");
@@ -115,18 +151,46 @@ mod tests {
     }
 
     #[test]
-    fn prefers_override_file_when_present() {
+    fn loads_user_instructions_before_workspace_instructions() {
+        let root = temp_path("sprocket-user-instructions");
+        let user_home = temp_path("sprocket-user-home");
+        fs::create_dir_all(user_home.join(".agents")).expect("user agents dir");
+        gix::init(&root).expect("git repository should be created");
+        fs::write(user_home.join(".agents/AGENTS.md"), "user instructions")
+            .expect("user instructions");
+        fs::write(root.join("AGENTS.md"), "workspace instructions")
+            .expect("workspace instructions");
+
+        let instructions = load_workspace_instructions_from(&root, Some(&user_home))
+            .expect("instructions should load");
+
+        assert_eq!(instructions.len(), 2);
+        assert_eq!(instructions[0].source, WorkspaceInstructionSource::User);
+        assert_eq!(instructions[0].contents, "user instructions");
+        assert_eq!(
+            instructions[1].source,
+            WorkspaceInstructionSource::Workspace
+        );
+        assert_eq!(instructions[1].contents, "workspace instructions");
+
+        fs::remove_dir_all(root).expect("temp workspace should be removed");
+        fs::remove_dir_all(user_home).expect("temp user home should be removed");
+    }
+
+    #[test]
+    fn ignores_agents_override_files() {
         let root = temp_path("sprocket-instructions-override");
         fs::create_dir_all(&root).expect("root dir should be created");
         gix::init(&root).expect("git repository should be created");
-        fs::write(root.join("AGENTS.md"), "versioned").expect("agents file");
+        fs::write(root.join("AGENTS.md"), "workspace instructions")
+            .expect("workspace instructions");
         fs::write(root.join("AGENTS.override.md"), "override").expect("override file");
 
-        let instructions = load_workspace_instructions(&root).expect("instructions should load");
+        let instructions =
+            load_workspace_instructions_from(&root, None).expect("instructions should load");
 
         assert_eq!(instructions.len(), 1);
-        assert!(instructions[0].path.ends_with("AGENTS.override.md"));
-        assert_eq!(instructions[0].contents, "override");
+        assert_eq!(instructions[0].contents, "workspace instructions");
 
         fs::remove_dir_all(root).expect("temp workspace should be removed");
     }
@@ -139,7 +203,8 @@ mod tests {
         fs::write(root.join("AGENTS.md"), "root instructions").expect("root instructions");
         fs::write(nested.join("AGENTS.md"), "nested instructions").expect("nested instructions");
 
-        let instructions = load_workspace_instructions(&nested).expect("instructions should load");
+        let instructions =
+            load_workspace_instructions_from(&nested, None).expect("instructions should load");
 
         assert_eq!(instructions.len(), 1);
         assert_eq!(instructions[0].contents, "nested instructions");

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -15,7 +15,7 @@ mod text;
 mod unified_diff;
 mod workspace;
 
-pub use agents::{WorkspaceInstruction, load_workspace_instructions};
+pub use agents::{WorkspaceInstruction, WorkspaceInstructionSource, load_workspace_instructions};
 pub use browse::{
     FilesystemBrowseEntry, FilesystemBrowseResult, browse_filesystem,
     resolve_or_create_workspace_root,


### PR DESCRIPTION
## Summary
- load `~/.agents/AGENTS.md` before repository-scoped instruction files
- stop recognizing `AGENTS.override.md`
- render user instructions in their own `# AGENTS.md specific to the user:` system-prompt section

## Testing
- `nix develop -c cargo test`
- `nix develop -c bun run test`
- `nix develop -c prek run -a`
- `nix develop -c bun run build` (web build passed; the combined command timed out while the desktop Rust build was still compiling, which is covered by `cargo test` and `prek` cargo-check)







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR loads global user instructions from `~/.agents/AGENTS.md` separately from repository-scoped instructions and presents each source in a distinct system-prompt section.
- Adds independent 32 KiB budgets for user and workspace instructions.
- Stops recognizing `AGENTS.override.md`.
- Tags instructions by source and renders user instructions before workspace instructions.
- Adds regression coverage for ordering, independent budgets, and ignored override files.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no outstanding correctness, security, or repository-rule issues.

The previously reported shared-budget issue is fully fixed by independent user and workspace limits, the other prior finding was withdrawn after the explicit read-error contract was clarified, and the latest prompt wording changes preserve the tested source ordering.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-workspace/src/agents.rs | Loads and classifies global and workspace instructions with independent byte budgets while removing override-file support. |
| crates/sprocket-agent/src/run.rs | Separates user and workspace instructions into ordered prompt sections and tests the resulting presentation. |
| crates/sprocket-workspace/src/lib.rs | Re-exports the new instruction-source enum for agent prompt construction. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Resolve current workspace] --> B[Load ~/.agents/AGENTS.md]
    A --> C[Walk project root to current directory]
    C --> D[Load applicable AGENTS.md files]
    B --> E[User instruction section]
    D --> F[Workspace instruction section]
    E --> G[Build agent system preamble]
    F --> G
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Update run.rs"](https://github.com/spikonado/sprocket/commit/02329175b342934aa583c7af8fa34230b6c0620b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60769966)</sub>

<!-- /greptile_comment -->