### PR TITLE
fix(auth): Preserve sessions and refresh Convex tokens reliably

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,9 +52,9 @@ The system has three main planes:
 3. **Cloud coordination plane:** Convex stores durable application state and
    coordinates run ownership. Completions go through the AI gateway.
 
-WorkOS establishes cloud user identity. Installed clients hold two independent
-WorkOS sessions: AuthKit JS owns the renderer session, while Rust owns the
-native session used by agent runs and machine registration. A separate local
+WorkOS establishes cloud user identity. Installed clients share one Rust-owned
+WorkOS session across the renderer, agent runs, and machine registration.
+Hosted web clients use AuthKit JS. A separate local
 pairing mechanism authorizes the browser or Electron renderer to access the
 machine-facing API.
 
@@ -203,12 +203,13 @@ that order and keeps no cross-thread transcript cache.
 
 Cloud and local authorization solve different problems:
 
-- **Browser cloud identity:** AuthKit JS owns a browser session and supplies
-  access tokens to the renderer's direct Convex client. Convex validates them
+- **Browser cloud identity:** AuthKit JS owns the hosted web session. Installed
+  renderers obtain short-lived access tokens from the Rust-owned session through
+  the paired, same-origin, loopback-only native token endpoint. Convex validates them
   as JWTs (`apps/web/src/convex/auth.config.ts`) and checks ownership before
   reading or changing user records.
-- **Native cloud identity:** Rust owns a separate WorkOS authorization-code
-  session for machine-side work. It generates PKCE and state, exchanges the
+- **Native cloud identity:** Rust owns the installed client's WorkOS authorization-code
+  session. It generates PKCE and state, exchanges the
   code on the loopback callback, keeps the access token in memory, and stores
   the refresh token in the operating system credential store. Rust fetches the
   public WorkOS client ID from the unauthenticated Convex query
@@ -237,9 +238,11 @@ deployment choice.
 
 The native authorization callback accepts only a loopback socket peer. Its
 pending state and PKCE verifier never enter the renderer, and the callback does
-not return the authorization code to JavaScript. The installed renderer then
-starts a separate AuthKit browser login. Installed sign-out clears the native
-credential before signing out the browser session.
+not return the authorization code to JavaScript. The installed renderer resumes
+that same session without another AuthKit browser login. Access-token responses
+are never cached, and refresh tokens never enter JavaScript. Installed sign-out
+clears the native credential. A missing or temporarily unavailable browser session
+does not sign out native work.
 
 Desktop releases package the renderer build and Rust server in the same
 installer, and Electron always launches the bundled server binary. These two

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -225,13 +225,28 @@ remaining run-id values in that same PR, then drop the field.
 ### Local sessions created before account binding
 
 Persisted local sessions created before native WorkOS account binding have no
-`userId`. They continue to deserialize so users receive an explicit sign-in
-error instead of losing the pairing credential, but account-scoped routes
-reject them until the user signs in again. New desktop login callbacks bind
-the authenticated WorkOS user to the local session that started the flow.
+`userId`. They continue to deserialize without losing the pairing credential.
+The paired, same-origin, loopback-only native token endpoint now resumes a
+valid native WorkOS session and persists its user binding on first use.
+Account-scoped routes still reject unbound sessions. Desktop login callbacks
+also bind the authenticated WorkOS user to the session that started the flow.
 
 Remove `SessionRecord.user_id` optionality after all supported installations
-have completed a native sign-in on a version that writes the binding.
+have completed a native sign-in or resume on a version that writes the binding.
+
+### Installed authentication session consolidation
+
+New installed renderers use `POST /api/auth/native-session/token` instead of
+maintaining a second AuthKit JS session. The existing keyring service and account
+derivation are unchanged, so valid native refresh tokens resume in place. Old
+browser cookies are ignored, not copied into native storage. Users whose native
+credentials were already deleted must sign in once to restore them.
+
+The renderer retains the legacy dual-session flow only when the token endpoint
+returns HTTP 404 or 405. Network, pairing, and provider errors do not trigger
+fallback or delete credentials. Existing login/status/sign-out endpoints remain
+available to released clients. Remove the legacy renderer path once supported
+local servers all provide the native token endpoint.
 
 Released desktop/CLI builds that still call retired Convex functions get a
 `ConvexError`: "This Sprocket version is no longer supported. Update to the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7628,6 +7628,7 @@ name = "sprocket-convex"
 version = "0.3.4"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "convex",
  "rustls",
  "serde",

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -1,7 +1,49 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { User } from '@workos-inc/authkit-js';
 import { get } from 'svelte/store';
