### PR TITLE
feat(workspace): Apply unified diffs with CRLF headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "diffy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
+checksum = "3e3dc2f773b6aaa63b1a7684b8589f670a8a0146a510b74d23a401c882364b49"
 dependencies = [
  "hashbrown 0.17.1",
 ]

--- a/crates/sprocket-workspace/Cargo.toml
+++ b/crates/sprocket-workspace/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
-diffy = { version = "0.5.0", features = ["std"] }
+diffy = { version = "0.5.2", features = ["std"] }
 gix = { version = "0.87", default-features = false, features = ["sha1", "max-performance-safe"] }
 libc = "0.2.186"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -849,6 +849,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn applies_unified_diff_with_crlf_headers() {
+        let root = temp_workspace();
+        fs::write(root.join("file.txt"), "before\n").unwrap();
+        let patch = "--- a/file.txt\r\n\
+            +++ b/file.txt\r\n\
+            @@ -1 +1 @@\r\n\
+            -before\r\n\
+            +after\r\n";
+
+        apply_workspace_patch(root.clone(), WorkspaceCancellation::new(), patch)
+            .await
+            .expect("CRLF unified diff headers should apply");
+
+        assert_eq!(
+            fs::read_to_string(root.join("file.txt")).unwrap(),
+            "after\n"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
     async fn applies_multi_file_patch() {
         let root = temp_workspace();
         fs::write(root.join("modify.txt"), "before\n").unwrap();

--- a/crates/sprocket-workspace/src/patch.rs
+++ b/crates/sprocket-workspace/src/patch.rs
@@ -731,6 +731,7 @@ mod tests {
     use super::{apply_workspace_patch, write_new_file};
     use crate::commands::{WorkspaceCancellation, WorkspaceOperationCancelled};
     use crate::test_support::temp_workspace;
+    use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
 
     static HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -867,6 +868,26 @@ mod tests {
             "after\n"
         );
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unidiff_headers_do_not_keep_a_trailing_carriage_return() {
+        let patch = "--- a/file.txt\r\n\
+            +++ b/file.txt\r\n\
+            @@ -1 +1 @@\r\n\
+            -before\r\n\
+            +after\r\n";
+        let parsed = PatchSet::parse(patch, ParseOptions::unidiff())
+            .next()
+            .expect("one file in the patch")
+            .expect("CRLF headers should parse");
+        match parsed.operation() {
+            FileOperation::Modify { original, modified } => {
+                assert_eq!(original.as_ref(), "a/file.txt");
+                assert_eq!(modified.as_ref(), "b/file.txt");
+            }
+            other => panic!("expected modify, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renovate #308 only bumps the lockfile to diffy 0.5.2. The useful change in that release is that `---`/`+++` headers with CRLF no longer treat the carriage return as part of the filename.

This PR pins `diffy` to 0.5.2 and adds an `apply_patch` test for a Windows-style unified diff.

Does not close #308. Leave the Renovate PR until this lands.

## Checks

- `cargo test -p sprocket-workspace applies_unified_diff_with_crlf_headers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95ce8e07-1521-4ad4-9042-5aaa8166a133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95ce8e07-1521-4ad4-9042-5aaa8166a133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR pins diffy to 0.5.2 and adds regression coverage for Windows-style unified-diff headers.
- Verifies that workspace patches containing CRLF headers apply successfully.
- Directly verifies that diffy does not retain `\r` in parsed filenames.
- Addresses the prior concern that the workspace-level test alone did not exercise the dependency behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the dependency behavior now covered by a focused regression test.

No actionable new issues were identified. The previous test-coverage thread was manually resolved, and the added direct `PatchSet::parse` test now verifies that CRLF header filenames do not retain a trailing carriage return.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.lock | Updates the resolved diffy package from 0.5.1 to 0.5.2 with the corresponding checksum. |
| crates/sprocket-workspace/Cargo.toml | Raises the minimum diffy dependency version to 0.5.2. |
| crates/sprocket-workspace/src/patch.rs | Adds workspace-level and direct-parser regression tests for CRLF unified-diff headers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(workspace): Parse CRLF unified-diff..."](https://github.com/spikonado/sprocket/commit/771792f693cbb5dd7766b28d746fa445d13ccbd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61103115)</sub>

<!-- /greptile_comment -->