### PR TITLE
fix(agent): Preserve provider reasoning across tool turns

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -219,6 +219,12 @@ agents may send empty placeholders until details load; the browser hides them
 after loading. Live overlays also omit empty reasoning slots. Completed display
 text comes from summary blocks, never redacted or encrypted content.
 
+Hidden empty reasoning keeps its timestamps on disk but does not anchor a
+visible work-section timer. The run-level elapsed time still covers the full
+run. Rig 0.42 groups reasoning before other content within each assistant
+message on replay; arbitrary interleaving and upstream message phases are not
+guaranteed by this client.
+
 No rewrite. The metadata fields are additive; there is no new schema field.
 
 Deploy the gateway reasoning-envelope support before releasing this client.

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,7 +4,7 @@ This file lists shims we still ship. When a removal PR merges, delete its
 entry. Age-out is a prod check for stored rows, or an explicit decision that
 a retired function name can disappear.
 
-Current as of 2026-09-05.
+Current as of 2026-09-03.
 
 ## Transcript projection API
 
@@ -182,61 +182,6 @@ agents that require the response field; current code does not consume it.
 migration runner, its cron, and both schema fields once both migrations report
 `success` and production scans find no remaining values. Historical documents
 in the now-unvalidated `threadMessages` table may be deleted independently.
-
-### 10. Transcript reasoning replay metadata
-
-Sources: completion items persisted by the local agent.
-
-New completion reasoning items may carry optional
-`providerMetadata.openai.itemId` and
-`providerMetadata.openai.reasoningEncryptedContent`. The encrypted field is
-gateway envelope state. Readers must persist and replay it unchanged, treat a
-missing or empty string as "no opaque state", and never require either field.
-
-Older stored completions omit the object. History reconstruction then keeps
-display text only and skips provider replay. Live overlays stay display-only
-and do not include the envelope.
-
-A stored `contextSummary` is not a safe prefix watermark. In-flight
-completions from the old generation can land after the save, and in-memory
-compaction can replace current-run text while durable `historyFromNumber`
-only drops the prior run. A `totalParts` snapshot at save time does not
-prove the retained tail is unchanged. When reload sees a context summary,
-it drops every loaded reasoning item. Newly generated reasoning stays in
-the running native Rig history and across tool turns of that process.
-Threads without a summary keep durable reasoning on reload.
-
-After an in-process compaction, the agent stops persisting opaque reasoning
-for that run. Native Rig history still carries it across tool turns. Only a
-summary that replaces exactly the prior-run history is saved for later runs;
-a summary that also replaces current-run messages stays in memory.
-
-Browser transcript projections omit reasoning provider metadata, including
-detail responses. Empty signed items remain in storage but are omitted from
-browser projections. Lightweight projections retain placeholders only for
-nonempty summaries, so users can still expand them to load details. Older
-agents may send empty placeholders until details load; the browser hides them
-after loading. Live overlays also omit empty reasoning slots. Completed display
-text comes from summary blocks, never redacted or encrypted content.
-
-Hidden empty reasoning keeps its timestamps on disk but does not anchor a
-visible work-section timer. The run-level elapsed time still covers the full
-run. Rig 0.42 groups reasoning before other content within each assistant
-message on replay; arbitrary interleaving and upstream message phases are not
-guaranteed by this client.
-
-No rewrite. The metadata fields are additive; there is no new schema field.
-
-Deploy the gateway reasoning-envelope support before releasing this client.
-Older clients can still use that gateway without replaying reasoning. Validate
-authenticated streaming, tool follow-up, transcript reload, and compaction
-against each enabled provider before rollout; local mocked SDK tests do not
-verify provider credentials or account retention eligibility.
-
-Safe when a prod check shows every supported agent writes the metadata on
-completed reasoning items, and a later rewrite either backfills missing
-`itemId` rows or documents that pre-metadata completions stay replay-less.
-Do not make the fields required until that scan.
 
 ## Client APIs
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,7 +4,7 @@ This file lists shims we still ship. When a removal PR merges, delete its
 entry. Age-out is a prod check for stored rows, or an explicit decision that
 a retired function name can disappear.
 
-Current as of 2026-09-03.
+Current as of 2026-09-05.
 
 ## Transcript projection API
 
@@ -147,6 +147,55 @@ agents that require the response field; current code does not consume it.
 migration runner, its cron, and both schema fields once both migrations report
 `success` and production scans find no remaining values. Historical documents
 in the now-unvalidated `threadMessages` table may be deleted independently.
+
+### 10. Transcript reasoning replay metadata
+
+Sources: completion items persisted by the local agent.
+
+New completion reasoning items may carry optional
+`providerMetadata.openai.itemId` and
+`providerMetadata.openai.reasoningEncryptedContent`. The encrypted field is
+gateway envelope state. Readers must persist and replay it unchanged, treat a
+missing or empty string as "no opaque state", and never require either field.
+
+Older stored completions omit the object. History reconstruction then keeps
+display text only and skips provider replay. Live overlays stay display-only
+and do not include the envelope.
+
+A stored `contextSummary` is not a safe prefix watermark. In-flight
+completions from the old generation can land after the save, and in-memory
+compaction can replace current-run text while durable `historyFromNumber`
+only drops the prior run. A `totalParts` snapshot at save time does not
+prove the retained tail is unchanged. When reload sees a context summary,
+it drops every loaded reasoning item. Newly generated reasoning stays in
+the running native Rig history and across tool turns of that process.
+Threads without a summary keep durable reasoning on reload.
+
+After an in-process compaction, the agent stops persisting opaque reasoning
+for that run. Native Rig history still carries it across tool turns. Only a
+summary that replaces exactly the prior-run history is saved for later runs;
+a summary that also replaces current-run messages stays in memory.
+
+Browser transcript projections omit reasoning provider metadata, including
+detail responses. Empty signed items remain in storage but are omitted from
+browser projections. Lightweight projections retain placeholders only for
+nonempty summaries, so users can still expand them to load details. Older
+agents may send empty placeholders until details load; the browser hides them
+after loading. Live overlays also omit empty reasoning slots. Completed display
+text comes from summary blocks, never redacted or encrypted content.
+
+No rewrite. The metadata fields are additive; there is no new schema field.
+
+Deploy the gateway reasoning-envelope support before releasing this client.
+Older clients can still use that gateway without replaying reasoning. Validate
+authenticated streaming, tool follow-up, transcript reload, and compaction
+against each enabled provider before rollout; local mocked SDK tests do not
+verify provider credentials or account retention eligibility.
+
+Safe when a prod check shows every supported agent writes the metadata on
+completed reasoning items, and a later rewrite either backfills missing
+`itemId` rows or documents that pre-metadata completions stay replay-less.
+Do not make the fields required until that scan.
 
 ## Client APIs
 

--- a/apps/web/src/lib/chat/assistant-timeline.test.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.test.ts
@@ -97,6 +97,52 @@ describe('assistant timeline', () => {
 		});
 	});
 