-import { authState, convexAuthLoading, convexAuthUserId } from './auth';
+import { z } from 'zod';
+import {
+	authState,
+	convexAuthLoading,
+	convexAuthUserId,
+	convexAuthRetryVersion,
+	getAccessToken,
+	getConvexAccessToken,
+	initializeAuth,
+	resetAuthRuntime,
+	setAuthRuntime,
+	signIn,
+	signOut,
+	type AuthRuntime
+} from './auth';
+
+const createAuthKitClient = vi.fn<AuthRuntime['createAuthKitClient']>();
+const ensureLocalSession = vi.fn<AuthRuntime['ensureLocalSession']>();
+const readDesktopBootstrap = vi.fn<AuthRuntime['readDesktopBootstrap']>();
+const resolveLocalApiBaseUrl = vi.fn<AuthRuntime['resolveLocalApiBaseUrl']>();
+const nativeTokenRequestSchema = z.object({ forceRefreshToken: z.boolean() });
+type NativeSessionTokenRequest = z.infer<typeof nativeTokenRequestSchema>;
+type TestJsonPayload =
+	| NativeSessionTokenRequest
+	| {
+			accessToken: string;
+			user: {
+				id: string;
+				email: string;
+				firstName: string | null;
+				lastName: string | null;
+				profilePictureUrl: string | null;
+			};
+	  }
+	| { error: string }
+	| { ok: true }
+	| {
+			status: 'authenticated' | 'signedOut' | 'pending' | 'unavailable' | 'failed';
+			user?: { id: string; email: string };
+			error?: string;
+	  }
+	| { authorizationUrl: string; loginId: string }
+	| null;
 
 const initialState = get(authState);
 const user: User = {
@@ -17,8 +59,19 @@ const user: User = {
 	createdAt: '',
 	updatedAt: ''
 };
+const nativeUser = {
+	id: 'user-a',
+	email: 'a@example.com',
+	firstName: 'Ada',
+	lastName: 'Lovelace',
+	profilePictureUrl: null
+};
 
-afterEach(() => authState.set(initialState));
+afterEach(() => {
+	resetAuthRuntime();
+	vi.useRealTimers();
+	authState.set(initialState);
+});
 
 describe('Convex auth dependencies', () => {
 	it('ignores token refreshes and unrelated UI state without hiding account changes', () => {
@@ -57,3 +110,556 @@ describe('Convex auth dependencies', () => {
 		}
 	});
 });
+
+describe('installed and hosted auth', () => {
+	const bootstrap = {
+		httpBaseUrl: 'http://localhost:17731',
+		pairingCredential: 'pairing-secret'
+	};
+	const convexClient = {
+		query: vi.fn(async () => ({ workosClientId: 'client_123' }))
+	};
+
+	beforeEach(() => {
+		resetAuthRuntime();
+		createAuthKitClient.mockReset();
+		ensureLocalSession.mockReset();
+		readDesktopBootstrap.mockReset();
+		resolveLocalApiBaseUrl.mockReset();
+		convexClient.query.mockClear();
+		resolveLocalApiBaseUrl.mockReturnValue('http://localhost:17731');
+		readDesktopBootstrap.mockResolvedValue(bootstrap);
+		ensureLocalSession.mockResolvedValue(undefined);
+		setAuthRuntime({
+			createAuthKitClient,
+			resolveLocalApiBaseUrl,
+			readDesktopBootstrap,
+			ensureLocalSession
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('resumes an installed native session without AuthKit JS', async () => {
+		stubInstalledWindow();
+		const fetch = stubFetch({
+			token: () => jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+
+		await initializeAuth(convexClient);
+
+		expect(createAuthKitClient).not.toHaveBeenCalled();
+		expect(ensureLocalSession).toHaveBeenCalledWith('http://localhost:17731', bootstrap);
+		expect(fetch).toHaveBeenCalledWith(
+			'/api/auth/native-session/token',
+			expect.objectContaining({ method: 'POST', credentials: 'include' })
+		);
+		expect(tokenBodies(fetch)).toEqual([{ forceRefreshToken: false }]);
+		expect(get(authState)).toMatchObject({
+			isReady: true,
+			isLoading: false,
+			user: nativeUser,
+			nativeSession: 'ready',
+			error: null
+		});
+	});
+
+	it('pairs the local session before asking for a native token', async () => {
+		stubInstalledWindow();
+		const order: string[] = [];
+		readDesktopBootstrap.mockImplementation(async () => {
+			order.push('bootstrap');
+			return bootstrap;
+		});
+		ensureLocalSession.mockImplementation(async () => {
+			order.push('pair');
+		});
+		stubFetch({
+			token: () => {
+				order.push('token');
+				return jsonResponse(200, null);
+			}
+		});
+
+		await initializeAuth(convexClient);
+
+		expect(order).toEqual(['bootstrap', 'pair', 'token']);
+		expect(get(authState).user).toBeNull();
+		expect(get(authState).nativeSession).toBe('notRequired');
+	});
+
+	it('does not delete a native session when legacy AuthKit JS has no user', async () => {
+		stubInstalledWindow();
+		const fetch = stubFetch({
+			token: () => jsonResponse(404, { error: 'not found' }),
+			nativeSessionGet: () =>
+				jsonResponse(200, {
+					status: 'authenticated',
+					user: { id: nativeUser.id, email: nativeUser.email }
+				})
+		});
+		createAuthKitClient.mockResolvedValue(mockAuthKitClient(null));
+
+		await initializeAuth(convexClient);
+
+		expect(createAuthKitClient).toHaveBeenCalled();
+		expect(fetch).not.toHaveBeenCalledWith(
+			'/api/auth/native-session',
+			expect.objectContaining({ method: 'DELETE' })
+		);
+		expect(get(authState)).toMatchObject({
+			user: null,
+			nativeSession: 'missing',
+			error: 'Finish setting up sign-in before starting an agent.'
+		});
+	});
+
+	it('keeps the current native user when a later token refresh is transient', async () => {
+		stubInstalledWindow();
+		const fetch = stubFetch({
+			token: () => jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+		await initializeAuth(convexClient);
+		fetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+			if (requestUrl(input).includes('/api/auth/native-session/token')) {
+				return jsonResponse(503, {
+					error: 'Native sign-in is temporarily unavailable. Try again.'
+				});
+			}
+			return unhandled(input, init);
+		});
+
+		await initializeAuth(convexClient);
+
+		expect(get(authState)).toMatchObject({
+			user: nativeUser,
+			nativeSession: 'ready',
+			isReady: true,
+			isLoading: false
+		});
+	});
+
+	it('keeps a legacy native session on a transient startup status call', async () => {
+		stubInstalledWindow();
+		createAuthKitClient.mockResolvedValue(mockAuthKitClient(user));
+		stubFetch({
+			token: () => jsonResponse(404, { error: 'not found' }),
+			nativeSessionGet: () => jsonResponse(503, { error: 'temporarily unavailable' })
+		});
+		authState.set({
+			...get(authState),
+			user,
+			nativeSession: 'ready',
+			isReady: true,
+			isLoading: false
+		});
+
+		await initializeAuth(convexClient);
+
+		expect(get(authState)).toMatchObject({
+			user: { id: 'user-a' },
+			nativeSession: 'ready',
+			isReady: true
+		});
+	});
+
+	it('settles Convex token fetch failures and retries without clearing the native user', async () => {
+		vi.useFakeTimers();
+		stubInstalledWindow();
+		let unavailable = false;
+		stubFetch({
+			token: () =>
+				unavailable
+					? jsonResponse(503, { error: 'Temporarily unavailable' })
+					: jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+		await initializeAuth(convexClient);
+		unavailable = true;
+		const version = get(convexAuthRetryVersion);
+		await expect(getConvexAccessToken({ forceRefreshToken: true })).resolves.toBeNull();
+		expect(get(authState).user).toEqual(nativeUser);
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(get(convexAuthRetryVersion)).toBe(version + 1);
+		unavailable = false;
+		await expect(getConvexAccessToken({ forceRefreshToken: true })).resolves.toBe('native-token');
+		expect(window.open).not.toHaveBeenCalled();
+	});
+
+	it('cancels scheduled Convex recovery when signing out', async () => {
+		vi.useFakeTimers();
+		stubInstalledWindow();
+		let unavailable = false;
+		stubFetch({
+			token: () =>
+				unavailable
+					? jsonResponse(503, { error: 'Temporarily unavailable' })
+					: jsonResponse(200, { accessToken: 'native-token', user: nativeUser }),
+			nativeSessionDelete: () => jsonResponse(200, { ok: true })
+		});
+		await initializeAuth(convexClient);
+		unavailable = true;
+		await getConvexAccessToken({ forceRefreshToken: true });
+		await signOut();
+		const version = get(convexAuthRetryVersion);
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(get(convexAuthRetryVersion)).toBe(version);
+		expect(get(authState).user).toBeNull();
+	});
+
+	it('signs in through PKCE then the native session without a second AuthKit redirect', async () => {
+		const { location } = stubInstalledWindow();
+		stubFetch({
+			desktopStart: () =>
+				jsonResponse(200, {
+					authorizationUrl: 'https://authkit.example/authorize',
+					loginId: 'login-1'
+				}),
+			desktopResult: () =>
+				jsonResponse(200, {
+					status: 'authenticated',
+					user: { id: nativeUser.id, email: nativeUser.email }
+				}),
+			token: () => jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+
+		await signIn();
+
+		expect(createAuthKitClient).not.toHaveBeenCalled();
+		expect(location.href).toBe('http://localhost:17731/');
+		expect(get(authState)).toMatchObject({
+			user: nativeUser,
+			nativeSession: 'ready',
+			isWaitingForBrowserSignIn: false,
+			error: null
+		});
+	});
+
+	it('maps forceRefreshToken through the native session endpoint and does not persist the token', async () => {
+		const { localStorage } = stubInstalledWindow();
+		const fetch = stubFetch({
+			token: () => jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+		await initializeAuth(convexClient);
+
+		const token = await getAccessToken({ forceRefreshToken: true });
+
+		expect(token).toBe('native-token');
+		expect(tokenBodies(fetch)).toEqual([{ forceRefreshToken: false }, { forceRefreshToken: true }]);
+		expect(localStorage.setItem).not.toHaveBeenCalled();
+		expect(get(authState)).not.toHaveProperty('accessToken');
+	});
+
+	it('keeps polling the same login through transient failures', async () => {
+		vi.useFakeTimers();
+		stubInstalledWindow();
+		let polls = 0;
+		const fetch = stubFetch({
+			desktopStart: () => jsonResponse(200, { authorizationUrl: 'https://authkit.example/native', loginId: 'login-1' }),
+			desktopResult: () => {
+				polls += 1;
+				if (polls === 1) return jsonResponse(503, { error: 'Unavailable' });
+				if (polls === 2) return jsonResponse(200, { status: 'unavailable', error: 'Retry' });
+				return jsonResponse(200, { status: 'authenticated', user: nativeUser });
+			},
+			token: () => jsonResponse(200, { accessToken: 'native-token', user: nativeUser })
+		});
+		const login = signIn();
+		await vi.advanceTimersByTimeAsync(3_100);
+		await login;
+		expect(polls).toBe(3);
+		expect(get(authState).user).toEqual(nativeUser);
+		expect(fetch.mock.calls.filter(([input]) => requestUrl(input).endsWith('/start'))).toHaveLength(1);
+	});
+
+	it('shares inflight native token requests', async () => {
+		stubInstalledWindow();
+		const pending = deferred<Response>();
+		const fetch = stubFetch({
+			token: () => pending.promise
+		});
+
+		const first = getAccessToken();
+		const second = getAccessToken();
+		pending.resolve(jsonResponse(200, { accessToken: 'shared-token', user: nativeUser }));
+
+		expect(await first).toBe('shared-token');
+		expect(await second).toBe('shared-token');
+		expect(tokenBodies(fetch)).toEqual([{ forceRefreshToken: false }]);
+	});
+
+	it('ignores a native token that finishes after an account switch', async () => {
+		stubInstalledWindow();
+		const pending = deferred<Response>();
+		let tokenCalls = 0;
+		stubFetch({
+			desktopStart: () =>
+				jsonResponse(200, {
+					authorizationUrl: 'https://authkit.example/authorize',
+					loginId: 'login-1'
+				}),
+			desktopResult: () =>
+				jsonResponse(200, {
+					status: 'authenticated',
+					user: { id: 'user-b', email: 'b@example.com' }
+				}),
+			token: () => {
+				tokenCalls += 1;
+				if (tokenCalls === 1) {
+					return pending.promise;
+				}
+				return jsonResponse(200, {
+					accessToken: 'b-token',
+					user: {
+						id: 'user-b',
+						email: 'b@example.com',
+						firstName: null,
+						lastName: null,
+						profilePictureUrl: null
+					}
+				});
+			}
+		});
+
+		const previousToken = getAccessToken();
+		await signIn();
+		pending.resolve(jsonResponse(200, { accessToken: 'late-token', user: nativeUser }));
+
+		expect(await previousToken).toBeNull();
+		expect(get(authState).user).toMatchObject({ id: 'user-b', email: 'b@example.com' });
+	});
+
+	it('ignores a native token that finishes after sign-out', async () => {
+		stubInstalledWindow();
+		const pending = deferred<Response>();
+		stubFetch({
+			token: () => pending.promise,
+			nativeSessionDelete: () => jsonResponse(200, { ok: true })
+		});
+
+		const tokenPromise = getAccessToken();
+		await signOut();
+		pending.resolve(jsonResponse(200, { accessToken: 'late-token', user: nativeUser }));
+
+		expect(await tokenPromise).toBeNull();
+		expect(createAuthKitClient).not.toHaveBeenCalled();
+		expect(get(authState)).toMatchObject({
+			user: null,
+			nativeSession: 'notRequired',
+			isLoading: false
+		});
+	});
+
+	it.each([404, 405])(
+		'falls back to AuthKit JS when the native token endpoint is %s',
+		async (status) => {
+			stubInstalledWindow();
+			createAuthKitClient.mockResolvedValue(mockAuthKitClient(user));
+			stubFetch({
+				token: () => jsonResponse(status, { error: 'missing' }),
+				nativeSessionGet: () =>
+					jsonResponse(200, {
+						status: 'authenticated',
+						user: { id: user.id, email: user.email }
+					})
+			});
+
+			await initializeAuth(convexClient);
+
+			expect(createAuthKitClient).toHaveBeenCalled();
+			expect(get(authState)).toMatchObject({
+				user: { id: 'user-a', email: 'a@example.com' },
+				nativeSession: 'ready',
+				error: null
+			});
+		}
+	);
+
+	it('surfaces pairing failure and account mismatch without treating them as signed out', async () => {
+		stubInstalledWindow();
+		stubFetch({
+			token: () => jsonResponse(401, { error: 'authentication required' })
+		});
+		await initializeAuth(convexClient);
+		expect(get(authState)).toMatchObject({
+			nativeSession: 'unavailable',
+			error: 'authentication required',
+			isReady: true
+		});
+
+		resetAuthRuntime();
+		resolveLocalApiBaseUrl.mockReturnValue('http://localhost:17731');
+		readDesktopBootstrap.mockResolvedValue(bootstrap);
+		ensureLocalSession.mockResolvedValue(undefined);
+		setAuthRuntime({
+			createAuthKitClient,
+			resolveLocalApiBaseUrl,
+			readDesktopBootstrap,
+			ensureLocalSession
+		});
+		stubInstalledWindow();
+		stubFetch({
+			token: () => jsonResponse(409, { error: 'session belongs to a different account' })
+		});
+		await initializeAuth(convexClient);
+		expect(get(authState)).toMatchObject({
+			nativeSession: 'mismatch',
+			error: 'session belongs to a different account'
+		});
+	});
+
+	it('keeps hosted AuthKit JS and inspects SDK state on refresh failure', async () => {
+		stubHostedWindow();
+		let sdkUser: User | null = user;
+		const client = mockAuthKitClient(user);
+		client.getUser.mockImplementation(() => sdkUser);
+		let onRefreshFailure: (() => void) | undefined;
+		createAuthKitClient.mockImplementation(async (_clientId, options) => {
+			onRefreshFailure = () => options?.onRefreshFailure?.({ signIn: client.signIn });
+			return client;
+		});
+
+		await initializeAuth(convexClient);
+		expect(ensureLocalSession).not.toHaveBeenCalled();
+		expect(get(authState).user).toMatchObject({ id: 'user-a' });
+
+		onRefreshFailure?.();
+		expect(get(authState).user).toMatchObject({ id: 'user-a' });
+		expect(get(authState).error).toBeNull();
+
+		sdkUser = null;
+		onRefreshFailure?.();
+		expect(get(authState).user).toBeNull();
+		expect(get(authState).error).toBe('Session refresh failed. Sign in again.');
+	});
+});
+
+function jsonResponse(status: number, payload: TestJsonPayload) {
+	return new Response(JSON.stringify(payload), {
+		status,
+		headers: { 'content-type': 'application/json' }
+	});
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+	if (input instanceof URL) {
+		return input.href;
+	}
+	if (input instanceof Request) {
+		return input.url;
+	}
+	return input;
+}
+
+function tokenBodies(fetch: ReturnType<typeof stubFetch>) {
+	const bodies: NativeSessionTokenRequest[] = [];
+	for (const [input, init] of fetch.mock.calls) {
+		if (!requestUrl(input).includes('/api/auth/native-session/token')) {
+			continue;
+		}
+		if ((init?.method ?? 'GET').toUpperCase() !== 'POST') {
+			continue;
+		}
+		const parsed = nativeTokenRequestSchema.safeParse(JSON.parse(String(init?.body ?? '{}')));
+		if (parsed.success) {
+			bodies.push(parsed.data);
+		}
+	}
+	return bodies;
+}
+
+function unhandled(input: RequestInfo | URL, init?: RequestInit) {
+	return jsonResponse(500, {
+		error: `unhandled ${init?.method ?? 'GET'} ${requestUrl(input)}`
+	});
+}
+
+function stubFetch(handlers: {
+	token?: (request: NativeSessionTokenRequest) => Response | Promise<Response>;
+	nativeSessionGet?: () => Response | Promise<Response>;
+	nativeSessionDelete?: () => Response | Promise<Response>;
+	desktopStart?: () => Response | Promise<Response>;
+	desktopResult?: () => Response | Promise<Response>;
+	desktopCancel?: () => Response | Promise<Response>;
+}) {
+	const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = requestUrl(input);
+		const method = (init?.method ?? 'GET').toUpperCase();
+		if (url.includes('/api/auth/native-session/token') && method === 'POST') {
+			const parsed = nativeTokenRequestSchema.safeParse(JSON.parse(String(init?.body ?? '{}')));
+			if (!parsed.success) {
+				return jsonResponse(400, { error: 'invalid token request' });
+			}
+			return handlers.token?.(parsed.data) ?? unhandled(input, init);
+		}
+		if (url.endsWith('/api/auth/native-session') && method === 'DELETE') {
+			return handlers.nativeSessionDelete?.() ?? unhandled(input, init);
+		}
+		if (url.endsWith('/api/auth/native-session') && method === 'GET') {
+			return handlers.nativeSessionGet?.() ?? unhandled(input, init);
+		}
+		if (url.includes('/api/auth/desktop-login/start') && method === 'POST') {
+			return handlers.desktopStart?.() ?? unhandled(input, init);
+		}
+		if (url.includes('/api/auth/desktop-login/result') && method === 'GET') {
+			return handlers.desktopResult?.() ?? unhandled(input, init);
+		}
+		if (url.includes('/api/auth/desktop-login/cancel') && method === 'POST') {
+			return handlers.desktopCancel?.() ?? jsonResponse(200, { ok: true });
+		}
+		return unhandled(input, init);
+	});
+	vi.stubGlobal('fetch', fetch);
+	return fetch;
+}
+
+function stubInstalledWindow() {
+	return stubWindow('localhost');
+}
+
+function stubHostedWindow() {
+	return stubWindow('sprocket.dev');
+}
+
+function stubWindow(hostname: string) {
+	const localStorage = {
+		getItem: vi.fn(),
+		setItem: vi.fn(),
+		removeItem: vi.fn()
+	};
+	const origin = hostname === 'localhost' ? 'http://localhost:17731' : `https://${hostname}`;
+	const location = {
+		hostname,
+		origin,
+		href: `${origin}/`,
+		replace: vi.fn()
+	};
+	vi.stubGlobal('window', {
+		location,
+		localStorage,
+		open: vi.fn(() => ({ opener: {} })),
+		sprocketDesktopBridge: undefined
+	});
+	return { location, localStorage };
+}
+
+function mockAuthKitClient(currentUser: User | null) {
+	return {
+		getUser: vi.fn(() => currentUser),
+		getAccessToken: vi.fn(async () => 'js-token'),
+		signIn: vi.fn(async () => {}),
+		signUp: vi.fn(async () => {}),
+		signOut: vi.fn(async () => {}),
+		getSignInUrl: vi.fn(async () => 'https://authkit.example/sign-in'),
+		getSignUpUrl: vi.fn(async () => 'https://authkit.example/sign-up')
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -356,7 +356,11 @@ describe('installed and hosted auth', () => {
 		stubInstalledWindow();
 		let polls = 0;
 		const fetch = stubFetch({
-			desktopStart: () => jsonResponse(200, { authorizationUrl: 'https://authkit.example/native', loginId: 'login-1' }),
+			desktopStart: () =>
+				jsonResponse(200, {
+					authorizationUrl: 'https://authkit.example/native',
+					loginId: 'login-1'
+				}),
 			desktopResult: () => {
 				polls += 1;
 				if (polls === 1) return jsonResponse(503, { error: 'Unavailable' });
@@ -370,7 +374,9 @@ describe('installed and hosted auth', () => {
 		await login;
 		expect(polls).toBe(3);
 		expect(get(authState).user).toEqual(nativeUser);
-		expect(fetch.mock.calls.filter(([input]) => requestUrl(input).endsWith('/start'))).toHaveLength(1);
+		expect(fetch.mock.calls.filter(([input]) => requestUrl(input).endsWith('/start'))).toHaveLength(
+			1
+		);
 	});
 
 	it('shares inflight native token requests', async () => {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -42,8 +42,10 @@ export const convexAuthRetryVersion = writable(0);
 /** UI-only: stays true until Convex confirms or rejects the post-retry token. */
 export const convexAuthRetryPending = writable(false);
 
-type AuthClient = Pick<Awaited<ReturnType<typeof createClient>>,
-	'getUser' | 'getAccessToken' | 'signIn' | 'signUp' | 'signOut' | 'getSignInUrl' | 'getSignUpUrl'>;
+type AuthClient = Pick<
+	Awaited<ReturnType<typeof createClient>>,
+	'getUser' | 'getAccessToken' | 'signIn' | 'signUp' | 'signOut' | 'getSignInUrl' | 'getSignUpUrl'
+>;
 type AuthBootstrapClient = {
 	query: (
 		query: typeof api.authBootstrap.getClientConfig,
@@ -842,7 +844,9 @@ async function fetchDesktopLoginResult(signal: AbortSignal) {
 	}
 	if (isTransientHttpStatus(response.status)) return null;
 	if (!response.ok) {
-		throw new Error(await errorMessageFromFailedResponse(response, 'Failed to check desktop sign-in status.'));
+		throw new Error(
+			await errorMessageFromFailedResponse(response, 'Failed to check desktop sign-in status.')
+		);
 	}
 	return desktopLoginResultSchema.parse(await response.json());
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,9 +1,16 @@
-import { browser } from '$app/environment';
 import { createClient, type User } from '@workos-inc/authkit-js';
 import { z } from 'zod';
 import { api } from '$convex/_generated/api';
 import { usesLoopbackBrowserAuth } from '../../../desktop/local-config.mjs';
+import {
+	ensureLocalSession,
+	readDesktopBootstrap,
+	resolveLocalApiBaseUrl,
+	type LocalBootstrap
+} from '$lib/local/client';
 import { derived, get, writable } from 'svelte/store';
+
+export type AuthUser = Pick<User, 'id' | 'email' | 'firstName' | 'lastName' | 'profilePictureUrl'>;
 
 type AuthStatus = {
 	isLoading: boolean;
@@ -11,7 +18,7 @@ type AuthStatus = {
 	isConfigured: boolean;
 	isWaitingForBrowserSignIn: boolean;
 	browserSignInUrl: string | null;
-	user: User | null;
+	user: AuthUser | null;
 	nativeSession: 'notRequired' | 'loading' | 'ready' | 'missing' | 'mismatch' | 'unavailable';
 	error: string | null;
 };
@@ -35,28 +42,176 @@ export const convexAuthRetryVersion = writable(0);
 /** UI-only: stays true until Convex confirms or rejects the post-retry token. */
 export const convexAuthRetryPending = writable(false);
 
-type AuthClient = Awaited<ReturnType<typeof createClient>>;
+type AuthClient = Pick<Awaited<ReturnType<typeof createClient>>,
+	'getUser' | 'getAccessToken' | 'signIn' | 'signUp' | 'signOut' | 'getSignInUrl' | 'getSignUpUrl'>;
 type AuthBootstrapClient = {
 	query: (
 		query: typeof api.authBootstrap.getClientConfig,
 		args: Record<string, never>
 	) => Promise<{ workosClientId: string }>;
 };
+type InstalledAuthMode = 'undecided' | 'native' | 'legacy';
+type AuthFlow = 'signIn' | 'signUp';
+type DesktopSignInAttempt = {
+	abort: AbortController;
+	loginId: string | null;
+};
+type NativeTokenOutcome =
+	| { kind: 'session'; accessToken: string; user: AuthUser }
+	| { kind: 'signedOut' }
+	| { kind: 'transient'; error: string }
+	| { kind: 'pairing'; error: string }
+	| { kind: 'mismatch'; error: string }
+	| { kind: 'legacyUnavailable' }
+	| { kind: 'error'; error: string }
+	| { kind: 'stale' };
 
 const DESKTOP_LOGIN_POLL_INTERVAL_MS = 1_500;
 const DESKTOP_LOGIN_TIMEOUT_MS = 5 * 60 * 1_000;
+const MISMATCH_ERROR =
+	'The browser and native sessions use different accounts. Sign out, then sign in with the same account.';
+const NATIVE_SETUP_ERROR = 'Finish setting up sign-in before starting an agent.';
+const TRANSIENT_AUTH_ERROR = 'Native sign-in is temporarily unavailable. Try again.';
+let convexRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+const ACCOUNT_BINDING_ERROR =
+	'This device is signed in with a different account. Sign out, then sign in with the same account.';
+
+export type AuthRuntime = {
+	createAuthKitClient: (...args: Parameters<typeof createClient>) => Promise<AuthClient>;
+	resolveLocalApiBaseUrl: () => string | null;
+	readDesktopBootstrap: (baseUrl: string) => Promise<LocalBootstrap | null>;
+	ensureLocalSession: (baseUrl: string, bootstrap?: LocalBootstrap | null) => Promise<void>;
+};
+
+const productionAuthRuntime: AuthRuntime = {
+	createAuthKitClient: createClient,
+	resolveLocalApiBaseUrl,
+	readDesktopBootstrap,
+	ensureLocalSession
+};
+
+let authRuntime: AuthRuntime = productionAuthRuntime;
+
+export function setAuthRuntime(nextRuntime: AuthRuntime) {
+	authRuntime = nextRuntime;
+}
+
+function currentWindow() {
+	return globalThis.window ?? null;
+}
 
 let authClientPromise: Promise<AuthClient | null> | null = null;
 let authConfigPromise: Promise<{ workosClientId: string }> | null = null;
 let bootstrapClient: AuthBootstrapClient | null = null;
 let isSigningOut = false;
-type DesktopSignInAttempt = {
-	abort: AbortController;
-	loginId: string | null;
-};
-type AuthFlow = 'signIn' | 'signUp';
 let desktopSignInAttempt: DesktopSignInAttempt | null = null;
 let desktopLoginStartQueue: Promise<void> = Promise.resolve();
+let installedAuthMode: InstalledAuthMode = 'undecided';
+let authGeneration = 0;
+let nativeTokenInflight: {
+	generation: number;
+	forceRefreshToken: boolean;
+	promise: Promise<NativeTokenOutcome>;
+} | null = null;
+
+export function resetAuthRuntime() {
+	clearConvexRecovery();
+	desktopSignInAttempt?.abort.abort();
+	desktopSignInAttempt = null;
+	desktopLoginStartQueue = Promise.resolve();
+	authClientPromise = null;
+	authConfigPromise = null;
+	bootstrapClient = null;
+	isSigningOut = false;
+	installedAuthMode = 'undecided';
+	authGeneration = 0;
+	nativeTokenInflight = null;
+	authRuntime = productionAuthRuntime;
+	convexAuthRetryVersion.set(0);
+	convexAuthRetryPending.set(false);
+	authState.set(initialState);
+}
+
+const errorMessagePayloadSchema = z.object({ error: z.string().optional() });
+const desktopLoginStartSchema = z.object({ authorizationUrl: z.url(), loginId: z.string() });
+const nativeAuthUserSchema = z.object({
+	id: z.string(),
+	email: z.email(),
+	firstName: z.string().nullable().optional(),
+	lastName: z.string().nullable().optional(),
+	profilePictureUrl: z.string().nullable().optional()
+});
+const nativeSessionTokenSchema = z
+	.object({
+		accessToken: z.string(),
+		user: nativeAuthUserSchema
+	})
+	.nullable();
+const desktopLoginResultSchema = z.discriminatedUnion('status', [
+	z.object({ status: z.literal('signedOut') }),
+	z.object({ status: z.literal('pending') }),
+	z.object({
+		status: z.literal('authenticated'),
+		user: z.object({ id: z.string(), email: z.email() })
+	}),
+	z.object({ status: z.literal('unavailable'), error: z.string() }),
+	z.object({ status: z.literal('failed'), error: z.string() })
+]);
+
+function toAuthUser(user: {
+	id: string;
+	email: string;
+	firstName?: string | null;
+	lastName?: string | null;
+	profilePictureUrl?: string | null;
+}): AuthUser {
+	return {
+		id: user.id,
+		email: user.email,
+		firstName: user.firstName ?? null,
+		lastName: user.lastName ?? null,
+		profilePictureUrl: user.profilePictureUrl ?? null
+	};
+}
+
+function signedOutState(overrides: Partial<AuthStatus> = {}): AuthStatus {
+	return {
+		isLoading: false,
+		isReady: true,
+		isConfigured: true,
+		isWaitingForBrowserSignIn: false,
+		browserSignInUrl: null,
+		user: null,
+		nativeSession: 'notRequired',
+		error: null,
+		...overrides
+	};
+}
+
+function isTransientHttpStatus(status: number) {
+	return (
+		status === 408 ||
+		status === 429 ||
+		status === 500 ||
+		status === 502 ||
+		status === 503 ||
+		status === 504
+	);
+}
+
+function isLegacyMissingEndpoint(status: number) {
+	return status === 404 || status === 405;
+}
+
+function isInstalledApp() {
+	return Boolean(getDesktopBridge() || isInstalledBrowserApp());
+}
+
+function invalidateAuthGeneration() {
+	clearConvexRecovery();
+	authGeneration += 1;
+	nativeTokenInflight = null;
+}
 
 function getAuthBootstrapClient() {
 	if (bootstrapClient) {
@@ -87,11 +242,12 @@ async function getClientId() {
 }
 
 function getDesktopBridge() {
-	if (!browser) {
+	const appWindow = currentWindow();
+	if (!appWindow) {
 		return null;
 	}
 
-	const bridge = window.sprocketDesktopBridge;
+	const bridge = appWindow.sprocketDesktopBridge;
 	if (!bridge?.getLocalBootstrap || !bridge.openExternal || !bridge.focusWindow) {
 		return null;
 	}
@@ -100,11 +256,25 @@ function getDesktopBridge() {
 }
 
 function isInstalledBrowserApp() {
-	return browser && usesLoopbackBrowserAuth(window.location.hostname, false);
+	const appWindow = currentWindow();
+	if (!appWindow) {
+		return false;
+	}
+	return usesLoopbackBrowserAuth(appWindow.location.hostname, false);
+}
+
+async function pairLocalSession() {
+	const baseUrl = authRuntime.resolveLocalApiBaseUrl();
+	if (!baseUrl) {
+		throw new Error('Unable to resolve the Sprocket server URL.');
+	}
+
+	const bootstrap = await authRuntime.readDesktopBootstrap(baseUrl);
+	await authRuntime.ensureLocalSession(baseUrl, bootstrap);
 }
 
 async function getAuthClient() {
-	if (!browser) {
+	if (!currentWindow()) {
 		return null;
 	}
 
@@ -115,39 +285,37 @@ async function getAuthClient() {
 	authClientPromise = (async () => {
 		const clientId = await getClientId();
 		if (!clientId) {
-			authState.set({
-				isLoading: false,
-				isReady: true,
-				isConfigured: false,
-				isWaitingForBrowserSignIn: false,
-				browserSignInUrl: null,
-				user: null,
-				nativeSession: 'notRequired',
-				error: null
-			});
+			authState.set(signedOutState({ isConfigured: false }));
 			return null;
 		}
 
 		let client: AuthClient | null = null;
 
 		try {
-			client = await createClient(clientId, {
-				redirectUri: `${window.location.origin}/callback`,
+			client = await authRuntime.createAuthKitClient(clientId, {
+				redirectUri: `${currentWindow()?.location.origin}/callback`,
 				onRedirectCallback: () => {
 					window.location.replace('/');
 				},
 				onRefresh: () => {
+					const sdkUser = client?.getUser() ?? null;
 					authState.update((current) => ({
 						...current,
-						user: client?.getUser() ?? null,
+						user: sdkUser ? toAuthUser(sdkUser) : null,
 						error: null
 					}));
 				},
 				onRefreshFailure: () => {
+					// authkit-js already keeps the stored session on transient
+					// refresh failures and clears it only for terminal ones.
+					const sdkUser = client?.getUser() ?? null;
 					authState.update((current) => ({
 						...current,
-						user: null,
-						error: current.user && !isSigningOut ? 'Session refresh failed. Sign in again.' : null
+						user: sdkUser ? toAuthUser(sdkUser) : null,
+						error:
+							current.user && !sdkUser && !isSigningOut
+								? 'Session refresh failed. Sign in again.'
+								: current.error
 					}));
 				}
 			});
@@ -159,8 +327,8 @@ async function getAuthClient() {
 				isConfigured: true,
 				isWaitingForBrowserSignIn: false,
 				browserSignInUrl: null,
-				user,
-				nativeSession: isInstalledBrowserApp() && user ? 'loading' : 'notRequired',
+				user: user ? toAuthUser(user) : null,
+				nativeSession: get(authState).nativeSession,
 				error: null
 			});
 			return client;
@@ -175,68 +343,195 @@ async function getAuthClient() {
 
 export async function initializeAuth(convexClient: AuthBootstrapClient) {
 	bootstrapClient = convexClient;
+	const generation = authGeneration;
+	const previous = get(authState);
 	authState.set({
-		...get(authState),
-		isLoading: true
+		...previous,
+		isLoading: true,
+		nativeSession: isInstalledApp() && !previous.user ? 'loading' : previous.nativeSession
 	});
 
 	try {
-		const client = await getAuthClient();
-		const user = client?.getUser() ?? null;
-		authState.update((current) => {
-			if (!current.isConfigured) {
-				return {
-					...current,
-					isLoading: false,
-					isReady: true
-				};
+		if (isInstalledApp()) {
+			await pairLocalSession();
+			if (generation !== authGeneration) {
+				return;
 			}
-
-			return {
-				isLoading: false,
-				isReady: true,
-				isConfigured: true,
-				isWaitingForBrowserSignIn: false,
-				browserSignInUrl: null,
-				user,
-				nativeSession: isInstalledBrowserApp() && user ? 'loading' : 'notRequired',
-				error: null
-			};
-		});
-		if (isInstalledBrowserApp() && user) {
-			await reconcileNativeSession(user.id);
-		} else if (isInstalledBrowserApp()) {
-			await clearNativeSession().catch(() => {});
+			await initializeInstalledAuth(generation);
+			return;
 		}
+
+		await initializeHostedAuth();
 	} catch (error) {
+		if (generation !== authGeneration) {
+			return;
+		}
 		authState.update((current) => ({
 			...current,
 			isLoading: false,
 			isReady: true,
 			isWaitingForBrowserSignIn: false,
 			browserSignInUrl: null,
-			user: null,
-			nativeSession: 'notRequired',
+			nativeSession: current.nativeSession === 'loading' ? 'unavailable' : current.nativeSession,
 			error: error instanceof Error ? error.message : 'Failed to initialize authentication.'
 		}));
 	}
 }
 
-const errorMessagePayloadSchema = z.object({ error: z.string().optional() });
-const desktopLoginStartSchema = z.object({ authorizationUrl: z.url(), loginId: z.string() });
-const desktopLoginResultSchema = z.discriminatedUnion('status', [
-	z.object({ status: z.literal('signedOut') }),
-	z.object({ status: z.literal('pending') }),
-	z.object({
-		status: z.literal('authenticated'),
-		user: z.object({ id: z.string(), email: z.email() })
-	}),
-	z.object({ status: z.literal('unavailable'), error: z.string() }),
-	z.object({ status: z.literal('failed'), error: z.string() })
-]);
+async function initializeHostedAuth() {
+	const client = await getAuthClient();
+	const user = client?.getUser() ?? null;
+	authState.update((current) => {
+		if (!current.isConfigured) {
+			return {
+				...current,
+				isLoading: false,
+				isReady: true
+			};
+		}
+
+		return {
+			isLoading: false,
+			isReady: true,
+			isConfigured: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
+			user: user ? toAuthUser(user) : null,
+			nativeSession: 'notRequired',
+			error: null
+		};
+	});
+}
+
+async function initializeInstalledAuth(generation: number) {
+	if (installedAuthMode !== 'legacy') {
+		const outcome = await requestNativeSessionToken(false, generation);
+		if (generation !== authGeneration) {
+			return;
+		}
+		if (outcome.kind !== 'legacyUnavailable') {
+			installedAuthMode = 'native';
+			applyNativeInitializeOutcome(outcome);
+			return;
+		}
+		installedAuthMode = 'legacy';
+	}
+
+	await initializeLegacyInstalledAuth();
+}
+
+function applyNativeInitializeOutcome(outcome: NativeTokenOutcome) {
+	switch (outcome.kind) {
+		case 'session':
+			authState.set({
+				isLoading: false,
+				isReady: true,
+				isConfigured: true,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				user: outcome.user,
+				nativeSession: 'ready',
+				error: null
+			});
+			return;
+		case 'signedOut':
+			authState.set(signedOutState());
+			return;
+		case 'transient':
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: current.nativeSession === 'loading' ? 'unavailable' : current.nativeSession,
+				error: current.nativeSession === 'loading' ? outcome.error : current.error
+			}));
+			return;
+		case 'pairing':
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: 'unavailable',
+				error: outcome.error
+			}));
+			return;
+		case 'mismatch':
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: 'mismatch',
+				error: outcome.error
+			}));
+			return;
+		case 'stale':
+			return;
+		case 'legacyUnavailable':
+			return;
+		case 'error':
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: current.nativeSession === 'loading' ? 'unavailable' : current.nativeSession,
+				error: outcome.error
+			}));
+	}
+}
+
+function nativeSessionAfterLegacyBrowserUser(
+	current: AuthStatus['nativeSession'],
+	hasBrowserUser: boolean
+): AuthStatus['nativeSession'] {
+	if (hasBrowserUser) {
+		return current === 'notRequired' || current === 'loading' ? 'loading' : current;
+	}
+	return current === 'ready' ? 'ready' : 'notRequired';
+}
+
+async function initializeLegacyInstalledAuth() {
+	const client = await getAuthClient();
+	const user = client?.getUser() ?? null;
+	authState.update((current) => {
+		if (!current.isConfigured) {
+			return {
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: 'notRequired'
+			};
+		}
+
+		return {
+			isLoading: false,
+			isReady: true,
+			isConfigured: true,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
+			user: user ? toAuthUser(user) : null,
+			nativeSession: nativeSessionAfterLegacyBrowserUser(current.nativeSession, Boolean(user)),
+			error: null
+		};
+	});
+	if (user) {
+		await reconcileNativeSession(user.id);
+		return;
+	}
+	await repairLegacyNativeSessionWithoutBrowserUser();
+}
 
 async function fetchNativeSessionStatus() {
-	const response = await fetch('/api/auth/native-session', { credentials: 'include' });
+	let response: Response;
+	try {
+		response = await fetch('/api/auth/native-session', { credentials: 'include' });
+	} catch (error) {
+		throw Object.assign(new Error(error instanceof Error ? error.message : TRANSIENT_AUTH_ERROR), {
+			name: 'TransientAuthError'
+		});
+	}
+	if (isTransientHttpStatus(response.status)) {
+		throw Object.assign(new Error(TRANSIENT_AUTH_ERROR), { name: 'TransientAuthError' });
+	}
 	if (!response.ok) {
 		throw new Error(
 			await errorMessageFromFailedResponse(response, 'Failed to check native sign-in.')
@@ -269,9 +564,7 @@ async function reconcileNativeSession(browserUserId: string) {
 			authState.update((current) => ({
 				...current,
 				nativeSession: matches ? 'ready' : 'mismatch',
-				error: matches
-					? null
-					: 'The browser and native sessions use different accounts. Sign out, then sign in with the same account.'
+				error: matches ? null : MISMATCH_ERROR
 			}));
 			return;
 		}
@@ -280,12 +573,67 @@ async function reconcileNativeSession(browserUserId: string) {
 			nativeSession: result.status === 'signedOut' ? 'missing' : 'unavailable',
 			error:
 				result.status === 'signedOut'
-					? 'Finish setting up sign-in before starting an agent.'
+					? NATIVE_SETUP_ERROR
 					: result.status === 'unavailable' || result.status === 'failed'
 						? result.error
 						: 'Native sign-in is still pending.'
 		}));
 	} catch (error) {
+		if (error instanceof Error && error.name === 'TransientAuthError') {
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: current.nativeSession === 'loading' ? 'unavailable' : current.nativeSession
+			}));
+			return;
+		}
+		authState.update((current) => ({
+			...current,
+			nativeSession: 'unavailable',
+			error: error instanceof Error ? error.message : 'Failed to check native sign-in.'
+		}));
+	}
+}
+
+async function repairLegacyNativeSessionWithoutBrowserUser() {
+	try {
+		const result = await fetchNativeSessionStatus();
+		if (result.status === 'authenticated') {
+			authState.update((current) => ({
+				...current,
+				nativeSession: 'missing',
+				error: NATIVE_SETUP_ERROR
+			}));
+			return;
+		}
+		if (result.status === 'signedOut') {
+			authState.update((current) => ({
+				...current,
+				user: null,
+				nativeSession: 'notRequired',
+				error: null
+			}));
+			return;
+		}
+		authState.update((current) => ({
+			...current,
+			nativeSession: 'unavailable',
+			error:
+				result.status === 'unavailable' || result.status === 'failed'
+					? result.error
+					: 'Native sign-in is still pending.'
+		}));
+	} catch (error) {
+		if (error instanceof Error && error.name === 'TransientAuthError') {
+			authState.update((current) => ({
+				...current,
+				isLoading: false,
+				isReady: true,
+				nativeSession: current.nativeSession === 'loading' ? 'unavailable' : current.nativeSession
+			}));
+			return;
+		}
 		authState.update((current) => ({
 			...current,
 			nativeSession: 'unavailable',
@@ -295,13 +643,124 @@ async function reconcileNativeSession(browserUserId: string) {
 }
 
 export async function reconcileNativeAuthentication() {
-	if (!isInstalledBrowserApp()) {
+	if (!isInstalledApp()) {
 		return;
+	}
+	const generation = authGeneration;
+	if (installedAuthMode !== 'legacy') {
+		const outcome = await requestNativeSessionToken(false, generation);
+		if (generation !== authGeneration) {
+			return;
+		}
+		if (outcome.kind !== 'legacyUnavailable') {
+			installedAuthMode = 'native';
+			applyNativeInitializeOutcome(outcome);
+			return;
+		}
+		installedAuthMode = 'legacy';
 	}
 	const user = get(authState).user;
 	if (user) {
 		await reconcileNativeSession(user.id);
+		return;
 	}
+	await repairLegacyNativeSessionWithoutBrowserUser();
+}
+
+async function requestNativeSessionToken(
+	forceRefreshToken: boolean,
+	generation: number
+): Promise<NativeTokenOutcome> {
+	if (generation !== authGeneration) {
+		return { kind: 'stale' };
+	}
+
+	const inflight = nativeTokenInflight;
+	if (inflight && inflight.generation === generation) {
+		const shared = await inflight.promise;
+		if (generation !== authGeneration) {
+			return { kind: 'stale' };
+		}
+		if (!forceRefreshToken || inflight.forceRefreshToken) {
+			return shared;
+		}
+	}
+
+	const promise = fetchNativeSessionToken(forceRefreshToken);
+	nativeTokenInflight = { generation, forceRefreshToken, promise };
+	try {
+		const outcome = await promise;
+		if (generation !== authGeneration) {
+			return { kind: 'stale' };
+		}
+		return outcome;
+	} finally {
+		if (nativeTokenInflight?.promise === promise) {
+			nativeTokenInflight = null;
+		}
+	}
+}
+
+async function fetchNativeSessionToken(forceRefreshToken: boolean): Promise<NativeTokenOutcome> {
+	let response: Response;
+	try {
+		response = await fetch('/api/auth/native-session/token', {
+			method: 'POST',
+			credentials: 'include',
+			signal: AbortSignal.timeout(30_000),
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ forceRefreshToken })
+		});
+	} catch (error) {
+		return {
+			kind: 'transient',
+			error: error instanceof Error ? error.message : TRANSIENT_AUTH_ERROR
+		};
+	}
+
+	if (isLegacyMissingEndpoint(response.status)) {
+		return { kind: 'legacyUnavailable' };
+	}
+	if (response.status === 401) {
+		return {
+			kind: 'pairing',
+			error: await errorMessageFromFailedResponse(
+				response,
+				'Pair with your Sprocket server to continue.'
+			)
+		};
+	}
+	if (response.status === 409) {
+		return {
+			kind: 'mismatch',
+			error: await errorMessageFromFailedResponse(response, ACCOUNT_BINDING_ERROR)
+		};
+	}
+	if (isTransientHttpStatus(response.status)) {
+		return {
+			kind: 'transient',
+			error: await errorMessageFromFailedResponse(response, TRANSIENT_AUTH_ERROR)
+		};
+	}
+	if (!response.ok) {
+		return {
+			kind: 'error',
+			error: await errorMessageFromFailedResponse(response, 'Failed to read the native session.')
+		};
+	}
+
+	const parsed = nativeSessionTokenSchema.safeParse(await response.json().catch(() => undefined));
+	if (!parsed.success) {
+		return { kind: 'error', error: 'Local server returned an invalid native session.' };
+	}
+	if (parsed.data === null) {
+		return { kind: 'signedOut' };
+	}
+	return {
+		kind: 'session',
+		accessToken: parsed.data.accessToken,
+		user: toAuthUser(parsed.data.user)
+	};
 }
 
 async function errorMessageFromFailedResponse(
@@ -370,6 +829,24 @@ async function startDesktopLoginInOrder(
 	}
 }
 
+async function fetchDesktopLoginResult(signal: AbortSignal) {
+	let response: Response;
+	try {
+		response = await fetch('/api/auth/desktop-login/result', {
+			credentials: 'include',
+			signal: AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+		});
+	} catch (error) {
+		if (signal.aborted) throw error;
+		return null;
+	}
+	if (isTransientHttpStatus(response.status)) return null;
+	if (!response.ok) {
+		throw new Error(await errorMessageFromFailedResponse(response, 'Failed to check desktop sign-in status.'));
+	}
+	return desktopLoginResultSchema.parse(await response.json());
+}
+
 async function pollDesktopLoginResult(signal: AbortSignal): Promise<{ id: string; email: string }> {
 	const startedAt = Date.now();
 
@@ -378,33 +855,14 @@ async function pollDesktopLoginResult(signal: AbortSignal): Promise<{ id: string
 			throw new Error('Sign-in timed out. Try again.');
 		}
 
-		const response = await fetch('/api/auth/desktop-login/result', {
-			credentials: 'include',
-			signal
-		});
+		const result = await fetchDesktopLoginResult(signal);
 
-		if (!response.ok) {
-			throw new Error(
-				await errorMessageFromFailedResponse(response, 'Failed to check desktop sign-in status.')
-			);
-		}
-
-		const payload = desktopLoginResultSchema.safeParse(await response.json());
-		if (!payload.success) {
-			throw new Error('Failed to check desktop sign-in status.');
-		}
-		const result = payload.data;
-
-		if (result.status === 'failed') {
+		if (result?.status === 'failed') {
 			throw new Error(result.error || 'Desktop sign-in failed.');
 		}
 
-		if (result.status === 'authenticated') {
+		if (result?.status === 'authenticated') {
 			return result.user;
-		}
-
-		if (result.status === 'unavailable') {
-			throw new Error(result.error);
 		}
 
 		await new Promise<void>((resolve, reject) => {
@@ -425,7 +883,7 @@ async function pollDesktopLoginResult(signal: AbortSignal): Promise<{ id: string
 	throw new DOMException('Aborted', 'AbortError');
 }
 
-async function authenticateWithLoopbackBrowser(flow: AuthFlow, browserUser: User | null) {
+async function authenticateWithLoopbackBrowser(flow: AuthFlow) {
 	const bridge = getDesktopBridge();
 	if (!bridge && !isInstalledBrowserApp()) {
 		throw new Error('Loopback browser sign-in is unavailable.');
@@ -493,36 +951,7 @@ async function authenticateWithLoopbackBrowser(flow: AuthFlow, browserUser: User
 			}
 		}
 		requireCurrentDesktopSignIn(attempt);
-		if (browserUser) {
-			if (nativeUser.id !== browserUser.id) {
-				authState.update((current) => ({
-					...current,
-					isWaitingForBrowserSignIn: false,
-					browserSignInUrl: null,
-					nativeSession: 'mismatch',
-					error:
-						'The browser and native sessions use different accounts. Sign out, then sign in with the same account.'
-				}));
-				return;
-			}
-			authState.update((current) => ({
-				...current,
-				isWaitingForBrowserSignIn: false,
-				browserSignInUrl: null,
-				nativeSession: 'ready',
-				error: null
-			}));
-			return;
-		}
-
-		const client = await getAuthClient();
-		if (!client) {
-			throw new Error('Browser authentication is not configured.');
-		}
-		const browserAuthorizeUrl =
-			flow === 'signUp' ? await client.getSignUpUrl() : await client.getSignInUrl();
-		requireCurrentDesktopSignIn(attempt);
-		window.location.href = browserAuthorizeUrl;
+		await completeInstalledSignIn(flow, attempt, nativeUser);
 	} catch (error) {
 		if (desktopSignInAttempt !== attempt) {
 			return;
@@ -549,6 +978,138 @@ async function authenticateWithLoopbackBrowser(flow: AuthFlow, browserUser: User
 			desktopSignInAttempt = null;
 		}
 	}
+}
+
+async function completeInstalledSignIn(
+	flow: AuthFlow,
+	attempt: DesktopSignInAttempt,
+	nativeUser: { id: string; email: string }
+) {
+	invalidateAuthGeneration();
+	if (installedAuthMode === 'legacy') {
+		await completeLegacyBrowserLogin(flow, attempt, nativeUser);
+		return;
+	}
+
+	const generation = authGeneration;
+	const outcome = await requestNativeSessionToken(false, generation);
+	requireCurrentDesktopSignIn(attempt);
+	if (outcome.kind === 'stale') {
+		return;
+	}
+	if (outcome.kind === 'legacyUnavailable') {
+		installedAuthMode = 'legacy';
+		await completeLegacyBrowserLogin(flow, attempt, nativeUser);
+		return;
+	}
+
+	installedAuthMode = 'native';
+	applyNativeLoginOutcome(outcome, toAuthUser(nativeUser));
+}
+
+function applyNativeLoginOutcome(outcome: NativeTokenOutcome, fallbackUser: AuthUser) {
+	switch (outcome.kind) {
+		case 'session':
+			authState.set({
+				isLoading: false,
+				isReady: true,
+				isConfigured: true,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				user: outcome.user,
+				nativeSession: 'ready',
+				error: null
+			});
+			return;
+		case 'transient':
+			authState.set({
+				isLoading: false,
+				isReady: true,
+				isConfigured: true,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				user: fallbackUser,
+				nativeSession: 'ready',
+				error: null
+			});
+			return;
+		case 'signedOut':
+			authState.set(
+				signedOutState({
+					error: 'Native sign-in finished without a session. Try again.'
+				})
+			);
+			return;
+		case 'pairing':
+			authState.update((current) => ({
+				...current,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				nativeSession: 'unavailable',
+				error: outcome.error
+			}));
+			return;
+		case 'mismatch':
+			authState.update((current) => ({
+				...current,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				nativeSession: 'mismatch',
+				error: outcome.error
+			}));
+			return;
+		case 'error':
+			authState.update((current) => ({
+				...current,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				nativeSession: 'unavailable',
+				error: outcome.error
+			}));
+			return;
+		case 'legacyUnavailable':
+		case 'stale':
+			return;
+	}
+}
+
+async function completeLegacyBrowserLogin(
+	flow: AuthFlow,
+	attempt: DesktopSignInAttempt,
+	nativeUser: { id: string; email: string }
+) {
+	const client = await getAuthClient();
+	requireCurrentDesktopSignIn(attempt);
+	const browserUser = client?.getUser() ?? null;
+	if (browserUser) {
+		if (nativeUser.id !== browserUser.id) {
+			authState.update((current) => ({
+				...current,
+				isWaitingForBrowserSignIn: false,
+				browserSignInUrl: null,
+				nativeSession: 'mismatch',
+				error: MISMATCH_ERROR
+			}));
+			return;
+		}
+		authState.update((current) => ({
+			...current,
+			isWaitingForBrowserSignIn: false,
+			browserSignInUrl: null,
+			user: toAuthUser(browserUser),
+			nativeSession: 'ready',
+			error: null
+		}));
+		return;
+	}
+
+	if (!client) {
+		throw new Error('Browser authentication is not configured.');
+	}
+	const browserAuthorizeUrl =
+		flow === 'signUp' ? await client.getSignUpUrl() : await client.getSignInUrl();
+	requireCurrentDesktopSignIn(attempt);
+	window.location.href = browserAuthorizeUrl;
 }
 
 function stopDesktopSignInPolling() {
@@ -600,6 +1161,11 @@ export function clearDesktopSignInOpenError() {
 }
 
 async function authenticate(flow: AuthFlow) {
+	if (isInstalledApp()) {
+		await authenticateWithLoopbackBrowser(flow);
+		return;
+	}
+
 	const client = await getAuthClient();
 	if (!client) {
 		return;
@@ -607,11 +1173,6 @@ async function authenticate(flow: AuthFlow) {
 
 	const clientId = await getClientId();
 	if (!clientId) {
-		return;
-	}
-
-	if (getDesktopBridge() || isInstalledBrowserApp()) {
-		await authenticateWithLoopbackBrowser(flow, client.getUser());
 		return;
 	}
 
@@ -632,42 +1193,59 @@ export async function signUp() {
 }
 
 export async function signOut() {
-	const client = await getAuthClient();
-	if (!client) {
-		return;
-	}
-
 	cancelDesktopSignIn();
 	isSigningOut = true;
+	invalidateAuthGeneration();
 	authState.update((current) => ({ ...current, isLoading: true }));
 
 	const errors: string[] = [];
 	let browserSignOutFailed = false;
+	let remainingBrowserUser: AuthUser | null = null;
 	try {
-		if (getDesktopBridge() || isInstalledBrowserApp()) {
+		if (isInstalledApp()) {
 			try {
 				await clearNativeSession();
 			} catch (error) {
 				errors.push(error instanceof Error ? error.message : 'Failed to clear native session.');
 			}
-		}
-		try {
-			await client.signOut({ navigate: false, returnTo: window.location.origin });
-		} catch (error) {
-			browserSignOutFailed = true;
-			errors.push(error instanceof Error ? error.message : 'Failed to clear browser session.');
+			if (installedAuthMode === 'legacy') {
+				const client = await getAuthClient();
+				if (client) {
+					try {
+						await client.signOut({ navigate: false, returnTo: window.location.origin });
+					} catch (error) {
+						browserSignOutFailed = true;
+						const sdkUser = client.getUser();
+						remainingBrowserUser = sdkUser ? toAuthUser(sdkUser) : null;
+						errors.push(
+							error instanceof Error ? error.message : 'Failed to clear browser session.'
+						);
+					}
+				}
+			}
+		} else {
+			const client = await getAuthClient();
+			if (!client) {
+				authState.set(signedOutState());
+				return;
+			}
+			try {
+				await client.signOut({ navigate: false, returnTo: window.location.origin });
+			} catch (error) {
+				browserSignOutFailed = true;
+				const sdkUser = client.getUser();
+				remainingBrowserUser = sdkUser ? toAuthUser(sdkUser) : null;
+				errors.push(error instanceof Error ? error.message : 'Failed to clear browser session.');
+			}
 		}
 		convexAuthRetryPending.set(false);
-		authState.set({
-			isLoading: false,
-			isReady: true,
-			isConfigured: true,
-			isWaitingForBrowserSignIn: false,
-			browserSignInUrl: null,
-			user: browserSignOutFailed ? client.getUser() : null,
-			nativeSession: errors.length === 0 ? 'notRequired' : 'unavailable',
-			error: errors.length === 0 ? null : errors.join(' ')
-		});
+		authState.set(
+			signedOutState({
+				user: browserSignOutFailed ? remainingBrowserUser : null,
+				nativeSession: errors.length === 0 ? 'notRequired' : 'unavailable',
+				error: errors.length === 0 ? null : errors.join(' ')
+			})
+		);
 	} catch (error) {
 		authState.update((current) => ({
 			...current,
@@ -682,6 +1260,108 @@ export async function signOut() {
 export async function getAccessToken({
 	forceRefreshToken = false
 }: { forceRefreshToken?: boolean } = {}) {
+	if (isInstalledApp() && installedAuthMode !== 'legacy') {
+		const generation = authGeneration;
+		const outcome = await requestNativeSessionToken(forceRefreshToken, generation);
+		if (generation !== authGeneration || outcome.kind === 'stale') {
+			return null;
+		}
+		if (outcome.kind === 'legacyUnavailable') {
+			installedAuthMode = 'legacy';
+			return await getAuthKitAccessToken({ forceRefreshToken });
+		}
+		installedAuthMode = 'native';
+		return applyNativeAccessTokenOutcome(outcome, generation);
+	}
+
+	return await getAuthKitAccessToken({ forceRefreshToken });
+}
+
+function clearConvexRecovery() {
+	if (convexRecoveryTimer !== null) {
+		clearTimeout(convexRecoveryTimer);
+		convexRecoveryTimer = null;
+	}
+}
+
+export async function getConvexAccessToken(options: { forceRefreshToken: boolean }) {
+	const generation = authGeneration;
+	try {
+		if (isInstalledApp() && get(authState).nativeSession === 'unavailable') {
+			await pairLocalSession();
+			if (generation !== authGeneration) return null;
+		}
+		const token = await getAccessToken(options);
+		if (generation !== authGeneration) return null;
+		clearConvexRecovery();
+		return token;
+	} catch (error) {
+		if (generation !== authGeneration) return null;
+		authState.update((current) => ({
+			...current,
+			error: error instanceof Error ? error.message : 'Session refresh is temporarily unavailable.'
+		}));
+		const state = get(authState);
+		if (state.user && state.nativeSession !== 'mismatch' && convexRecoveryTimer === null) {
+			convexRecoveryTimer = setTimeout(() => {
+				convexRecoveryTimer = null;
+				if (generation === authGeneration && get(authState).user) {
+					convexAuthRetryVersion.update((version) => version + 1);
+				}
+			}, 5_000);
+		}
+		// Convex does not catch fetcher rejections, including while its socket is stopped.
+		return null;
+	}
+}
+
+function applyNativeAccessTokenOutcome(outcome: NativeTokenOutcome, generation: number) {
+	if (generation !== authGeneration) {
+		return null;
+	}
+
+	switch (outcome.kind) {
+		case 'session':
+			authState.update((current) => ({
+				...current,
+				user: outcome.user,
+				nativeSession: 'ready',
+				error: null
+			}));
+			return outcome.accessToken;
+		case 'signedOut':
+			authState.update((current) => ({
+				...current,
+				user: null,
+				nativeSession: 'notRequired',
+				error: null
+			}));
+			return null;
+		case 'transient':
+			throw new Error(outcome.error);
+		case 'pairing':
+			authState.update((current) => ({
+				...current,
+				nativeSession: 'unavailable',
+				error: outcome.error
+			}));
+			throw new Error(outcome.error);
+		case 'mismatch':
+			authState.update((current) => ({
+				...current,
+				nativeSession: 'mismatch',
+				error: outcome.error
+			}));
+			throw new Error(outcome.error);
+		case 'error':
+			throw new Error(outcome.error);
+		case 'legacyUnavailable':
+		case 'stale':
+			return null;
+	}
+}
+
+async function getAuthKitAccessToken({ forceRefreshToken }: { forceRefreshToken: boolean }) {
 	const client = await getAuthClient();
 	if (!client) {
 		return null;
@@ -730,11 +1410,17 @@ export function advanceConvexAuthRetryPending(args: {
 }
 
 export async function retryConvexAuthentication() {
+	const generation = authGeneration;
 	authState.update((current) => ({ ...current, isLoading: true, error: null }));
 	convexAuthRetryPending.set(true);
 
 	try {
+		if (isInstalledApp()) {
+			await pairLocalSession();
+			if (generation !== authGeneration) return;
+		}
 		const token = await getAccessToken({ forceRefreshToken: true });
+		if (generation !== authGeneration) return;
 		if (!token) {
 			throw new Error('Your session has expired. Sign in again.');
 		}
@@ -743,6 +1429,7 @@ export async function retryConvexAuthentication() {
 		convexAuthRetryVersion.update((version) => version + 1);
 		authState.update((current) => ({ ...current, isLoading: false, error: null }));
 	} catch (error) {
+		if (generation !== authGeneration) return;
 		convexAuthRetryPending.set(false);
 		authState.update((current) => ({
 			...current,

--- a/apps/web/src/lib/components/home/auth-gate.svelte
+++ b/apps/web/src/lib/components/home/auth-gate.svelte
@@ -54,7 +54,7 @@
 			: showConfirming
 				? 'Verifying your secure connection before opening your projects.'
 				: authState.connectionFailed
-					? 'You’re signed in, but the secure connection could not be confirmed. Retry or sign out and sign in again.'
+					? 'Your session could not be confirmed. Retry when the connection is available.'
 					: showPreparing
 						? 'Getting account sign-in ready. This usually takes a moment.'
 						: 'Sign in to sync your coding threads, streaming responses, and projects.'
@@ -82,12 +82,12 @@
 		{/if}
 
 		{#snippet actions()}
+			{#if authState.connectionFailed && authState.isConfigured}
+				<Button onclick={onRetry} disabled={authState.isLoading}>{retryLabel}</Button>
+			{/if}
 			{#if authState.isAuthenticated}
-				{#if authState.connectionFailed}
-					<Button onclick={onRetry} disabled={authState.isLoading}>{retryLabel}</Button>
-				{/if}
 				<Button variant="outline" onclick={onSignOut}>Sign Out</Button>
-			{:else if authState.isConfigured}
+			{:else if authState.isConfigured && !authState.connectionFailed}
 				<Button onclick={onSignIn} disabled={authState.isLoading}>Sign In</Button>
 				<Button variant="outline" onclick={onSignUp} disabled={authState.isLoading}>
 					Create Account

--- a/apps/web/src/lib/components/home/settings-account.svelte
+++ b/apps/web/src/lib/components/home/settings-account.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { LogOut } from '@lucide/svelte';
-	import type { User } from '@workos-inc/authkit-js';
 	import { useAuth, useQuery } from 'convex-svelte';
 	import { api } from '$convex/_generated/api';
 	import { tierLabels } from '$convex/lib/tiers';
+	import type { AuthUser } from '$lib/auth';
 	import Button from '$lib/components/ui/button/button.svelte';
 
 	type Props = {
-		user: User | null;
+		user: AuthUser | null;
 		onSignOut: () => void;
 	};
 

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
 import {
 	createLocalClient,
+	ensureLocalSession,
 	readWorkspaceLaunchFromHash,
 	workspaceLaunchHash
 } from '$lib/local/client';
@@ -18,6 +19,32 @@ function runId(value: string): Id<'runs'> {
 
 afterEach(() => {
 	vi.unstubAllGlobals();
+});
+
+describe('local pairing', () => {
+	it("shares startup pairing so auth and the local API do not replace each other's cookie", async () => {
+		vi.stubGlobal('window', { location: { hash: '' } });
+		const fetch = vi.fn(async (url: string) => {
+			if (url.endsWith('/api/auth/session')) {
+				return Response.json({ authenticated: false });
+			}
+			return Response.json({ authenticated: true });
+		});
+		vi.stubGlobal('fetch', fetch);
+		const bootstrap = { httpBaseUrl: 'http://localhost:17731', pairingCredential: 'test' };
+		await Promise.all([
+			ensureLocalSession(bootstrap.httpBaseUrl, bootstrap),
+			ensureLocalSession(bootstrap.httpBaseUrl, bootstrap)
+		]);
+		expect(fetch.mock.calls.map(([url]) => url)).toEqual([
+			`${bootstrap.httpBaseUrl}/api/auth/session`,
+			`${bootstrap.httpBaseUrl}/api/auth/bootstrap`
+		]);
+
+		fetch.mockClear();
+		await ensureLocalSession(bootstrap.httpBaseUrl, bootstrap);
+		expect(fetch).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe('workspace launch fragments', () => {

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -394,7 +394,23 @@ export async function hasLocalSession(baseUrl: string): Promise<boolean> {
 	return session.success ? Boolean(session.data.authenticated) : false;
 }
 
+const localSessionRequests = new Map<string, Promise<void>>();
+
 export async function ensureLocalSession(baseUrl: string, bootstrap?: LocalBootstrap | null) {
+	const pending = localSessionRequests.get(baseUrl);
+	if (pending) {
+		return await pending;
+	}
+	const request = establishLocalSession(baseUrl, bootstrap);
+	localSessionRequests.set(baseUrl, request);
+	try {
+		await request;
+	} finally {
+		localSessionRequests.delete(baseUrl);
+	}
+}
+
+async function establishLocalSession(baseUrl: string, bootstrap?: LocalBootstrap | null) {
 	if (await hasLocalSession(baseUrl)) {
 		return;
 	}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 		convexAuthLoading,
 		convexAuthUserId,
 		convexAuthRetryVersion,
-		getAccessToken,
+		getConvexAccessToken,
 		initializeAuth
 	} from '$lib/auth';
 	import type { RuntimeConfig } from './+layout';
@@ -27,7 +27,7 @@
 		return {
 			isLoading: $convexAuthLoading,
 			isAuthenticated: Boolean($convexAuthUserId),
-			fetchAccessToken: getAccessToken
+			fetchAccessToken: getConvexAccessToken
 		};
 	});
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -110,6 +110,9 @@
 			$authState.nativeSession === 'mismatch' ||
 			$authState.nativeSession === 'unavailable'
 	);
+	const nativeSignInRequired = $derived(
+		$authState.nativeSession === 'missing' || $authState.nativeSession === 'mismatch'
+	);
 	const authReady = $derived(
 		$authState.isReady &&
 			!$authState.isLoading &&
@@ -2151,8 +2154,8 @@
 			overlayOpen={$authState.isWaitingForBrowserSignIn}
 			onSignIn={() => void signIn()}
 			onSignOut={() => void signOut()}
-			onRetry={() => void (nativeAuthBlocked ? signIn() : retryConvexAuthentication())}
-			retryLabel={nativeAuthBlocked ? 'Finish sign-in' : 'Retry'}
+			onRetry={() => void (nativeSignInRequired ? signIn() : retryConvexAuthentication())}
+			retryLabel={nativeSignInRequired ? 'Finish sign-in' : 'Retry'}
 			onSignUp={() => void signUp()}
 		/>
 		<BrowserSignInOverlay

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
 		proxy: {
 			'/api': {
 				target: DEV_API_URL,
-				changeOrigin: true
+				changeOrigin: false
 			}
 		}
 	},

--- a/crates/sprocket-convex/Cargo.toml
+++ b/crates/sprocket-convex/Cargo.toml
@@ -6,8 +6,12 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
+base64 = "0.22.1"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 rustls = { version = "0.23.40", features = ["ring"] }
-serde = "1.0.228"
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.52.1", features = ["sync", "time"] }
+tokio = { version = "1.52.1", features = ["rt", "sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1.52.1", features = ["macros", "rt", "sync", "test-util", "time"] }

--- a/crates/sprocket-convex/src/auth.rs
+++ b/crates/sprocket-convex/src/auth.rs
@@ -1,0 +1,664 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::{AuthSignedOut, AuthTokenFetcher};
+
+/// Matches Convex JS `authRefreshTokenLeewaySeconds` default.
+const REFRESH_LEEWAY_SECS: u64 = 10;
+/// Matches Convex JS: tokens shorter than this cannot be rescheduled.
+const MIN_TOKEN_LIFETIME_SECS: u64 = 2;
+/// Matches Convex JS `MAXIMUM_REFRESH_DELAY` (setTimeout's 32-bit cap).
+const MAXIMUM_REFRESH_DELAY: Duration = Duration::from_secs(20 * 24 * 60 * 60);
+
+pub(crate) type ApplyRefresh =
+    Arc<dyn Fn(u64) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+struct AuthSlots {
+    fetcher: Option<AuthTokenFetcher>,
+    pending_user_token: Option<Result<String, AuthSignedOut>>,
+}
+
+pub(crate) struct AuthState {
+    generation: AtomicU64,
+    fetch_epoch: AtomicU64,
+    slots: Mutex<AuthSlots>,
+    refresh: std::sync::Mutex<Option<JoinHandle<()>>>,
+    on_apply: std::sync::OnceLock<ApplyRefresh>,
+}
+
+impl AuthState {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            generation: AtomicU64::new(0),
+            fetch_epoch: AtomicU64::new(0),
+            slots: Mutex::new(AuthSlots {
+                fetcher: None,
+                pending_user_token: None,
+            }),
+            refresh: std::sync::Mutex::new(None),
+            on_apply: std::sync::OnceLock::new(),
+        })
+    }
+
+    pub(crate) fn set_on_apply(&self, on_apply: ApplyRefresh) {
+        let _ = self.on_apply.set(on_apply);
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
+        self.abort_refresh();
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn install(self: &Arc<Self>, fetcher: AuthTokenFetcher) -> u64 {
+        self.abort_refresh();
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
+        let mut slots = self.slots.lock().await;
+        slots.fetcher = Some(fetcher);
+        slots.pending_user_token = None;
+        generation
+    }
+
+    pub(crate) async fn clear(&self) {
+        self.shutdown();
+        let mut slots = self.slots.lock().await;
+        slots.fetcher = None;
+        slots.pending_user_token = None;
+    }
+
+    pub(crate) async fn resolve(
+        self: &Arc<Self>,
+        generation: u64,
+        force_refresh: bool,
+    ) -> anyhow::Result<String> {
+        if self.generation.load(Ordering::SeqCst) != generation {
+            anyhow::bail!("stale auth callback");
+        }
+
+        let (fetcher, pending, epoch) = {
+            let mut slots = self.slots.lock().await;
+            if force_refresh {
+                slots.pending_user_token = None;
+            }
+            let pending = if force_refresh {
+                None
+            } else {
+                slots.pending_user_token.take()
+            };
+            let epoch = if pending.is_some() {
+                self.fetch_epoch.load(Ordering::SeqCst)
+            } else {
+                self.fetch_epoch.fetch_add(1, Ordering::SeqCst) + 1
+            };
+            (slots.fetcher.clone(), pending, epoch)
+        };
+
+        let token = if let Some(token) = pending {
+            token?
+        } else {
+            let fetcher = fetcher.context("auth fetcher missing")?;
+            let token = fetcher(force_refresh).await?;
+            if self.generation.load(Ordering::SeqCst) != generation
+                || self.fetch_epoch.load(Ordering::SeqCst) != epoch
+            {
+                anyhow::bail!("stale auth callback");
+            }
+            token
+        };
+
+        Ok(token)
+    }
+
+    pub(crate) async fn arm(self: &Arc<Self>, generation: u64, token: &str) {
+        if self.generation.load(Ordering::SeqCst) != generation {
+            return;
+        }
+        self.abort_refresh();
+        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
+        let Some(delay) = refresh_delay_for_token(token, SystemTime::now()) else {
+            return;
+        };
+        let weak = Arc::downgrade(self);
+        let handle = tokio::spawn(scheduled_refresh(
+            weak,
+            generation,
+            delay.max(Duration::from_secs(1)),
+        ));
+        *lock_refresh(&self.refresh) = Some(handle);
+    }
+
+    fn abort_refresh(&self) {
+        if let Some(handle) = lock_refresh(&self.refresh).take() {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for AuthState {
+    fn drop(&mut self) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
+        if let Some(handle) = self
+            .refresh
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            handle.abort();
+        }
+    }
+}
+
+fn lock_refresh(
+    refresh: &std::sync::Mutex<Option<JoinHandle<()>>>,
+) -> std::sync::MutexGuard<'_, Option<JoinHandle<()>>> {
+    refresh
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Duration) {
+    tokio::time::sleep(delay).await;
+    let (fetcher, epoch) = {
+        let Some(auth) = weak.upgrade() else {
+            return;
+        };
+        if auth.generation.load(Ordering::SeqCst) != generation {
+            return;
+        }
+        // Capture, don't bump: bumping here would make a concurrent SDK
+        // reconnect fetch look stale and skip Authenticate.
+        let epoch = auth.fetch_epoch.load(Ordering::SeqCst);
+        let fetcher = auth.slots.lock().await.fetcher.clone();
+        (fetcher, epoch)
+    };
+    let Some(fetcher) = fetcher else {
+        return;
+    };
+    let mut retry_delay = Duration::from_secs(1);
+    let token = loop {
+        match fetcher(true).await {
+            Ok(token) => break Ok(token),
+            Err(error) if error.is::<AuthSignedOut>() => break Err(AuthSignedOut),
+            Err(_) => {}
+        }
+        tokio::time::sleep(retry_delay).await;
+        retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
+        let Some(auth) = weak.upgrade() else {
+            return;
+        };
+        if auth.generation() != generation || auth.fetch_epoch.load(Ordering::SeqCst) != epoch {
+            return;
+        }
+    };
+    let Some(auth) = weak.upgrade() else {
+        return;
+    };
+    if auth.generation.load(Ordering::SeqCst) != generation
+        || auth.fetch_epoch.load(Ordering::SeqCst) != epoch
+    {
+        return;
+    }
+    auth.slots.lock().await.pending_user_token = Some(token);
+    let on_apply = auth.on_apply.get().cloned();
+    drop(auth);
+    if let Some(on_apply) = on_apply {
+        on_apply(generation).await;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct JwtLifetime {
+    iat: u64,
+    exp: u64,
+}
+
+#[derive(Deserialize)]
+struct JwtDates {
+    iat: Option<u64>,
+    exp: Option<u64>,
+}
+
+fn decode_jwt_lifetime(token: &str) -> Option<JwtLifetime> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload.trim_end_matches('=')).ok()?;
+    let dates: JwtDates = serde_json::from_slice(&decoded).ok()?;
+    Some(JwtLifetime {
+        iat: dates.iat?,
+        exp: dates.exp?,
+    })
+}
+
+fn refresh_delay_for_token(token: &str, now: SystemTime) -> Option<Duration> {
+    refresh_delay(decode_jwt_lifetime(token)?, now)
+}
+
+fn refresh_delay(lifetime: JwtLifetime, now: SystemTime) -> Option<Duration> {
+    let full_secs = lifetime.exp.saturating_sub(lifetime.iat);
+    if full_secs <= MIN_TOKEN_LIFETIME_SECS {
+        return None;
+    }
+    let now_secs = now.duration_since(UNIX_EPOCH).ok()?.as_secs();
+    let remaining_secs = lifetime.exp.saturating_sub(now_secs);
+    // Fresh tokens: Convex JS uses `exp - iat` as validity starting now (clock-skew
+    // safe). Cached tokens: remaining wall time is shorter and must win.
+    let validity_secs = full_secs.min(remaining_secs);
+    let delay_secs = validity_secs.saturating_sub(REFRESH_LEEWAY_SECS);
+    Some(Duration::from_secs(delay_secs).min(MAXIMUM_REFRESH_DELAY))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio::time;
+
+    fn encode_json(value: serde_json::Value) -> String {
+        URL_SAFE_NO_PAD.encode(value.to_string().as_bytes())
+    }
+
+    fn jwt(iat: u64, exp: u64) -> String {
+        format!(
+            "{}.{}.sig",
+            encode_json(json!({ "alg": "none", "typ": "JWT" })),
+            encode_json(json!({ "iat": iat, "exp": exp })),
+        )
+    }
+
+    fn unix(now: SystemTime) -> u64 {
+        now.duration_since(UNIX_EPOCH).expect("unix time").as_secs()
+    }
+
+    fn counting_fetcher(fetches: Arc<Mutex<Vec<bool>>>, token: String) -> AuthTokenFetcher {
+        Arc::new(move |force_refresh| {
+            let fetches = Arc::clone(&fetches);
+            let token = token.clone();
+            Box::pin(async move {
+                fetches.lock().await.push(force_refresh);
+                Ok(token)
+            })
+        })
+    }
+
+    #[test]
+    fn refresh_delay_uses_remaining_lifetime_for_cached_tokens() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let delay = refresh_delay(
+            JwtLifetime {
+                iat: 900,
+                exp: 1_040,
+            },
+            now,
+        )
+        .expect("schedulable");
+        // remaining 40s, leeway 10s -> 30s, not the 140s full lifetime.
+        assert_eq!(delay, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn refresh_delay_uses_full_lifetime_when_token_is_fresh() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let delay = refresh_delay(
+            JwtLifetime {
+                iat: 1_000,
+                exp: 1_130,
+            },
+            now,
+        )
+        .expect("schedulable");
+        assert_eq!(delay, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn refresh_delay_is_immediate_inside_leeway() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let delay = refresh_delay(
+            JwtLifetime {
+                iat: 990,
+                exp: 1_005,
+            },
+            now,
+        )
+        .expect("schedulable");
+        assert_eq!(delay, Duration::ZERO);
+    }
+
+    #[test]
+    fn refresh_delay_skips_tokens_that_do_not_live_long_enough() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        assert_eq!(
+            refresh_delay(
+                JwtLifetime {
+                    iat: 1_000,
+                    exp: 1_002,
+                },
+                now,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_delay_caps_at_maximum() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let delay = refresh_delay(
+            JwtLifetime {
+                iat: 1_000,
+                exp: 1_000 + 40 * 24 * 60 * 60,
+            },
+            now,
+        )
+        .expect("schedulable");
+        assert_eq!(delay, MAXIMUM_REFRESH_DELAY);
+    }
+
+    #[test]
+    fn decode_jwt_lifetime_rejects_non_jwt() {
+        assert_eq!(decode_jwt_lifetime("not-a-jwt"), None);
+        assert_eq!(decode_jwt_lifetime("a.b"), None);
+    }
+
+    fn token_with_refresh_delay(delay: Duration) -> String {
+        let now = unix(SystemTime::now());
+        let lifetime = delay.as_secs() + REFRESH_LEEWAY_SECS;
+        jwt(now, now + lifetime)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduled_refresh_fetches_with_force_refresh() {
+        let auth = AuthState::new();
+        let fetches = Arc::new(Mutex::new(Vec::new()));
+        let token = token_with_refresh_delay(Duration::from_secs(60));
+        let generation = auth
+            .install(counting_fetcher(Arc::clone(&fetches), token.clone()))
+            .await;
+        let (applied, mut applied_rx) = mpsc::unbounded_channel();
+        auth.set_on_apply(Arc::new(move |generation| {
+            let applied = applied.clone();
+            Box::pin(async move {
+                let _ = applied.send(generation);
+            })
+        }));
+
+        auth.arm(generation, &token).await;
+        time::advance(Duration::from_secs(50)).await;
+        assert!(fetches.lock().await.is_empty());
+        time::advance(Duration::from_secs(20)).await;
+        assert_eq!(applied_rx.recv().await, Some(generation));
+        assert_eq!(*fetches.lock().await, vec![true]);
+        assert_eq!(
+            auth.slots
+                .lock()
+                .await
+                .pending_user_token
+                .as_ref()
+                .and_then(|token| token.as_ref().ok())
+                .map(String::as_str),
+            Some(token.as_str())
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn clear_cancels_scheduled_refresh() {
+        let auth = AuthState::new();
+        let fetches = Arc::new(Mutex::new(Vec::new()));
+        let token = token_with_refresh_delay(Duration::from_secs(60));
+        let generation = auth
+            .install(counting_fetcher(Arc::clone(&fetches), token.clone()))
+            .await;
+        let applied = Arc::new(AtomicUsize::new(0));
+        let applied_count = Arc::clone(&applied);
+        auth.set_on_apply(Arc::new(move |_| {
+            let applied_count = Arc::clone(&applied_count);
+            Box::pin(async move {
+                applied_count.fetch_add(1, Ordering::SeqCst);
+            })
+        }));
+
+        auth.arm(generation, &token).await;
+        auth.clear().await;
+        time::advance(Duration::from_secs(90)).await;
+        tokio::task::yield_now().await;
+
+        assert!(fetches.lock().await.is_empty());
+        assert_eq!(applied.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduled_refresh_retries_failure_without_waiting_for_token_expiry() {
+        let auth = AuthState::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let token = token_with_refresh_delay(Duration::from_secs(60));
+        let generation = auth
+            .install(Arc::new({
+                let attempts = Arc::clone(&attempts);
+                let token = token.clone();
+                move |force_refresh| {
+                    let attempts = Arc::clone(&attempts);
+                    let token = token.clone();
+                    Box::pin(async move {
+                        assert!(force_refresh);
+                        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                            anyhow::bail!("temporarily unavailable");
+                        }
+                        Ok(token)
+                    })
+                }
+            }))
+            .await;
+        let (applied, mut applied_rx) = mpsc::unbounded_channel();
+        auth.set_on_apply(Arc::new(move |generation| {
+            let applied = applied.clone();
+            Box::pin(async move {
+                let _ = applied.send(generation);
+            })
+        }));
+        auth.arm(generation, &token).await;
+        assert_eq!(applied_rx.recv().await, Some(generation));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn signed_out_refresh_is_applied_once_without_retrying() {
+        let auth = AuthState::new();
+        let generation = auth
+            .install(Arc::new(|_| Box::pin(async { Err(AuthSignedOut.into()) })))
+            .await;
+        let (applied, mut applied_rx) = mpsc::unbounded_channel();
+        auth.set_on_apply(Arc::new(move |generation| {
+            let applied = applied.clone();
+            Box::pin(async move {
+                let _ = applied.send(generation);
+            })
+        }));
+        auth.arm(
+            generation,
+            &token_with_refresh_delay(Duration::from_secs(10)),
+        )
+        .await;
+        assert_eq!(applied_rx.recv().await, Some(generation));
+        assert!(
+            auth.resolve(generation, false)
+                .await
+                .unwrap_err()
+                .is::<AuthSignedOut>()
+        );
+        time::advance(Duration::from_secs(120)).await;
+        assert!(applied_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replacement_aborts_the_previous_schedule() {
+        let auth = AuthState::new();
+        let fetches = Arc::new(Mutex::new(Vec::new()));
+        let first = token_with_refresh_delay(Duration::from_secs(120));
+        let second = token_with_refresh_delay(Duration::from_secs(60));
+        let generation = auth
+            .install(counting_fetcher(Arc::clone(&fetches), second.clone()))
+            .await;
+        let (applied, mut applied_rx) = mpsc::unbounded_channel();
+        auth.set_on_apply(Arc::new(move |_| {
+            let applied = applied.clone();
+            Box::pin(async move {
+                let _ = applied.send(());
+            })
+        }));
+
+        auth.arm(generation, &first).await;
+        auth.arm(generation, &second).await;
+        time::advance(Duration::from_secs(61)).await;
+        applied_rx.recv().await.expect("second schedule applied");
+        assert_eq!(fetches.lock().await.len(), 1);
+
+        time::advance(Duration::from_secs(120)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(fetches.lock().await.len(), 1);
+        assert!(applied_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn last_clone_drop_aborts_scheduled_refresh() {
+        let auth = AuthState::new();
+        let fetches = Arc::new(Mutex::new(Vec::new()));
+        let token = token_with_refresh_delay(Duration::from_secs(60));
+        let generation = auth
+            .install(counting_fetcher(Arc::clone(&fetches), token.clone()))
+            .await;
+        let applied = Arc::new(AtomicUsize::new(0));
+        let applied_count = Arc::clone(&applied);
+        auth.set_on_apply(Arc::new(move |_| {
+            let applied_count = Arc::clone(&applied_count);
+            Box::pin(async move {
+                applied_count.fetch_add(1, Ordering::SeqCst);
+            })
+        }));
+        auth.arm(generation, &token).await;
+
+        let clone = Arc::clone(&auth);
+        drop(clone);
+        drop(auth);
+        time::advance(Duration::from_secs(90)).await;
+        tokio::task::yield_now().await;
+
+        assert!(fetches.lock().await.is_empty());
+        assert_eq!(applied.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn last_clone_drop_does_not_wait_for_a_hung_refresh_fetch() {
+        let auth = AuthState::new();
+        let (started_tx, started_rx) = oneshot::channel();
+        let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+        let dropped = Arc::new(AtomicUsize::new(0));
+        let dropped_count = Arc::clone(&dropped);
+        let fetcher: AuthTokenFetcher = Arc::new(move |_force_refresh| {
+            let dropped_count = Arc::clone(&dropped_count);
+            let started_tx = Arc::clone(&started_tx);
+            Box::pin(async move {
+                struct Flag(Arc<AtomicUsize>);
+                impl Drop for Flag {
+                    fn drop(&mut self) {
+                        self.0.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+                let _flag = Flag(dropped_count);
+                let _ = started_tx
+                    .lock()
+                    .await
+                    .take()
+                    .expect("refresh starts once")
+                    .send(());
+                std::future::pending::<()>().await;
+                Ok("unused".to_string())
+            })
+        });
+        let token = token_with_refresh_delay(Duration::ZERO);
+        let generation = auth.install(fetcher).await;
+        auth.arm(generation, &token).await;
+        time::advance(Duration::from_millis(1)).await;
+        started_rx.await.expect("refresh fetch started");
+
+        let started_at = std::time::Instant::now();
+        drop(auth);
+        assert!(started_at.elapsed() < Duration::from_millis(200));
+        tokio::task::yield_now().await;
+        for _ in 0..16 {
+            if dropped.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resolve_preserves_forced_refresh_and_uses_pending_for_callback_apply() {
+        let auth = AuthState::new();
+        let fetches = Arc::new(Mutex::new(Vec::new()));
+        let token = "cached-token".to_string();
+        let generation = auth
+            .install(counting_fetcher(Arc::clone(&fetches), token.clone()))
+            .await;
+
+        assert_eq!(auth.resolve(generation, true).await.expect("forced"), token);
+        assert_eq!(*fetches.lock().await, vec![true]);
+
+        auth.slots.lock().await.pending_user_token = Some(Ok("pending-token".to_string()));
+        assert_eq!(
+            auth.resolve(generation, false).await.expect("pending"),
+            "pending-token"
+        );
+        assert_eq!(*fetches.lock().await, vec![true]);
+        assert!(auth.slots.lock().await.pending_user_token.is_none());
+
+        assert_eq!(
+            auth.resolve(generation, false).await.expect("cached"),
+            token
+        );
+        assert_eq!(*fetches.lock().await, vec![true, false]);
+    }
+
+    #[tokio::test]
+    async fn resolve_does_not_apply_after_clear() {
+        let auth = AuthState::new();
+        let (continue_tx, continue_rx) = oneshot::channel();
+        let continue_rx = Arc::new(Mutex::new(Some(continue_rx)));
+        let fetcher: AuthTokenFetcher = Arc::new(move |force_refresh| {
+            let continue_rx = Arc::clone(&continue_rx);
+            Box::pin(async move {
+                if let Some(continue_rx) = continue_rx.lock().await.take() {
+                    continue_rx.await.expect("continue");
+                }
+                Ok(format!("token-{force_refresh}"))
+            })
+        });
+        let generation = auth.install(fetcher).await;
+        let resolve = {
+            let auth = Arc::clone(&auth);
+            tokio::spawn(async move { auth.resolve(generation, true).await })
+        };
+        tokio::task::yield_now().await;
+        auth.clear().await;
+        continue_tx.send(()).expect("unblock fetch");
+        assert!(resolve.await.expect("join").is_err());
+    }
+}

--- a/crates/sprocket-convex/src/lib.rs
+++ b/crates/sprocket-convex/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -10,8 +10,10 @@ use rustls::crypto::ring::default_provider;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+mod auth;
 mod decode;
 
+use auth::AuthState;
 pub use decode::{
     decode_function_result, decode_labeled_function_result, deserialize_convex_u32,
     deserialize_convex_u64,
@@ -19,12 +21,35 @@ pub use decode::{
 
 const CONVEX_RPC_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 
+/// The boolean requests a fresh JWT. Return `AuthSignedOut` only for a terminal session failure.
 pub type AuthTokenFetcher =
     Arc<dyn Fn(bool) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>> + Send + Sync>;
 
+#[derive(Debug)]
+pub struct AuthSignedOut;
+
+impl std::fmt::Display for AuthSignedOut {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("authentication session is signed out")
+    }
+}
+
+impl std::error::Error for AuthSignedOut {}
+
+struct Inner {
+    convex: Mutex<ConvexClient>,
+    auth: Arc<AuthState>,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.auth.shutdown();
+    }
+}
+
 #[derive(Clone)]
 pub struct Client {
-    inner: Arc<Mutex<ConvexClient>>,
+    inner: Arc<Inner>,
 }
 
 impl Client {
@@ -33,21 +58,32 @@ impl Client {
         let client = ConvexClient::new(deployment_url)
             .await
             .context("failed to initialize Convex client")?;
-        Ok(Self {
-            inner: Arc::new(Mutex::new(client)),
-        })
+        let inner = Arc::new(Inner {
+            convex: Mutex::new(client),
+            auth: AuthState::new(),
+        });
+        let inner_weak = Arc::downgrade(&inner);
+        inner.auth.set_on_apply(Arc::new(move |generation| {
+            let inner_weak = inner_weak.clone();
+            Box::pin(async move {
+                apply_pending_token(inner_weak, generation).await;
+            })
+        }));
+        Ok(Self { inner })
     }
 
     pub async fn set_auth_token_fetcher(&self, fetcher: AuthTokenFetcher) {
-        self.inner
-            .lock()
-            .await
-            .set_auth_callback(Some(convex_auth_fetcher(fetcher)))
+        let mut convex = self.inner.convex.lock().await;
+        let generation = self.inner.auth.install(fetcher).await;
+        convex
+            .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&self.inner), generation)))
             .await;
     }
 
     pub async fn clear_auth(&self) {
-        self.inner.lock().await.set_auth_callback(None).await;
+        let mut convex = self.inner.convex.lock().await;
+        self.inner.auth.clear().await;
+        convex.set_auth_callback(None).await;
     }
 
     pub async fn query(
@@ -55,7 +91,7 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner).await;
+        let mut convex = clone_locked(&self.inner.convex).await;
         timeout(CONVEX_RPC_TIMEOUT, convex.query(function, args))
             .await
             .with_context(|| format!("query timed out for {function}"))?
@@ -67,7 +103,7 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<QuerySubscription> {
-        let mut convex = clone_locked(&self.inner).await;
+        let mut convex = clone_locked(&self.inner.convex).await;
         timeout(CONVEX_RPC_TIMEOUT, convex.subscribe(function, args))
             .await
             .with_context(|| format!("subscription timed out for {function}"))?
@@ -79,7 +115,7 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner).await;
+        let mut convex = clone_locked(&self.inner.convex).await;
         timeout(CONVEX_RPC_TIMEOUT, convex.mutation(function, args))
             .await
             .with_context(|| format!("mutation timed out for {function}"))?
@@ -91,7 +127,7 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner).await;
+        let mut convex = clone_locked(&self.inner.convex).await;
         timeout(CONVEX_RPC_TIMEOUT, convex.action(function, args))
             .await
             .with_context(|| format!("action timed out for {function}"))?
@@ -103,9 +139,34 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
-fn convex_auth_fetcher(fetcher: AuthTokenFetcher) -> convex::AuthTokenFetcher {
+fn sdk_fetcher(inner: Weak<Inner>, generation: u64) -> convex::AuthTokenFetcher {
     Box::new(move |force_refresh| {
-        let fetcher = fetcher.clone();
-        Box::pin(async move { fetcher(force_refresh).await.map(AuthenticationToken::User) })
+        let inner = inner.clone();
+        Box::pin(async move {
+            let auth = {
+                let inner = inner.upgrade().context("convex client dropped")?;
+                Arc::clone(&inner.auth)
+            };
+            let token = match auth.resolve(generation, force_refresh).await {
+                Ok(token) => token,
+                Err(error) if error.is::<AuthSignedOut>() => return Ok(AuthenticationToken::None),
+                Err(error) => return Err(error),
+            };
+            auth.arm(generation, &token).await;
+            Ok(AuthenticationToken::User(token))
+        })
     })
+}
+
+async fn apply_pending_token(inner: Weak<Inner>, generation: u64) {
+    let Some(inner) = inner.upgrade() else {
+        return;
+    };
+    let mut convex = inner.convex.lock().await;
+    if inner.auth.generation() != generation {
+        return;
+    }
+    convex
+        .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&inner), generation)))
+        .await;
 }

--- a/crates/sprocket-server/README.md
+++ b/crates/sprocket-server/README.md
@@ -12,7 +12,7 @@ full process topology.
 
 - Establish local browser or desktop authorization.
 - Own the installed client's native WorkOS session and refresh its access
-  tokens for machine-side Convex calls.
+  tokens for renderer and machine-side Convex calls.
 - Resolve, attach, and revalidate local workspaces.
 - Start agent runs with the Rust-owned WorkOS token fetcher.
 - Detach accepted launches from browser requests and hand active work a
@@ -29,9 +29,9 @@ pairing/session data and this machine’s folder list (`workspacePath` plus
 those threads onto local folders whose key matches.
 
 Local authorization and cloud authentication are separate. A local session
-permits access to machine-facing operations. Rust owns a WorkOS session for
-agent runs and machine registration, separate from the renderer's AuthKit
-session. Rust keeps the native access token in memory and stores its refresh
+permits access to machine-facing operations. Rust owns one WorkOS session for
+the installed renderer, agent runs, and machine registration. Hosted web pages
+use AuthKit JS instead. Rust keeps the access token in memory and stores its refresh
 token in the operating system credential store. It scopes the credential by
 Convex deployment and data directory so development and installed sessions do
 not overwrite each other.
@@ -41,6 +41,31 @@ query `authBootstrap:getClientConfig`. Native auth failures do not block server
 startup. The local loopback flow keeps PKCE, state, code exchange, and refresh
 rotation in Rust; neither the authorization code nor native refresh token is
 returned to the renderer.
+
+The installed renderer obtains a short-lived access token and user from
+`POST /api/auth/native-session/token`. This endpoint requires a paired local
+session, a loopback socket peer, and matching loopback Origin and Host headers.
+It returns `Cache-Control: no-store`. An unbound local session binds to the
+native user on first use; an existing binding to another user is rejected.
+The renderer does not persist the access token. Missing browser AuthKit cookies
+never delete native credentials.
+
+Credential operations finish even if their HTTP request or Convex callback is
+cancelled. Concurrent refreshes share a completed rotation, and a failed keyring
+write retains the new refresh token for a later persistence attempt. Only a
+terminal `invalid_grant` clears the session; transport and storage failures remain
+retryable. Forced refresh never returns the token that Convex rejected.
+
+The Rust Convex wrapper refreshes before JWT expiry, retries failed refreshes
+with backoff, and maps an authoritative signed-out result to Convex's unauthenticated
+token. Its refresh task ends when the last client is dropped or auth is cleared.
+The browser's Convex adapter settles failed token fetches with `null`, preserving
+the provider user and retrying the Convex connection separately. Throwing from
+that callback can leave the Convex JS socket stopped.
+
+References: [WorkOS session resilience](https://workos.com/docs/authkit/session-resilience),
+[Convex AuthKit](https://docs.convex.dev/auth/authkit/), and
+[Convex custom provider callbacks](https://docs.convex.dev/auth/advanced/custom-auth).
 
 Machine registration returns the canonical native user ID. Agent launch checks
 it against the renderer's browser user ID and rejects mismatched accounts.

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -10,7 +10,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use convex::{FunctionResult, Value};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sprocket_convex::{AuthTokenFetcher, Client as ConvexClient};
+use sprocket_convex::{AuthSignedOut, AuthTokenFetcher, Client as ConvexClient};
 use tokio::sync::{Mutex, OnceCell};
 use tokio::time::timeout;
 use workos::helpers::AuthKitAuthorizationUrlParams;
@@ -25,6 +25,9 @@ const LOGIN_ATTEMPT_TTL: Duration = Duration::from_secs(5 * 60);
 const ACCESS_TOKEN_REFRESH_MARGIN_SECS: u64 = 60;
 const KEYRING_SERVICE: &str = "dev.sprocket.native-auth";
 const KEYRING_ACCOUNT_PREFIX: &str = "workos-refresh-token";
+const NATIVE_SESSION_SIGNED_OUT: &str = "native WorkOS session is signed out";
+const NATIVE_SESSION_EXPIRED: &str = "native WorkOS session expired";
+const NATIVE_SESSION_UNAVAILABLE: &str = "Native sign-in is temporarily unavailable. Try again.";
 
 #[derive(Clone, Debug)]
 pub(crate) struct NativeAuthConfig {
@@ -33,12 +36,28 @@ pub(crate) struct NativeAuthConfig {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct NativeUser {
+pub struct NativeUser {
     pub id: String,
     pub email: String,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     pub profile_picture_url: Option<String>,
+}
+
+#[derive(Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeBrowserSession {
+    pub access_token: String,
+    pub user: NativeUser,
+}
+
+impl std::fmt::Debug for NativeBrowserSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("NativeBrowserSession")
+            .field("user", &self.user)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -161,14 +180,42 @@ struct AccessToken {
     expires_at: u64,
 }
 
-#[derive(Default)]
 struct NativeSession {
     pending: PendingLogins,
     access_token: Option<AccessToken>,
+    refresh_token: Option<String>,
+    refresh_token_persisted: bool,
+    refresh_generation: u64,
     user: Option<NativeUser>,
     login_errors: HashMap<String, String>,
     suppress_persisted_resume: bool,
     sign_out_generation: u64,
+}
+
+impl Default for NativeSession {
+    fn default() -> Self {
+        Self {
+            pending: PendingLogins::default(),
+            access_token: None,
+            refresh_token: None,
+            refresh_token_persisted: true,
+            refresh_generation: 0,
+            user: None,
+            login_errors: HashMap::new(),
+            suppress_persisted_resume: false,
+            sign_out_generation: 0,
+        }
+    }
+}
+
+impl NativeSession {
+    fn clear_authenticated_state(&mut self) {
+        self.access_token = None;
+        self.refresh_token = None;
+        self.refresh_token_persisted = true;
+        self.user = None;
+        self.suppress_persisted_resume = true;
+    }
 }
 
 pub(crate) struct NativeAuthManager {
@@ -198,17 +245,17 @@ impl NativeAuthManager {
         client: WorkOsClient,
         callback_url: String,
         refresh_tokens: Arc<dyn RefreshTokenStore>,
-    ) -> Self {
+    ) -> Arc<Self> {
         let client_cell = OnceCell::new();
         assert!(client_cell.set(client).is_ok());
-        Self {
+        Arc::new(Self {
             deployment_url: None,
             client: client_cell,
             callback_url,
             refresh_tokens,
             credential_operation: Mutex::new(()),
             session: Mutex::new(NativeSession::default()),
-        }
+        })
     }
 
     #[cfg(test)]
@@ -216,7 +263,7 @@ impl NativeAuthManager {
         config: NativeAuthConfig,
         callback_url: String,
         refresh_tokens: Arc<dyn RefreshTokenStore>,
-    ) -> Self {
+    ) -> Arc<Self> {
         let client = WorkOsClient::builder()
             .client_id(config.workos_client_id)
             .build();
@@ -225,11 +272,23 @@ impl NativeAuthManager {
 
     #[cfg(test)]
     pub(crate) fn configured_for_test(config: NativeAuthConfig, callback_url: String) -> Arc<Self> {
-        Arc::new(Self::with_store(
-            config,
-            callback_url,
-            Arc::new(EmptyRefreshTokenStore),
-        ))
+        Self::with_store(config, callback_url, Arc::new(EmptyRefreshTokenStore))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn authenticate_for_test(&self, user_id: &str) {
+        let mut session = self.session.lock().await;
+        session.access_token = Some(AccessToken {
+            value: "test-access-token".to_string(),
+            expires_at: unix_time_secs() + 3_600,
+        });
+        session.user = Some(NativeUser {
+            id: user_id.to_string(),
+            email: "test@example.com".to_string(),
+            first_name: None,
+            last_name: None,
+            profile_picture_url: None,
+        });
     }
 
     async fn client(&self) -> anyhow::Result<&WorkOsClient> {
@@ -299,6 +358,19 @@ impl NativeAuthManager {
     }
 
     pub async fn complete_login(
+        self: &Arc<Self>,
+        code: &str,
+        state: &str,
+    ) -> anyhow::Result<(NativeUser, String)> {
+        let manager = Arc::clone(self);
+        let code = code.to_string();
+        let state = state.to_string();
+        tokio::spawn(async move { manager.complete_login_inner(&code, &state).await })
+            .await
+            .context("native login task failed")?
+    }
+
+    async fn complete_login_inner(
         &self,
         code: &str,
         state: &str,
@@ -366,7 +438,7 @@ impl NativeAuthManager {
         Ok(())
     }
 
-    pub async fn status(&self, session_token: &str) -> NativeLoginStatus {
+    pub async fn status(self: &Arc<Self>, session_token: &str) -> NativeLoginStatus {
         {
             let mut session = self.session.lock().await;
             purge_expired_logins(&mut session.pending);
@@ -378,32 +450,15 @@ impl NativeAuthManager {
                     error: error.clone(),
                 };
             }
-            if let Some(user) = &session.user {
-                return NativeLoginStatus::Authenticated { user: user.clone() };
-            }
         }
 
-        if let Err(error) = self.access_token(false).await {
-            let message = error.to_string();
-            return if message.contains("native WorkOS session is signed out")
-                || message.contains("native WorkOS session expired")
-            {
-                NativeLoginStatus::SignedOut
-            } else {
-                NativeLoginStatus::Unavailable {
-                    error: "Native sign-in is temporarily unavailable. Try again.".to_string(),
-                }
-            };
+        match self.browser_session(false).await {
+            Ok(Some(session)) => NativeLoginStatus::Authenticated { user: session.user },
+            Ok(None) => NativeLoginStatus::SignedOut,
+            Err(_) => NativeLoginStatus::Unavailable {
+                error: NATIVE_SESSION_UNAVAILABLE.to_string(),
+            },
         }
-
-        self.session
-            .lock()
-            .await
-            .user
-            .as_ref()
-            .map_or(NativeLoginStatus::SignedOut, |user| {
-                NativeLoginStatus::Authenticated { user: user.clone() }
-            })
     }
 
     pub async fn cancel_login(&self, session_token: &str, login_id: &str) {
@@ -430,7 +485,14 @@ impl NativeAuthManager {
         }
     }
 
-    pub async fn sign_out(&self) -> anyhow::Result<()> {
+    pub async fn sign_out(self: &Arc<Self>) -> anyhow::Result<()> {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move { manager.sign_out_inner().await })
+            .await
+            .context("native sign-out task failed")?
+    }
+
+    async fn sign_out_inner(&self) -> anyhow::Result<()> {
         let _credential_operation = self.credential_operation.lock().await;
         let sign_out_generation = self
             .session
@@ -454,30 +516,95 @@ impl NativeAuthManager {
             let manager = Arc::clone(&manager);
             let expected_user_id = expected_user_id.clone();
             Box::pin(async move {
-                manager
+                let result = manager
                     .access_token_for_user(force_refresh, &expected_user_id)
-                    .await
+                    .await;
+                match result {
+                    Err(error) if is_authoritative_unauthenticated(&error) => {
+                        Err(AuthSignedOut.into())
+                    }
+                    result => result,
+                }
             })
         })
     }
 
-    pub async fn require_user(&self, expected_user_id: &str) -> anyhow::Result<()> {
+    pub async fn require_user(self: &Arc<Self>, expected_user_id: &str) -> anyhow::Result<()> {
         self.access_token_for_user(false, expected_user_id).await?;
         Ok(())
     }
 
-    async fn access_token(&self, force_refresh: bool) -> anyhow::Result<String> {
+    pub async fn browser_session(
+        self: &Arc<Self>,
+        force_refresh: bool,
+    ) -> anyhow::Result<Option<NativeBrowserSession>> {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move { manager.browser_session_inner(force_refresh).await })
+            .await
+            .context("native session task failed")?
+    }
+
+    async fn browser_session_inner(
+        &self,
+        force_refresh: bool,
+    ) -> anyhow::Result<Option<NativeBrowserSession>> {
+        let refresh_generation = self.session.lock().await.refresh_generation;
         let _credential_operation = self.credential_operation.lock().await;
-        self.access_token_locked(force_refresh).await
+        match self
+            .access_token_locked(force_refresh, refresh_generation)
+            .await
+        {
+            Ok(access_token) => {
+                let user = self
+                    .session
+                    .lock()
+                    .await
+                    .user
+                    .clone()
+                    .context("native WorkOS session has no user")?;
+                Ok(Some(NativeBrowserSession { access_token, user }))
+            }
+            Err(error) if is_authoritative_unauthenticated(&error) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    #[cfg(test)]
+    async fn access_token(self: &Arc<Self>, force_refresh: bool) -> anyhow::Result<String> {
+        self.browser_session(force_refresh)
+            .await?
+            .map(|session| session.access_token)
+            .context(NATIVE_SESSION_SIGNED_OUT)
     }
 
     async fn access_token_for_user(
+        self: &Arc<Self>,
+        force_refresh: bool,
+        expected_user_id: &str,
+    ) -> anyhow::Result<String> {
+        let manager = Arc::clone(self);
+        let expected_user_id = expected_user_id.to_string();
+        // A cancelled HTTP request or Convex refresh must not drop a rotated token
+        // or release the credential lock while a keyring write is still running.
+        tokio::spawn(async move {
+            manager
+                .access_token_for_user_inner(force_refresh, &expected_user_id)
+                .await
+        })
+        .await
+        .context("native token task failed")?
+    }
+
+    async fn access_token_for_user_inner(
         &self,
         force_refresh: bool,
         expected_user_id: &str,
     ) -> anyhow::Result<String> {
+        let refresh_generation = self.session.lock().await.refresh_generation;
         let _credential_operation = self.credential_operation.lock().await;
-        let token = self.access_token_locked(force_refresh).await?;
+        let token = self
+            .access_token_locked(force_refresh, refresh_generation)
+            .await?;
         let session = self.session.lock().await;
         let user = session
             .user
@@ -489,24 +616,27 @@ impl NativeAuthManager {
         Ok(token)
     }
 
-    async fn access_token_locked(&self, force_refresh: bool) -> anyhow::Result<String> {
-        let refresh_before = unix_time_secs().saturating_add(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
-        if !force_refresh {
+    async fn access_token_locked(
+        &self,
+        force_refresh: bool,
+        refresh_generation: u64,
+    ) -> anyhow::Result<String> {
+        let reusable = {
             let session = self.session.lock().await;
-            if let Some(access_token) = &session.access_token
-                && access_token.expires_at > refresh_before
-            {
-                return Ok(access_token.value.clone());
-            }
+            reusable_access_token(&session, force_refresh, refresh_generation)
+        };
+        if let Some(access_token) = reusable {
+            self.flush_refresh_token().await?;
+            return Ok(access_token);
         }
         if self.session.lock().await.suppress_persisted_resume {
-            anyhow::bail!("native WorkOS session is signed out");
+            return Err(anyhow!(NATIVE_SESSION_SIGNED_OUT));
         }
 
         let refresh_token = self
             .load_refresh_token()
             .await?
-            .context("native WorkOS session is signed out")?;
+            .context(NATIVE_SESSION_SIGNED_OUT)?;
         let response = self
             .client()
             .await?
@@ -525,35 +655,26 @@ impl NativeAuthManager {
                     .context("WorkOS response omitted access token")
             }
             Err(error) if is_terminal_refresh_error(&error) => {
-                let mut session = self.session.lock().await;
-                session.access_token = None;
-                session.user = None;
-                session.suppress_persisted_resume = true;
-                drop(session);
+                self.session.lock().await.clear_authenticated_state();
                 self.clear_refresh_token().await?;
-                Err(error).context("native WorkOS session expired")
-            }
-            Err(error) if is_transient_refresh_error(&error) => {
-                let session = self.session.lock().await;
-                if let Some(access_token) = &session.access_token
-                    && access_token.expires_at > unix_time_secs()
-                {
-                    tracing::warn!(
-                        "native WorkOS refresh failed; retaining current access token: {error}"
-                    );
-                    return Ok(access_token.value.clone());
-                }
-                Err(error).context("failed to refresh native WorkOS session")
+                Err(error).context(NATIVE_SESSION_EXPIRED)
             }
             Err(error) => {
                 let session = self.session.lock().await;
-                if let Some(access_token) = &session.access_token
-                    && access_token.expires_at > unix_time_secs()
-                {
+                let retained_access_token = session.access_token.as_ref().and_then(|token| {
+                    (!force_refresh && token.expires_at > unix_time_secs())
+                        .then(|| token.value.clone())
+                });
+                if let Some(access_token) = retained_access_token {
+                    let kind = if is_transient_refresh_error(&error) {
+                        "transient"
+                    } else {
+                        "unrecognized"
+                    };
                     tracing::warn!(
-                        "native WorkOS refresh returned an unrecognized error; retaining current access token: {error}"
+                        "native WorkOS refresh failed ({kind}); retaining current access token: {error}"
                     );
-                    return Ok(access_token.value.clone());
+                    return Ok(access_token);
                 }
                 Err(error).context("failed to refresh native WorkOS session")
             }
@@ -574,20 +695,30 @@ impl NativeAuthManager {
         let access_token = response.access_token.into_inner();
         let expires_at = jwt_expiration(&access_token)?;
         let refresh_token = response.refresh_token.into_inner();
-        self.save_refresh_token(refresh_token).await?;
-
-        let mut session = self.session.lock().await;
-        session.access_token = Some(AccessToken {
-            value: access_token,
-            expires_at,
-        });
-        session.user = Some(user.clone());
-        session.login_errors.clear();
-        session.suppress_persisted_resume = false;
+        {
+            let mut session = self.session.lock().await;
+            session.access_token = Some(AccessToken {
+                value: access_token,
+                expires_at,
+            });
+            session.refresh_token = Some(refresh_token);
+            session.refresh_token_persisted = false;
+            session.refresh_generation = session.refresh_generation.wrapping_add(1);
+            session.user = Some(user.clone());
+            session.login_errors.clear();
+            session.suppress_persisted_resume = false;
+        }
+        self.flush_refresh_token().await?;
         Ok(user)
     }
 
     async fn load_refresh_token(&self) -> anyhow::Result<Option<String>> {
+        {
+            let session = self.session.lock().await;
+            if let Some(token) = &session.refresh_token {
+                return Ok(Some(token.clone()));
+            }
+        }
         let store = Arc::clone(&self.refresh_tokens);
         let token = tokio::task::spawn_blocking(move || store.load())
             .await
@@ -596,8 +727,32 @@ impl NativeAuthManager {
             Some(token) if token.trim().is_empty() => {
                 anyhow::bail!("stored WorkOS refresh token is empty")
             }
-            token => Ok(token),
+            Some(token) => {
+                let mut session = self.session.lock().await;
+                if session.refresh_token.is_none() {
+                    session.refresh_token = Some(token.clone());
+                    session.refresh_token_persisted = true;
+                }
+                Ok(session.refresh_token.clone())
+            }
+            None => Ok(None),
         }
+    }
+
+    async fn flush_refresh_token(&self) -> anyhow::Result<()> {
+        let token = {
+            let session = self.session.lock().await;
+            if session.refresh_token_persisted {
+                return Ok(());
+            }
+            session.refresh_token.clone()
+        };
+        let Some(token) = token else {
+            return Ok(());
+        };
+        self.save_refresh_token(token).await?;
+        self.session.lock().await.refresh_token_persisted = true;
+        Ok(())
     }
 
     async fn save_refresh_token(&self, refresh_token: String) -> anyhow::Result<()> {
@@ -661,20 +816,40 @@ fn unix_time_secs() -> u64 {
         .map_or(0, |duration| duration.as_secs())
 }
 
+fn reusable_access_token(
+    session: &NativeSession,
+    force_refresh: bool,
+    refresh_generation: u64,
+) -> Option<String> {
+    let access_token = session.access_token.as_ref()?;
+    let now = unix_time_secs();
+    if access_token.expires_at <= now {
+        return None;
+    }
+    let rotated_while_waiting = session.refresh_generation != refresh_generation;
+    if force_refresh {
+        return rotated_while_waiting.then(|| access_token.value.clone());
+    }
+    let refresh_before = now.saturating_add(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
+    (access_token.expires_at > refresh_before).then(|| access_token.value.clone())
+}
+
+fn is_authoritative_unauthenticated(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let message = cause.to_string();
+        message == NATIVE_SESSION_SIGNED_OUT || message == NATIVE_SESSION_EXPIRED
+    })
+}
+
 fn is_terminal_refresh_error(error: &workos::Error) -> bool {
     matches!(error.status(), Some(400 | 401)) && error.code() == Some("invalid_grant")
 }
 
 fn is_transient_refresh_error(error: &workos::Error) -> bool {
-    matches!(
-        error,
-        workos::Error::Network(network)
-            if matches!(
-                network.kind,
-                workos::transport::TransportErrorKind::Connect
-                    | workos::transport::TransportErrorKind::Timeout
-            )
-    ) || matches!(error.status(), Some(408 | 429 | 500 | 502 | 503 | 504))
+    matches!(error, workos::Error::Network(_))
+        || error.is_rate_limited()
+        || error.is_server_error()
+        || matches!(error.status(), Some(408))
 }
 
 fn provider_error(error: &workos::Error) -> String {
@@ -769,14 +944,20 @@ mod tests {
         token: std::sync::Mutex<Option<String>>,
         fail_save: AtomicBool,
         fail_clear: AtomicBool,
+        fail_load: AtomicBool,
     }
 
     impl MemoryRefreshTokenStore {
+        fn empty() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
         fn with_token(token: &str) -> Arc<Self> {
             Arc::new(Self {
                 token: std::sync::Mutex::new(Some(token.to_string())),
                 fail_save: AtomicBool::new(false),
                 fail_clear: AtomicBool::new(false),
+                fail_load: AtomicBool::new(false),
             })
         }
 
@@ -787,6 +968,9 @@ mod tests {
 
     impl RefreshTokenStore for MemoryRefreshTokenStore {
         fn load(&self) -> anyhow::Result<Option<String>> {
+            if self.fail_load.load(Ordering::SeqCst) {
+                anyhow::bail!("credential store unavailable");
+            }
             Ok(self.token())
         }
 
@@ -810,6 +994,16 @@ mod tests {
     fn access_token(expires_at: u64) -> String {
         let claims = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{expires_at}}}"#));
         format!("e30.{claims}.signature")
+    }
+
+    fn native_user() -> NativeUser {
+        NativeUser {
+            id: "user_123".to_string(),
+            email: "ada@example.com".to_string(),
+            first_name: Some("Ada".to_string()),
+            last_name: Some("Lovelace".to_string()),
+            profile_picture_url: None,
+        }
     }
 
     fn authentication_response(access_token: String, refresh_token: &str) -> AuthenticateResponse {
@@ -840,16 +1034,35 @@ mod tests {
         .expect("authentication response")
     }
 
-    async fn manager_with_response(
+    async fn manager_with_handler<H>(
         store: Arc<MemoryRefreshTokenStore>,
-        status: StatusCode,
-        body: serde_json::Value,
-    ) -> NativeAuthManager {
+        handler: H,
+    ) -> Arc<NativeAuthManager>
+    where
+        H: Fn(serde_json::Value) -> (StatusCode, serde_json::Value) + Clone + Send + Sync + 'static,
+    {
+        manager_with_delayed_handler(store, Duration::ZERO, handler).await
+    }
+
+    async fn manager_with_delayed_handler<H>(
+        store: Arc<MemoryRefreshTokenStore>,
+        delay: Duration,
+        handler: H,
+    ) -> Arc<NativeAuthManager>
+    where
+        H: Fn(serde_json::Value) -> (StatusCode, serde_json::Value) + Clone + Send + Sync + 'static,
+    {
         let app = axum::Router::new().route(
             "/user_management/authenticate",
-            post(move || {
-                let body = body.clone();
-                async move { (status, Json(body)) }
+            post(move |Json(body): Json<serde_json::Value>| {
+                let handler = handler.clone();
+                async move {
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    }
+                    let (status, body) = handler(body);
+                    (status, Json(body))
+                }
             }),
         );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -866,6 +1079,14 @@ mod tests {
             .base_url(format!("http://{address}"))
             .build();
         NativeAuthManager::with_client(client, "http://127.0.0.1/callback".to_string(), store)
+    }
+
+    async fn manager_with_response(
+        store: Arc<MemoryRefreshTokenStore>,
+        status: StatusCode,
+        body: serde_json::Value,
+    ) -> Arc<NativeAuthManager> {
+        manager_with_handler(store, move |_| (status, body.clone())).await
     }
 
     fn config_result(client_id: Value) -> FunctionResult {
@@ -951,14 +1172,17 @@ mod tests {
         )
         .await;
 
+        let session = manager
+            .browser_session(false)
+            .await
+            .unwrap()
+            .expect("persisted WorkOS session resumes");
+        assert_eq!(session.access_token, expected_access_token);
+        assert_eq!(session.user, native_user());
         assert!(matches!(
             manager.status("paired-session").await,
             NativeLoginStatus::Authenticated { .. }
         ));
-        assert_eq!(
-            manager.access_token(false).await.unwrap(),
-            expected_access_token
-        );
         assert_eq!(store.token().as_deref(), Some("refresh-new"));
     }
 
@@ -1012,6 +1236,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn signed_out_fetcher_returns_a_terminal_auth_error() {
+        let manager = NativeAuthManager::configured_for_test(
+            NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            "http://127.0.0.1/callback".to_string(),
+        );
+        let fetcher = manager.auth_token_fetcher_for_user("user_123".to_string());
+        assert!(fetcher(false).await.unwrap_err().is::<AuthSignedOut>());
+    }
+
+    #[tokio::test]
     async fn authorization_code_exchange_installs_the_native_session() {
         let store = MemoryRefreshTokenStore::with_token("refresh-old");
         let expected_access_token = access_token(unix_time_secs() + 3_600);
@@ -1061,7 +1297,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_rotation_does_not_replace_the_in_memory_session() {
+    async fn persist_failure_keeps_the_rotated_refresh_token_in_memory() {
         let store = MemoryRefreshTokenStore::with_token("refresh-old");
         let manager = NativeAuthManager::with_store(
             NativeAuthConfig {
@@ -1070,29 +1306,42 @@ mod tests {
             "http://127.0.0.1/callback".to_string(),
             store.clone(),
         );
-        manager
-            .accept_authentication(authentication_response(
-                access_token(unix_time_secs() + 3_600),
-                "refresh-current",
-            ))
-            .await
-            .unwrap();
         store.fail_save.store(true, Ordering::SeqCst);
+        let expected_access_token = access_token(unix_time_secs() + 3_600);
 
         let error = manager
             .accept_authentication(authentication_response(
-                access_token(unix_time_secs() + 7_200),
-                "refresh-replacement",
+                expected_access_token.clone(),
+                "refresh-new",
             ))
             .await
-            .expect_err("failed persistence must reject new session");
+            .expect_err("failed persistence must surface a store error");
 
         assert!(error.to_string().contains("credential store unavailable"));
-        assert_eq!(store.token().as_deref(), Some("refresh-current"));
+        assert_eq!(store.token().as_deref(), Some("refresh-old"));
         assert_eq!(
-            manager.session.lock().await.user.as_ref().unwrap().email,
-            "ada@example.com"
+            manager.session.lock().await.refresh_token.as_deref(),
+            Some("refresh-new")
         );
+        assert!(
+            manager
+                .browser_session(false)
+                .await
+                .expect_err("unpersisted rotation is unavailable, not signed out")
+                .to_string()
+                .contains("credential store unavailable")
+        );
+
+        store.fail_save.store(false, Ordering::SeqCst);
+        let session = manager
+            .browser_session(false)
+            .await
+            .expect("retrying persist must succeed without contacting WorkOS")
+            .expect("session remains signed in");
+
+        assert_eq!(session.access_token, expected_access_token);
+        assert_eq!(session.user, native_user());
+        assert_eq!(store.token().as_deref(), Some("refresh-new"));
     }
 
     #[tokio::test]
@@ -1167,7 +1416,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forced_refresh_returns_a_still_valid_token_after_transient_failure() {
+    async fn forced_refresh_does_not_return_a_rejected_token_after_transient_failure() {
         let store = MemoryRefreshTokenStore::with_token("refresh-current");
         let manager = manager_with_response(
             Arc::clone(&store),
@@ -1192,8 +1441,9 @@ mod tests {
             .unwrap()
             .value
             .clone();
+        assert!(manager.access_token(true).await.is_err());
         assert_eq!(
-            manager.access_token(true).await.unwrap(),
+            manager.access_token(false).await.unwrap(),
             current_access_token
         );
         assert_eq!(store.token().as_deref(), Some("refresh-current"));
@@ -1204,38 +1454,24 @@ mod tests {
         let store = MemoryRefreshTokenStore::with_token("refresh-current");
         let requests = Arc::new(AtomicUsize::new(0));
         let expected_access_token = access_token(unix_time_secs() + 3_600);
-        let response = serde_json::to_value(authentication_response(
-            expected_access_token.clone(),
-            "refresh-new",
-        ))
-        .unwrap();
-        let app = axum::Router::new().route(
-            "/user_management/authenticate",
-            post({
+        let manager = Arc::new(
+            manager_with_delayed_handler(store, Duration::from_millis(25), {
                 let requests = Arc::clone(&requests);
-                move || {
-                    let requests = Arc::clone(&requests);
-                    let response = response.clone();
-                    async move {
-                        requests.fetch_add(1, Ordering::SeqCst);
-                        tokio::time::sleep(Duration::from_millis(25)).await;
-                        Json(response)
-                    }
+                let expected_access_token = expected_access_token.clone();
+                move |_| {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    (
+                        StatusCode::OK,
+                        serde_json::to_value(authentication_response(
+                            expected_access_token.clone(),
+                            "refresh-new",
+                        ))
+                        .unwrap(),
+                    )
                 }
-            }),
+            })
+            .await,
         );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        let client = WorkOsClient::builder()
-            .client_id("client_test")
-            .base_url(format!("http://{address}"))
-            .build();
-        let manager = Arc::new(NativeAuthManager::with_client(
-            client,
-            "http://127.0.0.1/callback".to_string(),
-            store,
-        ));
 
         let first_manager = Arc::clone(&manager);
         let second_manager = Arc::clone(&manager);
@@ -1247,6 +1483,61 @@ mod tests {
         assert_eq!(first.unwrap(), expected_access_token);
         assert_eq!(second.unwrap(), expected_access_token);
         assert_eq!(requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_token_consumer_does_not_cancel_refresh_rotation() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let app = axum::Router::new().route(
+            "/user_management/authenticate",
+            post({
+                let started = Arc::clone(&started);
+                let release = Arc::clone(&release);
+                move || {
+                    let started = Arc::clone(&started);
+                    let release = Arc::clone(&release);
+                    async move {
+                        started.notify_one();
+                        release.notified().await;
+                        Json(authentication_response(
+                            access_token(unix_time_secs() + 3_600),
+                            "rotated",
+                        ))
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let store = MemoryRefreshTokenStore::with_token("old");
+        let manager = NativeAuthManager::with_client(
+            WorkOsClient::builder()
+                .client_id("client_test")
+                .base_url(format!("http://{address}"))
+                .build(),
+            "http://127.0.0.1/callback".to_string(),
+            store.clone(),
+        );
+        let request = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            async move { manager.browser_session(false).await }
+        });
+        timeout(Duration::from_secs(2), started.notified())
+            .await
+            .unwrap();
+        request.abort();
+        assert!(request.await.unwrap_err().is_cancelled());
+        release.notify_one();
+        let session = timeout(Duration::from_secs(2), manager.browser_session(false))
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.user, native_user());
+        assert_eq!(store.token().as_deref(), Some("rotated"));
+        server.abort();
     }
 
     #[tokio::test]
@@ -1271,6 +1562,229 @@ mod tests {
         assert!(manager.sign_out().await.is_err());
         assert!(manager.session.lock().await.user.is_none());
         assert!(manager.session.lock().await.access_token.is_none());
-        assert!(manager.access_token(false).await.is_err());
+        assert!(manager.browser_session(false).await.unwrap().is_none());
+    }
+
+    #[test]
+    fn browser_session_serializes_camel_case() {
+        let json = serde_json::to_value(NativeBrowserSession {
+            access_token: "token".to_string(),
+            user: native_user(),
+        })
+        .unwrap();
+
+        assert_eq!(json["accessToken"], "token");
+        assert_eq!(json["user"]["firstName"], "Ada");
+        assert_eq!(json["user"]["profilePictureUrl"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn browser_session_is_none_when_signed_out() {
+        let manager = NativeAuthManager::with_store(
+            NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            "http://127.0.0.1/callback".to_string(),
+            MemoryRefreshTokenStore::empty(),
+        );
+
+        assert!(manager.browser_session(false).await.unwrap().is_none());
+        assert!(matches!(
+            manager.status("paired-session").await,
+            NativeLoginStatus::SignedOut
+        ));
+    }
+
+    #[tokio::test]
+    async fn browser_session_is_none_after_a_terminal_refresh_failure() {
+        let store = MemoryRefreshTokenStore::with_token("expired-refresh");
+        let manager = manager_with_response(
+            Arc::clone(&store),
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": "invalid_grant",
+                "error_description": "refresh token expired"
+            }),
+        )
+        .await;
+
+        assert!(manager.browser_session(false).await.unwrap().is_none());
+        assert_eq!(store.token(), None);
+        assert!(matches!(
+            manager.status("paired-session").await,
+            NativeLoginStatus::SignedOut
+        ));
+    }
+
+    #[tokio::test]
+    async fn browser_session_errors_when_the_credential_store_cannot_load() {
+        let store = MemoryRefreshTokenStore::with_token("refresh-current");
+        store.fail_load.store(true, Ordering::SeqCst);
+        let manager = NativeAuthManager::with_store(
+            NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            "http://127.0.0.1/callback".to_string(),
+            store,
+        );
+
+        assert!(
+            manager
+                .browser_session(false)
+                .await
+                .expect_err("store outage is transient")
+                .to_string()
+                .contains("credential store unavailable")
+        );
+        assert!(matches!(
+            manager.status("paired-session").await,
+            NativeLoginStatus::Unavailable { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn status_does_not_trust_a_stale_in_memory_user() {
+        let manager = manager_with_response(
+            MemoryRefreshTokenStore::with_token("expired-refresh"),
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": "invalid_grant",
+                "error_description": "refresh token expired"
+            }),
+        )
+        .await;
+        {
+            let mut session = manager.session.lock().await;
+            session.user = Some(native_user());
+            session.access_token = Some(AccessToken {
+                value: access_token(unix_time_secs().saturating_sub(30)),
+                expires_at: unix_time_secs().saturating_sub(30),
+            });
+        }
+
+        assert!(matches!(
+            manager.status("paired-session").await,
+            NativeLoginStatus::SignedOut
+        ));
+        assert!(manager.browser_session(false).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn status_reports_unavailable_when_a_stale_user_cannot_refresh() {
+        let manager = manager_with_response(
+            MemoryRefreshTokenStore::with_token("refresh-current"),
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({ "error": "unavailable" }),
+        )
+        .await;
+        {
+            let mut session = manager.session.lock().await;
+            session.user = Some(native_user());
+            session.access_token = Some(AccessToken {
+                value: access_token(unix_time_secs().saturating_sub(30)),
+                expires_at: unix_time_secs().saturating_sub(30),
+            });
+        }
+
+        assert!(matches!(
+            manager.status("paired-session").await,
+            NativeLoginStatus::Unavailable { .. }
+        ));
+        assert!(manager.browser_session(false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn refresh_after_persist_failure_uses_the_rotated_token() {
+        let store = MemoryRefreshTokenStore::with_token("refresh-old");
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let expected_access_token = access_token(unix_time_secs() + 3_600);
+        let manager = manager_with_handler(Arc::clone(&store), {
+            let seen = Arc::clone(&seen);
+            let expected_access_token = expected_access_token.clone();
+            move |body| {
+                seen.lock().unwrap().push(
+                    body["refresh_token"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+                (
+                    StatusCode::OK,
+                    serde_json::to_value(authentication_response(
+                        expected_access_token.clone(),
+                        "refresh-newer",
+                    ))
+                    .unwrap(),
+                )
+            }
+        })
+        .await;
+        store.fail_save.store(true, Ordering::SeqCst);
+        manager
+            .accept_authentication(authentication_response(
+                access_token(unix_time_secs() + 30),
+                "refresh-new",
+            ))
+            .await
+            .expect_err("rotation must be remembered even when persist fails");
+        store.fail_save.store(false, Ordering::SeqCst);
+
+        let session = manager
+            .browser_session(false)
+            .await
+            .unwrap()
+            .expect("session recovers with the rotated refresh token");
+
+        assert_eq!(session.access_token, expected_access_token);
+        assert_eq!(seen.lock().unwrap().as_slice(), ["refresh-new"]);
+        assert_eq!(store.token().as_deref(), Some("refresh-newer"));
+    }
+
+    #[tokio::test]
+    async fn queued_force_refresh_reuses_a_completed_rotation() {
+        let store = MemoryRefreshTokenStore::with_token("refresh-current");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let expected_access_token = access_token(unix_time_secs() + 3_600);
+        let manager =
+            manager_with_delayed_handler(Arc::clone(&store), Duration::from_millis(25), {
+                let requests = Arc::clone(&requests);
+                let expected_access_token = expected_access_token.clone();
+                move |_| {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    (
+                        StatusCode::OK,
+                        serde_json::to_value(authentication_response(
+                            expected_access_token.clone(),
+                            "refresh-new",
+                        ))
+                        .unwrap(),
+                    )
+                }
+            })
+            .await;
+        manager
+            .accept_authentication(authentication_response(
+                access_token(unix_time_secs() + 3_600),
+                "refresh-current",
+            ))
+            .await
+            .unwrap();
+        let manager = Arc::new(manager);
+
+        let first_manager = Arc::clone(&manager);
+        let second_manager = Arc::clone(&manager);
+        let (first, second) = tokio::join!(
+            first_manager.browser_session(true),
+            second_manager.browser_session(true)
+        );
+
+        let first = first.unwrap().expect("forced refresh stays signed in");
+        let second = second
+            .unwrap()
+            .expect("queued force refresh stays signed in");
+        assert_eq!(first.access_token, expected_access_token);
+        assert_eq!(second.access_token, expected_access_token);
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        assert_eq!(store.token().as_deref(), Some("refresh-new"));
     }
 }

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -45,6 +45,12 @@ struct DesktopLoginStartRequest {
     flow: Option<NativeLoginFlow>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeSessionTokenRequest {
+    force_refresh_token: bool,
+}
+
 pub fn routes() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/auth/session", get(session))
@@ -59,6 +65,7 @@ pub fn routes() -> axum::Router<AppState> {
             "/auth/native-session",
             get(desktop_login_result).delete(native_sign_out),
         )
+        .route("/auth/native-session/token", post(native_session_token))
 }
 
 async fn session(
@@ -306,6 +313,87 @@ async fn native_sign_out(
     Ok(Json(DesktopLoginStartResponse { ok: true }))
 }
 
+async fn native_session_token(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<NativeSessionTokenRequest>,
+) -> Response {
+    let result = native_session_token_response(&state, peer, &headers, &jar, payload).await;
+    let mut response = result.into_response();
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+    response
+}
+
+async fn native_session_token_response(
+    state: &AppState,
+    peer: SocketAddr,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+    payload: NativeSessionTokenRequest,
+) -> Result<Json<Option<crate::native_auth::NativeBrowserSession>>, ApiError> {
+    if !peer.ip().is_loopback() || !is_loopback_same_origin(headers) {
+        return Err(ApiError::with_status(
+            StatusCode::FORBIDDEN,
+            anyhow::anyhow!("native tokens are only available to the local application"),
+        ));
+    }
+    let session_token = require_session(&state.auth, headers, jar)
+        .await
+        .map_err(|_| ApiError::authentication_required())?;
+    let session = state
+        .native_auth
+        .browser_session(payload.force_refresh_token)
+        .await
+        .map_err(|error| {
+            tracing::warn!("native browser session unavailable: {error:#}");
+            ApiError::with_status(
+                StatusCode::SERVICE_UNAVAILABLE,
+                anyhow::anyhow!("Native sign-in is temporarily unavailable. Try again."),
+            )
+        })?;
+    if let Some(session) = &session {
+        if state.auth.session_has_user(&session_token).await {
+            state
+                .auth
+                .require_session_user(&session_token, &session.user.id)
+                .await
+                .map_err(|error| ApiError::with_status(StatusCode::CONFLICT, error))?;
+        } else {
+            state
+                .auth
+                .bind_session_user(&session_token, &session.user.id)
+                .await
+                .map_err(ApiError::internal)?;
+        }
+    }
+    Ok(Json(session))
+}
+
+fn is_loopback_same_origin(headers: &HeaderMap) -> bool {
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Ok(url) = url::Url::parse(origin) else {
+        return false;
+    };
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"))
+        && matches!(url.scheme(), "http" | "https")
+        && origin == format!("{}://{host}", url.scheme())
+}
+
 fn desktop_bootstrap_response(state: &AppState) -> Json<DesktopBootstrapResponse> {
     Json(DesktopBootstrapResponse {
         http_base_url: state.http_base_url.clone(),
@@ -490,6 +578,136 @@ mod tests {
     fn with_peer(mut request: Request<Body>, peer: SocketAddr) -> Request<Body> {
         request.extensions_mut().insert(ConnectInfo(peer));
         request
+    }
+
+    fn native_token_request(session_token: Option<&str>, origin: &str) -> Request<Body> {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/api/auth/native-session/token")
+            .header(header::HOST, "127.0.0.1:7731")
+            .header(header::ORIGIN, origin)
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(session_token) = session_token {
+            request = request.header(header::COOKIE, session_cookie(session_token));
+        }
+        request
+            .body(Body::from(r#"{"forceRefreshToken":false}"#))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn native_token_requires_pairing_and_does_not_cache_signed_out_response() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+        let unpaired = app
+            .clone()
+            .oneshot(with_peer(
+                native_token_request(None, "http://127.0.0.1:7731"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(unpaired.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(unpaired.headers()[header::CACHE_CONTROL], "no-store");
+
+        let signed_out = app
+            .oneshot(with_peer(
+                native_token_request(Some(&session_token), "http://127.0.0.1:7731"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(signed_out.status(), StatusCode::OK);
+        assert_eq!(signed_out.headers()[header::CACHE_CONTROL], "no-store");
+        assert!(read_json(signed_out).await.is_null());
+    }
+
+    #[tokio::test]
+    async fn native_token_rejects_cross_origin_and_remote_requests_even_when_paired() {
+        let (state, session_token, _) = test_state(true).await;
+        let app = router(state);
+        for origin in [
+            "https://attacker.example",
+            "http://127.0.0.1:8080",
+            "null",
+            "http://127.0.0.1:7731/",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(with_peer(
+                    native_token_request(Some(&session_token), origin),
+                    loopback_peer(),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{origin}");
+        }
+
+        let mut request = native_token_request(Some(&session_token), "http://127.0.0.1:7731");
+        request
+            .headers_mut()
+            .insert("x-forwarded-for", "127.0.0.1".parse().unwrap());
+        let response = app.oneshot(with_peer(request, lan_peer())).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn native_token_binds_a_resumed_session_but_rejects_another_account() {
+        let (state, session_token, _) = test_state(true).await;
+        let auth = Arc::clone(&state.auth);
+        let native_auth = Arc::clone(&state.native_auth);
+        native_auth.authenticate_for_test("user-a").await;
+        let app = router(state);
+        let response = app
+            .clone()
+            .oneshot(with_peer(
+                native_token_request(Some(&session_token), "http://127.0.0.1:7731"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let payload = read_json(response).await;
+        assert_eq!(payload["accessToken"], "test-access-token");
+        assert_eq!(payload["user"]["id"], "user-a");
+        assert!(payload.get("refreshToken").is_none());
+        auth.require_session_user(&session_token, "user-a")
+            .await
+            .unwrap();
+
+        native_auth.authenticate_for_test("user-b").await;
+        let response = app
+            .oneshot(with_peer(
+                native_token_request(Some(&session_token), "http://127.0.0.1:7731"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(read_json(response).await.get("accessToken").is_none());
+        auth.require_session_user(&session_token, "user-a")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn token_origin_validation_rejects_missing_headers_and_dns_rebinding() {
+        let mut headers = HeaderMap::new();
+        assert!(!is_loopback_same_origin(&headers));
+        headers.insert(header::HOST, "localhost:5173".parse().unwrap());
+        assert!(!is_loopback_same_origin(&headers));
+        headers.insert(header::ORIGIN, "http://localhost:5173".parse().unwrap());
+        assert!(is_loopback_same_origin(&headers));
+        headers.insert(header::HOST, "[::1]:17731".parse().unwrap());
+        headers.insert(header::ORIGIN, "http://[::1]:17731".parse().unwrap());
+        assert!(is_loopback_same_origin(&headers));
+        headers.insert(header::HOST, "attacker.example:7731".parse().unwrap());
+        headers.insert(
+            header::ORIGIN,
+            "http://attacker.example:7731".parse().unwrap(),
+        );
+        assert!(!is_loopback_same_origin(&headers));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix native session loss and Convex token-refresh failures across the installed renderer and Rust clients.

### Causes

- Installed clients maintained independent AuthKit JS and native WorkOS sessions. Startup deleted the native credential whenever the browser session was missing. A valid hosted WorkOS session then made the next browser login look like a no-op.
- Convex Rust 0.10.4 refreshes auth on reconnect, not before a JWT expires on a live socket.
- Failed credential-store writes discarded rotated refresh tokens. Cancelling a token consumer could also interrupt rotation before persistence.
- Convex JS does not catch token-fetcher rejections. A refresh failure could leave its socket stopped. The UI also routed temporary native failures to a new OAuth login rather than a retry.

### Changes

- Use one Rust-owned WorkOS session for installed renderers and agents. Hosted web still uses AuthKit JS.
- Add a paired, same-origin, loopback-only token endpoint with no-store responses. Refresh tokens stay in the OS credential store and never enter JavaScript.
- Preserve rotated credentials through persistence failures and let credential operations finish after consumer cancellation. Share concurrent refreshes and validate account bindings.
- Refresh Rust Convex tokens before expiry, retry with backoff, cancel refresh tasks with the client lifecycle, and map authoritative sign-out to unauthenticated Convex auth.
- Settle browser Convex callbacks without rejected promises, recover the Convex connection separately from provider identity, and keep login polling alive through temporary failures.
- Show Retry for unavailable sessions. Keep the old installed-server flow only for explicit 404/405 responses, without destructive startup cleanup. Document its removal gate and the in-place session-binding migration.

The existing Convex issuer/JWKS configuration already matches the current AuthKit docs and is unchanged. No Convex schema changes or deployment are needed for this PR.

## Validation

- Targeted native-auth, Convex refresh, frontend-auth, and token-endpoint tests
- `cargo test --quiet`
- `bun run test`
- `bun run build`
- `prek run -a`

Tests cover startup resume, expired/failed refreshes, cancellation during rotation, persistence retry, account transitions, sign-out races, refresh-task lifecycle, local pairing concurrency, legacy fallback, and token-endpoint origin/peer/session checks.

Live WorkOS login and a production long-lived WebSocket soak test were not performed. WebSocket close messages can still occur for ordinary network interruptions; this fixes the verified auth-driven failure paths rather than suppressing those logs.

## References

- https://workos.com/docs/authkit/session-resilience
- https://workos.com/docs/authkit/sessions
- https://docs.convex.dev/auth/authkit/
- https://docs.convex.dev/auth/advanced/custom-auth
- Repository Convex AI guidelines and installed Convex/AuthKit SDK sources




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates installed-client authentication around a Rust-owned WorkOS session and improves Convex token renewal and failure recovery.

- Adds a paired, same-origin, loopback-only endpoint that supplies short-lived access tokens without exposing refresh tokens to JavaScript.
- Preserves rotated native credentials across persistence failures and coordinates concurrent refreshes.
- Proactively refreshes Rust Convex authentication with lifecycle-aware retry and cancellation.
- Separates temporary provider and Convex failures from authoritative sign-out in the web authentication flow.
- Retains the legacy installed-renderer flow only for servers that explicitly lack the new endpoint.
- Adds broad coverage for account transitions, cancellation, retry, persistence, pairing, and endpoint boundary checks.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable regression introduced since the previous review.

The latest revision only reformats authentication implementation and test code, and the current review found no outstanding behavioral, security, or repository-rule violations.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/auth.ts | Consolidates installed authentication around native sessions and adds non-rejecting Convex token recovery; the latest revision contains formatting-only changes. |
| crates/sprocket-server/src/native_auth.rs | Adds coordinated native credential refresh, account binding, persistence recovery, and cancellation-safe rotation. |
| crates/sprocket-server/src/routes/auth.rs | Adds the protected native-session token endpoint with pairing, origin, peer, and account checks. |
| crates/sprocket-convex/src/auth.rs | Implements proactive JWT refresh, retry backoff, and lifecycle cancellation for Rust Convex clients. |
| crates/sprocket-convex/src/lib.rs | Integrates managed authentication refresh into the shared Convex client lifecycle. |
| apps/web/src/lib/local/client.ts | Extends local-session bootstrap support needed before requesting native tokens. |
| apps/web/src/lib/auth.test.ts | Covers native-session resume, retries, legacy fallback, account transitions, and stale asynchronous results. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Installed Renderer
    participant Server as Local Rust Server
    participant Store as OS Credential Store
    participant WorkOS
    participant Convex

    UI->>Server: Pair local session
    UI->>Server: POST /api/auth/native-session/token
    Server->>Server: Validate origin, loopback peer, and session
    Server->>Store: Load native refresh credential
    Server->>WorkOS: Refresh when required
    WorkOS-->>Server: Access token and rotated credential
    Server->>Store: Persist rotated credential
    Server-->>UI: Short-lived access token and user
    UI->>Convex: Authenticate with access token
    loop Before token expiry
        Server->>WorkOS: Refresh with retry/backoff
        WorkOS-->>Server: Replacement token
        Server->>Convex: Update authenticated token
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style(auth): Format session recovery and..."](https://github.com/spikonado/sprocket/commit/01a3180d5a3e5776e334d232d1f41736381e3814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60926179)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Local server authentication](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-authentication.md)
- Knowledge Base — [Convex provider client](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/convex-provider.md)
- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
</details>


<!-- /greptile_comment -->