### PR TITLE
fix(agent): Keep workspace context in conversation history

### DIFF
--- a/crates/sprocket-agent/src/compaction.rs
+++ b/crates/sprocket-agent/src/compaction.rs
@@ -61,6 +61,7 @@ pub(crate) struct ContextCompactionHook {
     service_tier: String,
     context_budget: ContextBudget,
     prior_history_len: usize,
+    initial_context: Arc<[Message]>,
     gateway_url: String,
     persist_reasoning_replay: Arc<AtomicBool>,
     state: Arc<Mutex<CompactionState>>,
@@ -76,6 +77,7 @@ impl ContextCompactionHook {
         service_tier: String,
         context_budget: ContextBudget,
         prior_history_len: usize,
+        initial_context: Arc<[Message]>,
         gateway_url: String,
         persist_reasoning_replay: Arc<AtomicBool>,
     ) -> Self {
@@ -88,6 +90,7 @@ impl ContextCompactionHook {
             service_tier,
             context_budget,
             prior_history_len,
+            initial_context,
             gateway_url,
             persist_reasoning_replay,
             state: Arc::new(Mutex::new(CompactionState::default())),
@@ -171,20 +174,26 @@ impl ContextCompactionHook {
             (state.last_input_tokens, state.active_summary.clone())
         };
 
+        let Some(raw_history) = history.strip_prefix(self.initial_context.as_ref()) else {
+            return CompletionCallAction::stop(
+                "The conversation's initial workspace context was lost.".to_string(),
+            );
+        };
         let (effective_history, suffix_raw) =
-            rebuild_effective_history(history, active_summary.as_ref());
+            rebuild_effective_history(raw_history, active_summary.as_ref());
+        let request_history = prepend_initial_context(&self.initial_context, &effective_history);
         if !should_compact(
             last_input_tokens,
             self.context_budget.auto_compact_token_limit,
-            &effective_history,
+            &request_history,
         ) {
-            return continue_with_history(active_summary.is_some(), effective_history);
+            return continue_with_history(active_summary.is_some(), request_history);
         }
 
         let prior_boundary = prior_boundary_in_effective(
             active_summary.as_ref(),
             self.prior_history_len,
-            history.len(),
+            raw_history.len(),
             &suffix_raw,
         );
         let split = choose_split_index(
@@ -193,7 +202,7 @@ impl ContextCompactionHook {
             self.context_budget.auto_compact_token_limit,
         );
         if split == 0 {
-            return continue_with_history(active_summary.is_some(), effective_history);
+            return continue_with_history(active_summary.is_some(), request_history);
         }
 
         let prefix = &effective_history[..split];
@@ -225,8 +234,12 @@ impl ContextCompactionHook {
         let processed_tokens = billed_tokens;
         let summary_text = summary;
         let compacted_summary = context_summary_text(&summary_text);
-        let replaced_prefix_len =
-            next_replaced_prefix_len(active_summary.as_ref(), history.len(), split, &suffix_raw);
+        let replaced_prefix_len = next_replaced_prefix_len(
+            active_summary.as_ref(),
+            raw_history.len(),
+            split,
+            &suffix_raw,
+        );
         let persist_for_future_runs =
             should_persist_for_future_runs(self.prior_history_len, replaced_prefix_len);
 
@@ -260,13 +273,14 @@ impl ContextCompactionHook {
             state.active_summary = Some(CompactedContext {
                 summary: summary_text,
                 replaced_prefix_len,
-                reasoning_from_len: history.len(),
+                reasoning_from_len: raw_history.len(),
             });
         }
         self.persist_reasoning_replay
             .store(false, Ordering::Release);
 
-        let mut compacted = vec![Message::user(compacted_summary)];
+        let mut compacted = self.initial_context.to_vec();
+        compacted.push(Message::user(compacted_summary));
         compacted.extend(tail);
         CompletionCallAction::patch(RequestPatch::new().history(compacted))
     }
@@ -337,14 +351,15 @@ impl ContextCompactionHook {
         has_active_summary: bool,
         effective_history: &[Message],
     ) -> CompletionCallAction {
-        let estimated = estimate_context_tokens(effective_history);
+        let request_history = prepend_initial_context(&self.initial_context, effective_history);
+        let estimated = estimate_context_tokens(&request_history);
         if estimated >= self.context_budget.context_window_tokens {
             return CompletionCallAction::stop(format!(
                 "Context compaction failed and the conversation (~{estimated} tokens) exceeds the model context window ({} tokens).",
                 self.context_budget.context_window_tokens
             ));
         }
-        continue_with_history(has_active_summary, effective_history.to_vec())
+        continue_with_history(has_active_summary, request_history)
     }
 }
 
@@ -361,9 +376,16 @@ fn context_summary_text(summary: &str) -> String {
     )
 }
 
-fn continue_with_history(has_active_summary: bool, history: Vec<Message>) -> CompletionCallAction {
+fn prepend_initial_context(initial_context: &[Message], history: &[Message]) -> Vec<Message> {
+    initial_context.iter().chain(history).cloned().collect()
+}
+
+fn continue_with_history(
+    has_active_summary: bool,
+    request_history: Vec<Message>,
+) -> CompletionCallAction {
     if has_active_summary {
-        CompletionCallAction::patch(RequestPatch::new().history(history))
+        CompletionCallAction::patch(RequestPatch::new().history(request_history))
     } else {
         CompletionCallAction::Continue
     }
@@ -735,6 +757,55 @@ mod tests {
         }
         assert_eq!(effective[1], user_text("kept a"));
         assert_eq!(effective[2], user_text("kept b"));
+    }
+
+    #[test]
+    fn reinserts_initial_context_before_compacted_history_without_summarizing_it() {
+        let initial_context = vec![user_text("canonical workspace context")];
+        let history = vec![user_text("covered"), user_text("kept")];
+        let active = CompactedContext {
+            summary: "Prior work is done.".to_string(),
+            replaced_prefix_len: 1,
+            reasoning_from_len: 1,
+        };
+
+        let (effective, _) = rebuild_effective_history(&history, Some(&active));
+        let request_history = prepend_initial_context(&initial_context, &effective);
+
+        assert_eq!(request_history[0], initial_context[0]);
+        assert!(is_summary_user_message(&request_history[1]));
+        assert_eq!(request_history[2], user_text("kept"));
+        assert_eq!(
+            request_history
+                .iter()
+                .filter(|message| **message == initial_context[0])
+                .count(),
+            1
+        );
+        let summarized = completion_messages_json(effective.iter())
+            .expect("serialize summary input")
+            .to_string();
+        assert!(!summarized.contains("canonical workspace context"));
+    }
+
+    #[test]
+    fn active_summary_history_patch_keeps_initial_context_at_the_front() {
+        let initial_context = vec![user_text("canonical workspace context")];
+        let effective = vec![
+            user_text(&context_summary_text("summary")),
+            user_text("kept"),
+        ];
+
+        let CompletionCallAction::Patch(patch) =
+            continue_with_history(true, prepend_initial_context(&initial_context, &effective))
+        else {
+            panic!("active summaries must patch request history");
+        };
+        let history = patch.history.expect("patched history");
+
+        assert_eq!(history[0], initial_context[0]);
+        assert!(is_summary_user_message(&history[1]));
+        assert_eq!(history[2], user_text("kept"));
     }
 
     #[test]

--- a/crates/sprocket-agent/src/compaction.rs
+++ b/crates/sprocket-agent/src/compaction.rs
@@ -202,7 +202,12 @@ impl ContextCompactionHook {
             self.context_budget.auto_compact_token_limit,
         );
         if split == 0 {
-            return continue_with_history(active_summary.is_some(), request_history);
+            return continue_without_compaction(
+                active_summary.is_some(),
+                request_history,
+                self.context_budget.context_window_tokens,
+                "The conversation has no history that can be compacted",
+            );
         }
 
         let prefix = &effective_history[..split];
@@ -352,14 +357,12 @@ impl ContextCompactionHook {
         effective_history: &[Message],
     ) -> CompletionCallAction {
         let request_history = prepend_initial_context(&self.initial_context, effective_history);
-        let estimated = estimate_context_tokens(&request_history);
-        if estimated >= self.context_budget.context_window_tokens {
-            return CompletionCallAction::stop(format!(
-                "Context compaction failed and the conversation (~{estimated} tokens) exceeds the model context window ({} tokens).",
-                self.context_budget.context_window_tokens
-            ));
-        }
-        continue_with_history(has_active_summary, request_history)
+        continue_without_compaction(
+            has_active_summary,
+            request_history,
+            self.context_budget.context_window_tokens,
+            "Context compaction failed",
+        )
     }
 }
 
@@ -389,6 +392,21 @@ fn continue_with_history(
     } else {
         CompletionCallAction::Continue
     }
+}
+
+fn continue_without_compaction(
+    has_active_summary: bool,
+    request_history: Vec<Message>,
+    context_window_tokens: u64,
+    overflow_reason: &str,
+) -> CompletionCallAction {
+    let estimated = estimate_context_tokens(&request_history);
+    if estimated >= context_window_tokens {
+        return CompletionCallAction::stop(format!(
+            "{overflow_reason}, and the conversation (~{estimated} tokens) exceeds the model context window ({context_window_tokens} tokens)."
+        ));
+    }
+    continue_with_history(has_active_summary, request_history)
 }
 
 fn rebuild_effective_history(
@@ -806,6 +824,23 @@ mod tests {
         assert_eq!(history[0], initial_context[0]);
         assert!(is_summary_user_message(&history[1]));
         assert_eq!(history[2], user_text("kept"));
+    }
+
+    #[test]
+    fn uncompacted_history_cannot_exceed_the_model_context_window() {
+        let request_history = vec![user_text(&"x".repeat(400))];
+        let action = continue_without_compaction(
+            false,
+            request_history,
+            50,
+            "The conversation has no history that can be compacted",
+        );
+
+        let CompletionCallAction::Stop(reason) = action else {
+            panic!("oversized uncompacted history must stop the run");
+        };
+        assert!(reason.contains("no history that can be compacted"));
+        assert!(reason.contains("exceeds the model context window (50 tokens)"));
     }
 
     #[test]

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -77,7 +77,8 @@ pub(crate) struct AgentProviderRequest {
     pub(crate) run_started_at: u64,
     pub(crate) live: Arc<LiveCompletionHub>,
     pub(crate) prompt: Message,
-    pub(crate) preamble: String,
+    pub(crate) base_instructions: String,
+    pub(crate) initial_context: Vec<Message>,
     pub(crate) prior_history: Vec<Message>,
     pub(crate) workspace_root: PathBuf,
     pub(crate) skills: Arc<[WorkspaceSkill]>,
@@ -167,7 +168,7 @@ where
     let session_shutdown = CommandSessionShutdown::new(tools.command_sessions.clone());
     let agent = completion_client
         .agent(model)
-        .preamble(&request.preamble)
+        .preamble(&request.base_instructions)
         .tool(tools.apply_patch)
         .tool(tools.ask_question)
         .tool(tools.await_question)
@@ -222,6 +223,7 @@ where
 
     let prompt_hook = AgentPromptHook::new(tool_call_tracker);
     let prior_history_len = request.prior_history.len();
+    let initial_context: Arc<[Message]> = request.initial_context.into();
     let gateway_hook = GatewayRequestHook::new(
         request.reasoning_effort.clone(),
         request.service_tier.clone(),
@@ -235,6 +237,7 @@ where
         request.service_tier,
         request.context_budget,
         prior_history_len,
+        initial_context.clone(),
         gateway_url,
         persist_reasoning_replay,
     );
@@ -250,9 +253,10 @@ where
         }
     };
 
+    let history = initial_context.iter().cloned().chain(request.prior_history);
     let mut stream = agent
         .stream_prompt(request.prompt)
-        .history(request.prior_history)
+        .history(history)
         .max_turns(AGENT_MAX_TURNS)
         .add_hook(prompt_hook)
         .add_hook(gateway_hook)

--- a/crates/sprocket-agent/src/reasoning_integration_tests.rs
+++ b/crates/sprocket-agent/src/reasoning_integration_tests.rs
@@ -291,6 +291,50 @@ fn first_index(events: &[Observed], kind: Observed) -> Option<usize> {
     events.iter().position(|event| *event == kind)
 }
 
+#[test]
+fn responses_keep_thread_context_in_history_and_base_instructions_separate() {
+    const BASE_INSTRUCTIONS: &str = "stable base instructions";
+    const INITIAL_CONTEXT: &str = "unique initial workspace context";
+
+    let client = openai::Client::builder()
+        .api_key("test-key")
+        .base_url("http://127.0.0.1:1")
+        .build()
+        .expect("openai responses client");
+    let model = client.completion_model("gateway-model");
+    let request = model
+        .completion_request(Message::user("current request"))
+        .preamble(BASE_INSTRUCTIONS.to_string())
+        .messages([
+            Message::user(INITIAL_CONTEXT),
+            Message::user("earlier request"),
+            Message::assistant("earlier response"),
+        ])
+        .build();
+    let wire =
+        openai::responses_api::CompletionRequest::try_from(("gateway-model".to_string(), request))
+            .expect("native responses request");
+    let wire = serde_json::to_value(wire).expect("serialize responses request");
+
+    assert_eq!(wire["instructions"], BASE_INSTRUCTIONS);
+    assert!(
+        !wire["instructions"]
+            .as_str()
+            .unwrap()
+            .contains(INITIAL_CONTEXT)
+    );
+    let input = wire["input"].as_array().expect("responses input");
+    assert_eq!(input[0]["role"], "user");
+    assert!(input[0].to_string().contains(INITIAL_CONTEXT));
+    assert_eq!(
+        input
+            .iter()
+            .filter(|item| item.to_string().contains(INITIAL_CONTEXT))
+            .count(),
+        1
+    );
+}
+
 #[tokio::test]
 async fn gateway_responses_stream_completes_reasoning_before_text_and_tools() {
     let (base_url, server) = spawn_gateway_sse(gateway_sse_body());

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -90,11 +90,16 @@ impl RunFinalStatus {
     }
 }
 
-fn build_workspace_preamble(
+struct WorkspacePromptContext {
+    base_instructions: String,
+    initial_context: Message,
+}
+
+fn build_workspace_prompt_context(
     workspace_path: &str,
     workspace_instructions: &[WorkspaceInstruction],
     skills: &[WorkspaceSkill],
-) -> String {
+) -> WorkspacePromptContext {
     let user_instructions = workspace_instructions
         .iter()
         .filter(|instruction| instruction.source == WorkspaceInstructionSource::User)
@@ -138,7 +143,7 @@ fn build_workspace_preamble(
         format!("<SKILLS>\n{entries}\n</SKILLS>")
     };
 
-    [
+    let base_instructions = [
         "# System Instructions",
         "",
         "## Identity",
@@ -192,12 +197,10 @@ fn build_workspace_preamble(
         "## Skills",
         "",
         "Skills are reusable instruction packages.",
-        "The available skills are listed below.",
+        "The available skills are listed in the initial conversation context.",
         "When a task matches a skill's description, call the read_skill tool with its name before proceeding, and follow the returned instructions as needed.",
         "If the user writes $skill-name in their message (for example $code-review), they are explicitly invoking that skill: read it with read_skill and apply it, even if you would not have selected it yourself.",
         "Skills may reference bundled files; for on-disk skills, the read_skill result includes a dir path for reading those with exec_command when needed.",
-        "",
-        &skills_block,
         "",
         "## AGENTS.md Spec",
         "",
@@ -205,12 +208,29 @@ fn build_workspace_preamble(
         "Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
         "Follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
         "The user's `AGENTS.md`, located at `~/.agents/AGENTS.md`, applies to every workspace.",
-        "The user's AGENTS.md and the AGENTS.md for the current workspace path are already included below and do not need to be re-read.",
+        "The user's AGENTS.md and the AGENTS.md for the current workspace path are included in the initial conversation context and do not need to be re-read.",
         "If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
-        "",
-        &instruction_block,
     ]
-    .join("\n")
+    .join("\n");
+    let initial_context = Message::user(
+        [
+            "The following thread-scoped workspace context was loaded when this conversation began.",
+            "",
+            "## Available Skills",
+            "",
+            &skills_block,
+            "",
+            "## Preloaded AGENTS.md Instructions",
+            "",
+            &instruction_block,
+        ]
+        .join("\n"),
+    );
+
+    WorkspacePromptContext {
+        base_instructions,
+        initial_context,
+    }
 }
 
 async fn cleanup_twice<T, F, Fut>(
@@ -826,12 +846,15 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
             content: prompt_contents,
         };
         let provider = AgentProvider::default_for_run(&context, &gateway_url);
-        let preamble =
-            build_workspace_preamble(&request.workspace_path, &workspace_instructions, &skills);
-        Ok((prompt, provider, preamble, skills))
+        let prompt_context = build_workspace_prompt_context(
+            &request.workspace_path,
+            &workspace_instructions,
+            &skills,
+        );
+        Ok((prompt, provider, prompt_context, skills))
     })();
 
-    let (prompt, provider, preamble, skills) = match prepared {
+    let (prompt, provider, prompt_context, skills) = match prepared {
         Ok(values) => values,
         Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };
@@ -886,7 +909,8 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
                     run_started_at: context.run.started_at,
                     live: live.clone(),
                     prompt,
-                    preamble,
+                    base_instructions: prompt_context.base_instructions,
+                    initial_context: vec![prompt_context.initial_context],
                     prior_history: prior_history.messages,
                     workspace_root,
                     skills,
@@ -933,11 +957,23 @@ fn image_media_type(media_type: &str) -> anyhow::Result<ImageMediaType> {
 
 #[cfg(test)]
 mod tests {
+    use rig::completion::Message;
+    use rig::message::UserContent;
     use sprocket_workspace::{
         SkillSource, WorkspaceInstruction, WorkspaceInstructionSource, WorkspaceSkill,
     };
 
-    use super::{build_workspace_preamble, submission_owned_by_another_executor};
+    use super::{build_workspace_prompt_context, submission_owned_by_another_executor};
+
+    fn initial_context_text(message: &Message) -> &str {
+        match message {
+            Message::User { content } => match content.first() {
+                Some(UserContent::Text(text)) => &text.text,
+                other => panic!("expected initial context text, got {other:?}"),
+            },
+            other => panic!("expected initial context user message, got {other:?}"),
+        }
+    }
 
     #[test]
     fn submission_conflict_errors_match_the_convex_sentinel() {
@@ -956,7 +992,7 @@ mod tests {
     }
 
     #[test]
-    fn preamble_renders_skills_block() {
+    fn initial_context_renders_skills_block() {
         let skills = [WorkspaceSkill {
             name: "pdf-processing".to_string(),
             description: "Handle PDFs".to_string(),
@@ -964,24 +1000,27 @@ mod tests {
                 contents: "---\nname: pdf-processing\ndescription: Handle PDFs\n---\n",
             },
         }];
-        let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
-        assert!(preamble.contains("## Skills"));
-        assert!(preamble.contains("<SKILLS>"));
-        assert!(preamble.contains("- name: pdf-processing"));
-        assert!(preamble.contains("description: Handle PDFs"));
-        assert!(!preamble.contains("No skills are installed."));
+        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &skills);
+        let initial_context = initial_context_text(&prompt_context.initial_context);
+        assert!(initial_context.contains("## Available Skills"));
+        assert!(initial_context.contains("<SKILLS>"));
+        assert!(initial_context.contains("- name: pdf-processing"));
+        assert!(initial_context.contains("description: Handle PDFs"));
+        assert!(!initial_context.contains("No skills are installed."));
+        assert!(!prompt_context.base_instructions.contains("pdf-processing"));
     }
 
     #[test]
-    fn preamble_renders_empty_skills_line() {
-        let preamble = build_workspace_preamble("/tmp/project", &[], &[]);
-        assert!(preamble.contains("## Skills"));
-        assert!(preamble.contains("No skills are installed."));
-        assert!(!preamble.contains("<SKILLS>"));
+    fn initial_context_renders_empty_skills_line() {
+        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &[]);
+        let initial_context = initial_context_text(&prompt_context.initial_context);
+        assert!(initial_context.contains("## Available Skills"));
+        assert!(initial_context.contains("No skills are installed."));
+        assert!(!initial_context.contains("<SKILLS>"));
     }
 
     #[test]
-    fn preamble_collapses_multiline_skill_descriptions() {
+    fn initial_context_collapses_multiline_skill_descriptions() {
         let skills = [WorkspaceSkill {
             name: "demo".to_string(),
             description: "Line one\nline two".to_string(),
@@ -989,13 +1028,14 @@ mod tests {
                 contents: "---\nname: demo\ndescription: Line one\n---\n",
             },
         }];
-        let preamble = build_workspace_preamble("/tmp/project", &[], &skills);
-        assert!(preamble.contains("description: Line one line two"));
-        assert!(!preamble.contains("description: Line one\n"));
+        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &skills);
+        let initial_context = initial_context_text(&prompt_context.initial_context);
+        assert!(initial_context.contains("description: Line one line two"));
+        assert!(!initial_context.contains("description: Line one\n"));
     }
 
     #[test]
-    fn preamble_renders_user_instructions_before_workspace_instructions() {
+    fn initial_context_renders_user_instructions_before_workspace_instructions() {
         let instructions = [
             WorkspaceInstruction {
                 path: "/home/user/.agents/AGENTS.md".to_string(),
@@ -1013,15 +1053,28 @@ mod tests {
             },
         ];
 
-        let preamble = build_workspace_preamble("/tmp/project", &instructions, &[]);
+        let prompt_context = build_workspace_prompt_context("/tmp/project", &instructions, &[]);
+        let initial_context = initial_context_text(&prompt_context.initial_context);
 
         let user_heading = "# The user's AGENTS.md:";
         let workspace_heading = "# AGENTS.md instructions for /tmp/project:";
-        assert!(preamble.contains(user_heading));
-        assert!(preamble.contains(workspace_heading));
+        assert!(initial_context.contains(user_heading));
+        assert!(initial_context.contains(workspace_heading));
         assert!(
-            preamble.find(user_heading).expect("user heading")
-                < preamble.find(workspace_heading).expect("workspace heading")
+            initial_context.find(user_heading).expect("user heading")
+                < initial_context
+                    .find(workspace_heading)
+                    .expect("workspace heading")
+        );
+        assert!(
+            !prompt_context
+                .base_instructions
+                .contains("user instructions")
+        );
+        assert!(
+            !prompt_context
+                .base_instructions
+                .contains("workspace instructions")
         );
     }
 }

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -118,12 +118,12 @@ fn build_workspace_prompt_context(
         let mut blocks = Vec::new();
         if !user_instructions.is_empty() {
             blocks.push(format!(
-                "# The user's AGENTS.md:\n<INSTRUCTIONS>\n{user_instructions}\n</INSTRUCTIONS>"
+                "### The user's AGENTS.md\n<INSTRUCTIONS>\n{user_instructions}\n</INSTRUCTIONS>"
             ));
         }
         if !project_instructions.is_empty() {
             blocks.push(format!(
-                "# AGENTS.md instructions for {workspace_path}:\n<INSTRUCTIONS>\n{project_instructions}\n</INSTRUCTIONS>"
+                "### AGENTS.md instructions for {workspace_path}\n<INSTRUCTIONS>\n{project_instructions}\n</INSTRUCTIONS>"
             ));
         }
         blocks.join("\n\n")
@@ -214,7 +214,9 @@ fn build_workspace_prompt_context(
     .join("\n");
     let initial_context = Message::user(
         [
-            "The following thread-scoped workspace context was loaded when this conversation began.",
+            "# Thread-Scoped Workspace Context",
+            "",
+            "The following workspace context was loaded when this conversation began.",
             "",
             "## Available Skills",
             "",
@@ -1002,6 +1004,7 @@ mod tests {
         }];
         let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &skills);
         let initial_context = initial_context_text(&prompt_context.initial_context);
+        assert!(initial_context.starts_with("# Thread-Scoped Workspace Context\n"));
         assert!(initial_context.contains("## Available Skills"));
         assert!(initial_context.contains("<SKILLS>"));
         assert!(initial_context.contains("- name: pdf-processing"));
@@ -1056,10 +1059,18 @@ mod tests {
         let prompt_context = build_workspace_prompt_context("/tmp/project", &instructions, &[]);
         let initial_context = initial_context_text(&prompt_context.initial_context);
 
-        let user_heading = "# The user's AGENTS.md:";
-        let workspace_heading = "# AGENTS.md instructions for /tmp/project:";
+        let user_heading = "### The user's AGENTS.md";
+        let workspace_heading = "### AGENTS.md instructions for /tmp/project";
+        let agents_heading = "## Preloaded AGENTS.md Instructions";
+        assert!(initial_context.contains(agents_heading));
         assert!(initial_context.contains(user_heading));
         assert!(initial_context.contains(workspace_heading));
+        assert!(
+            initial_context
+                .find(agents_heading)
+                .expect("agents heading")
+                < initial_context.find(user_heading).expect("user heading")
+        );
         assert!(
             initial_context.find(user_heading).expect("user heading")
                 < initial_context


### PR DESCRIPTION
## Summary

- split stable agent instructions from thread-scoped skills and `AGENTS.md` context
- place workspace context once at the front of reconstructed conversation history instead of injecting it as fresh system instructions
- preserve that initial context through active summaries and compaction while excluding it from summary input
- add regression coverage for Responses API serialization and compaction boundaries

## Testing

- `nix develop -c cargo test -p sprocket-agent` (124 passed)
- `nix develop -c cargo fmt --all -- --check`
- `git diff --check`
- pre-commit hooks, including `cargo-check`, ESLint, Oxlint, Svelte check, and Prettier






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR separates stable system instructions from thread-scoped workspace context and preserves that context across model history reconstruction and compaction.
- Sends skills and preloaded `AGENTS.md` instructions once as the first user-history message.
- Excludes initial workspace context from generated summaries while restoring it before subsequent completion requests.
- Applies the hard context-window guard when no history can be compacted.
- Adds regression coverage for Responses API serialization, context ordering, and compaction boundaries.
- The previous oversized-request finding is fixed, and its thread is resolved.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no outstanding or newly introduced actionable issue remains.

The initial workspace context is retained at the front of completion history, excluded from compaction summary input, restored after compaction, and included in hard-window size checks. The previous oversized uncompacted-history finding is fixed and its review thread is resolved.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/compaction.rs | Preserves initial workspace context outside summary input, restores it to patched history, and guards uncompacted oversized requests. |
| crates/sprocket-agent/src/provider.rs | Separates stable provider instructions from initial thread context and prepends the latter to reconstructed history. |
| crates/sprocket-agent/src/run.rs | Builds stable instructions and thread-scoped workspace context separately, with clarified Markdown hierarchy. |
| crates/sprocket-agent/src/reasoning_integration_tests.rs | Verifies Responses API serialization keeps initial workspace context in history exactly once and outside system instructions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Stable base instructions] --> D[Provider request]
  B[Initial workspace context] --> C[Conversation history]
  E[Prior thread history] --> C
  C --> F{Compaction needed?}
  F -->|No| D
  F -->|Yes| G[Summarize compactable history only]
  G --> H[Initial context + summary + recent tail]
  H --> D
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): Correct workspace context he..."](https://github.com/spikonado/sprocket/commit/0110041b9f60fab1bf40da1c5b4cde83a012a8f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60873004)</sub>

**Context used:**

- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
- Knowledge Base — [Agent run lifecycle](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-run-lifecycle.md)

<!-- /greptile_comment -->