+	it('keeps unloaded reasoning reachable until its summary is fetched', () => {
+		const parts = [{ type: 'reasoning' as const, id: 'unloaded', text: '' }];
+		expect(buildAssistantTimeline(parts, [], false)).toEqual(parts);
+		expect(buildAssistantTimeline(parts, [], true)).toEqual([]);
+	});
+
+	it('hides empty reasoning and keeps later tool then text in arrival order', () => {
+		const timeline = buildAssistantTimeline(
+			[
+				{ type: 'reasoning', id: 'r-empty', text: '' },
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'pwd' } },
+				{
+					type: 'tool-result',
+					callId: 'call-1',
+					name: 'exec_command',
+					output: { output: '/workspace' }
+				},
+				{ type: 'reasoning', id: 'r-blank', text: '   ' },
+				{ type: 'text', id: 't1', text: 'Done' }
+			],
+			[]
+		);
+
+		expect(timeline.map((item) => item.type)).toEqual(['tool', 'text']);
+		expect(timeline[0]).toMatchObject({ type: 'tool', callId: 'call-1' });
+		expect(timeline[1]).toMatchObject({ type: 'text', id: 't1', text: 'Done' });
+	});
+
+	it('keeps nonempty reasoning before a following empty slot, tool, and text', () => {
+		const timeline = buildAssistantTimeline(
+			[
+				{ type: 'reasoning', id: 'r1', text: 'plan' },
+				{ type: 'reasoning', id: 'r-empty', text: '' },
+				{ type: 'tool-call', callId: 'call-1', name: 'exec_command', input: { cmd: 'pwd' } },
+				{ type: 'text', id: 't1', text: 'Done' }
+			],
+			[]
+		);
+
+		expect(timeline.map((item) => (item.type === 'reasoning' ? item.id : item.type))).toEqual([
+			'r1',
+			'tool',
+			'text'
+		]);
+	});
+
 	it('correlates reversed same-name jobs by payload and keeps remaining jobs visible', () => {
 		const first = executorJob('job-1', 1, { payload: { cmd: 'one' } });
 		const second = executorJob('job-2', 2, { payload: { cmd: 'two' } });

--- a/apps/web/src/lib/chat/assistant-timeline.ts
+++ b/apps/web/src/lib/chat/assistant-timeline.ts
@@ -437,7 +437,8 @@ export function assistantTimelineToolError(
 
 export function buildAssistantTimeline(
 	parts: AssistantPart[],
-	jobs: ExecutorJob[]
+	jobs: ExecutorJob[],
+	detailsLoaded = true
 ): AssistantTimelineItem[] {
 	const resultsByCallId = new Map(
 		parts
@@ -468,11 +469,11 @@ export function buildAssistantTimeline(
 
 	for (const part of parts) {
 		if (part.type === 'tool-result') continue;
-		if (part.type === 'reasoning') {
+		if (part.type === 'reasoning' && !detailsLoaded) {
 			timeline.push(part);
 			continue;
 		}
-		if (part.type === 'text') {
+		if (part.type === 'reasoning' || part.type === 'text') {
 			if (part.text.trim().length > 0) timeline.push(part);
 			continue;
 		}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -325,7 +325,11 @@
 							</div>
 						{:else}
 							{@const messageActions = actions.filter((job) => job.runId === message.runId)}
-							{@const timeline = buildAssistantTimeline(message.parts, messageActions)}
+							{@const timeline = buildAssistantTimeline(
+								message.parts,
+								messageActions,
+								message.detailsLoaded !== false
+							)}
 							{@const timelineTools = timeline.filter(
 								(item): item is AssistantTimelineTool => item.type === 'tool'
 							)}

--- a/crates/sprocket-agent/src/compaction.rs
+++ b/crates/sprocket-agent/src/compaction.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -12,6 +13,9 @@ use tokio::time::timeout;
 
 use crate::convex::RuntimeClient;
 use crate::history_json::completion_messages_json;
+use crate::reasoning::{
+    kept_suffix_raw_indices, strip_assistant_reasoning, strip_pre_compaction_reasoning,
+};
 use crate::types::{ContextBudget, gateway_api_v1_url};
 
 const CONTEXT_USAGE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -37,6 +41,8 @@ const COMPACTED_CONTEXT_PREAMBLE: &str = "The conversation context was automatic
 struct CompactedContext {
     summary: String,
     replaced_prefix_len: usize,
+    /// Raw length when this summary was written. Suffix reasoning before this index is dropped.
+    reasoning_from_len: usize,
 }
 
 #[derive(Debug, Default)]
@@ -56,6 +62,7 @@ pub(crate) struct ContextCompactionHook {
     context_budget: ContextBudget,
     prior_history_len: usize,
     gateway_url: String,
+    persist_reasoning_replay: Arc<AtomicBool>,
     state: Arc<Mutex<CompactionState>>,
 }
 
@@ -70,6 +77,7 @@ impl ContextCompactionHook {
         context_budget: ContextBudget,
         prior_history_len: usize,
         gateway_url: String,
+        persist_reasoning_replay: Arc<AtomicBool>,
     ) -> Self {
         Self {
             runtime,
@@ -81,6 +89,7 @@ impl ContextCompactionHook {
             context_budget,
             prior_history_len,
             gateway_url,
+            persist_reasoning_replay,
             state: Arc::new(Mutex::new(CompactionState::default())),
         }
     }
@@ -162,7 +171,8 @@ impl ContextCompactionHook {
             (state.last_input_tokens, state.active_summary.clone())
         };
 
-        let effective_history = rebuild_effective_history(history, active_summary.as_ref());
+        let (effective_history, suffix_raw) =
+            rebuild_effective_history(history, active_summary.as_ref());
         if !should_compact(
             last_input_tokens,
             self.context_budget.auto_compact_token_limit,
@@ -175,6 +185,7 @@ impl ContextCompactionHook {
             active_summary.as_ref(),
             self.prior_history_len,
             history.len(),
+            &suffix_raw,
         );
         let split = choose_split_index(
             &effective_history,
@@ -186,7 +197,9 @@ impl ContextCompactionHook {
         }
 
         let prefix = &effective_history[..split];
-        let tail = effective_history[split..].to_vec();
+        let mut tail = effective_history[split..].to_vec();
+        let tail_len = tail.len();
+        strip_pre_compaction_reasoning(&mut tail, 0, tail_len);
         let messages_json = match completion_messages_json(prefix.iter()) {
             Ok(value) => value.to_string(),
             Err(error) => {
@@ -213,7 +226,7 @@ impl ContextCompactionHook {
         let summary_text = summary;
         let compacted_summary = context_summary_text(&summary_text);
         let replaced_prefix_len =
-            next_replaced_prefix_len(active_summary.as_ref(), history.len(), split);
+            next_replaced_prefix_len(active_summary.as_ref(), history.len(), split, &suffix_raw);
         let persist_for_future_runs =
             should_persist_for_future_runs(self.prior_history_len, replaced_prefix_len);
 
@@ -247,8 +260,11 @@ impl ContextCompactionHook {
             state.active_summary = Some(CompactedContext {
                 summary: summary_text,
                 replaced_prefix_len,
+                reasoning_from_len: history.len(),
             });
         }
+        self.persist_reasoning_replay
+            .store(false, Ordering::Release);
 
         let mut compacted = vec![Message::user(compacted_summary)];
         compacted.extend(tail);
@@ -356,30 +372,43 @@ fn continue_with_history(has_active_summary: bool, history: Vec<Message>) -> Com
 fn rebuild_effective_history(
     history: &[Message],
     active_summary: Option<&CompactedContext>,
-) -> Vec<Message> {
+) -> (Vec<Message>, Vec<usize>) {
     let Some(active) = active_summary else {
-        return history.to_vec();
+        return (history.to_vec(), (0..history.len()).collect());
     };
+    let suffix_raw = kept_suffix_raw_indices(
+        history,
+        active.replaced_prefix_len,
+        active.reasoning_from_len,
+    );
+    let strip_end = active.reasoning_from_len.min(history.len());
     let mut effective = vec![Message::user(context_summary_text(&active.summary))];
-    let suffix_start = active.replaced_prefix_len.min(history.len());
-    effective.extend(history[suffix_start..].iter().cloned());
-    effective
+    for &raw in &suffix_raw {
+        let mut message = history[raw].clone();
+        if raw < strip_end {
+            strip_assistant_reasoning(std::slice::from_mut(&mut message));
+        }
+        effective.push(message);
+    }
+    (effective, suffix_raw)
 }
 
 fn next_replaced_prefix_len(
     active_summary: Option<&CompactedContext>,
     raw_history_len: usize,
     effective_split: usize,
+    suffix_raw: &[usize],
 ) -> usize {
     match active_summary {
         None => effective_split.min(raw_history_len),
         Some(active) => {
-            // effective = [summary] + raw[replaced_prefix_len..]
-            // compacting effective[..split] advances the raw cutoff by (split - 1).
-            let advanced = effective_split.saturating_sub(1);
-            active
-                .replaced_prefix_len
-                .saturating_add(advanced)
+            if effective_split <= 1 {
+                return active.replaced_prefix_len.min(raw_history_len);
+            }
+            suffix_raw
+                .get(effective_split - 2)
+                .map(|raw| raw.saturating_add(1))
+                .unwrap_or(raw_history_len)
                 .min(raw_history_len)
         }
     }
@@ -467,14 +496,16 @@ fn should_compact(
 }
 
 fn estimate_context_tokens(messages: &[Message]) -> u64 {
-    match serde_json::to_string(messages) {
+    let mut stripped = messages.to_vec();
+    strip_assistant_reasoning(&mut stripped);
+    match serde_json::to_string(&stripped) {
         Ok(serialized) => serialized.len().div_ceil(3) as u64,
         Err(error) => {
             eprintln!(
                 "sprocket-agent: failed to serialize messages for context token estimate: {error}"
             );
-            let content_bytes: usize = messages.iter().map(rough_message_content_bytes).sum();
-            content_bytes.max(messages.len()).div_ceil(3) as u64
+            let content_bytes: usize = stripped.iter().map(rough_message_content_bytes).sum();
+            content_bytes.max(stripped.len()).div_ceil(3) as u64
         }
     }
 }
@@ -493,6 +524,7 @@ fn rough_message_content_bytes(message: &Message) -> usize {
             .iter()
             .map(|part| match part {
                 AssistantContent::Text(text) => text.text.len(),
+                AssistantContent::Reasoning(reasoning) => reasoning.display_text().len(),
                 _ => 1,
             })
             .sum(),
@@ -503,16 +535,20 @@ fn prior_boundary_in_effective(
     active_summary: Option<&CompactedContext>,
     prior_history_len: usize,
     raw_history_len: usize,
+    suffix_raw: &[usize],
 ) -> Option<usize> {
     let boundary = prior_history_len.min(raw_history_len);
     match active_summary {
         None => (boundary > 0).then_some(boundary),
         Some(active) => {
-            // effective = [summary] + raw[replaced_prefix_len..]
             if boundary <= active.replaced_prefix_len {
                 return None;
             }
-            Some(1 + (boundary - active.replaced_prefix_len))
+            let offset = suffix_raw
+                .iter()
+                .position(|&raw| raw >= boundary)
+                .unwrap_or(suffix_raw.len());
+            Some(1 + offset)
         }
     }
 }
@@ -562,10 +598,8 @@ fn adjust_split_for_tool_results(history: &[Message], mut split: usize) -> usize
     split
 }
 
-/// Durable thread summaries require a prior-run cutoff. Persist only when prior
-/// history exists and the compacted prefix covers all of it.
 fn should_persist_for_future_runs(prior_history_len: usize, replaced_prefix_len: usize) -> bool {
-    prior_history_len > 0 && replaced_prefix_len >= prior_history_len
+    prior_history_len > 0 && replaced_prefix_len == prior_history_len
 }
 
 fn is_tool_result_user(message: &Message) -> bool {
@@ -620,6 +654,24 @@ mod tests {
         }
     }
 
+    fn assistant_reasoning_only(text: &str) -> Message {
+        Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::Reasoning(rig::message::Reasoning::new(
+                text,
+            ))],
+        }
+    }
+
+    fn assistant_encrypted(envelope: &str) -> Message {
+        Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::Reasoning(
+                rig::message::Reasoning::encrypted(envelope),
+            )],
+        }
+    }
+
     #[test]
     fn split_point_does_not_orphan_leading_tool_result() {
         let history = vec![
@@ -664,9 +716,11 @@ mod tests {
         let active = CompactedContext {
             summary: "Prior work is done.".to_string(),
             replaced_prefix_len: 1,
+            reasoning_from_len: 1,
         };
 
-        let effective = rebuild_effective_history(&history, Some(&active));
+        let (effective, suffix_raw) = rebuild_effective_history(&history, Some(&active));
+        assert_eq!(suffix_raw, vec![1, 2]);
         assert_eq!(effective.len(), 3);
         match &effective[0] {
             Message::User { content } => {
@@ -698,22 +752,141 @@ mod tests {
 
     #[test]
     fn advances_replaced_prefix_len_in_raw_coordinates() {
-        assert_eq!(next_replaced_prefix_len(None, 10, 4), 4);
+        assert_eq!(next_replaced_prefix_len(None, 10, 4, &[]), 4);
         let active = CompactedContext {
             summary: "s".to_string(),
             replaced_prefix_len: 3,
+            reasoning_from_len: 3,
         };
-        // effective split 3 => summary + 2 raw messages compacted => raw cutoff 5
-        assert_eq!(next_replaced_prefix_len(Some(&active), 10, 3), 5);
+        let suffix_raw: Vec<usize> = (3..10).collect();
+        assert_eq!(
+            next_replaced_prefix_len(Some(&active), 10, 3, &suffix_raw),
+            5
+        );
+        assert_eq!(
+            next_replaced_prefix_len(Some(&active), 10, 1, &suffix_raw),
+            3
+        );
     }
 
     #[test]
-    fn persist_gate_requires_covered_prior_history() {
+    fn rebuild_strips_pre_compaction_reasoning_and_keeps_later_state() {
+        let history = vec![
+            user_text("covered"),
+            Message::Assistant {
+                id: None,
+                content: vec![
+                    AssistantContent::Reasoning(rig::message::Reasoning::new("stale")),
+                    AssistantContent::tool_call(
+                        "call_1",
+                        "exec_command",
+                        serde_json::json!({ "cmd": "pwd" }),
+                    ),
+                ],
+            },
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(
+                    rig::message::Reasoning::encrypted("new-envelope"),
+                )],
+            },
+        ];
+        let active = CompactedContext {
+            summary: "Prior work is done.".to_string(),
+            replaced_prefix_len: 1,
+            reasoning_from_len: 2,
+        };
+
+        let (effective, suffix_raw) = rebuild_effective_history(&history, Some(&active));
+        assert_eq!(suffix_raw, vec![1, 2]);
+        assert_eq!(effective.len(), 3);
+        match &effective[1] {
+            Message::Assistant { content, .. } => {
+                assert_eq!(content.len(), 1);
+                assert!(matches!(content[0], AssistantContent::ToolCall(_)));
+            }
+            other => panic!("expected stripped tail assistant, got {other:?}"),
+        }
+        match &effective[2] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected post-compaction reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn repeated_compaction_maps_around_removed_reasoning_only_messages() {
+        let history = vec![
+            user_text("covered"),
+            assistant_reasoning_only("stale-a"),
+            user_text("kept"),
+            assistant_reasoning_only("stale-b"),
+            assistant_encrypted("keep-envelope"),
+        ];
+        let first = CompactedContext {
+            summary: "first".to_string(),
+            replaced_prefix_len: 1,
+            reasoning_from_len: 4,
+        };
+
+        let (effective, suffix_raw) = rebuild_effective_history(&history, Some(&first));
+        assert_eq!(suffix_raw, vec![2, 4]);
+        assert_eq!(effective.len(), 3);
+        assert_eq!(effective[1], user_text("kept"));
+        match &effective[2] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected post-boundary reasoning, got {other:?}"),
+        }
+
+        assert_eq!(
+            prior_boundary_in_effective(Some(&first), 4, history.len(), &suffix_raw),
+            Some(2)
+        );
+        assert_eq!(
+            next_replaced_prefix_len(Some(&first), history.len(), 2, &suffix_raw),
+            3
+        );
+
+        let second = CompactedContext {
+            summary: "second".to_string(),
+            replaced_prefix_len: 3,
+            reasoning_from_len: history.len(),
+        };
+        let mut after_second = history.clone();
+        after_second.push(assistant_encrypted("post-second"));
+        let (effective2, suffix_raw2) = rebuild_effective_history(&after_second, Some(&second));
+        assert_eq!(suffix_raw2, vec![5]);
+        assert_eq!(effective2.len(), 2);
+        match &effective2[1] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected reasoning added after the second compaction, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_estimate_ignores_encrypted_reasoning_envelopes() {
+        let baseline = estimate_context_tokens(&[user_text("hi")]);
+        let envelope = "A".repeat(12_000);
+        let estimated = estimate_context_tokens(&[user_text("hi"), assistant_encrypted(&envelope)]);
+        assert!(
+            estimated < baseline + 40,
+            "base64 envelope expanded estimate from {baseline} to {estimated}"
+        );
+        assert!(estimated < 200);
+    }
+
+    #[test]
+    fn persist_gate_requires_exact_prior_history() {
         assert!(!should_persist_for_future_runs(0, 0));
         assert!(!should_persist_for_future_runs(0, 4));
         assert!(!should_persist_for_future_runs(6, 4));
         assert!(should_persist_for_future_runs(6, 6));
-        assert!(should_persist_for_future_runs(6, 8));
+        assert!(!should_persist_for_future_runs(6, 8));
     }
 
     #[test]

--- a/crates/sprocket-agent/src/history_json.rs
+++ b/crates/sprocket-agent/src/history_json.rs
@@ -77,7 +77,6 @@ pub(crate) fn completion_messages_json<'a>(
             }
             Message::Assistant { content, .. } => {
                 let mut parts: Vec<serde_json::Value> = Vec::new();
-                let mut has_openai_reasoning_reference = false;
                 for item in content.iter() {
                     match item {
                         AssistantContent::Text(text) => {
@@ -88,43 +87,26 @@ pub(crate) fn completion_messages_json<'a>(
                             if let Some(provider_options) = &text.additional_params {
                                 part["providerOptions"] = provider_options.clone().into_value();
                             }
-                            if !has_openai_reasoning_reference {
-                                strip_openai_item_reference(&mut part);
-                            }
+                            strip_provider_replay_state(&mut part);
                             parts.push(part);
                         }
                         AssistantContent::Reasoning(reasoning) => {
-                            let encrypted = reasoning.content.iter().find_map(|content| {
-                                if let ReasoningContent::Encrypted(value) = content {
-                                    Some(value.clone())
-                                } else {
-                                    None
-                                }
-                            });
-                            let mut openai = serde_json::Map::new();
-                            if let Some(id) = &reasoning.id {
-                                openai.insert("itemId".to_string(), id.clone().into());
-                                if id.starts_with("rs_") {
-                                    has_openai_reasoning_reference = true;
-                                }
-                            }
-                            if let Some(encrypted) = encrypted {
-                                openai.insert(
-                                    "reasoningEncryptedContent".to_string(),
-                                    encrypted.into(),
-                                );
-                            }
-                            let text = reasoning.display_text();
-                            if !text.is_empty() || !openai.is_empty() {
-                                let mut part = serde_json::json!({
+                            let text = reasoning
+                                .content
+                                .iter()
+                                .filter_map(|block| match block {
+                                    ReasoningContent::Summary(text)
+                                    | ReasoningContent::Text { text, .. } => Some(text.as_str()),
+                                    ReasoningContent::Encrypted(_)
+                                    | ReasoningContent::Redacted { .. } => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            if !text.is_empty() {
+                                parts.push(serde_json::json!({
                                     "type": "reasoning",
                                     "text": text
-                                });
-                                if !openai.is_empty() {
-                                    part["providerOptions"] =
-                                        serde_json::json!({ "openai": openai });
-                                }
-                                parts.push(part);
+                                }));
                             }
                         }
                         AssistantContent::ToolCall(tool_call) => {
@@ -142,9 +124,7 @@ pub(crate) fn completion_messages_json<'a>(
                             if let Some(provider_options) = &tool_call.additional_params {
                                 part["providerOptions"] = provider_options.clone();
                             }
-                            if !has_openai_reasoning_reference {
-                                strip_openai_item_reference(&mut part);
-                            }
+                            strip_provider_replay_state(&mut part);
                             parts.push(part);
                         }
                         _ => {
@@ -168,7 +148,7 @@ pub(crate) fn completion_messages_json<'a>(
     Ok(serde_json::Value::Array(messages))
 }
 
-fn strip_openai_item_reference(part: &mut serde_json::Value) {
+fn strip_provider_replay_state(part: &mut serde_json::Value) {
     let Some(provider_options) = part
         .get_mut("providerOptions")
         .and_then(serde_json::Value::as_object_mut)
@@ -183,6 +163,7 @@ fn strip_openai_item_reference(part: &mut serde_json::Value) {
     };
 
     openai.remove("itemId");
+    openai.remove("reasoningEncryptedContent");
     if openai.is_empty() {
         provider_options.remove("openai");
     }
@@ -394,44 +375,80 @@ mod tests {
     }
 
     #[test]
-    fn preserves_openai_item_reference_after_reasoning_reference() {
+    fn excludes_opaque_reasoning_state_and_item_references_from_summarizer_json() {
         let messages = vec![Message::Assistant {
             id: None,
             content: vec![
                 AssistantContent::Reasoning(Reasoning {
                     id: Some("rs_123".to_string()),
-                    content: vec![ReasoningContent::Text {
-                        text: String::new(),
-                        signature: None,
-                    }],
+                    content: vec![
+                        ReasoningContent::Summary("visible step".to_string()),
+                        ReasoningContent::Encrypted("envelope".to_string()),
+                        ReasoningContent::Redacted {
+                            data: "redacted-secret".to_string(),
+                        },
+                    ],
                 }),
                 AssistantContent::Text(Text {
                     text: "Grounded answer".to_string(),
                     additional_params: AdditionalParams::from_entries([(
                         "openai",
-                        serde_json::json!({ "itemId": "msg_123" }),
+                        serde_json::json!({
+                            "itemId": "msg_123",
+                            "phase": "final_answer",
+                            "reasoningEncryptedContent": "text-envelope"
+                        }),
                     )]),
                 }),
             ],
         }];
 
         let structured = completion_messages_json(messages.iter()).expect("structured");
+        let serialized = structured.to_string();
 
         assert_eq!(
             structured[0]["content"],
             serde_json::json!([
                 {
                     "type": "reasoning",
-                    "text": "",
-                    "providerOptions": { "openai": { "itemId": "rs_123" } }
+                    "text": "visible step"
                 },
                 {
                     "type": "text",
                     "text": "Grounded answer",
-                    "providerOptions": { "openai": { "itemId": "msg_123" } }
+                    "providerOptions": { "openai": { "phase": "final_answer" } }
                 }
             ])
         );
+        assert!(!serialized.contains("envelope"));
+        assert!(!serialized.contains("itemId"));
+        assert!(!serialized.contains("rs_123"));
+        assert!(!serialized.contains("msg_123"));
+    }
+
+    #[test]
+    fn omits_empty_opaque_reasoning_from_summarizer_json() {
+        let messages = vec![Message::Assistant {
+            id: None,
+            content: vec![
+                AssistantContent::Reasoning(Reasoning {
+                    id: Some("rs_empty".to_string()),
+                    content: vec![ReasoningContent::Encrypted("secret".to_string())],
+                }),
+                AssistantContent::Text(Text::new("answer")),
+            ],
+        }];
+
+        let structured = completion_messages_json(messages.iter()).expect("structured");
+        let serialized = structured.to_string();
+
+        assert_eq!(
+            structured[0]["content"],
+            serde_json::json!([{ "type": "text", "text": "answer" }])
+        );
+        assert!(!serialized.contains("secret"));
+        assert!(!serialized.contains("rs_empty"));
+        assert!(!serialized.contains("reasoning"));
     }
 
     #[test]

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -5,6 +5,7 @@ mod history_json;
 mod hooks;
 mod live;
 mod provider;
+mod reasoning;
 mod run;
 mod tools;
 mod transcript;

--- a/crates/sprocket-agent/src/live.rs
+++ b/crates/sprocket-agent/src/live.rs
@@ -82,13 +82,6 @@ impl LiveAssistantParts {
         self.tool_index.clear();
     }
 
-    pub fn items_json(&self) -> Vec<serde_json::Value> {
-        self.parts
-            .iter()
-            .map(|part| serde_json::to_value(part).expect("live assistant parts always serialize"))
-            .collect()
-    }
-
     pub fn apply_text_delta(
         &mut self,
         event_type: &str,
@@ -430,7 +423,10 @@ mod tests {
                 }
             ]
         );
-        assert_eq!(parts.items_json()[0]["startedAt"], serde_json::json!(10));
+        assert_eq!(
+            serde_json::to_value(&parts.parts).unwrap()[0]["startedAt"],
+            serde_json::json!(10)
+        );
     }
 
     #[test]

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
@@ -18,6 +19,7 @@ use crate::hooks::{AgentPromptHook, GatewayRequestHook, ToolCallTracker};
 use crate::live::{
     LiveAssistantPart, LiveCompletionHub, LiveCompletionOverlay, join_assistant_text_parts,
 };
+use crate::reasoning::{apply_completed_reasoning, merge_provider_metadata};
 use crate::tools::agent_tools;
 use crate::types::{ContextBudget, RunContextResponse, gateway_api_v1_url};
 
@@ -188,6 +190,7 @@ where
     eprintln!("sprocket-agent: built agent {}", request.run_id);
     eprintln!("sprocket-agent: prompting model {}", request.run_id);
 
+    let persist_reasoning_replay = Arc::new(AtomicBool::new(true));
     let mut transcript = match TranscriptSink::start(
         runtime.clone(),
         request.live.clone(),
@@ -195,6 +198,7 @@ where
         request.claim_id.clone(),
         request.thread_id.clone(),
         request.run_started_at,
+        persist_reasoning_replay.clone(),
     )
     .await
     {
@@ -231,6 +235,7 @@ where
         request.context_budget,
         prior_history_len,
         gateway_url,
+        persist_reasoning_replay,
     );
 
     let mut finished = match runtime.run_finished_subscription(&request.run_id).await {
@@ -307,12 +312,17 @@ where
                             StreamedAssistantContent::Text(text),
                         ))) => {
                             streamed_text.push_str(&text.text);
-                            transcript.push_text(&text.text);
+                            transcript.push_text(&text);
                         }
                         Some(Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
                             StreamedAssistantContent::ReasoningDelta { id, reasoning, .. },
                         ))) => {
                             transcript.push_reasoning(&id, &reasoning);
+                        }
+                        Some(Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
+                            StreamedAssistantContent::Reasoning { reasoning, id },
+                        ))) => {
+                            transcript.complete_reasoning(&id, &reasoning);
                         }
                         Some(Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
                             StreamedAssistantContent::ToolCall { tool_call, internal_call_id },
@@ -331,7 +341,6 @@ where
                         }
                         Some(Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
                             StreamedAssistantContent::ToolCallDelta { .. }
-                            | StreamedAssistantContent::Reasoning { .. }
                             | StreamedAssistantContent::Final(_)
                             | StreamedAssistantContent::Unknown(_),
                         )))
@@ -389,6 +398,10 @@ where
 
 const TRANSCRIPT_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 
+#[cfg(test)]
+#[path = "reasoning_integration_tests.rs"]
+mod reasoning_integration_tests;
+
 fn transcript_error(
     error: anyhow::Error,
     final_text: &str,
@@ -418,9 +431,11 @@ struct TranscriptSink {
     parts: Vec<LiveAssistantPart>,
     text_index: HashMap<String, usize>,
     tool_index: HashMap<String, usize>,
+    provider_metadata: HashMap<String, serde_json::Value>,
     last_publish: Instant,
     unpublished: usize,
     streamed: bool,
+    persist_reasoning_replay: Arc<AtomicBool>,
 }
 
 impl TranscriptSink {
@@ -431,6 +446,7 @@ impl TranscriptSink {
         claim_id: String,
         thread_id: String,
         run_started_at: u64,
+        persist_reasoning_replay: Arc<AtomicBool>,
     ) -> anyhow::Result<Self> {
         runtime
             .register_completion_attempt(&run_id, &claim_id, 1)
@@ -447,16 +463,22 @@ impl TranscriptSink {
             parts: Vec::new(),
             text_index: HashMap::new(),
             tool_index: HashMap::new(),
+            provider_metadata: HashMap::new(),
             last_publish: Instant::now(),
             unpublished: 0,
             streamed: false,
+            persist_reasoning_replay,
         })
     }
 
-    fn push_text(&mut self, text: &str) {
-        let id = format!("{}:text", self.stream_id);
+    fn push_text(&mut self, text: &rig::message::Text) {
+        let id = contiguous_text_id(&self.parts, &self.stream_id);
         let turn_id = Some(self.stream_id.clone());
-        self.apply_text_delta("text", id, text, turn_id);
+        if let Some(params) = &text.additional_params {
+            self.provider_metadata
+                .insert(format!("text:{id}"), params.clone().into_value());
+        }
+        self.apply_text_delta("text", id, &text.text, turn_id);
         self.publish_if_needed(false);
     }
 
@@ -465,6 +487,20 @@ impl TranscriptSink {
         let turn_id = Some(self.stream_id.clone());
         self.apply_text_delta("reasoning", part_id, text, turn_id);
         self.publish_if_needed(false);
+    }
+
+    fn complete_reasoning(&mut self, correlator: &str, reasoning: &rig::message::Reasoning) {
+        self.streamed = true;
+        self.unpublished += 1;
+        apply_completed_reasoning(
+            &mut self.parts,
+            &mut self.text_index,
+            &mut self.provider_metadata,
+            &self.stream_id,
+            correlator,
+            reasoning,
+        );
+        self.publish_if_needed(true);
     }
 
     fn push_tool_call(
@@ -483,6 +519,7 @@ impl TranscriptSink {
         self.parts.clear();
         self.text_index.clear();
         self.tool_index.clear();
+        self.provider_metadata.clear();
         self.unpublished = 0;
         self.streamed = false;
     }
@@ -523,10 +560,11 @@ impl TranscriptSink {
     }
 
     fn items_json(&self) -> Vec<serde_json::Value> {
-        self.parts
-            .iter()
-            .map(|part| serde_json::to_value(part).expect("live assistant parts always serialize"))
-            .collect()
+        durable_items_json(
+            &self.parts,
+            &self.provider_metadata,
+            self.persist_reasoning_replay.load(Ordering::Acquire),
+        )
     }
 
     fn has_unpublished(&self) -> bool {
@@ -559,7 +597,7 @@ impl TranscriptSink {
             run_status: "running".to_string(),
             stream_id: Some(self.stream_id.clone()),
             text: join_assistant_text_parts(&self.parts),
-            parts: self.parts.clone(),
+            parts: visible_live_parts(&self.parts),
             run_started_at: self.run_started_at,
         });
     }
@@ -651,6 +689,47 @@ impl Drop for TranscriptSink {
     }
 }
 
+fn visible_live_parts(parts: &[LiveAssistantPart]) -> Vec<LiveAssistantPart> {
+    parts
+        .iter()
+        .filter(|part| {
+            !matches!(part, LiveAssistantPart::Reasoning { text, .. } if text.trim().is_empty())
+        })
+        .cloned()
+        .collect()
+}
+
+fn durable_items_json(
+    parts: &[LiveAssistantPart],
+    provider_metadata: &HashMap<String, serde_json::Value>,
+    persist_reasoning_replay: bool,
+) -> Vec<serde_json::Value> {
+    parts
+        .iter()
+        .map(|part| {
+            let key = match part {
+                LiveAssistantPart::Text { id, .. } => format!("text:{id}"),
+                LiveAssistantPart::Reasoning { id, .. } => format!("reasoning:{id}"),
+                LiveAssistantPart::ToolCall {
+                    part_id, call_id, ..
+                } => part_id.clone().unwrap_or_else(|| call_id.clone()),
+            };
+            let metadata = match part {
+                LiveAssistantPart::Reasoning { .. } if !persist_reasoning_replay => None,
+                _ => provider_metadata.get(&key),
+            };
+            merge_provider_metadata(part, metadata)
+        })
+        .collect()
+}
+
+fn contiguous_text_id(parts: &[LiveAssistantPart], stream_id: &str) -> String {
+    match parts.last() {
+        Some(LiveAssistantPart::Text { id, .. }) => id.clone(),
+        _ => format!("{stream_id}:text:{}", parts.len()),
+    }
+}
+
 /// Stops persistent command sessions on the normal path and if this future is
 /// dropped early (for example when claim lease renewal fails).
 struct CommandSessionShutdown {
@@ -682,12 +761,64 @@ impl Drop for CommandSessionShutdown {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use rig::completion::FinishReason;
 
     use super::{
         ProviderErrorDisposition, RUN_NO_LONGER_ACTIVE, classify_provider_error,
-        incomplete_completion_error,
+        contiguous_text_id, durable_items_json, incomplete_completion_error, visible_live_parts,
     };
+    use crate::live::LiveAssistantPart;
+
+    #[test]
+    fn live_projection_omits_empty_reasoning_without_removing_durable_state() {
+        let parts = vec![
+            LiveAssistantPart::Reasoning {
+                id: "empty".into(),
+                text: " \n".into(),
+                turn_id: None,
+            },
+            LiveAssistantPart::Reasoning {
+                id: "visible".into(),
+                text: "plan".into(),
+                turn_id: None,
+            },
+        ];
+        let metadata = HashMap::from([("reasoning:empty".into(), reasoning_envelope())]);
+        let live = visible_live_parts(&parts);
+        assert_eq!(live.len(), 1);
+        assert!(matches!(&live[0], LiveAssistantPart::Reasoning { id, .. } if id == "visible"));
+        let durable = durable_items_json(&parts, &metadata, true);
+        assert_eq!(durable.len(), 2);
+        assert_eq!(durable[0]["providerMetadata"], reasoning_envelope());
+    }
+
+    #[test]
+    fn text_after_reasoning_or_tools_starts_a_new_transcript_part() {
+        let mut parts = vec![LiveAssistantPart::Text {
+            id: "stream:text:0".into(),
+            text: "Before".into(),
+            turn_id: Some("stream".into()),
+        }];
+        assert_eq!(contiguous_text_id(&parts, "stream"), "stream:text:0");
+        parts.push(LiveAssistantPart::Reasoning {
+            id: "stream:reasoning".into(),
+            text: "".into(),
+            turn_id: Some("stream".into()),
+        });
+        assert_eq!(contiguous_text_id(&parts, "stream"), "stream:text:2");
+        parts.push(LiveAssistantPart::ToolCall {
+            part_id: None,
+            call_id: "call".into(),
+            name: "read".into(),
+            input: serde_json::json!({}),
+            turn_id: Some("stream".into()),
+        });
+        assert_eq!(contiguous_text_id(&parts, "stream"), "stream:text:3");
+    }
 
     #[test]
     fn classifies_superseded_completion_without_treating_it_as_failure() {
@@ -717,5 +848,78 @@ mod tests {
 
         assert!(error.to_string().contains("output token limit"));
         assert!(incomplete_completion_error(Some(&FinishReason::Stop)).is_none());
+    }
+
+    fn reasoning_envelope() -> serde_json::Value {
+        serde_json::json!({
+            "openai": {
+                "itemId": "rs_1",
+                "reasoningEncryptedContent": "envelope"
+            }
+        })
+    }
+
+    #[test]
+    fn items_json_omits_reasoning_metadata_after_compaction_keeps_visible_text() {
+        let persist_reasoning_replay = Arc::new(AtomicBool::new(true));
+        let mut parts = vec![LiveAssistantPart::Reasoning {
+            id: "stream:r1".into(),
+            text: "visible plan".into(),
+            turn_id: Some("stream".into()),
+        }];
+        let mut provider_metadata =
+            HashMap::from([("reasoning:stream:r1".to_string(), reasoning_envelope())]);
+        parts.push(LiveAssistantPart::Text {
+            id: "stream:text:1".into(),
+            text: "hello".into(),
+            turn_id: Some("stream".into()),
+        });
+        assert_eq!(contiguous_text_id(&parts, "stream"), "stream:text:1");
+        parts.push(LiveAssistantPart::Reasoning {
+            id: "stream:r2".into(),
+            text: "".into(),
+            turn_id: Some("stream".into()),
+        });
+        parts.push(LiveAssistantPart::Text {
+            id: "stream:text:3".into(),
+            text: " after".into(),
+            turn_id: Some("stream".into()),
+        });
+        assert_eq!(contiguous_text_id(&parts, "stream"), "stream:text:3");
+        provider_metadata.insert("reasoning:stream:r2".to_string(), reasoning_envelope());
+
+        let before = durable_items_json(
+            &parts,
+            &provider_metadata,
+            persist_reasoning_replay.load(Ordering::Acquire),
+        );
+        assert_eq!(before[0]["text"], "visible plan");
+        assert_eq!(before[0]["providerMetadata"], reasoning_envelope());
+        assert_eq!(before[1]["text"], "hello");
+        assert!(before[1].get("providerMetadata").is_none());
+        assert_eq!(before[2]["providerMetadata"], reasoning_envelope());
+
+        persist_reasoning_replay.store(false, Ordering::Release);
+        let after = durable_items_json(
+            &parts,
+            &provider_metadata,
+            persist_reasoning_replay.load(Ordering::Acquire),
+        );
+        assert_eq!(after[0]["type"], "reasoning");
+        assert_eq!(after[0]["text"], "visible plan");
+        assert!(after[0].get("providerMetadata").is_none());
+        assert_eq!(after[1]["text"], "hello");
+        assert_eq!(after[2]["text"], "");
+        assert!(after[2].get("providerMetadata").is_none());
+        assert_eq!(after[3]["text"], " after");
+        assert_eq!(
+            provider_metadata.get("reasoning:stream:r1"),
+            Some(&reasoning_envelope()),
+            "native in-process metadata stays after durable omit"
+        );
+        match &parts[0] {
+            LiveAssistantPart::Reasoning { text, .. } => assert_eq!(text, "visible plan"),
+            other => panic!("expected live reasoning text, got {other:?}"),
+        }
     }
 }

--- a/crates/sprocket-agent/src/reasoning.rs
+++ b/crates/sprocket-agent/src/reasoning.rs
@@ -1,0 +1,552 @@
+use std::collections::HashMap;
+
+use rig::completion::Message;
+use rig::message::{AssistantContent, Reasoning, ReasoningContent};
+use serde_json::Value as JsonValue;
+
+use crate::live::LiveAssistantPart;
+
+/// Durable OpenAI-shaped metadata already stored on transcript reasoning items.
+/// `encrypted` is gateway envelope bytes: persist and replay as-is, never decode.
+pub(crate) fn openai_reasoning_metadata(
+    item_id: Option<&str>,
+    encrypted: Option<&str>,
+) -> Option<JsonValue> {
+    let item_id = item_id.map(str::trim).filter(|id| !id.is_empty());
+    let encrypted = opaque_encrypted(encrypted);
+    if item_id.is_none() && encrypted.is_none() {
+        return None;
+    }
+    let mut openai = serde_json::Map::new();
+    if let Some(item_id) = item_id {
+        openai.insert("itemId".to_string(), JsonValue::String(item_id.to_string()));
+    }
+    if let Some(encrypted) = encrypted {
+        openai.insert(
+            "reasoningEncryptedContent".to_string(),
+            JsonValue::String(encrypted.to_string()),
+        );
+    }
+    Some(serde_json::json!({ "openai": openai }))
+}
+
+pub(crate) fn opaque_encrypted(value: Option<&str>) -> Option<&str> {
+    value.filter(|content| !content.is_empty())
+}
+
+pub(crate) fn opaque_reasoning_blob(reasoning: &Reasoning) -> Option<&str> {
+    opaque_encrypted(reasoning.encrypted_content())
+}
+
+/// Durable reload cannot treat a part-number cutoff as an unchanged prefix.
+/// In-flight old generations can commit later, and in-memory compaction can
+/// replace current-run text while durable `historyFromNumber` only drops the
+/// prior run. When a context summary is present, drop every loaded reasoning
+/// item. Newly generated reasoning stays in the running native Rig history.
+pub(crate) fn skip_reasoning_on_reload(context_summary: Option<&str>) -> bool {
+    context_summary.is_some_and(|summary| !summary.is_empty())
+}
+
+pub(crate) fn strip_assistant_reasoning(messages: &mut [Message]) {
+    for message in messages {
+        strip_message_reasoning(message);
+    }
+}
+
+fn strip_message_reasoning(message: &mut Message) {
+    if let Message::Assistant { content, .. } = message {
+        content.retain(|part| !matches!(part, AssistantContent::Reasoning(_)));
+    }
+}
+
+fn assistant_has_only_reasoning(message: &Message) -> bool {
+    match message {
+        Message::Assistant { content, .. } => {
+            !content.is_empty()
+                && content
+                    .iter()
+                    .all(|part| matches!(part, AssistantContent::Reasoning(_)))
+        }
+        _ => false,
+    }
+}
+
+fn compaction_reasoning_range(
+    message_count: usize,
+    replaced_prefix_len: usize,
+    reasoning_from_len: usize,
+) -> (usize, usize) {
+    let start = replaced_prefix_len.min(message_count);
+    (start, reasoning_from_len.min(message_count).max(start))
+}
+
+/// Live display is summary blocks only. Rig's `display_text` also joins
+/// `Text` and `Redacted`, which must not become transcript text.
+fn reasoning_summary_text(reasoning: &Reasoning) -> String {
+    reasoning
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ReasoningContent::Summary(text) => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Drop reasoning in `[replaced_prefix_len, reasoning_from_len)` and remove
+/// assistants that become empty. Later messages keep newly generated state.
+pub(crate) fn strip_pre_compaction_reasoning(
+    messages: &mut Vec<Message>,
+    replaced_prefix_len: usize,
+    reasoning_from_len: usize,
+) {
+    let (start, end) =
+        compaction_reasoning_range(messages.len(), replaced_prefix_len, reasoning_from_len);
+    let mut kept = Vec::with_capacity(messages.len());
+    for (index, mut message) in std::mem::take(messages).into_iter().enumerate() {
+        if index >= start && index < end {
+            if assistant_has_only_reasoning(&message) {
+                continue;
+            }
+            strip_message_reasoning(&mut message);
+        }
+        kept.push(message);
+    }
+    *messages = kept;
+}
+
+/// Raw indices that survive `strip_pre_compaction_reasoning` on a suffix
+/// starting at `replaced_prefix_len`.
+pub(crate) fn kept_suffix_raw_indices(
+    messages: &[Message],
+    replaced_prefix_len: usize,
+    reasoning_from_len: usize,
+) -> Vec<usize> {
+    let (start, end) =
+        compaction_reasoning_range(messages.len(), replaced_prefix_len, reasoning_from_len);
+    (start..messages.len())
+        .filter(|&index| index >= end || !assistant_has_only_reasoning(&messages[index]))
+        .collect()
+}
+
+pub(crate) fn apply_completed_reasoning(
+    parts: &mut Vec<LiveAssistantPart>,
+    text_index: &mut HashMap<String, usize>,
+    provider_metadata: &mut HashMap<String, JsonValue>,
+    stream_id: &str,
+    correlator: &str,
+    reasoning: &Reasoning,
+) {
+    let id = format!("{stream_id}:{correlator}");
+    let key = format!("reasoning:{id}");
+    let text = reasoning_summary_text(reasoning);
+    let metadata =
+        openai_reasoning_metadata(reasoning.id.as_deref(), opaque_reasoning_blob(reasoning));
+    if let Some(metadata) = metadata {
+        provider_metadata.insert(key.clone(), metadata);
+    } else {
+        provider_metadata.remove(&key);
+    }
+    if let Some(&index) = text_index.get(&key) {
+        if let LiveAssistantPart::Reasoning {
+            text: existing,
+            turn_id,
+            ..
+        } = &mut parts[index]
+        {
+            *existing = text;
+            *turn_id = Some(stream_id.to_string());
+            return;
+        }
+    }
+    text_index.insert(key, parts.len());
+    parts.push(LiveAssistantPart::Reasoning {
+        id,
+        text,
+        turn_id: Some(stream_id.to_string()),
+    });
+}
+
+pub(crate) fn merge_provider_metadata(
+    part: &LiveAssistantPart,
+    metadata: Option<&JsonValue>,
+) -> JsonValue {
+    let mut value = serde_json::to_value(part).expect("live assistant parts always serialize");
+    if let Some(metadata) = metadata {
+        value
+            .as_object_mut()
+            .expect("live assistant part object")
+            .insert("providerMetadata".to_string(), metadata.clone());
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::message::{ReasoningContent, Text};
+
+    fn reasoning_with(id: Option<&str>, content: Vec<ReasoningContent>) -> Reasoning {
+        Reasoning {
+            id: id.map(str::to_string),
+            content,
+        }
+    }
+
+    #[test]
+    fn empty_opaque_state_keeps_item_id_without_an_encrypted_block() {
+        let metadata = openai_reasoning_metadata(Some("rs_empty"), Some(""));
+        assert_eq!(
+            metadata,
+            Some(serde_json::json!({ "openai": { "itemId": "rs_empty" } }))
+        );
+        assert!(openai_reasoning_metadata(Some("  "), Some("")).is_none());
+        assert!(opaque_encrypted(Some("")).is_none());
+        assert!(opaque_encrypted(None).is_none());
+    }
+
+    #[test]
+    fn opaque_encrypted_preserves_nonempty_original_bytes() {
+        assert_eq!(opaque_encrypted(Some(" envelope ")), Some(" envelope "));
+        assert_eq!(opaque_encrypted(Some("  ")), Some("  "));
+        assert_eq!(
+            openai_reasoning_metadata(Some("rs_1"), Some(" envelope ")),
+            Some(serde_json::json!({
+                "openai": {
+                    "itemId": "rs_1",
+                    "reasoningEncryptedContent": " envelope "
+                }
+            }))
+        );
+        assert_eq!(
+            openai_reasoning_metadata(None, Some(" envelope ")),
+            Some(serde_json::json!({
+                "openai": { "reasoningEncryptedContent": " envelope " }
+            }))
+        );
+    }
+
+    #[test]
+    fn completed_reasoning_replaces_delta_text_and_stores_opaque_state() {
+        let mut parts = vec![LiveAssistantPart::Reasoning {
+            id: "agent:run:claim:1:corr".to_string(),
+            text: "partial".to_string(),
+            turn_id: Some("agent:run:claim:1".to_string()),
+        }];
+        let mut text_index = HashMap::from([("reasoning:agent:run:claim:1:corr".to_string(), 0)]);
+        let mut provider_metadata = HashMap::new();
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "agent:run:claim:1",
+            "corr",
+            &reasoning_with(
+                Some("rs_123"),
+                vec![
+                    ReasoningContent::Summary("done".to_string()),
+                    ReasoningContent::Encrypted("envelope".to_string()),
+                    ReasoningContent::Redacted {
+                        data: "redacted-state".to_string(),
+                    },
+                    ReasoningContent::Text {
+                        text: "raw-state".to_string(),
+                        signature: None,
+                    },
+                    ReasoningContent::Summary("second".to_string()),
+                ],
+            ),
+        );
+
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            LiveAssistantPart::Reasoning { text, .. } => {
+                assert_eq!(text, "done\nsecond");
+                assert!(!text.contains("envelope"));
+                assert!(!text.contains("redacted-state"));
+                assert!(!text.contains("raw-state"));
+            }
+            other => panic!("expected reasoning part, got {other:?}"),
+        }
+        assert_eq!(
+            provider_metadata["reasoning:agent:run:claim:1:corr"],
+            serde_json::json!({
+                "openai": {
+                    "itemId": "rs_123",
+                    "reasoningEncryptedContent": "envelope"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn empty_signed_completion_inserts_a_durable_slot_without_live_ciphertext() {
+        let mut parts = Vec::new();
+        let mut text_index = HashMap::new();
+        let mut provider_metadata = HashMap::new();
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "corr",
+            &reasoning_with(
+                Some("rs_signed"),
+                vec![ReasoningContent::Encrypted("opaque".to_string())],
+            ),
+        );
+
+        match &parts[0] {
+            LiveAssistantPart::Reasoning { text, .. } => assert!(text.is_empty()),
+            other => panic!("expected reasoning part, got {other:?}"),
+        }
+        let item =
+            merge_provider_metadata(&parts[0], provider_metadata.get("reasoning:stream:corr"));
+        assert_eq!(item["text"], "");
+        assert_eq!(item["providerMetadata"]["openai"]["itemId"], "rs_signed");
+        assert_eq!(
+            item["providerMetadata"]["openai"]["reasoningEncryptedContent"],
+            "opaque"
+        );
+    }
+
+    #[test]
+    fn interleaved_reasoning_keeps_arrival_order_beside_tool_calls() {
+        let mut parts = vec![LiveAssistantPart::Reasoning {
+            id: "stream:r1".to_string(),
+            text: "first".to_string(),
+            turn_id: Some("stream".to_string()),
+        }];
+        let mut text_index = HashMap::from([("reasoning:stream:r1".to_string(), 0)]);
+        let mut provider_metadata = HashMap::new();
+        parts.push(LiveAssistantPart::ToolCall {
+            part_id: Some("call-1".to_string()),
+            call_id: "call_1".to_string(),
+            name: "exec_command".to_string(),
+            input: serde_json::json!({ "cmd": "pwd" }),
+            turn_id: Some("stream".to_string()),
+        });
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "r2",
+            &reasoning_with(
+                Some("rs_2"),
+                vec![ReasoningContent::Summary("after".to_string())],
+            ),
+        );
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "r1",
+            &reasoning_with(
+                Some("rs_1"),
+                vec![ReasoningContent::Summary("first done".to_string())],
+            ),
+        );
+
+        assert_eq!(parts.len(), 3);
+        match &parts[0] {
+            LiveAssistantPart::Reasoning { text, .. } => assert_eq!(text, "first done"),
+            other => panic!("expected first reasoning, got {other:?}"),
+        }
+        match &parts[1] {
+            LiveAssistantPart::ToolCall { call_id, .. } => assert_eq!(call_id, "call_1"),
+            other => panic!("expected tool call, got {other:?}"),
+        }
+        match &parts[2] {
+            LiveAssistantPart::Reasoning { text, .. } => assert_eq!(text, "after"),
+            other => panic!("expected second reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compaction_strips_old_reasoning_and_keeps_later_state() {
+        let mut messages = vec![
+            Message::user("old"),
+            Message::Assistant {
+                id: None,
+                content: vec![
+                    AssistantContent::Reasoning(Reasoning::new("stale")),
+                    AssistantContent::Text(Text::new("kept text")),
+                ],
+            },
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(Reasoning::encrypted(
+                    "new-envelope",
+                ))],
+            },
+        ];
+
+        strip_pre_compaction_reasoning(&mut messages, 1, 2);
+
+        assert_eq!(messages.len(), 3);
+        match &messages[1] {
+            Message::Assistant { content, .. } => {
+                assert_eq!(content.len(), 1);
+                assert!(matches!(content[0], AssistantContent::Text(_)));
+            }
+            other => panic!("expected stripped assistant, got {other:?}"),
+        }
+        match &messages[2] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected new reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compaction_strip_removes_reasoning_only_assistants() {
+        let messages = vec![
+            Message::user("old"),
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(Reasoning::new("stale"))],
+            },
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(Reasoning::encrypted("new"))],
+            },
+        ];
+        assert_eq!(kept_suffix_raw_indices(&messages, 1, 2), vec![2]);
+
+        let mut stripped = messages;
+        strip_pre_compaction_reasoning(&mut stripped, 1, 2);
+        assert_eq!(stripped.len(), 2);
+        match &stripped[1] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected surviving reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reload_drops_all_reasoning_when_a_context_summary_is_present() {
+        assert!(!skip_reasoning_on_reload(None));
+        assert!(skip_reasoning_on_reload(Some("summary")));
+        assert!(!skip_reasoning_on_reload(Some("")));
+        assert!(skip_reasoning_on_reload(Some("   ")));
+    }
+
+    #[test]
+    fn empty_assistants_are_not_reasoning_only() {
+        let messages = vec![
+            Message::user("old"),
+            Message::Assistant {
+                id: None,
+                content: vec![],
+            },
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(Reasoning::new("stale"))],
+            },
+        ];
+        assert_eq!(kept_suffix_raw_indices(&messages, 1, 3), vec![1]);
+
+        let mut stripped = messages;
+        strip_pre_compaction_reasoning(&mut stripped, 1, 3);
+        assert_eq!(stripped.len(), 2);
+        match &stripped[1] {
+            Message::Assistant { content, .. } => assert!(content.is_empty()),
+            other => panic!("expected empty assistant to remain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inverted_compaction_range_does_not_strip() {
+        let messages = vec![
+            Message::user("old"),
+            Message::Assistant {
+                id: None,
+                content: vec![AssistantContent::Reasoning(Reasoning::new("keep"))],
+            },
+        ];
+        assert_eq!(
+            kept_suffix_raw_indices(&messages, 5, 1),
+            Vec::<usize>::new()
+        );
+
+        let mut stripped = messages.clone();
+        strip_pre_compaction_reasoning(&mut stripped, 5, 1);
+        assert_eq!(stripped.len(), 2);
+        match &stripped[1] {
+            Message::Assistant { content, .. } => {
+                assert!(matches!(content[0], AssistantContent::Reasoning(_)));
+            }
+            other => panic!("expected untouched reasoning, got {other:?}"),
+        }
+        assert_eq!(kept_suffix_raw_indices(&messages, 0, 0), vec![0, 1]);
+    }
+
+    #[test]
+    fn completed_reasoning_without_opaque_state_clears_metadata() {
+        let mut parts = Vec::new();
+        let mut text_index = HashMap::new();
+        let mut provider_metadata = HashMap::new();
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "corr",
+            &reasoning_with(
+                Some("rs_1"),
+                vec![ReasoningContent::Encrypted("envelope".to_string())],
+            ),
+        );
+        assert!(provider_metadata.contains_key("reasoning:stream:corr"));
+
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "corr",
+            &reasoning_with(None, vec![ReasoningContent::Summary("visible".to_string())]),
+        );
+        assert!(!provider_metadata.contains_key("reasoning:stream:corr"));
+        match &parts[0] {
+            LiveAssistantPart::Reasoning { text, .. } => assert_eq!(text, "visible"),
+            other => panic!("expected updated reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stale_reasoning_index_still_inserts_a_new_part() {
+        let mut parts = vec![LiveAssistantPart::ToolCall {
+            part_id: Some("call-1".to_string()),
+            call_id: "call_1".to_string(),
+            name: "exec_command".to_string(),
+            input: serde_json::json!({ "cmd": "pwd" }),
+            turn_id: Some("stream".to_string()),
+        }];
+        let mut text_index = HashMap::from([("reasoning:stream:corr".to_string(), 0)]);
+        let mut provider_metadata = HashMap::new();
+        apply_completed_reasoning(
+            &mut parts,
+            &mut text_index,
+            &mut provider_metadata,
+            "stream",
+            "corr",
+            &reasoning_with(
+                Some("rs_1"),
+                vec![ReasoningContent::Summary("late".to_string())],
+            ),
+        );
+
+        assert_eq!(parts.len(), 2);
+        match &parts[1] {
+            LiveAssistantPart::Reasoning { text, .. } => assert_eq!(text, "late"),
+            other => panic!("expected appended reasoning, got {other:?}"),
+        }
+        assert_eq!(text_index["reasoning:stream:corr"], 1);
+    }
+}

--- a/crates/sprocket-agent/src/reasoning_integration_tests.rs
+++ b/crates/sprocket-agent/src/reasoning_integration_tests.rs
@@ -1,0 +1,553 @@
+//! Native Rig streaming, durable transcript reload, and Responses serialization.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Message};
+use rig::message::{AssistantContent, Reasoning};
+use rig::providers::openai;
+use rig::streaming::StreamedAssistantContent;
+use serde_json::{Value as JsonValue, json};
+
+use super::{contiguous_text_id, durable_items_json};
+use crate::live::LiveAssistantPart;
+use crate::reasoning::{apply_completed_reasoning, merge_provider_metadata};
+use crate::transcript::{TranscriptPart, TranscriptStore, agent_history_from_parts};
+use crate::types::{AgentHistoryMessage, deserialize_agent_history};
+
+const STREAM_ID: &str = "stream";
+const ITEM_ID: &str = "rs_gateway";
+const ENVELOPE: &str = "gway-envelope-v1";
+const DELTA_SUMMARY: &str = "partial";
+const DONE_SUMMARY: &str = "full gateway summary";
+const TOOL_CALL_ID: &str = "call_1";
+const TOOL_NAME: &str = "exec_command";
+const TEXT: &str = "done.";
+
+#[derive(Debug, PartialEq, Eq)]
+enum Observed {
+    ReasoningDelta,
+    ReasoningDone,
+    Text,
+    ToolCall,
+}
+
+fn sse(event: JsonValue) -> String {
+    format!("data: {event}\n\n")
+}
+
+fn gateway_response(status: &str, output: Vec<JsonValue>) -> JsonValue {
+    json!({
+        "id": "resp_gateway",
+        "object": "response",
+        "created_at": 0,
+        "status": status,
+        "model": "gateway-model",
+        "output": output,
+        "tools": [],
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "total_tokens": 2
+        }
+    })
+}
+
+/// Gateway wire order: empty encrypted reasoning item, summary delta, then
+/// authoritative completed reasoning, then function call, then text.
+fn gateway_sse_body() -> String {
+    let empty_reasoning = json!({
+        "type": "reasoning",
+        "id": ITEM_ID,
+        "summary": [],
+        "content": [],
+        "encrypted_content": "",
+        "status": "in_progress"
+    });
+    let completed_reasoning = json!({
+        "type": "reasoning",
+        "id": ITEM_ID,
+        "summary": [{ "type": "summary_text", "text": DONE_SUMMARY }],
+        "encrypted_content": ENVELOPE,
+        "status": "completed"
+    });
+    let function_call = json!({
+        "type": "function_call",
+        "id": "fc_1",
+        "call_id": TOOL_CALL_ID,
+        "name": TOOL_NAME,
+        "arguments": "{\"cmd\":\"pwd\"}",
+        "status": "completed"
+    });
+    let message = json!({
+        "type": "message",
+        "id": "msg_1",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{ "type": "output_text", "text": TEXT }]
+    });
+
+    [
+        sse(json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": gateway_response("in_progress", vec![]),
+        })),
+        sse(json!({
+            "type": "response.output_item.added",
+            "item_id": ITEM_ID,
+            "output_index": 0,
+            "sequence_number": 1,
+            "item": empty_reasoning,
+        })),
+        sse(json!({
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": ITEM_ID,
+            "output_index": 0,
+            "summary_index": 0,
+            "sequence_number": 2,
+            "delta": DELTA_SUMMARY,
+        })),
+        sse(json!({
+            "type": "response.output_item.done",
+            "item_id": ITEM_ID,
+            "output_index": 0,
+            "sequence_number": 3,
+            "item": completed_reasoning.clone(),
+        })),
+        sse(json!({
+            "type": "response.output_item.added",
+            "item_id": "fc_1",
+            "output_index": 1,
+            "sequence_number": 4,
+            "item": function_call.clone(),
+        })),
+        sse(json!({
+            "type": "response.output_item.done",
+            "item_id": "fc_1",
+            "output_index": 1,
+            "sequence_number": 5,
+            "item": function_call.clone(),
+        })),
+        sse(json!({
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "output_index": 2,
+            "content_index": 0,
+            "sequence_number": 6,
+            "delta": TEXT,
+        })),
+        sse(json!({
+            "type": "response.completed",
+            "sequence_number": 7,
+            "response": gateway_response(
+                "completed",
+                vec![completed_reasoning, function_call, message],
+            ),
+        })),
+    ]
+    .concat()
+}
+
+fn header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn content_length(headers: &str) -> usize {
+    headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            (name.eq_ignore_ascii_case("content-length"))
+                .then(|| value.trim().parse().ok())
+                .flatten()
+        })
+        .unwrap_or(0)
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 2048];
+    loop {
+        let read = match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(read) => read,
+        };
+        buf.extend_from_slice(&chunk[..read]);
+        let Some(end) = header_end(&buf) else {
+            continue;
+        };
+        let headers = std::str::from_utf8(&buf[..end]).unwrap_or("");
+        let body_start = end + 4;
+        let needed = body_start + content_length(headers);
+        while buf.len() < needed {
+            match stream.read(&mut chunk) {
+                Ok(0) | Err(_) => return buf.get(body_start..).unwrap_or_default().to_vec(),
+                Ok(read) => buf.extend_from_slice(&chunk[..read]),
+            }
+        }
+        return buf[body_start..needed].to_vec();
+    }
+    Vec::new()
+}
+
+fn spawn_gateway_sse(sse_body: String) -> (String, thread::JoinHandle<Vec<Vec<u8>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral listener");
+    listener.set_nonblocking(true).expect("nonblocking accept");
+    let addr = listener.local_addr().expect("listener address");
+    let handle = thread::spawn(move || {
+        let mut captured = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(8);
+        let mut idle_since = None;
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let _ = stream.set_nonblocking(false);
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+                    captured.push(read_http_request(&mut stream));
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\n\
+                         Content-Type: text/event-stream\r\n\
+                         Cache-Control: no-cache\r\n\
+                         Connection: close\r\n\
+                         Content-Length: {}\r\n\
+                         \r\n\
+                         {sse_body}",
+                        sse_body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                    idle_since = Some(Instant::now());
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if idle_since.is_some_and(|since| since.elapsed() > Duration::from_millis(250))
+                    {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+        captured
+    });
+    (format!("http://{addr}"), handle)
+}
+
+fn live_reasoning_text(parts: &[LiveAssistantPart]) -> Option<&str> {
+    parts.iter().find_map(|part| match part {
+        LiveAssistantPart::Reasoning { text, .. } => Some(text.as_str()),
+        _ => None,
+    })
+}
+
+fn apply_reasoning_delta(
+    parts: &mut Vec<LiveAssistantPart>,
+    text_index: &mut HashMap<String, usize>,
+    correlator: &str,
+    delta: &str,
+) {
+    let id = format!("{STREAM_ID}:{correlator}");
+    let key = format!("reasoning:{id}");
+    if let Some(&index) = text_index.get(&key) {
+        if let LiveAssistantPart::Reasoning { text, .. } = &mut parts[index] {
+            text.push_str(delta);
+        }
+        return;
+    }
+    text_index.insert(key, parts.len());
+    parts.push(LiveAssistantPart::Reasoning {
+        id,
+        text: delta.to_string(),
+        turn_id: Some(STREAM_ID.to_string()),
+    });
+}
+
+async fn durable_history_from_parts(
+    parts: &[LiveAssistantPart],
+    provider_metadata: &HashMap<String, JsonValue>,
+) -> Vec<AgentHistoryMessage> {
+    let items = durable_items_json(parts, provider_metadata, true);
+    let part: TranscriptPart = serde_json::from_value(json!({
+        "number": 0,
+        "sourceKey": "completion:test",
+        "kind": "completion",
+        "runId": "run",
+        "completion": { "streamId": STREAM_ID, "items": items }
+    }))
+    .expect("transcript fixture");
+    let tool_result: TranscriptPart = serde_json::from_value(json!({
+        "number": 1,
+        "sourceKey": "tool:test:finished",
+        "kind": "tool",
+        "runId": "run",
+        "tool": {
+            "toolInvocationId": "test",
+            "callId": TOOL_CALL_ID,
+            "name": TOOL_NAME,
+            "output": "/workspace",
+            "status": "completed"
+        }
+    }))
+    .expect("tool result fixture");
+    let dir = std::env::temp_dir().join(format!("sprocket-native-replay-{}", uuid::Uuid::new_v4()));
+    let store = TranscriptStore::new(dir.clone());
+    store
+        .append_parts("user", "thread", &[part, tool_result])
+        .await
+        .unwrap();
+    let loaded = store.read_parts("user", "thread", &[0, 1]).await.unwrap();
+    let state = store.load_state("user", "thread").await.unwrap();
+    let history = agent_history_from_parts(&state, &loaded, None);
+    tokio::fs::remove_dir_all(dir).await.unwrap();
+    history
+}
+
+fn first_index(events: &[Observed], kind: Observed) -> Option<usize> {
+    events.iter().position(|event| *event == kind)
+}
+
+#[tokio::test]
+async fn gateway_responses_stream_completes_reasoning_before_text_and_tools() {
+    let (base_url, server) = spawn_gateway_sse(gateway_sse_body());
+    let client = openai::Client::builder()
+        .api_key("test-key")
+        .base_url(&base_url)
+        .build()
+        .expect("openai responses client");
+    let model = client.completion_model("gateway-model");
+    let request = model.completion_request("hello").build();
+    let mut stream = model
+        .stream(request)
+        .await
+        .expect("mocked responses stream");
+
+    let mut parts = Vec::new();
+    let mut text_index = HashMap::new();
+    let mut provider_metadata = HashMap::new();
+    let mut observed = Vec::new();
+    let mut completed: Option<Reasoning> = None;
+
+    while let Some(item) = stream.next().await {
+        match item.expect("stream item") {
+            StreamedAssistantContent::ReasoningDelta { id, reasoning, .. } => {
+                observed.push(Observed::ReasoningDelta);
+                apply_reasoning_delta(&mut parts, &mut text_index, &id, &reasoning);
+                let text = live_reasoning_text(&parts).expect("live reasoning after delta");
+                assert_eq!(text, DELTA_SUMMARY);
+                assert!(
+                    !text.contains(ENVELOPE),
+                    "deltas must not surface ciphertext"
+                );
+            }
+            StreamedAssistantContent::Reasoning { reasoning, id } => {
+                observed.push(Observed::ReasoningDone);
+                assert_eq!(reasoning.id.as_deref(), Some(ITEM_ID));
+                assert_eq!(reasoning.display_text(), DONE_SUMMARY);
+                assert_eq!(reasoning.encrypted_content(), Some(ENVELOPE));
+                assert!(
+                    !reasoning.display_text().contains(ENVELOPE),
+                    "completed live summary must not include envelope bytes"
+                );
+                apply_completed_reasoning(
+                    &mut parts,
+                    &mut text_index,
+                    &mut provider_metadata,
+                    STREAM_ID,
+                    &id,
+                    &reasoning,
+                );
+                completed = Some(reasoning);
+            }
+            StreamedAssistantContent::Text(text) => {
+                observed.push(Observed::Text);
+                parts.push(LiveAssistantPart::Text {
+                    id: contiguous_text_id(&parts, STREAM_ID),
+                    text: text.text,
+                    turn_id: Some(STREAM_ID.to_string()),
+                });
+            }
+            StreamedAssistantContent::ToolCall { tool_call, .. } => {
+                observed.push(Observed::ToolCall);
+                parts.push(LiveAssistantPart::ToolCall {
+                    part_id: Some(tool_call.id.as_str().to_string()),
+                    call_id: tool_call.wire_call_id().to_string(),
+                    name: tool_call.function.name,
+                    input: tool_call.function.arguments,
+                    turn_id: Some(STREAM_ID.to_string()),
+                });
+            }
+            StreamedAssistantContent::ToolCallDelta { .. }
+            | StreamedAssistantContent::Final(_)
+            | StreamedAssistantContent::Unknown(_) => {}
+        }
+    }
+
+    let reasoning_delta = first_index(&observed, Observed::ReasoningDelta)
+        .expect("gateway summary delta must stream");
+    let reasoning_done = first_index(&observed, Observed::ReasoningDone)
+        .expect("gateway done item must yield completed reasoning");
+    let text = first_index(&observed, Observed::Text).expect("gateway text must stream");
+    let tool =
+        first_index(&observed, Observed::ToolCall).expect("gateway function call must stream");
+    assert!(
+        reasoning_delta < reasoning_done,
+        "summary delta must precede the authoritative done item, got {observed:?}"
+    );
+    assert!(
+        reasoning_done < text && reasoning_done < tool,
+        "gateway completes reasoning before text/tool, got {observed:?}"
+    );
+    assert_ne!(
+        text, tool,
+        "function call and text must both appear as distinct stream events: {observed:?}"
+    );
+    assert_eq!(
+        observed
+            .iter()
+            .filter(|event| **event == Observed::ReasoningDone)
+            .count(),
+        1,
+        "empty added item must not yield a second completed reasoning, got {observed:?}"
+    );
+
+    let completed = completed.expect("completed reasoning");
+    let reasoning_part = parts
+        .iter()
+        .find(|part| matches!(part, LiveAssistantPart::Reasoning { .. }))
+        .expect("live reasoning part");
+    let live_text = live_reasoning_text(&parts).expect("live reasoning text");
+    assert_eq!(live_text, DONE_SUMMARY);
+    assert!(!live_text.contains(ENVELOPE));
+    assert_ne!(live_text, DELTA_SUMMARY, "done summary is authoritative");
+    assert!(
+        parts
+            .iter()
+            .any(|part| matches!(part, LiveAssistantPart::Text { text, .. } if text == TEXT))
+    );
+    assert!(parts.iter().any(|part| {
+        matches!(
+            part,
+            LiveAssistantPart::ToolCall {
+                call_id,
+                name,
+                ..
+            } if call_id == TOOL_CALL_ID && name == TOOL_NAME
+        )
+    }));
+
+    let reasoning_key = match reasoning_part {
+        LiveAssistantPart::Reasoning { id, .. } => format!("reasoning:{id}"),
+        _ => panic!("expected reasoning part"),
+    };
+    assert_eq!(
+        provider_metadata[&reasoning_key],
+        json!({
+            "openai": {
+                "itemId": ITEM_ID,
+                "reasoningEncryptedContent": ENVELOPE
+            }
+        })
+    );
+    for value in provider_metadata.values() {
+        if let Some(encrypted) = value.pointer("/openai/reasoningEncryptedContent") {
+            assert_eq!(encrypted, ENVELOPE);
+        }
+    }
+    let durable = merge_provider_metadata(reasoning_part, provider_metadata.get(&reasoning_key));
+    assert_eq!(durable["text"], DONE_SUMMARY);
+    assert_eq!(
+        durable["providerMetadata"]["openai"]["reasoningEncryptedContent"],
+        ENVELOPE
+    );
+    assert_eq!(completed.encrypted_content(), Some(ENVELOPE));
+
+    let history =
+        deserialize_agent_history(durable_history_from_parts(&parts, &provider_metadata).await)
+            .expect("durable history conversion");
+    match &history[0] {
+        Message::Assistant { content, .. } => {
+            let reasoning = content.iter().find_map(|part| match part {
+                AssistantContent::Reasoning(reasoning) => Some(reasoning),
+                _ => None,
+            });
+            let reasoning = reasoning.expect("durable reasoning");
+            assert_eq!(reasoning.id.as_deref(), Some(ITEM_ID));
+            assert_eq!(reasoning.display_text(), DONE_SUMMARY);
+            assert_eq!(reasoning.encrypted_content(), Some(ENVELOPE));
+            assert_eq!(content.len(), 3);
+            assert!(content.iter().any(|part| matches!(
+                part,
+                AssistantContent::ToolCall(call)
+                    if call.wire_call_id() == TOOL_CALL_ID
+                        && call.function.name == TOOL_NAME
+                        && call.function.arguments == json!({ "cmd": "pwd" })
+            )));
+            assert!(content.iter().any(|part| matches!(
+                part, AssistantContent::Text(text) if text.text == TEXT
+            )));
+        }
+        other => panic!("expected assistant history, got {other:?}"),
+    }
+
+    let replay = openai::responses_api::CompletionRequest::try_from((
+        "gateway-model".to_string(),
+        model
+            .completion_request(Message::user("next"))
+            .messages(std::iter::once(Message::user("hello")).chain(history))
+            .additional_params(json!({ "reasoning": { "effort": "medium" } }))
+            .build(),
+    ))
+    .expect("native responses replay request");
+    let replay = serde_json::to_value(&replay).expect("serialize replay");
+    let reasoning_input = replay["input"]
+        .as_array()
+        .expect("replay input")
+        .iter()
+        .find(|item| item.get("type").and_then(JsonValue::as_str) == Some("reasoning"))
+        .expect("replay should carry the native reasoning item");
+    assert_eq!(reasoning_input["id"], ITEM_ID);
+    assert_eq!(reasoning_input["encrypted_content"], ENVELOPE);
+    assert_eq!(
+        reasoning_input["summary"],
+        json!([{ "type": "summary_text", "text": DONE_SUMMARY }])
+    );
+    let inputs = replay["input"].as_array().unwrap();
+    assert_eq!(inputs.len(), 6);
+    assert_eq!(inputs[1]["type"], "reasoning");
+    let (text_index, tool_index) = if text < tool { (2, 3) } else { (3, 2) };
+    assert_eq!(inputs[tool_index]["type"], "function_call");
+    assert_eq!(inputs[tool_index]["call_id"], TOOL_CALL_ID);
+    assert_eq!(inputs[tool_index]["name"], TOOL_NAME);
+    assert_eq!(inputs[text_index]["role"], "assistant");
+    assert_eq!(inputs[text_index]["content"], TEXT);
+    assert_eq!(inputs[4]["type"], "function_call_output");
+    assert_eq!(inputs[4]["call_id"], TOOL_CALL_ID);
+    assert!(inputs[4]["output"].to_string().contains("/workspace"));
+
+    let after_compaction = durable_items_json(&parts, &provider_metadata, false);
+    assert!(
+        after_compaction
+            .iter()
+            .all(|item| item["providerMetadata"].is_null())
+    );
+    assert_eq!(after_compaction[0]["text"], DONE_SUMMARY);
+
+    let requests = server.join().expect("gateway mock thread");
+    assert!(
+        requests.iter().any(|body| {
+            let Ok(value) = serde_json::from_slice::<JsonValue>(body) else {
+                return false;
+            };
+            value.get("stream") == Some(&json!(true))
+                && value.get("model") == Some(&json!("gateway-model"))
+        }),
+        "mocked Responses POST should be a stream request, got {requests:?}"
+    );
+}

--- a/crates/sprocket-agent/src/transcript/history.rs
+++ b/crates/sprocket-agent/src/transcript/history.rs
@@ -661,6 +661,7 @@ mod tests {
             source_key: format!("completion:{number}"),
             kind: TranscriptPartKind::Completion,
             run_id: "run".into(),
+            created_at: None,
             prompt: None,
             completion: Some(TranscriptCompletionBody {
                 stream_id: Some("s".into()),
@@ -761,6 +762,7 @@ mod tests {
                 number: 1,
                 source_key: "completion:1".into(),
                 kind: TranscriptPartKind::Completion,
+                created_at: None,
                 run_id: "run".into(),
                 prompt: None,
                 completion: Some(TranscriptCompletionBody {

--- a/crates/sprocket-agent/src/transcript/history.rs
+++ b/crates/sprocket-agent/src/transcript/history.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::reasoning::{opaque_encrypted, skip_reasoning_on_reload};
 use crate::transcript::types::{TranscriptPart, TranscriptPartKind, TranscriptToolBody};
 use crate::types::{
     AgentHistoryContent, AgentHistoryMessage, AgentHistoryRole, AgentHistoryToolResultItem,
@@ -179,6 +180,11 @@ pub fn agent_history_from_parts(
                     let mut contents = Vec::new();
                     for item in &completion.items {
                         if let Some(content) = completion_item_to_history(item) {
+                            if matches!(content, AgentHistoryContent::Reasoning { .. })
+                                && skip_reasoning_on_reload(state.context_summary.as_deref())
+                            {
+                                continue;
+                            }
                             contents.push(content);
                         }
                     }
@@ -234,12 +240,14 @@ fn completion_item_to_history(item: &serde_json::Value) -> Option<AgentHistoryCo
                 .unwrap_or("");
             let item_id = openai_field(item, "itemId")
                 .and_then(|value| value.as_str())
+                .and_then(|id| opaque_encrypted(Some(id)))
                 .map(str::to_string);
-            let encrypted =
-                openai_field(item, "reasoningEncryptedContent").and_then(|value| value.as_str());
+            let encrypted = opaque_encrypted(
+                openai_field(item, "reasoningEncryptedContent").and_then(|value| value.as_str()),
+            );
             let mut blocks = Vec::new();
             if !text.is_empty() {
-                blocks.push(serde_json::json!({ "type": "text", "content": { "text": text } }));
+                blocks.push(serde_json::json!({ "type": "summary", "content": text }));
             }
             if let Some(content) = encrypted {
                 blocks.push(serde_json::json!({ "type": "encrypted", "content": content }));
@@ -635,5 +643,139 @@ mod tests {
         assert!(serialized.contains("rs_123"));
         assert!(serialized.contains("encrypted"));
         assert!(serialized.contains("enc"));
+    }
+
+    fn reasoning_completion(number: u32, item: serde_json::Value) -> TranscriptPart {
+        TranscriptPart {
+            number,
+            source_key: format!("completion:{number}"),
+            kind: TranscriptPartKind::Completion,
+            run_id: "run".into(),
+            prompt: None,
+            completion: Some(TranscriptCompletionBody {
+                stream_id: Some("s".into()),
+                items: vec![item],
+            }),
+            tool: None,
+        }
+    }
+
+    #[test]
+    fn reloads_empty_opaque_reasoning_without_inventing_ciphertext() {
+        let state = TranscriptState::new("user".into(), "thread".into());
+        let history = agent_history_from_parts(
+            &state,
+            &[reasoning_completion(
+                0,
+                serde_json::json!({
+                    "type": "reasoning",
+                    "text": "",
+                    "providerMetadata": {
+                        "openai": {
+                            "itemId": "rs_empty",
+                            "reasoningEncryptedContent": ""
+                        }
+                    }
+                }),
+            )],
+            None,
+        );
+        assert_eq!(history.len(), 1);
+        match &history[0].contents[0] {
+            AgentHistoryContent::Reasoning { id, blocks_json } => {
+                assert_eq!(id.as_deref(), Some("rs_empty"));
+                assert_eq!(blocks_json, "[]");
+            }
+            other => panic!("expected empty signed reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compaction_reload_drops_all_loaded_reasoning_regardless_of_part_number() {
+        // A context summary is not proof the retained prefix is unchanged.
+        // In-flight old generations can commit later, and in-memory compaction
+        // can replace current-run text while historyFromNumber only drops the
+        // prior run. Fail closed: drop every loaded reasoning item.
+        let mut state = TranscriptState::new("user".into(), "thread".into());
+        state.context_summary = Some("Prior work is done.".into());
+        state.history_from_number = 1;
+        let history = agent_history_from_parts(
+            &state,
+            &[
+                prompt(0, "old", "covered"),
+                reasoning_completion(
+                    1,
+                    serde_json::json!({
+                        "type": "reasoning",
+                        "text": "stale-tail",
+                        "providerMetadata": {
+                            "openai": {
+                                "itemId": "rs_tail",
+                                "reasoningEncryptedContent": "tail-envelope"
+                            }
+                        }
+                    }),
+                ),
+                reasoning_completion(
+                    3,
+                    serde_json::json!({
+                        "type": "reasoning",
+                        "text": "also-stale",
+                        "providerMetadata": {
+                            "openai": {
+                                "itemId": "rs_later",
+                                "reasoningEncryptedContent": "later-envelope"
+                            }
+                        }
+                    }),
+                ),
+            ],
+            None,
+        );
+        let serialized = format!("{history:?}");
+        assert!(serialized.contains("Prior work is done."));
+        assert!(!serialized.contains("rs_tail"));
+        assert!(!serialized.contains("tail-envelope"));
+        assert!(!serialized.contains("rs_later"));
+        assert!(!serialized.contains("later-envelope"));
+    }
+
+    #[test]
+    fn compaction_reload_keeps_text_while_dropping_reasoning() {
+        let mut state = TranscriptState::new("user".into(), "thread".into());
+        state.context_summary = Some("Prior work is done.".into());
+        state.history_from_number = 1;
+        let history = agent_history_from_parts(
+            &state,
+            &[TranscriptPart {
+                number: 1,
+                source_key: "completion:1".into(),
+                kind: TranscriptPartKind::Completion,
+                run_id: "run".into(),
+                prompt: None,
+                completion: Some(TranscriptCompletionBody {
+                    stream_id: Some("s".into()),
+                    items: vec![
+                        serde_json::json!({
+                            "type": "reasoning",
+                            "text": "stale",
+                            "providerMetadata": {
+                                "openai": {
+                                    "itemId": "rs_old",
+                                    "reasoningEncryptedContent": "old-envelope"
+                                }
+                            }
+                        }),
+                        serde_json::json!({ "type": "text", "text": "kept answer" }),
+                    ],
+                }),
+                tool: None,
+            }],
+            None,
+        );
+        let serialized = format!("{history:?}");
+        assert!(serialized.contains("kept answer"));
+        assert!(!serialized.contains("rs_old"));
+        assert!(!serialized.contains("old-envelope"));
     }
 }

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -672,6 +672,7 @@ fn project_messages(
                     for mut item in completion.items {
                         // Released UIs understand omitted timestamps, but not explicit nulls.
                         if let Some(object) = item.as_object_mut() {
+                            object.remove("providerMetadata");
                             for key in ["startedAt", "completedAt"] {
                                 if object.get(key).is_some_and(JsonValue::is_null) {
                                     object.remove(key);
@@ -693,7 +694,6 @@ fn project_messages(
                                     continue;
                                 }
                                 if let Some(object) = item.as_object_mut() {
-                                    object.remove("providerMetadata");
                                     if !include_details {
                                         object.insert(
                                             "text".to_string(),
@@ -705,7 +705,6 @@ fn project_messages(
                             Some("tool-call") if !include_details => {
                                 if let Some(object) = item.as_object_mut() {
                                     object.insert("input".to_string(), JsonValue::Null);
-                                    object.remove("providerMetadata");
                                 }
                             }
                             Some("tool-result") if !include_details => {
@@ -713,7 +712,6 @@ fn project_messages(
                                     let output = object.remove("output").unwrap_or(JsonValue::Null);
                                     object
                                         .insert("output".to_string(), tool_output_summary(output));
-                                    object.remove("providerMetadata");
                                 }
                             }
                             _ => {}
@@ -1031,6 +1029,44 @@ mod tests {
         assert_eq!(details[0].parts[1]["input"]["cmd"], "pwd");
         assert_eq!(details[0].parts[2]["output"], "secret output");
         assert!(details[0].details_loaded);
+    }
+
+    #[test]
+    fn projections_strip_all_completion_metadata_without_changing_replay_items() {
+        let metadata = serde_json::json!({
+            "openai": { "itemId": "provider-item", "reasoningEncryptedContent": "opaque" }
+        });
+        let mut part = completion(0);
+        let items = vec![
+            serde_json::json!({
+                "type": "text", "id": "t", "text": "answer", "startedAt": 10,
+                "completedAt": 20, "providerMetadata": metadata
+            }),
+            serde_json::json!({
+                "type": "tool-call", "callId": "c", "name": "read", "input": {},
+                "providerMetadata": metadata
+            }),
+            serde_json::json!({
+                "type": "tool-result", "callId": "c", "name": "read", "output": "ok",
+                "providerMetadata": metadata
+            }),
+        ];
+        part.completion.as_mut().unwrap().items = items.clone();
+
+        for include_details in [false, true] {
+            let messages = project_messages("user", "thread", vec![part.clone()], include_details);
+            assert_eq!(messages[0].text, "answer");
+            assert_eq!(messages[0].parts.len(), 3);
+            assert_eq!(messages[0].parts[0]["startedAt"], 10);
+            assert_eq!(messages[0].parts[0]["completedAt"], 20);
+            for item in &messages[0].parts {
+                assert!(item.get("providerMetadata").is_none());
+            }
+            let rendered = serde_json::to_string(&messages).unwrap();
+            assert!(!rendered.contains("provider-item"));
+            assert!(!rendered.contains("opaque"));
+        }
+        assert_eq!(part.completion.unwrap().items, items);
     }
 
     #[test]

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -673,13 +673,22 @@ fn project_messages(
                                     response.text.push_str(text);
                                 }
                             }
-                            Some("reasoning") if !include_details => {
+                            Some("reasoning") => {
+                                if item
+                                    .get("text")
+                                    .and_then(JsonValue::as_str)
+                                    .is_none_or(|text| text.trim().is_empty())
+                                {
+                                    continue;
+                                }
                                 if let Some(object) = item.as_object_mut() {
-                                    object.insert(
-                                        "text".to_string(),
-                                        JsonValue::String(String::new()),
-                                    );
                                     object.remove("providerMetadata");
+                                    if !include_details {
+                                        object.insert(
+                                            "text".to_string(),
+                                            JsonValue::String(String::new()),
+                                        );
+                                    }
                                 }
                             }
                             Some("tool-call") if !include_details => {
@@ -928,6 +937,114 @@ mod tests {
         assert_eq!(details[0].parts[1]["input"]["cmd"], "pwd");
         assert_eq!(details[0].parts[2]["output"], "secret output");
         assert!(details[0].details_loaded);
+    }
+
+    #[test]
+    fn detailed_projection_keeps_reasoning_summary_and_drops_ciphertext() {
+        const ENVELOPE: &str = "opaque-envelope-bytes";
+        let mut part = completion(0);
+        part.completion.as_mut().unwrap().items[0] = serde_json::json!({
+            "type": "reasoning",
+            "id": "r1",
+            "text": "visible plan",
+            "turnId": "stream-1",
+            "providerMetadata": {
+                "openai": {
+                    "itemId": "rs_123",
+                    "reasoningEncryptedContent": ENVELOPE
+                }
+            }
+        });
+
+        let summary = project_messages("user", "thread", vec![part.clone()], false);
+        let details = project_messages("user", "thread", vec![part.clone()], true);
+
+        assert_eq!(summary[0].text, "answer");
+        assert_eq!(details[0].text, "answer");
+        assert_eq!(summary[0].parts[0]["text"], "");
+        assert_eq!(details[0].parts[0]["text"], "visible plan");
+        assert_eq!(details[0].parts[0]["id"], "r1");
+        assert_eq!(details[0].parts[0]["turnId"], "stream-1");
+
+        for message in [&summary[0], &details[0]] {
+            assert!(message.parts[0].get("providerMetadata").is_none());
+            let rendered = serde_json::to_string(message).unwrap();
+            assert!(
+                !rendered.contains(ENVELOPE),
+                "renderer projection leaked ciphertext: {rendered}"
+            );
+            assert!(!rendered.contains("reasoningEncryptedContent"));
+            assert!(!rendered.contains("rs_123"));
+        }
+
+        assert_eq!(
+            part.completion.as_ref().unwrap().items[0]["providerMetadata"]["openai"]["reasoningEncryptedContent"],
+            ENVELOPE
+        );
+    }
+
+    #[tokio::test]
+    async fn message_details_omit_ciphertext_and_leave_stored_reasoning_intact() {
+        const ENVELOPE: &str = "stored-opaque-envelope";
+        let dir = std::env::temp_dir().join(format!(
+            "sprocket-reasoning-privacy-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let store = TranscriptStore::new(dir.clone());
+        let mut part = completion(0);
+        part.completion.as_mut().unwrap().items = vec![
+            serde_json::json!({
+                "type": "reasoning",
+                "id": "r1",
+                "text": "",
+                "providerMetadata": {
+                    "openai": {
+                        "itemId": "rs_empty",
+                        "reasoningEncryptedContent": ENVELOPE
+                    }
+                }
+            }),
+            serde_json::json!({ "type": "text", "id": "t1", "text": "answer" }),
+        ];
+        store.append_parts("user", "thread", &[part]).await.unwrap();
+
+        let details = store
+            .message_details("user", "thread", &[0])
+            .await
+            .unwrap()
+            .unwrap();
+        let rendered = serde_json::to_string(&details).unwrap();
+        assert_eq!(details.parts.len(), 1);
+        assert_eq!(details.parts[0]["type"], "text");
+        assert_eq!(details.text, "answer");
+        assert!(details.parts[0].get("providerMetadata").is_none());
+        assert!(!rendered.contains(ENVELOPE));
+        assert!(!rendered.contains("reasoningEncryptedContent"));
+
+        let stored = store.read_parts("user", "thread", &[0]).await.unwrap();
+        assert_eq!(
+            stored[0].completion.as_ref().unwrap().items[0]["providerMetadata"]["openai"]["reasoningEncryptedContent"],
+            ENVELOPE
+        );
+
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[test]
+    fn lightweight_projection_keeps_only_reasoning_with_a_summary_to_load() {
+        let mut part = completion(0);
+        part.completion.as_mut().unwrap().items = vec![
+            serde_json::json!({ "type": "reasoning", "id": "empty", "text": "" }),
+            serde_json::json!({ "type": "reasoning", "id": "blank", "text": " \n" }),
+            serde_json::json!({ "type": "reasoning", "id": "visible", "text": "plan" }),
+            serde_json::json!({ "type": "text", "id": "answer", "text": "done" }),
+        ];
+
+        let messages = project_messages("user", "thread", vec![part], false);
+        assert_eq!(messages[0].parts.len(), 2);
+        assert_eq!(messages[0].parts[0]["id"], "visible");
+        assert_eq!(messages[0].parts[0]["text"], "");
+        assert!(!messages[0].details_loaded);
     }
 
     #[test]

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -588,4 +588,59 @@ mod tests {
         );
         assert_eq!(image.media_type, Some(ImageMediaType::PNG));
     }
+
+    #[test]
+    fn reloads_encrypted_reasoning_as_native_rig_blocks() {
+        let history = vec![AgentHistoryMessage {
+            role: AgentHistoryRole::Assistant,
+            assistant_id: None,
+            contents: vec![AgentHistoryContent::Reasoning {
+                id: Some("rs_123".to_string()),
+                blocks_json: serde_json::json!([
+                    { "type": "summary", "content": "think" },
+                    { "type": "encrypted", "content": "envelope" }
+                ])
+                .to_string(),
+            }],
+        }];
+
+        let messages = deserialize_agent_history(history).expect("messages");
+        match &messages[0] {
+            Message::Assistant { content, .. } => match content.iter().next() {
+                Some(AssistantContent::Reasoning(reasoning)) => {
+                    assert_eq!(reasoning.id.as_deref(), Some("rs_123"));
+                    assert_eq!(reasoning.display_text(), "think");
+                    assert_eq!(reasoning.encrypted_content(), Some("envelope"));
+                }
+                other => panic!("expected reasoning, got {other:?}"),
+            },
+            other => panic!("expected assistant message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reloads_empty_signed_reasoning_without_opaque_blocks() {
+        let history = vec![AgentHistoryMessage {
+            role: AgentHistoryRole::Assistant,
+            assistant_id: None,
+            contents: vec![AgentHistoryContent::Reasoning {
+                id: Some("rs_empty".to_string()),
+                blocks_json: "[]".to_string(),
+            }],
+        }];
+
+        let messages = deserialize_agent_history(history).expect("messages");
+        match &messages[0] {
+            Message::Assistant { content, .. } => match content.iter().next() {
+                Some(AssistantContent::Reasoning(reasoning)) => {
+                    assert_eq!(reasoning.id.as_deref(), Some("rs_empty"));
+                    assert!(reasoning.content.is_empty());
+                    assert!(reasoning.encrypted_content().is_none());
+                    assert!(reasoning.display_text().is_empty());
+                }
+                other => panic!("expected empty signed reasoning, got {other:?}"),
+            },
+            other => panic!("expected assistant message, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Consume completed native Responses reasoning, preserve opaque gateway envelopes in durable transcript metadata, and restore them for tool follow-up and uncompacted reloads.
- Keep ciphertext out of live overlays, browser detail responses, and summarizer input. Keep unloaded visible-summary placeholders reachable while hiding genuinely empty reasoning disclosures.
- Invalidate old reasoning after compaction. Stop writing replay state after in-process compaction and drop all loaded reasoning when a context summary exists. No schema migration or required new fields.
- Integrate the latest work-indicator timing changes. Completed visible reasoning preserves its original start timestamp and records its completion timestamp.

## Validation
- `cargo test -p sprocket-agent --lib`: 121 passed, including native Rig HTTP SSE parsing, production live-part accumulation, actual transcript disk reload, and native Responses replay serialization.
- `bun run test`: passed, including 321 web tests across 54 files and the npm tests.
- Svelte check: 0 errors, 0 warnings.
- Prettier check, cargo fmt check, and all non-Cargo Prek hooks passed.
- `cargo test --workspace`: 258 tests passed locally before the metadata-projection follow-up. Current-head CI `cargo test`: 259 passed, including all 121 agent tests.
- `bun run build`: passed for web and desktop.
- `cargo check`: passed.
- Metadata-projection follow-up: focused regression and all 121 agent tests passed, with formatting and non-Cargo Prek hooks passing. Current-head build/test and Prek CI checks passed; Greptile reviewed the follow-up at 5/5 with no remaining findings.

## Rollout and limits
Companion gateway PR: https://github.com/spikonado/ai-gateway/pull/3. Deploy gateway support before releasing this client. The gateway review is already 5/5 with passing tests.

No authenticated provider completions were run. Before rollout, verify Anthropic account retention eligibility and run authenticated unary, streaming, tool-follow-up, reload, and compaction smoke tests for each enabled provider. Bedrock remains disabled.

The mocked integration test does not exercise the complete TranscriptSink RPC/Convex path. Rig 0.42 groups reasoning before other content within an assistant message; arbitrary interleaving and upstream message-phase preservation are not guaranteed. Hidden empty reasoning keeps timestamps on disk but does not anchor visible work-section timers; run-level elapsed time is unchanged. The compatibility inventory is unchanged by this PR.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves native provider reasoning state across tool turns and uncompacted transcript reloads while preventing opaque replay metadata from reaching browser projections, live overlays, and summarization.
- Captures completed reasoning and provider replay metadata in durable transcript items.
- Reconstructs native reasoning blocks for safe reload and tool-follow-up behavior.
- Invalidates stale reasoning around compaction and excludes opaque state from summary requests.
- Keeps visible reasoning, text, tools, and timing correctly ordered in the web transcript.
- Adds focused Rust and web regression coverage for persistence, projection, reload, compaction, and timeline behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable regression remains in the reviewed reasoning replay, compaction, privacy projection, or timeline paths.

The current implementation retains opaque provider state only where model replay requires it, strips it from user-facing and summarization boundaries, and invalidates potentially stale reasoning after compaction. The earlier metadata-projection concern is addressed by unconditional removal of `providerMetadata` from projected completion items.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/reasoning.rs | Centralizes opaque reasoning metadata extraction, replay reconstruction, compaction filtering, and completed-reasoning correlation. |
| crates/sprocket-agent/src/provider.rs | Captures completed provider reasoning and persists replay metadata while keeping live output display-only. |
| crates/sprocket-agent/src/compaction.rs | Removes stale reasoning across repeated compactions and disables durable replay metadata after in-process compaction. |
| crates/sprocket-agent/src/transcript/history.rs | Reconstructs native reasoning on uncompacted reload and drops loaded reasoning when a context summary exists. |
| crates/sprocket-agent/src/transcript/store.rs | Strips provider metadata from all browser projections and omits genuinely empty reasoning while preserving durable storage. |
| crates/sprocket-agent/src/history_json.rs | Limits summarizer input to visible reasoning text and removes opaque provider replay fields. |
| crates/sprocket-agent/src/live.rs | Applies completed reasoning without losing its original streamed start timestamp. |
| apps/web/src/lib/chat/assistant-timeline.ts | Preserves unloaded reasoning placeholders and hides empty reasoning after details are available. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Passes transcript detail-loading state into timeline assembly. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Provider[Provider stream] --> Sink[Transcript sink]
  Sink --> Live[Display-only live overlay]
  Sink --> Durable[Durable transcript]
  Durable -->|No context summary| Replay[Native reasoning replay]
  Durable -->|Context summary exists| Strip[Drop loaded reasoning]
  Durable --> Projection[Browser projection]
  Projection -->|Remove provider metadata| UI[Assistant timeline]
  Durable --> Summarizer[Compaction summarizer]
  Summarizer -->|Visible text only| Summary[Context summary]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: Remove reasoning notes from compat..."](https://github.com/spikonado/sprocket/commit/3be2a52d8ff2a9cb813f2261e9ed4c0b2670c87f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60785234)</sub>

**Context used:**

- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Chat, timeline, and artifacts UI](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-chat-and-artifacts.md)

<!-- /greptile_comment -->