### PR TITLE
perf(ui): Load transcript history by parts on demand

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,7 +4,7 @@ This file lists shims we still ship. When a removal PR merges, delete its
 entry. Age-out is a prod check for stored rows, or an explicit decision that
 a retired function name can disappear.
 
-Current as of 2026-09-06.
+Current as of 2026-09-07.
 
 ## Transcript projection API
 
@@ -44,10 +44,15 @@ meaning unknown instead of a sequence number. Remove it once supported clients n
 longer read it; the current section timer uses assistant-part timestamps.
 
 PR #295 keeps `/api/transcript/page` returning raw `parts` for released clients.
-The projected-message client uses `/api/transcript/messages`; the legacy route
-reads the same complete message window and returns its original parts. The
-JSONL replica format is unchanged. Remove the legacy route after all supported
-clients use the projected-message endpoint.
+The projected-message client uses `/api/transcript/messages` and `/api/transcript/details`.
+Those routes still page by complete messages and may scan past the requested part
+window to a message boundary. Current UI pages numbered Convex transcript parts
+through `/api/transcript/parts` and `/api/transcript/part-details`. The JSONL
+replica format is unchanged. The transcript watcher applies Convex state metadata
+and does not prefetch numbered part bodies; released clients still download them
+through the preserved paging routes. Remove `/api/transcript/page`,
+`/api/transcript/messages`, and `/api/transcript/details` after all supported
+clients use the part-bounded endpoints.
 
 ## Stored schema
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
 		"@typescript/native": "npm:typescript@7.0.2",
 		"convex-test": "^0.0.56",
 		"eslint": "^10.0.0",
+		"jsdom": "^30.0.1",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.7.4",
 		"tailwindcss": "^4.2.4",

--- a/apps/web/src/lib/chat/transcript-section-keys.ts
+++ b/apps/web/src/lib/chat/transcript-section-keys.ts
@@ -1,0 +1,39 @@
+import { assistantTimelinePartKey, type AssistantTimelineSection } from './assistant-timeline';
+
+export class TranscriptSectionKeys {
+	private messages = new Map<string, Map<string, string>>();
+	private nextId = 0;
+
+	retain(messageIds: string[]) {
+		const retained = new Set(messageIds);
+		for (const id of this.messages.keys()) {
+			if (!retained.has(id)) this.messages.delete(id);
+		}
+	}
+
+	reconcile(messageId: string, sections: AssistantTimelineSection[]) {
+		const previous = this.messages.get(messageId);
+		const next = new Map<string, string>();
+		const claimed = new Set<string>();
+		const keyed = sections.map((section) => {
+			if (section.type === 'text') {
+				return { ...section, renderKey: assistantTimelinePartKey(section) };
+			}
+			const members = section.blocks.flatMap((block) =>
+				block.type === 'reasoning'
+					? [assistantTimelinePartKey(block)]
+					: block.tools.map((tool) => `tool:${tool.callId}`)
+			);
+			// Parts can arrive at either end; a split must not reuse one key for both sections.
+			const existing = members
+				.map((member) => previous?.get(member))
+				.find((key) => key !== undefined && !claimed.has(key));
+			const renderKey = existing ?? `work:${this.nextId++}`;
+			claimed.add(renderKey);
+			for (const member of members) next.set(member, renderKey);
+			return { ...section, renderKey };
+		});
+		this.messages.set(messageId, next);
+		return keyed;
+	}
+}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -78,7 +78,7 @@
 	let adjustingScroll = false;
 
 	const SCROLL_EPSILON_PX = 28;
-	const LOAD_OLDER_THRESHOLD_PX = 2_000;
+	const LOAD_OLDER_THRESHOLD_PX = 200;
 
 	function updateStickToBottom() {
 		const viewport = scrollViewport;
@@ -90,7 +90,13 @@
 		}
 		const distanceToBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
 		stickToBottom = distanceToBottom <= SCROLL_EPSILON_PX;
-		if (hasOlder && !loadingOlder && onLoadOlder && viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX) {
+		if (
+			!stickToBottom &&
+			hasOlder &&
+			!loadingOlder &&
+			onLoadOlder &&
+			viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX
+		) {
 			onLoadOlder();
 		}
 	}
@@ -223,6 +229,20 @@
 			bind:this={scrollContent}
 			class="mx-auto flex min-h-full w-full max-w-5xl flex-col px-4 py-8"
 		>
+			{#if hasOlder && onLoadOlder}
+				<button
+					type="button"
+					class="text-muted-foreground hover:text-foreground mb-6 self-center text-sm disabled:opacity-50"
+					disabled={loadingOlder}
+					onclick={() => {
+						stickToBottom = false;
+						onLoadOlder?.();
+					}}
+				>
+					{loadingOlder ? 'Loading earlier messages...' : 'Load earlier messages'}
+				</button>
+			{/if}
+
 			{#if currentError}
 				<div
 					role="alert"

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -13,11 +13,11 @@
 		isAssistantResponseStreaming,
 		partitionWorkSectionTools,
 		workSectionTimingAnchor,
-		type AssistantTimelineSection,
 		type AssistantTimelineTool,
 		type AssistantTimelineWorkBlock
 	} from '$lib/chat/assistant-timeline';
 	import { toolKindIcon, toolLogIcon } from '$lib/chat/tool-icons';
+	import { TranscriptSectionKeys } from '$lib/chat/transcript-section-keys';
 	import {
 		changedFileCount,
 		fullToolSummary,
@@ -143,10 +143,8 @@
 		return !isArtifactToolGroup(block);
 	}
 
-	function sectionKey(section: AssistantTimelineSection, next?: AssistantTimelineSection) {
-		if (section.type === 'text') return assistantTimelinePartKey(section);
-		return `work:${next?.type === 'text' ? assistantTimelinePartKey(next) : 'tail'}`;
-	}
+	const sectionKeys = new TranscriptSectionKeys();
+	$effect.pre(() => sectionKeys.retain(messages.map((message) => message._id)));
 
 	const userMessageClass =
 		'user-bubble w-fit max-w-[33rem] rounded-xl border px-5 py-3.5 text-[15.5px] leading-7 text-foreground';
@@ -399,7 +397,10 @@
 							)}
 							{@const sessionCommands = buildCommandSessionCommandMap(timelineTools)}
 							{@const blocks = groupAssistantTimeline(timeline)}
-							{@const sections = groupAssistantTimelineSections(blocks)}
+							{@const sections = sectionKeys.reconcile(
+								message._id,
+								groupAssistantTimelineSections(blocks)
+							)}
 							{@const isStreaming = isAssistantResponseStreaming(message, activeRunId)}
 							{@const openSessions = buildOpenExecCommandSessions(timelineTools, isStreaming)}
 							{@const hasPersistedAssistantContent = timeline.some(
@@ -417,7 +418,7 @@
 									{#if !hasPersistedAssistantContent && (message.text || (isStreaming && timeline.length === 0))}
 										<ChatMarkdown content={message.text || '...'} className="text-foreground" />
 									{/if}
-									{#each sections as section, sectionIndex (sectionKey(section, sections[sectionIndex + 1]))}
+									{#each sections as section, sectionIndex (section.renderKey)}
 										{#if section.type === 'text'}
 											<div
 												data-transcript-anchor={`${message._id}:${assistantTimelinePartKey(section)}`}
@@ -448,7 +449,7 @@
 											{#if visibleBlocks.length > 0 || workInProgress || runningTools.length > 0}
 												<div
 													class="space-y-3"
-													data-transcript-anchor={`${message._id}:${sectionKey(section, nextSection)}`}
+													data-transcript-anchor={`${message._id}:${section.renderKey}`}
 												>
 													<WorkDisclosure
 														inProgress={workInProgress}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -13,6 +13,7 @@
 		isAssistantResponseStreaming,
 		partitionWorkSectionTools,
 		workSectionTimingAnchor,
+		type AssistantTimelineSection,
 		type AssistantTimelineTool,
 		type AssistantTimelineWorkBlock
 	} from '$lib/chat/assistant-timeline';
@@ -140,6 +141,11 @@
 
 	function isVisibleWorkBlock(block: AssistantTimelineWorkBlock): boolean {
 		return !isArtifactToolGroup(block);
+	}
+
+	function sectionKey(section: AssistantTimelineSection, next?: AssistantTimelineSection) {
+		if (section.type === 'text') return assistantTimelinePartKey(section);
+		return `work:${next?.type === 'text' ? assistantTimelinePartKey(next) : 'tail'}`;
 	}
 
 	const userMessageClass =
@@ -411,7 +417,7 @@
 									{#if !hasPersistedAssistantContent && (message.text || (isStreaming && timeline.length === 0))}
 										<ChatMarkdown content={message.text || '...'} className="text-foreground" />
 									{/if}
-									{#each sections as section, sectionIndex (section.type === 'work' ? `work:${section.key}` : assistantTimelinePartKey(section))}
+									{#each sections as section, sectionIndex (sectionKey(section, sections[sectionIndex + 1]))}
 										{#if section.type === 'text'}
 											<div
 												data-transcript-anchor={`${message._id}:${assistantTimelinePartKey(section)}`}
@@ -442,7 +448,7 @@
 											{#if visibleBlocks.length > 0 || workInProgress || runningTools.length > 0}
 												<div
 													class="space-y-3"
-													data-transcript-anchor={`${message._id}:work:${section.key}`}
+													data-transcript-anchor={`${message._id}:${sectionKey(section, nextSection)}`}
 												>
 													<WorkDisclosure
 														inProgress={workInProgress}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -4,6 +4,7 @@
 	import {
 		assistantTimelineToolError,
 		assistantTimelineToolFailureKind,
+		assistantTimelinePartKey,
 		buildAssistantTimeline,
 		buildCommandSessionCommandMap,
 		buildOpenExecCommandSessions,
@@ -76,6 +77,7 @@
 	let scrollContent = $state<HTMLDivElement | null>(null);
 	let stickToBottom = $state(true);
 	let adjustingScroll = false;
+	let touchY: number | undefined;
 
 	const SCROLL_EPSILON_PX = 28;
 	const LOAD_OLDER_THRESHOLD_PX = 200;
@@ -98,6 +100,32 @@
 			viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX
 		) {
 			onLoadOlder();
+		}
+	}
+
+	function loadOlderOnUpwardIntent() {
+		const viewport = scrollViewport;
+		if (
+			viewport &&
+			hasOlder &&
+			!loadingOlder &&
+			viewport.clientHeight > 0 &&
+			viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX
+		) {
+			stickToBottom = false;
+			onLoadOlder?.();
+		}
+	}
+
+	function handleHistoryKey(event: KeyboardEvent) {
+		if (
+			event.target instanceof Element &&
+			event.target.closest('input, textarea, button, [contenteditable="true"]')
+		) {
+			return;
+		}
+		if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
+			loadOlderOnUpwardIntent();
 		}
 	}
 
@@ -156,8 +184,8 @@
 		viewport.scrollTop = viewport.scrollHeight;
 	}
 
-	function firstVisibleMessage(viewport: HTMLDivElement) {
-		const elements = viewport.querySelectorAll<HTMLElement>('[data-message-id]');
+	function firstVisibleAnchor(viewport: HTMLDivElement) {
+		const elements = viewport.querySelectorAll<HTMLElement>('[data-transcript-anchor]');
 		const top = viewport.getBoundingClientRect().top;
 		let low = 0;
 		let high = elements.length;
@@ -175,9 +203,10 @@
 		untrack(() => {
 			const viewport = scrollViewport;
 			if (!viewport) return;
-			const anchor = stickToBottom ? undefined : firstVisibleMessage(viewport);
+			const anchor = stickToBottom ? undefined : firstVisibleAnchor(viewport);
 			const offset = anchor?.getBoundingClientRect().top;
 			const scrollTop = viewport.scrollTop;
+			const scrollHeight = viewport.scrollHeight;
 			void tick().then(() => {
 				if (viewport !== scrollViewport) return;
 				adjustingScroll = true;
@@ -189,41 +218,14 @@
 					viewport.scrollTop === scrollTop
 				) {
 					viewport.scrollTop += anchor.getBoundingClientRect().top - offset;
+				} else if (anchor && !anchor.isConnected && viewport.scrollTop === scrollTop) {
+					viewport.scrollTop += viewport.scrollHeight - scrollHeight;
 				}
 				requestAnimationFrame(() => {
 					adjustingScroll = false;
 				});
 			});
 		});
-	});
-
-	$effect(() => {
-		void messages;
-		const viewport = scrollViewport;
-		if (!viewport || !hasOlder || loadingOlder) return;
-		const retryDelay = stale ? 2_000 : 0;
-		let retryTimer: ReturnType<typeof setTimeout> | undefined;
-		let cancelled = false;
-		function fillViewport() {
-			if (
-				!cancelled &&
-				viewport &&
-				!loadingOlder &&
-				viewport.clientHeight > 0 &&
-				viewport.scrollHeight - viewport.clientHeight <= SCROLL_EPSILON_PX
-			) {
-				onLoadOlder?.();
-			}
-		}
-		void tick().then(() => {
-			if (cancelled) return;
-			if (retryDelay) retryTimer = setTimeout(fillViewport, retryDelay);
-			else fillViewport();
-		});
-		return () => {
-			cancelled = true;
-			clearTimeout(retryTimer);
-		};
 	});
 
 	$effect(() => {
@@ -249,10 +251,28 @@
 </script>
 
 <div class="relative min-h-0 flex-1">
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex, a11y_no_noninteractive_element_interactions (Keyboard users must be able to page history even when it does not overflow.) -->
 	<div
 		class="hide-scrollbar h-full overflow-auto"
+		role="region"
+		aria-label="Conversation history"
+		tabindex="0"
 		bind:this={scrollViewport}
 		onscroll={updateStickToBottom}
+		onwheel={(event) => {
+			if (event.deltaY < 0) loadOlderOnUpwardIntent();
+		}}
+		onkeydown={handleHistoryKey}
+		ontouchstart={(event) => {
+			touchY = event.touches[0]?.clientY;
+		}}
+		ontouchmove={(event) => {
+			const nextY = event.touches[0]?.clientY;
+			if (nextY !== undefined && touchY !== undefined && nextY > touchY) {
+				loadOlderOnUpwardIntent();
+			}
+			touchY = nextY;
+		}}
 	>
 		<div
 			bind:this={scrollContent}
@@ -297,7 +317,11 @@
 				<div class="space-y-8 pb-14">
 					{#each messages as message (message._id)}
 						{#if message.type === 'prompt'}
-							<div data-message-id={message._id} class="flex flex-col items-end gap-1.5">
+							<div
+								data-message-id={message._id}
+								data-transcript-anchor={message._id}
+								class="flex flex-col items-end gap-1.5"
+							>
 								{#if message.attachments.length}
 									<ul
 										class="flex max-w-132 flex-wrap justify-end gap-2"
@@ -387,9 +411,13 @@
 									{#if !hasPersistedAssistantContent && (message.text || (isStreaming && timeline.length === 0))}
 										<ChatMarkdown content={message.text || '...'} className="text-foreground" />
 									{/if}
-									{#each sections as section, sectionIndex (`${section.type}-${section.type === 'work' ? section.key : section.id}-${sectionIndex}`)}
+									{#each sections as section, sectionIndex (section.type === 'work' ? `work:${section.key}` : assistantTimelinePartKey(section))}
 										{#if section.type === 'text'}
-											<ChatMarkdown content={section.text || ' '} className="text-foreground" />
+											<div
+												data-transcript-anchor={`${message._id}:${assistantTimelinePartKey(section)}`}
+											>
+												<ChatMarkdown content={section.text || ' '} className="text-foreground" />
+											</div>
 										{:else}
 											{@const { settledBlocks, runningTools } = partitionWorkSectionTools(
 												section.blocks,
@@ -412,104 +440,116 @@
 														: undefined
 											})}
 											{#if visibleBlocks.length > 0 || workInProgress || runningTools.length > 0}
-												<WorkDisclosure
-													inProgress={workInProgress}
-													startedAtMs={timing.startedAtMs}
-													completedAtMs={timing.completedAtMs}
-													detailsKey={`${message.sourceNumbers?.join(',')}:${message.detailsLoaded}`}
-													onExpand={() => onLoadDetails?.(message)}
+												<div
+													class="space-y-3"
+													data-transcript-anchor={`${message._id}:work:${section.key}`}
 												>
-													{#each visibleBlocks as block, blockIndex (`${block.type}-${block.type === 'tool-group' ? block.tools.map((tool) => tool.callId).join(',') : block.id}-${blockIndex}`)}
-														{#if block.type === 'reasoning'}
-															{@const reasoningInProgress =
-																workInProgress &&
-																runningTools.length === 0 &&
-																blockIndex === visibleBlocks.length - 1}
-															<ReasoningDisclosure
-																text={block.text}
-																inProgress={reasoningInProgress}
-															/>
-														{:else}
-															<ToolCallsDisclosure
-																label={toolGroupLabel(block.toolKey)}
-																icon={toolKindIcon(block.toolKey)}
-																tools={block.tools}
-																defaultExpanded={block.toolKey === 'apply_patch'
-																	? changedFileCount(block.tools) <= 2
-																	: undefined}
-															>
-																{#snippet toolRow(tool)}
-																	{@const toolError = assistantTimelineToolError(tool, isStreaming)}
-																	{@const toolFailureKind = assistantTimelineToolFailureKind(
-																		tool,
-																		isStreaming
-																	)}
-																	{@const toolSummary = toolItemSummary(tool, sessionCommands)}
-																	{#if toolError && toolFailureKind}
-																		<details class="min-w-0">
-																			<summary
-																				class="min-w-0 cursor-pointer text-left"
+													<WorkDisclosure
+														inProgress={workInProgress}
+														startedAtMs={timing.startedAtMs}
+														completedAtMs={timing.completedAtMs}
+														detailsKey={`${message.sourceNumbers?.join(',')}:${message.detailsLoaded}`}
+														onExpand={() => onLoadDetails?.(message)}
+													>
+														{#each visibleBlocks as block, blockIndex (`${block.type}-${block.type === 'tool-group' ? block.tools.map((tool) => tool.callId).join(',') : block.id}-${blockIndex}`)}
+															{#if block.type === 'reasoning'}
+																{@const reasoningInProgress =
+																	workInProgress &&
+																	runningTools.length === 0 &&
+																	blockIndex === visibleBlocks.length - 1}
+																<ReasoningDisclosure
+																	text={block.text}
+																	inProgress={reasoningInProgress}
+																/>
+															{:else}
+																<ToolCallsDisclosure
+																	label={toolGroupLabel(block.toolKey)}
+																	icon={toolKindIcon(block.toolKey)}
+																	tools={block.tools}
+																	defaultExpanded={block.toolKey === 'apply_patch'
+																		? changedFileCount(block.tools) <= 2
+																		: undefined}
+																>
+																	{#snippet toolRow(tool)}
+																		{@const toolError = assistantTimelineToolError(
+																			tool,
+																			isStreaming
+																		)}
+																		{@const toolFailureKind = assistantTimelineToolFailureKind(
+																			tool,
+																			isStreaming
+																		)}
+																		{@const toolSummary = toolItemSummary(tool, sessionCommands)}
+																		{#if toolError && toolFailureKind}
+																			<details class="min-w-0">
+																				<summary
+																					class="min-w-0 cursor-pointer text-left"
+																					title={fullToolSummary(
+																						tool,
+																						isStreaming,
+																						sessionCommands
+																					)}
+																				>
+																					<span class={toolSummaryClass(tool)}>{toolSummary}</span>
+																					<span
+																						class={toolFailureKind === 'failed'
+																							? 'text-destructive'
+																							: 'text-amber-800 dark:text-amber-200'}
+																					>
+																						({toolFailureKind})
+																					</span>
+																				</summary>
+																				<p
+																					class="mt-1.5 text-xs leading-5 wrap-break-word whitespace-pre-wrap {toolFailureKind ===
+																					'failed'
+																						? 'text-destructive'
+																						: 'text-amber-800 dark:text-amber-200'}"
+																					role="status"
+																				>
+																					{toolError}
+																				</p>
+																			</details>
+																		{:else}
+																			<p
+																				class={`min-w-0 ${toolSummaryClass(tool)}`}
 																				title={fullToolSummary(tool, isStreaming, sessionCommands)}
 																			>
-																				<span class={toolSummaryClass(tool)}>{toolSummary}</span>
-																				<span
-																					class={toolFailureKind === 'failed'
-																						? 'text-destructive'
-																						: 'text-amber-800 dark:text-amber-200'}
-																				>
-																					({toolFailureKind})
-																				</span>
-																			</summary>
-																			<p
-																				class="mt-1.5 text-xs leading-5 wrap-break-word whitespace-pre-wrap {toolFailureKind ===
-																				'failed'
-																					? 'text-destructive'
-																					: 'text-amber-800 dark:text-amber-200'}"
-																				role="status"
-																			>
-																				{toolError}
+																				{toolSummary}
 																			</p>
-																		</details>
-																	{:else}
-																		<p
-																			class={`min-w-0 ${toolSummaryClass(tool)}`}
-																			title={fullToolSummary(tool, isStreaming, sessionCommands)}
-																		>
-																			{toolSummary}
-																		</p>
-																	{/if}
-																{/snippet}
-															</ToolCallsDisclosure>
-														{/if}
+																		{/if}
+																	{/snippet}
+																</ToolCallsDisclosure>
+															{/if}
+														{/each}
+													</WorkDisclosure>
+													{#each sectionMandateApprovals as approval (approval.mandateId)}
+														<MandateApprovalForm {approval} />
 													{/each}
-												</WorkDisclosure>
-											{/if}
-											{#each sectionMandateApprovals as approval (approval.mandateId)}
-												<MandateApprovalForm {approval} />
-											{/each}
-											{#if runningTools.length > 0}
-												<ToolCallsDisclosure
-													label="Running"
-													icon={LoaderCircle}
-													iconClass="animate-spin"
-													tools={runningTools}
-													defaultExpanded={true}
-												>
-													{#snippet toolRow(tool)}
-														{@const ToolIcon = toolLogIcon(tool)}
-														{@const toolSummary = toolItemSummary(tool, sessionCommands)}
-														<p
-															class="flex min-w-0 items-start gap-1.5"
-															title={`${toolSummary} (running)`}
+													{#if runningTools.length > 0}
+														<ToolCallsDisclosure
+															label="Running"
+															icon={LoaderCircle}
+															iconClass="animate-spin"
+															tools={runningTools}
+															defaultExpanded={true}
 														>
-															<ToolIcon
-																class="text-muted-foreground mt-1.5 size-3 shrink-0"
-																aria-hidden="true"
-															/>
-															<span class={toolSummaryClass(tool)}>{toolSummary}</span>
-														</p>
-													{/snippet}
-												</ToolCallsDisclosure>
+															{#snippet toolRow(tool)}
+																{@const ToolIcon = toolLogIcon(tool)}
+																{@const toolSummary = toolItemSummary(tool, sessionCommands)}
+																<p
+																	class="flex min-w-0 items-start gap-1.5"
+																	title={`${toolSummary} (running)`}
+																>
+																	<ToolIcon
+																		class="text-muted-foreground mt-1.5 size-3 shrink-0"
+																		aria-hidden="true"
+																	/>
+																	<span class={toolSummaryClass(tool)}>{toolSummary}</span>
+																</p>
+															{/snippet}
+														</ToolCallsDisclosure>
+													{/if}
+												</div>
 											{/if}
 										{/if}
 									{/each}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -200,20 +200,29 @@
 	$effect(() => {
 		void messages;
 		const viewport = scrollViewport;
-		if (!viewport || !hasOlder) return;
+		if (!viewport || !hasOlder || loadingOlder) return;
+		const retryDelay = stale ? 2_000 : 0;
+		let retryTimer: ReturnType<typeof setTimeout> | undefined;
 		let cancelled = false;
-		void tick().then(() => {
+		function fillViewport() {
 			if (
 				!cancelled &&
+				viewport &&
 				!loadingOlder &&
 				viewport.clientHeight > 0 &&
 				viewport.scrollHeight <= viewport.clientHeight
 			) {
 				onLoadOlder?.();
 			}
+		}
+		void tick().then(() => {
+			if (cancelled) return;
+			if (retryDelay) retryTimer = setTimeout(fillViewport, retryDelay);
+			else fillViewport();
 		});
 		return () => {
 			cancelled = true;
+			clearTimeout(retryTimer);
 		};
 	});
 

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -198,6 +198,26 @@
 	});
 
 	$effect(() => {
+		void messages;
+		const viewport = scrollViewport;
+		if (!viewport || !hasOlder) return;
+		let cancelled = false;
+		void tick().then(() => {
+			if (
+				!cancelled &&
+				!loadingOlder &&
+				viewport.clientHeight > 0 &&
+				viewport.scrollHeight <= viewport.clientHeight
+			) {
+				onLoadOlder?.();
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	$effect(() => {
 		const viewport = scrollViewport;
 		const content = scrollContent;
 		if (!viewport || !content || !globalThis.ResizeObserver) {
@@ -229,20 +249,6 @@
 			bind:this={scrollContent}
 			class="mx-auto flex min-h-full w-full max-w-5xl flex-col px-4 py-8"
 		>
-			{#if hasOlder && onLoadOlder}
-				<button
-					type="button"
-					class="text-muted-foreground hover:text-foreground mb-6 self-center text-sm disabled:opacity-50"
-					disabled={loadingOlder}
-					onclick={() => {
-						stickToBottom = false;
-						onLoadOlder?.();
-					}}
-				>
-					{loadingOlder ? 'Loading earlier messages...' : 'Load earlier messages'}
-				</button>
-			{/if}
-
 			{#if currentError}
 				<div
 					role="alert"

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -210,7 +210,7 @@
 				viewport &&
 				!loadingOlder &&
 				viewport.clientHeight > 0 &&
-				viewport.scrollHeight <= viewport.clientHeight
+				viewport.scrollHeight - viewport.clientHeight <= SCROLL_EPSILON_PX
 			) {
 				onLoadOlder?.();
 			}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -214,4 +214,31 @@ describe('transcript viewport paging', () => {
 		expect(anchor.getBoundingClientRect().top).toBe(offset);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
+
+	it('keeps a work disclosure open when a page prepends parts into that section', async () => {
+		const response: ThreadMessage = {
+			...message(3),
+			_id: 'response:run',
+			type: 'response',
+			parts: [
+				{ type: 'reasoning', id: 'r3', text: 'Recent reasoning' },
+				{ type: 'text', id: 't4', text: 'Answer' }
+			]
+		};
+		const { props, viewport } = await renderTranscript([response]);
+		const button = viewport.querySelector<HTMLButtonElement>('button[aria-expanded]');
+		if (!button) throw new Error('Missing work disclosure');
+		button.click();
+		await settle();
+		expect(button.getAttribute('aria-expanded')).toBe('true');
+		props.messages = [
+			{
+				...response,
+				parts: [{ type: 'reasoning', id: 'r2', text: 'Older reasoning' }, ...response.parts]
+			}
+		];
+		await settle();
+		expect(button.isConnected).toBe(true);
+		expect(button.getAttribute('aria-expanded')).toBe('true');
+	});
 });

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -30,7 +30,7 @@ async function settle() {
 	await vi.advanceTimersByTimeAsync(16);
 }
 
-async function renderTranscript(numbers: number[]) {
+async function renderTranscript(numbers: number[], viewportHeight = 600) {
 	const props = $state<ComponentProps<typeof ThreadTranscript>>({
 		currentError: null,
 		runError: null,
@@ -49,8 +49,8 @@ async function renderTranscript(numbers: number[]) {
 	let scrollTop = 0;
 	// jsdom has no layout. Model fixed-height rows while exercising the real DOM and effects.
 	Object.defineProperties(viewport, {
-		clientHeight: { get: () => 600 },
-		scrollHeight: { get: () => Math.max(600, messageElements().length * 300) },
+		clientHeight: { get: () => viewportHeight },
+		scrollHeight: { get: () => Math.max(viewportHeight, messageElements().length * 300) },
 		scrollTop: {
 			get: () => scrollTop,
 			set: (top: number) => {
@@ -62,7 +62,12 @@ async function renderTranscript(numbers: number[]) {
 		this: HTMLElement
 	) {
 		const index = messageElements().indexOf(this);
-		return new DOMRect(0, index < 0 ? 0 : index * 300 - scrollTop, 800, index < 0 ? 600 : 300);
+		return new DOMRect(
+			0,
+			index < 0 ? 0 : index * 300 - scrollTop,
+			800,
+			index < 0 ? viewportHeight : 300
+		);
 	});
 	await settle();
 	return {
@@ -138,6 +143,13 @@ describe('transcript viewport paging', () => {
 		cleanup = undefined;
 		await vi.advanceTimersByTimeAsync(2_000);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+	});
+
+	it('fills pages whose small overflow cannot leave the bottom-stick threshold', async () => {
+		const { props, scrollTo } = await renderTranscript([1, 2, 3], 880);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		scrollTo(0);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 
 	it('preserves the visible message offset when an older page is prepended', async () => {

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -241,4 +241,36 @@ describe('transcript viewport paging', () => {
 		expect(button.isConnected).toBe(true);
 		expect(button.getAttribute('aria-expanded')).toBe('true');
 	});
+
+	it.each([false, true])(
+		'keeps disclosure state on its own work when sections split: %s',
+		async (split) => {
+			const first = { type: 'reasoning' as const, id: 'r1', text: 'First work' };
+			const second = { type: 'reasoning' as const, id: 'r2', text: 'Second work' };
+			const response: ThreadMessage = {
+				...message(3),
+				_id: 'response:run',
+				type: 'response',
+				parts: split ? [first, second] : [first]
+			};
+			const { props, viewport } = await renderTranscript([response]);
+			const original = viewport.querySelector<HTMLButtonElement>(
+				'[data-transcript-anchor] > div > button'
+			);
+			if (!original) throw new Error('Missing original work disclosure');
+			original.click();
+			await settle();
+			props.messages = [
+				{ ...response, parts: [first, { type: 'text', id: 't1', text: 'Update' }, second] }
+			];
+			await settle();
+			const buttons = viewport.querySelectorAll<HTMLButtonElement>(
+				'[data-transcript-anchor] > div > button'
+			);
+			expect(buttons).toHaveLength(2);
+			expect(buttons[0]).toBe(original);
+			expect(buttons[0]?.getAttribute('aria-expanded')).toBe('true');
+			expect(buttons[1]?.getAttribute('aria-expanded')).toBe('false');
+		}
+	);
 });

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -30,11 +30,11 @@ async function settle() {
 	await vi.advanceTimersByTimeAsync(16);
 }
 
-async function renderTranscript(numbers: number[], viewportHeight = 600) {
+async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600) {
 	const props = $state<ComponentProps<typeof ThreadTranscript>>({
 		currentError: null,
 		runError: null,
-		messages: numbers.map(message),
+		messages,
 		actions: [],
 		activeRunId: null,
 		project: null,
@@ -45,7 +45,9 @@ async function renderTranscript(numbers: number[], viewportHeight = 600) {
 	cleanup = () => unmount(component);
 	const viewport = document.querySelector<HTMLDivElement>('.overflow-auto');
 	if (!viewport) throw new Error('Missing transcript viewport');
-	const messageElements = () => [...viewport.querySelectorAll<HTMLElement>('[data-message-id]')];
+	const messageElements = () => [
+		...viewport.querySelectorAll<HTMLElement>('[data-transcript-anchor]')
+	];
 	let scrollTop = 0;
 	// jsdom has no layout. Model fixed-height rows while exercising the real DOM and effects.
 	Object.defineProperties(viewport, {
@@ -90,7 +92,7 @@ afterEach(async () => {
 
 describe('transcript viewport paging', () => {
 	it('loads only near the top, not at the bottom or while an older page is loading', async () => {
-		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3]);
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3].map(message));
 		expect(props.onLoadOlder).not.toHaveBeenCalled();
 		scrollTo(300);
 		expect(viewport.scrollTop).toBe(300);
@@ -104,56 +106,104 @@ describe('transcript viewport paging', () => {
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 
-	it('fills a short viewport silently without loading beyond it', async () => {
-		const { props, viewport } = await renderTranscript([3]);
+	it('loads short history only on upward gestures, never to fill the viewport automatically', async () => {
+		const { props, viewport } = await renderTranscript([message(3)]);
 		expect(viewport.textContent).not.toContain('Load earlier messages');
 		expect(viewport.scrollHeight).toBe(viewport.clientHeight);
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
 		expect(viewport.textContent).not.toContain('Loading earlier messages');
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.messages = [message(2), ...props.messages];
 		props.loadingOlder = false;
 		await settle();
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
-		props.messages = [message(1), ...props.messages];
-		await settle();
-		expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		viewport.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 	});
 
-	it('retries failed short-page loads after a delay and cancels the retry on unmount', async () => {
-		const { props } = await renderTranscript([3]);
+	it('allows retry by touch after a failed short-page load without a background retry loop', async () => {
+		const { props, viewport } = await renderTranscript([message(3)]);
+		const touch = (type: string, clientY: number) => {
+			const event = new Event(type, { bubbles: true });
+			Object.defineProperty(event, 'touches', { value: [{ clientY }] });
+			viewport.dispatchEvent(event);
+		};
+		touch('touchstart', 100);
+		touch('touchmove', 150);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
 		props.stale = true;
 		props.loadingOlder = false;
-		flushSync();
-		await tick();
-		await vi.advanceTimersByTimeAsync(1_999);
+		await settle();
+		await vi.advanceTimersByTimeAsync(10_000);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
-		await vi.advanceTimersByTimeAsync(1);
+		touch('touchstart', 100);
+		touch('touchmove', 150);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+	});
+
+	it('accepts upward gestures within the bottom-stick tolerance', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3].map(message), 880);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		scrollTo(0);
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries from the top of overflowing history without requiring another scroll event', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4].map(message));
+		scrollTo(0);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
 		props.loadingOlder = false;
+		props.stale = true;
 		await settle();
-		await cleanup?.();
-		cleanup = undefined;
-		await vi.advanceTimersByTimeAsync(2_000);
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 	});
 
-	it('fills pages whose small overflow cannot leave the bottom-stick threshold', async () => {
-		const { props, scrollTo } = await renderTranscript([1, 2, 3], 880);
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
-		scrollTo(0);
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+	it('preserves a text section when older parts are prepended inside the same response', async () => {
+		const response: ThreadMessage = {
+			...message(3),
+			_id: 'response:run',
+			type: 'response',
+			parts: [3, 4, 5, 6].map((number) => ({
+				type: 'text',
+				id: `text-${number}`,
+				text: `Part ${number}`
+			}))
+		};
+		const { props, viewport, scrollTo } = await renderTranscript([response]);
+		scrollTo(150);
+		const anchor = viewport.querySelector<HTMLElement>(
+			'[data-transcript-anchor="response:run:text::text-3"]'
+		);
+		if (!anchor) throw new Error('Missing visible response section');
+		const offset = anchor.getBoundingClientRect().top;
+		props.messages = [
+			{
+				...response,
+				parts: [{ type: 'text', id: 'text-2', text: 'Older part' }, ...response.parts]
+			}
+		];
+		await settle();
+		expect(anchor.isConnected).toBe(true);
+		expect(anchor.getBoundingClientRect().top).toBe(offset);
+		expect(viewport.scrollTop).toBe(450);
 	});
 
 	it('preserves the visible message offset when an older page is prepended', async () => {
-		const { props, viewport, scrollTo } = await renderTranscript([3, 4, 5, 6]);
+		const { props, viewport, scrollTo } = await renderTranscript([3, 4, 5, 6].map(message));
 		scrollTo(150);
 		const anchor = viewport.querySelector<HTMLElement>('[data-message-id="prompt:3"]');
 		if (!anchor) throw new Error('Missing visible message');

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount, type ComponentProps } from 'svelte';
+import type { Id } from '$convex/_generated/dataModel';
+import type { ThreadMessage } from '$lib/types/sprocket';
+import ThreadTranscript from './thread-transcript.svelte';
+
+let cleanup: (() => Promise<void>) | undefined;
+
+function message(number: number): ThreadMessage {
+	return {
+		_id: `prompt:${number}`,
+		// SAFETY: Fixture IDs never leave the mounted component.
+		threadId: 'thread' as Id<'threadRecords'>,
+		// SAFETY: Fixture IDs never leave the mounted component.
+		runId: `run-${number}` as Id<'runs'>,
+		userId: 'user',
+		type: 'prompt',
+		text: `Message ${number}`,
+		parts: [],
+		attachments: [],
+		runStatus: 'completed',
+		runStartedAt: 1,
+		sourceNumbers: [number]
+	};
+}
+
+async function settle() {
+	flushSync();
+	await tick();
+	await vi.runOnlyPendingTimersAsync();
+}
+
+async function renderTranscript(numbers: number[]) {
+	const props = $state<ComponentProps<typeof ThreadTranscript>>({
+		currentError: null,
+		runError: null,
+		messages: numbers.map(message),
+		actions: [],
+		activeRunId: null,
+		project: null,
+		hasOlder: true,
+		onLoadOlder: vi.fn()
+	});
+	const component = mount(ThreadTranscript, { target: document.body, props });
+	cleanup = () => unmount(component);
+	const viewport = document.querySelector<HTMLDivElement>('.overflow-auto');
+	if (!viewport) throw new Error('Missing transcript viewport');
+	const messageElements = () => [...viewport.querySelectorAll<HTMLElement>('[data-message-id]')];
+	let scrollTop = 0;
+	// jsdom has no layout. Model fixed-height rows while exercising the real DOM and effects.
+	Object.defineProperties(viewport, {
+		clientHeight: { get: () => 600 },
+		scrollHeight: { get: () => Math.max(600, messageElements().length * 300) },
+		scrollTop: {
+			get: () => scrollTop,
+			set: (top: number) => {
+				scrollTop = Math.max(0, Math.min(top, viewport.scrollHeight - viewport.clientHeight));
+			}
+		}
+	});
+	vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+		this: HTMLElement
+	) {
+		const index = messageElements().indexOf(this);
+		return new DOMRect(0, index < 0 ? 0 : index * 300 - scrollTop, 800, index < 0 ? 600 : 300);
+	});
+	await settle();
+	return {
+		props,
+		viewport,
+		scrollTo(top: number) {
+			viewport.scrollTop = top;
+			viewport.dispatchEvent(new Event('scroll'));
+		}
+	};
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(async () => {
+	await cleanup?.();
+	cleanup = undefined;
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe('transcript viewport paging', () => {
+	it('loads only near the top, not at the bottom or while an older page is loading', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3]);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		scrollTo(300);
+		expect(viewport.scrollTop).toBe(300);
+		scrollTo(201);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		scrollTo(200);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.loadingOlder = true;
+		await settle();
+		scrollTo(0);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+	});
+
+	it('offers explicit paging when a short page cannot scroll', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1]);
+		scrollTo(0);
+		expect(viewport.scrollHeight).toBe(viewport.clientHeight);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		const button = [...document.querySelectorAll('button')].find(
+			(element) => element.textContent?.trim() === 'Load earlier messages'
+		);
+		if (!button) throw new Error('Missing earlier messages button');
+		button.click();
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.loadingOlder = true;
+		await settle();
+		expect(button.disabled).toBe(true);
+		button.click();
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.messages = [message(0), ...props.messages];
+		props.loadingOlder = false;
+		props.hasOlder = false;
+		await settle();
+		expect(button.isConnected).toBe(false);
+	});
+
+	it('preserves the visible message offset when an older page is prepended', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([3, 4, 5, 6]);
+		scrollTo(150);
+		const anchor = viewport.querySelector<HTMLElement>('[data-message-id="prompt:3"]');
+		if (!anchor) throw new Error('Missing visible message');
+		const offset = anchor.getBoundingClientRect().top;
+		props.messages = [message(1), message(2), ...props.messages];
+		await settle();
+		expect(viewport.scrollTop).toBe(750);
+		expect(anchor.getBoundingClientRect().top).toBe(offset);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -27,7 +27,7 @@ function message(number: number): ThreadMessage {
 async function settle() {
 	flushSync();
 	await tick();
-	await vi.runOnlyPendingTimersAsync();
+	await vi.advanceTimersByTimeAsync(16);
 }
 
 async function renderTranscript(numbers: number[]) {
@@ -99,7 +99,7 @@ describe('transcript viewport paging', () => {
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 
-	it('fills a short viewport silently without loading beyond it or retrying on loading-state changes', async () => {
+	it('fills a short viewport silently without loading beyond it', async () => {
 		const { props, viewport } = await renderTranscript([3]);
 		expect(viewport.textContent).not.toContain('Load earlier messages');
 		expect(viewport.scrollHeight).toBe(viewport.clientHeight);
@@ -107,15 +107,36 @@ describe('transcript viewport paging', () => {
 		props.loadingOlder = true;
 		await settle();
 		expect(viewport.textContent).not.toContain('Loading earlier messages');
-		props.loadingOlder = false;
-		await settle();
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.messages = [message(2), ...props.messages];
+		props.loadingOlder = false;
 		await settle();
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 		props.messages = [message(1), ...props.messages];
 		await settle();
 		expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries failed short-page loads after a delay and cancels the retry on unmount', async () => {
+		const { props } = await renderTranscript([3]);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.loadingOlder = true;
+		await settle();
+		props.stale = true;
+		props.loadingOlder = false;
+		flushSync();
+		await tick();
+		await vi.advanceTimersByTimeAsync(1_999);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+		props.loadingOlder = true;
+		await settle();
+		props.loadingOlder = false;
+		await settle();
+		await cleanup?.();
+		cleanup = undefined;
+		await vi.advanceTimersByTimeAsync(2_000);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 	});
 

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -99,27 +99,24 @@ describe('transcript viewport paging', () => {
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 
-	it('offers explicit paging when a short page cannot scroll', async () => {
-		const { props, viewport, scrollTo } = await renderTranscript([1]);
-		scrollTo(0);
+	it('fills a short viewport silently without loading beyond it or retrying on loading-state changes', async () => {
+		const { props, viewport } = await renderTranscript([3]);
+		expect(viewport.textContent).not.toContain('Load earlier messages');
 		expect(viewport.scrollHeight).toBe(viewport.clientHeight);
-		expect(props.onLoadOlder).not.toHaveBeenCalled();
-		const button = [...document.querySelectorAll('button')].find(
-			(element) => element.textContent?.trim() === 'Load earlier messages'
-		);
-		if (!button) throw new Error('Missing earlier messages button');
-		button.click();
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
-		expect(button.disabled).toBe(true);
-		button.click();
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
-		props.messages = [message(0), ...props.messages];
+		expect(viewport.textContent).not.toContain('Loading earlier messages');
 		props.loadingOlder = false;
-		props.hasOlder = false;
 		await settle();
-		expect(button.isConnected).toBe(false);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.messages = [message(2), ...props.messages];
+		await settle();
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+		props.messages = [message(1), ...props.messages];
+		await settle();
+		expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 	});
 
 	it('preserves the visible message offset when an older page is prepended', async () => {

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -75,19 +75,39 @@ describe('projected transcript pages', () => {
 		controller.abort();
 		await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
 		expect(fetch).toHaveBeenCalledWith(
-			'http://127.0.0.1:7731/api/transcript/messages',
+			'http://127.0.0.1:7731/api/transcript/parts',
 			expect.objectContaining({ signal: controller.signal })
 		);
 	});
 
-	it('uses the message endpoint without changing the legacy parts endpoint', async () => {
+	it('uses the part-bounded endpoint without falling back to message paging', async () => {
+		const message = {
+			id: 'response:run-1',
+			threadId: 'thread-1',
+			runId: 'run-1',
+			userId: 'user-1',
+			type: 'response',
+			text: 'Last completion',
+			attachments: [],
+			parts: [{ type: 'text', id: 'text-499', text: 'Last completion' }],
+			runStatus: 'completed',
+			runStartedAt: 1,
+			sourceNumbers: [499],
+			streamIds: ['stream-499'],
+			detailsLoaded: false
+		};
+		const parts = [
+			{ number: 498, kind: 'completion', message: null },
+			{ number: 499, kind: 'completion', message }
+		];
 		const fetch = vi.fn(async () =>
 			Response.json({
 				threadId: 'thread-1',
-				totalParts: 0,
-				historyFromNumber: 0,
+				totalParts: 500,
+				historyFromNumber: 498,
 				stale: false,
-				messages: []
+				parts,
+				nextBefore: 498
 			})
 		);
 		vi.stubGlobal('fetch', fetch);
@@ -96,10 +116,36 @@ describe('projected transcript pages', () => {
 			threadId: threadRecordId('thread-1'),
 			limit: 12
 		});
-		expect(page.messages).toEqual([]);
+		expect(page.nextBefore).toBe(498);
+		expect(page.parts).toEqual([
+			parts[0],
+			{ ...parts[1], message: { ...message, id: undefined, _id: message.id } }
+		]);
 		expect(fetch).toHaveBeenCalledWith(
-			'http://127.0.0.1:7731/api/transcript/messages',
+			'http://127.0.0.1:7731/api/transcript/parts',
 			expect.objectContaining({ method: 'POST' })
+		);
+	});
+
+	it('requests cancellable per-part details and preserves non-display part numbers', async () => {
+		const fetch = vi.fn(async () =>
+			Response.json([{ number: 498, kind: 'completion', message: null }])
+		);
+		vi.stubGlobal('fetch', fetch);
+		const controller = new AbortController();
+		const request = { userId: 'user-1', threadId: threadRecordId('thread-1'), numbers: [498] };
+		const details = await createLocalClient('http://127.0.0.1:7731').fetchTranscriptDetails(
+			request,
+			controller.signal
+		);
+		expect(details).toEqual([{ number: 498, kind: 'completion', message: null }]);
+		expect(fetch).toHaveBeenCalledWith(
+			'http://127.0.0.1:7731/api/transcript/part-details',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify(request),
+				signal: controller.signal
+			})
 		);
 	});
 });

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -59,6 +59,27 @@ describe('workspace launch fragments', () => {
 });
 
 describe('projected transcript pages', () => {
+	it('cancels an in-flight page request when its thread is left', async () => {
+		const fetch = vi.fn(
+			(_url: string, init: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					init.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+				})
+		);
+		vi.stubGlobal('fetch', fetch);
+		const controller = new AbortController();
+		const pending = createLocalClient('http://127.0.0.1:7731').fetchTranscriptPage(
+			{ userId: 'user-1', threadId: threadRecordId('thread-1'), limit: 12 },
+			controller.signal
+		);
+		controller.abort();
+		await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+		expect(fetch).toHaveBeenCalledWith(
+			'http://127.0.0.1:7731/api/transcript/messages',
+			expect.objectContaining({ signal: controller.signal })
+		);
+	});
+
 	it('uses the message endpoint without changing the legacy parts endpoint', async () => {
 		const fetch = vi.fn(async () =>
 			Response.json({

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -5,6 +5,7 @@ import type {
 	LiveCompletionOverlay,
 	LiveCompletionWatchEvent,
 	LocalTranscriptPage,
+	LocalTranscriptPart,
 	ProjectAttachment,
 	ThreadMessage,
 	ThreadCacheSnapshot,
@@ -79,12 +80,17 @@ const transcriptMessageSchema = z.object({
 	streamIds: z.array(z.string()),
 	detailsLoaded: z.boolean()
 });
+const localTranscriptPartSchema = z.object({
+	number: z.int().nonnegative(),
+	kind: z.enum(['prompt', 'completion', 'tool']),
+	message: transcriptMessageSchema.nullable()
+});
 const localTranscriptPageSchema = z.object({
 	threadId: z.string(),
 	totalParts: z.int(),
 	historyFromNumber: z.int(),
 	stale: z.boolean(),
-	messages: z.array(transcriptMessageSchema),
+	parts: z.array(localTranscriptPartSchema),
 	nextBefore: z.int().optional()
 });
 const transcriptWatchEventSchema = z.object({
@@ -154,7 +160,17 @@ function parseLocalTranscriptPage(
 		historyFromNumber: page.historyFromNumber,
 		stale: page.stale,
 		nextBefore: page.nextBefore,
-		messages: page.messages.map(parseTranscriptMessage)
+		parts: page.parts.map(parseLocalTranscriptPart)
+	};
+}
+
+function parseLocalTranscriptPart(
+	part: z.infer<typeof localTranscriptPartSchema>
+): LocalTranscriptPart {
+	return {
+		number: part.number,
+		kind: part.kind,
+		message: part.message ? parseTranscriptMessage(part.message) : null
 	};
 }
 
@@ -570,20 +586,21 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 			return { runId: asConvexId(result.runId), threadId: asConvexId(result.threadId) };
 		},
 		fetchTranscriptPage: async (requestBody, signal) => {
-			const page = await request('/api/transcript/messages', localTranscriptPageSchema, {
+			const page = await request('/api/transcript/parts', localTranscriptPageSchema, {
 				method: 'POST',
 				body: JSON.stringify(requestBody),
 				signal
 			});
 			return parseLocalTranscriptPage(page);
 		},
-		fetchTranscriptDetails: async (requestBody) =>
-			parseTranscriptMessage(
-				await request('/api/transcript/details', transcriptMessageSchema, {
+		fetchTranscriptDetails: async (requestBody, signal) =>
+			(
+				await request('/api/transcript/part-details', z.array(localTranscriptPartSchema), {
 					method: 'POST',
-					body: JSON.stringify(requestBody)
+					body: JSON.stringify(requestBody),
+					signal
 				})
-			),
+			).map(parseLocalTranscriptPart),
 		watchTranscript: async (requestBody, handlers) => {
 			await postSse(`${baseUrl}/api/transcript/watch`, requestBody, handlers.signal, (data) => {
 				const parsed = transcriptWatchEventSchema.safeParse(JSON.parse(data));

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -569,10 +569,11 @@ export function createLocalClient(baseUrl: string): DesktopApi {
 			});
 			return { runId: asConvexId(result.runId), threadId: asConvexId(result.threadId) };
 		},
-		fetchTranscriptPage: async (requestBody) => {
+		fetchTranscriptPage: async (requestBody, signal) => {
 			const page = await request('/api/transcript/messages', localTranscriptPageSchema, {
 				method: 'POST',
-				body: JSON.stringify(requestBody)
+				body: JSON.stringify(requestBody),
+				signal
 			});
 			return parseLocalTranscriptPage(page);
 		},

--- a/apps/web/src/lib/project/transcript-history.test.ts
+++ b/apps/web/src/lib/project/transcript-history.test.ts
@@ -34,10 +34,32 @@ function page(numbers: number[], nextBefore?: number): LocalTranscriptPage {
 	};
 }
 
+function texts(history: TranscriptHistory) {
+	return history.messages.map((entry) => entry.text);
+}
+
 afterEach(() => vi.useRealTimers());
 
 describe('TranscriptHistory', () => {
-	it('loads all older pages without waiting for a scroll event', async () => {
+	it('keeps watch-triggered refreshes within the recent page instead of expanding older history', async () => {
+		const fetchPage = vi.fn(async ({ before = 100, limit }: { before?: number; limit: number }) => {
+			const start = Math.max(0, before - limit);
+			return page(
+				Array.from({ length: before - start }, (_, index) => start + index),
+				start
+			);
+		});
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.refresh();
+		expect(history.messages).toHaveLength(12);
+		expect(history.messages[0]?.sourceNumbers).toEqual([88]);
+		expect(history.nextBefore).toBe(88);
+		expect(fetchPage.mock.calls.map(([request]) => request.limit)).toEqual([12, 12]);
+		history.stop();
+	});
+
+	it('loads a bounded first page without automatically paging older history', async () => {
 		vi.useFakeTimers();
 		const fetchPage = vi
 			.fn()
@@ -46,11 +68,102 @@ describe('TranscriptHistory', () => {
 			.mockResolvedValueOnce(page([0, 1]));
 		const history = new TranscriptHistory(fetchPage, () => {});
 		await history.refresh();
-		expect(history.messages.map((entry) => entry.text)).toEqual(['4', '5']);
+		expect(texts(history)).toEqual(['4', '5']);
+		expect(history.nextBefore).toBe(4);
 		await vi.runAllTimersAsync();
-		expect(history.messages.map((entry) => entry.text)).toEqual(['0', '1', '2', '3', '4', '5']);
-		expect(fetchPage.mock.calls.map(([request]) => request.limit)).toEqual([12, 40, 40]);
+		expect(texts(history)).toEqual(['4', '5']);
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([{ limit: 12 }]);
 		history.stop();
+	});
+
+	it('loads the next older page only when asked', async () => {
+		vi.useFakeTimers();
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce(page([4, 5], 4))
+			.mockResolvedValueOnce(page([2, 3], 2))
+			.mockResolvedValueOnce(page([0, 1]));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.loadOlder();
+		expect(texts(history)).toEqual(['2', '3', '4', '5']);
+		expect(history.nextBefore).toBe(2);
+		await vi.runAllTimersAsync();
+		expect(texts(history)).toEqual(['2', '3', '4', '5']);
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
+			{ limit: 12 },
+			{ before: 4, limit: 40 }
+		]);
+		history.stop();
+	});
+
+	it('does not retry a failed older page on a timer', async () => {
+		vi.useFakeTimers();
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce(page([4, 5], 4))
+			.mockRejectedValueOnce(new Error('offline'));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.loadOlder();
+		expect(texts(history)).toEqual(['4', '5']);
+		expect(history.nextBefore).toBe(4);
+		expect(history.stale).toBe(true);
+		await vi.runAllTimersAsync();
+		expect(fetchPage).toHaveBeenCalledTimes(2);
+		history.stop();
+	});
+
+	it('keeps an older-page request that arrives during refresh', async () => {
+		vi.useFakeTimers();
+		let resolveFirst: (value: LocalTranscriptPage) => void = () => {};
+		const fetchPage = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<LocalTranscriptPage>((done) => {
+						resolveFirst = done;
+					})
+			)
+			.mockResolvedValueOnce(page([2, 3], 2))
+			.mockResolvedValueOnce(page([0, 1]));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		const first = history.refresh();
+		await history.loadOlder();
+		await history.loadOlder();
+		expect(fetchPage).toHaveBeenCalledTimes(1);
+		resolveFirst(page([4, 5], 4));
+		await first;
+		await Promise.resolve();
+		expect(texts(history)).toEqual(['2', '3', '4', '5']);
+		expect(history.nextBefore).toBe(2);
+		await vi.runAllTimersAsync();
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
+			{ limit: 12 },
+			{ before: 4, limit: 40 }
+		]);
+		history.stop();
+	});
+
+	it('ignores a queued older page after stop', async () => {
+		let resolveFirst: (value: LocalTranscriptPage) => void = () => {};
+		const fetchPage = vi.fn(
+			() =>
+				new Promise<LocalTranscriptPage>((done) => {
+					resolveFirst = done;
+				})
+		);
+		const changed = vi.fn();
+		const history = new TranscriptHistory(fetchPage, changed);
+		const first = history.refresh();
+		await history.loadOlder();
+		history.stop();
+		resolveFirst(page([4, 5], 4));
+		await first;
+		await Promise.resolve();
+		expect(fetchPage).toHaveBeenCalledTimes(1);
+		expect(changed).not.toHaveBeenCalled();
+		expect(texts(history)).toEqual([]);
 	});
 
 	it('fills every gap after reconnecting beyond the newest page', async () => {
@@ -63,16 +176,7 @@ describe('TranscriptHistory', () => {
 		const history = new TranscriptHistory(fetchPage, () => {});
 		await history.refresh();
 		await history.refresh();
-		expect(history.messages.map((entry) => entry.text)).toEqual([
-			'0',
-			'1',
-			'2',
-			'3',
-			'4',
-			'5',
-			'6',
-			'7'
-		]);
+		expect(texts(history)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7']);
 		expect(history.nextBefore).toBeUndefined();
 		history.stop();
 	});
@@ -108,10 +212,10 @@ describe('TranscriptHistory', () => {
 		const history = new TranscriptHistory(fetchPage, () => {});
 		await history.refresh();
 		await history.refresh();
-		expect(history.messages.map((entry) => entry.text)).toEqual(['0', '1']);
+		expect(texts(history)).toEqual(['0', '1']);
 		expect(history.stale).toBe(true);
 		await vi.runAllTimersAsync();
-		expect(history.messages.map((entry) => entry.text)).toEqual(['0', '1', '2', '3', '4', '5']);
+		expect(texts(history)).toEqual(['0', '1', '2', '3', '4', '5']);
 		history.stop();
 	});
 });

--- a/apps/web/src/lib/project/transcript-history.test.ts
+++ b/apps/web/src/lib/project/transcript-history.test.ts
@@ -1,25 +1,32 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
-import type { LocalTranscriptPage, ThreadMessage } from '$lib/types/sprocket';
+import type { AssistantPart } from '$convex/lib/assistantParts';
+import type { LocalTranscriptPage, LocalTranscriptPart, ThreadMessage } from '$lib/types/sprocket';
 import { TranscriptHistory } from './transcript-history';
 
 // SAFETY: These tests only compare opaque fixture IDs.
 const threadId = 'thread' as Id<'threadRecords'>;
 
-function message(number: number): ThreadMessage {
+function promptPart(number: number): LocalTranscriptPart {
 	return {
-		_id: `prompt:${number}`,
-		threadId,
-		// SAFETY: These tests only compare opaque fixture IDs.
-		runId: `run-${number}` as Id<'runs'>,
-		userId: 'user',
-		type: 'prompt',
-		text: String(number),
-		parts: [],
-		attachments: [],
-		runStatus: 'completed',
-		runStartedAt: 1,
-		sourceNumbers: [number]
+		number,
+		kind: 'prompt',
+		message: {
+			_id: `prompt:run-${number}`,
+			threadId,
+			// SAFETY: These tests only compare opaque fixture IDs.
+			runId: `run-${number}` as Id<'runs'>,
+			userId: 'user',
+			type: 'prompt',
+			text: String(number),
+			parts: [],
+			attachments: [],
+			runStatus: 'completed',
+			runStartedAt: 1,
+			sourceNumbers: [number],
+			streamIds: [],
+			detailsLoaded: true
+		}
 	};
 }
 
@@ -29,8 +36,79 @@ function page(numbers: number[], nextBefore?: number): LocalTranscriptPage {
 		totalParts: 100,
 		historyFromNumber: 0,
 		stale: false,
-		messages: numbers.map(message),
+		parts: numbers.map(promptPart),
 		nextBefore
+	};
+}
+
+function partsPage(parts: LocalTranscriptPart[], nextBefore?: number): LocalTranscriptPage {
+	return {
+		threadId,
+		totalParts: 100,
+		historyFromNumber: 0,
+		stale: false,
+		parts,
+		nextBefore
+	};
+}
+
+function completionPart(
+	number: number,
+	runId: string,
+	overrides: Partial<ThreadMessage> = {}
+): LocalTranscriptPart {
+	const text = overrides.text ?? `t${number}`;
+	return {
+		number,
+		kind: 'completion',
+		message: {
+			_id: `response:${runId}`,
+			threadId,
+			// SAFETY: These tests only compare opaque fixture IDs.
+			runId: runId as Id<'runs'>,
+			userId: 'user',
+			type: 'response',
+			text,
+			parts: overrides.parts ?? [{ type: 'text', id: `t-${number}`, text }],
+			attachments: [],
+			runStatus: 'completed',
+			runStartedAt: 0,
+			sourceNumbers: [number],
+			streamIds: overrides.streamIds ?? [`stream-${number}`],
+			detailsLoaded: false,
+			...overrides
+		}
+	};
+}
+
+function toolPart(number: number, runId: string, parts: AssistantPart[]): LocalTranscriptPart {
+	return {
+		number,
+		kind: 'tool',
+		message: {
+			_id: `response:${runId}`,
+			threadId,
+			// SAFETY: These tests only compare opaque fixture IDs.
+			runId: runId as Id<'runs'>,
+			userId: 'user',
+			type: 'response',
+			text: '',
+			parts,
+			attachments: [],
+			runStatus: 'completed',
+			runStartedAt: 0,
+			sourceNumbers: [number],
+			streamIds: [],
+			detailsLoaded: false
+		}
+	};
+}
+
+function windowedFetch(parts: LocalTranscriptPart[], total = parts.length) {
+	return async ({ before = total, limit }: { before?: number; limit: number }) => {
+		const start = Math.max(0, before - limit);
+		const slice = parts.filter((part) => part.number >= start && part.number < before);
+		return partsPage(slice, start > 0 ? start : undefined);
 	};
 }
 
@@ -216,6 +294,194 @@ describe('TranscriptHistory', () => {
 		expect(history.stale).toBe(true);
 		await vi.runAllTimersAsync();
 		expect(texts(history)).toEqual(['0', '1', '2', '3', '4', '5']);
+		history.stop();
+	});
+
+	it('assembles a long response split across a 12-part refresh and 40-part prepend', async () => {
+		const runId = 'run-long';
+		const parts = Array.from({ length: 52 }, (_, number) => completionPart(number, runId));
+		const fetchPage = vi.fn(windowedFetch(parts));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		expect(history.messages).toHaveLength(1);
+		expect(history.messages[0]?.sourceNumbers).toEqual(
+			Array.from({ length: 12 }, (_, index) => 40 + index)
+		);
+		expect(history.messages[0]?.text).toBe(
+			Array.from({ length: 12 }, (_, index) => `t${40 + index}`).join('')
+		);
+		expect(history.nextBefore).toBe(40);
+
+		await history.loadOlder();
+		const fullText = parts.map((part) => part.message?.text).join('');
+		expect(history.messages).toHaveLength(1);
+		expect(history.messages[0]?.text).toBe(fullText);
+		expect(history.messages[0]?.sourceNumbers).toEqual(parts.map((part) => part.number));
+		expect(history.messages[0]?.parts).toHaveLength(52);
+		expect(history.nextBefore).toBeUndefined();
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
+			{ limit: 12 },
+			{ before: 40, limit: 40 }
+		]);
+
+		await history.refresh();
+		expect(history.messages[0]?.text).toBe(fullText);
+		expect(history.messages[0]?.sourceNumbers).toEqual(parts.map((part) => part.number));
+		expect(
+			history.messages[0]?.parts.map((part) => (part.type === 'text' ? part.text : ''))
+		).toEqual(parts.map((part) => part.message?.text));
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
+			{ limit: 12 },
+			{ before: 40, limit: 40 },
+			{ limit: 12 }
+		]);
+		history.stop();
+	});
+
+	it('uses the newest raw part as the catch-up cursor so a loaded response is not rescanned', async () => {
+		const runId = 'run-long';
+		const parts = Array.from({ length: 52 }, (_, number) => completionPart(number, runId));
+		const fetchPage = vi.fn(windowedFetch(parts));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.loadOlder();
+		await history.refresh();
+		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
+			{ limit: 12 },
+			{ before: 40, limit: 40 },
+			{ limit: 12 }
+		]);
+		history.stop();
+	});
+
+	it('keeps terminal tools across a page boundary until the completion that owns their calls arrives', async () => {
+		const runId = 'run-1';
+		const older = [
+			completionPart(0, runId, { text: 'previous turn' }),
+			toolPart(1, runId, [
+				{ type: 'tool-call', callId: 'b', name: 'exec_command', input: null, startedAt: 1_100 }
+			]),
+			toolPart(2, runId, [
+				{ type: 'tool-call', callId: 'a', name: 'exec_command', input: null, startedAt: 1_200 }
+			]),
+			toolPart(3, runId, [
+				{ type: 'tool-call', callId: 'a', name: 'exec_command', input: null },
+				{
+					type: 'tool-result',
+					callId: 'a',
+					name: 'exec_command',
+					output: { status: 'completed' },
+					completedAt: 1_800
+				}
+			])
+		];
+		const newest = [
+			completionPart(4, runId, {
+				text: 'checking',
+				streamIds: ['stream-4'],
+				parts: [
+					{ type: 'reasoning', id: 'r', text: '' },
+					{ type: 'text', id: 't', text: 'checking' },
+					{ type: 'tool-call', callId: 'a', name: 'exec_command', input: null },
+					{ type: 'tool-call', callId: 'b', name: 'exec_command', input: null }
+				]
+			}),
+			toolPart(5, runId, [
+				{ type: 'tool-call', callId: 'b', name: 'exec_command', input: null },
+				{
+					type: 'tool-result',
+					callId: 'b',
+					name: 'exec_command',
+					output: { status: 'completed' },
+					completedAt: 2_400
+				}
+			]),
+			completionPart(6, runId, { text: 'answer', streamIds: ['stream-6'] })
+		];
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce(partsPage(newest, 4))
+			.mockResolvedValueOnce(partsPage(older));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.loadOlder();
+		expect(history.messages).toHaveLength(1);
+		expect(history.messages[0]?.parts.map((part) => part.type)).toEqual([
+			'text',
+			'reasoning',
+			'text',
+			'tool-call',
+			'tool-result',
+			'tool-call',
+			'tool-result',
+			'text'
+		]);
+		expect(history.messages[0]?.parts[3]).toMatchObject({ callId: 'a', startedAt: 1_200 });
+		expect(history.messages[0]?.parts[4]).toMatchObject({ callId: 'a', completedAt: 1_800 });
+		expect(history.messages[0]?.parts[5]).toMatchObject({ callId: 'b', startedAt: 1_100 });
+		expect(history.messages[0]?.parts[6]).toMatchObject({ callId: 'b', completedAt: 2_400 });
+		expect(history.messages[0]?.text).toBe('previous turncheckinganswer');
+		history.stop();
+	});
+
+	it('applies delayed details only to already-loaded parts and keeps them across lightweight refreshes', async () => {
+		const runId = 'run-1';
+		const light = (number: number, text: string, reasoning: string) =>
+			completionPart(number, runId, {
+				text,
+				detailsLoaded: false,
+				parts: [
+					{ type: 'reasoning', id: `r-${number}`, text: reasoning },
+					{ type: 'text', id: `t-${number}`, text }
+				]
+			});
+		const detailed = (number: number, text: string, reasoning: string) =>
+			completionPart(number, runId, {
+				text,
+				detailsLoaded: true,
+				parts: [
+					{ type: 'reasoning', id: `r-${number}`, text: reasoning },
+					{ type: 'text', id: `t-${number}`, text }
+				]
+			});
+		let resolveRefresh: (value: LocalTranscriptPage) => void = () => {};
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce(partsPage([light(10, 'head', ''), light(11, 'tail', '')], 10))
+			.mockImplementationOnce(
+				() =>
+					new Promise<LocalTranscriptPage>((done) => {
+						resolveRefresh = done;
+					})
+			)
+			.mockResolvedValueOnce(partsPage([light(10, 'head', ''), light(11, 'tail', '')], 10));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		expect(history.messages[0]?.detailsLoaded).toBe(false);
+		expect(history.detailsNumbers(history.messages[0]!)).toEqual([10, 11]);
+
+		const pending = history.refresh();
+		history.applyDetails([detailed(10, 'head', 'plan'), detailed(99, 'unloaded', 'nope')]);
+		expect(history.messages[0]?.parts[0]).toMatchObject({ type: 'reasoning', text: 'plan' });
+		expect(history.detailsNumbers(history.messages[0]!)).toEqual([11]);
+		expect(history.messages[0]?.detailsLoaded).toBe(false);
+
+		resolveRefresh(partsPage([light(10, 'head', ''), light(11, 'tail', '')], 10));
+		await pending;
+		expect(history.messages[0]?.parts[0]).toMatchObject({ type: 'reasoning', text: 'plan' });
+		expect(history.detailsNumbers(history.messages[0]!)).toEqual([11]);
+
+		history.applyDetails([detailed(11, 'tail', 'more')]);
+		expect(history.messages[0]?.detailsLoaded).toBe(true);
+		expect(history.detailsNumbers(history.messages[0]!)).toEqual([]);
+		expect(
+			history.messages[0]?.parts.map((part) => (part.type === 'reasoning' ? part.text : part.type))
+		).toEqual(['plan', 'text', 'more', 'text']);
+
+		await history.refresh();
+		expect(history.messages[0]?.detailsLoaded).toBe(true);
+		expect(history.messages[0]?.parts[0]).toMatchObject({ text: 'plan' });
+		expect(history.messages[0]?.parts[2]).toMatchObject({ text: 'more' });
 		history.stop();
 	});
 });

--- a/apps/web/src/lib/project/transcript-history.ts
+++ b/apps/web/src/lib/project/transcript-history.ts
@@ -1,11 +1,30 @@
-import type { LocalTranscriptPage, ThreadMessage } from '$lib/types/sprocket';
-import { mergeTranscriptMessages } from '$lib/project/transcript';
+import type { LocalTranscriptPage, LocalTranscriptPart, ThreadMessage } from '$lib/types/sprocket';
+import { assembleTranscriptParts } from './transcript-parts';
 
 type PageRequest = { before?: number; limit: number };
 
 const RECENT_PAGE_LIMIT = 12;
 const OLDER_PAGE_LIMIT = 40;
 const REFRESH_RETRY_MS = 2_000;
+
+function sameMessage(left: ThreadMessage, right: ThreadMessage): boolean {
+	return (
+		left._id === right._id &&
+		left.text === right.text &&
+		left.detailsLoaded === right.detailsLoaded &&
+		JSON.stringify(left.sourceNumbers) === JSON.stringify(right.sourceNumbers) &&
+		JSON.stringify(left.streamIds) === JSON.stringify(right.streamIds) &&
+		JSON.stringify(left.parts) === JSON.stringify(right.parts)
+	);
+}
+
+function stabilizeMessages(previous: ThreadMessage[], next: ThreadMessage[]): ThreadMessage[] {
+	const byId = new Map(previous.map((message) => [message._id, message]));
+	return next.map((message) => {
+		const current = byId.get(message._id);
+		return current && sameMessage(current, message) ? current : message;
+	});
+}
 
 export class TranscriptHistory {
 	messages: ThreadMessage[] = [];
@@ -14,6 +33,7 @@ export class TranscriptHistory {
 	loadingOlder = false;
 	stale = false;
 	error: string | null = null;
+	private parts = new Map<number, LocalTranscriptPart>();
 	private stopped = false;
 	private refreshing = false;
 	private refreshPending = false;
@@ -31,6 +51,13 @@ export class TranscriptHistory {
 		clearTimeout(this.refreshRetryTimer);
 	}
 
+	detailsNumbers(message: ThreadMessage): number[] {
+		return (message.sourceNumbers ?? []).filter((number) => {
+			const part = this.parts.get(number);
+			return part?.message != null && part.message.detailsLoaded !== true;
+		});
+	}
+
 	async refresh() {
 		if (this.stopped) return;
 		if (this.refreshing) {
@@ -42,23 +69,24 @@ export class TranscriptHistory {
 		try {
 			do {
 				this.refreshPending = false;
-				const newestSource = this.messages.at(-1)?.sourceNumbers?.[0];
-				let incoming: ThreadMessage[] = [];
+				const newestLoaded = this.newestLoadedNumber();
+				const incoming: LocalTranscriptPart[] = [];
 				let newestPage: LocalTranscriptPage | undefined;
 				let before: number | undefined;
 				do {
 					const page = await this.fetchPage({ before, limit: RECENT_PAGE_LIMIT });
 					if (this.stopped) return;
 					newestPage ??= page;
-					incoming = mergeTranscriptMessages(incoming, page.messages);
+					incoming.push(...page.parts);
 					if (page.nextBefore === undefined) break;
 					if (before !== undefined && page.nextBefore >= before) {
 						throw new Error('Transcript history cursor did not advance');
 					}
 					before = page.nextBefore;
-				} while (newestSource !== undefined && before > newestSource);
-				if (this.messages.length === 0) this.nextBefore = newestPage.nextBefore;
-				this.messages = mergeTranscriptMessages(this.messages, incoming);
+				} while (newestLoaded !== undefined && before !== undefined && before > newestLoaded);
+				if (!newestPage) return;
+				if (this.parts.size === 0) this.nextBefore = newestPage.nextBefore;
+				this.commit(incoming);
 				this.stale = newestPage.stale;
 				this.error = null;
 				this.loading = false;
@@ -97,7 +125,7 @@ export class TranscriptHistory {
 			if (page.nextBefore !== undefined && page.nextBefore >= before) {
 				throw new Error('Transcript history cursor did not advance');
 			}
-			this.messages = mergeTranscriptMessages(this.messages, page.messages);
+			this.commit(page.parts);
 			this.nextBefore = page.nextBefore;
 			this.stale = page.stale;
 		} catch {
@@ -108,9 +136,35 @@ export class TranscriptHistory {
 		}
 	}
 
-	applyDetails(message: ThreadMessage) {
+	applyDetails(parts: LocalTranscriptPart[]) {
 		if (this.stopped) return;
-		this.messages = mergeTranscriptMessages(this.messages, [message]);
+		this.commit(parts.filter((part) => this.parts.has(part.number)));
 		this.changed();
+	}
+
+	private newestLoadedNumber(): number | undefined {
+		let newest: number | undefined;
+		for (const number of this.parts.keys()) {
+			newest = newest === undefined ? number : Math.max(newest, number);
+		}
+		return newest;
+	}
+
+	private ingest(parts: LocalTranscriptPart[]) {
+		for (const part of parts) {
+			const current = this.parts.get(part.number);
+			if (current?.message?.detailsLoaded === true && part.message?.detailsLoaded !== true) {
+				continue;
+			}
+			this.parts.set(part.number, part);
+		}
+	}
+
+	private commit(parts: LocalTranscriptPart[]) {
+		this.ingest(parts);
+		this.messages = stabilizeMessages(
+			this.messages,
+			assembleTranscriptParts([...this.parts.values()])
+		);
 	}
 }

--- a/apps/web/src/lib/project/transcript-history.ts
+++ b/apps/web/src/lib/project/transcript-history.ts
@@ -3,6 +3,10 @@ import { mergeTranscriptMessages } from '$lib/project/transcript';
 
 type PageRequest = { before?: number; limit: number };
 
+const RECENT_PAGE_LIMIT = 12;
+const OLDER_PAGE_LIMIT = 40;
+const REFRESH_RETRY_MS = 2_000;
+
 export class TranscriptHistory {
 	messages: ThreadMessage[] = [];
 	nextBefore: number | undefined;
@@ -13,7 +17,7 @@ export class TranscriptHistory {
 	private stopped = false;
 	private refreshing = false;
 	private refreshPending = false;
-	private prefetchTimer: ReturnType<typeof setTimeout> | undefined;
+	private loadOlderPending = false;
 	private refreshRetryTimer: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(
@@ -23,15 +27,8 @@ export class TranscriptHistory {
 
 	stop() {
 		this.stopped = true;
-		clearTimeout(this.prefetchTimer);
+		this.loadOlderPending = false;
 		clearTimeout(this.refreshRetryTimer);
-	}
-
-	private prefetch(delay = 25) {
-		clearTimeout(this.prefetchTimer);
-		if (!this.stopped && this.nextBefore !== undefined) {
-			this.prefetchTimer = setTimeout(() => void this.loadOlder(), delay);
-		}
 	}
 
 	async refresh() {
@@ -50,7 +47,7 @@ export class TranscriptHistory {
 				let newestPage: LocalTranscriptPage | undefined;
 				let before: number | undefined;
 				do {
-					const page = await this.fetchPage({ before, limit: this.loading ? 12 : 40 });
+					const page = await this.fetchPage({ before, limit: RECENT_PAGE_LIMIT });
 					if (this.stopped) return;
 					newestPage ??= page;
 					incoming = mergeTranscriptMessages(incoming, page.messages);
@@ -73,26 +70,29 @@ export class TranscriptHistory {
 				this.loading = false;
 				this.error = this.messages.length ? null : 'Could not load conversation history.';
 				this.changed();
-				this.refreshRetryTimer = setTimeout(() => void this.refresh(), 2_000);
+				this.refreshRetryTimer = setTimeout(() => void this.refresh(), REFRESH_RETRY_MS);
 			}
 		} finally {
 			this.refreshing = false;
-			this.prefetch();
+			if (this.loadOlderPending && !this.stopped) {
+				this.loadOlderPending = false;
+				void this.loadOlder();
+			}
 		}
 	}
 
 	async loadOlder() {
-		if (this.stopped || this.loadingOlder || this.nextBefore === undefined) return;
+		if (this.stopped || this.loadingOlder) return;
 		if (this.refreshing) {
-			this.prefetch();
+			this.loadOlderPending = true;
 			return;
 		}
+		if (this.nextBefore === undefined) return;
 		const before = this.nextBefore;
 		this.loadingOlder = true;
 		this.changed();
-		let retryDelay = 25;
 		try {
-			const page = await this.fetchPage({ before, limit: 40 });
+			const page = await this.fetchPage({ before, limit: OLDER_PAGE_LIMIT });
 			if (this.stopped) return;
 			if (page.nextBefore !== undefined && page.nextBefore >= before) {
 				throw new Error('Transcript history cursor did not advance');
@@ -101,14 +101,10 @@ export class TranscriptHistory {
 			this.nextBefore = page.nextBefore;
 			this.stale = page.stale;
 		} catch {
-			this.stale = true;
-			retryDelay = 2_000;
+			if (!this.stopped) this.stale = true;
 		} finally {
 			this.loadingOlder = false;
-			if (!this.stopped) {
-				this.changed();
-				this.prefetch(retryDelay);
-			}
+			if (!this.stopped) this.changed();
 		}
 	}
 

--- a/apps/web/src/lib/project/transcript-parts.test.ts
+++ b/apps/web/src/lib/project/transcript-parts.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+import type { Id } from '$convex/_generated/dataModel';
+import type { AssistantPart } from '$convex/lib/assistantParts';
+import type { LocalTranscriptPart, ThreadMessage } from '$lib/types/sprocket';
+import { assembleTranscriptParts } from './transcript-parts';
+
+// SAFETY: These tests only compare opaque fixture IDs.
+const threadId = 'thread' as Id<'threadRecords'>;
+
+function promptPart(number: number, runId = `run-${number}`): LocalTranscriptPart {
+	return {
+		number,
+		kind: 'prompt',
+		message: {
+			_id: `prompt:${runId}`,
+			threadId,
+			// SAFETY: These tests only compare opaque fixture IDs.
+			runId: runId as Id<'runs'>,
+			userId: 'user',
+			type: 'prompt',
+			text: String(number),
+			parts: [],
+			attachments: [],
+			runStatus: 'completed',
+			runStartedAt: 0,
+			sourceNumbers: [number],
+			streamIds: [],
+			detailsLoaded: true
+		}
+	};
+}
+
+function responseMessage(
+	number: number,
+	runId: string,
+	overrides: Partial<ThreadMessage> = {}
+): ThreadMessage {
+	return {
+		_id: `response:${runId}`,
+		threadId,
+		// SAFETY: These tests only compare opaque fixture IDs.
+		runId: runId as Id<'runs'>,
+		userId: 'user',
+		type: 'response',
+		text: '',
+		parts: [],
+		attachments: [],
+		runStatus: 'completed',
+		runStartedAt: 0,
+		sourceNumbers: [number],
+		streamIds: [],
+		detailsLoaded: false,
+		...overrides
+	};
+}
+
+function completionPart(
+	number: number,
+	runId: string,
+	overrides: Partial<ThreadMessage> = {}
+): LocalTranscriptPart {
+	const text = overrides.text ?? `t${number}`;
+	return {
+		number,
+		kind: 'completion',
+		message: responseMessage(number, runId, {
+			text,
+			parts: overrides.parts ?? [{ type: 'text', id: `t-${number}`, text }],
+			streamIds: overrides.streamIds ?? [`stream-${number}`],
+			...overrides
+		})
+	};
+}
+
+function toolPart(
+	number: number,
+	runId: string,
+	parts: AssistantPart[],
+	detailsLoaded = false
+): LocalTranscriptPart {
+	return {
+		number,
+		kind: 'tool',
+		message: responseMessage(number, runId, { parts, detailsLoaded })
+	};
+}
+
+function call(callId: string, startedAt?: number): Extract<AssistantPart, { type: 'tool-call' }> {
+	return {
+		type: 'tool-call',
+		callId,
+		name: 'exec_command',
+		input: null,
+		startedAt
+	};
+}
+
+function result(callId: string, completedAt?: number): AssistantPart {
+	return {
+		type: 'tool-result',
+		callId,
+		name: 'exec_command',
+		output: { status: 'completed' },
+		completedAt
+	};
+}
+
+describe('assembleTranscriptParts', () => {
+	it('groups prompts and responses by run in numeric order', () => {
+		const messages = assembleTranscriptParts([
+			completionPart(3, 'run-2', { text: 'later' }),
+			promptPart(0, 'run-1'),
+			promptPart(2, 'run-2'),
+			completionPart(1, 'run-1', { text: 'first' })
+		]);
+		expect(messages.map((message) => message._id)).toEqual([
+			'prompt:run-1',
+			'response:run-1',
+			'prompt:run-2',
+			'response:run-2'
+		]);
+		expect(messages.map((message) => message.text)).toEqual(['0', 'first', '2', 'later']);
+	});
+
+	it('joins disjoint completion pages for the same run without dropping either slice', () => {
+		const messages = assembleTranscriptParts([
+			completionPart(10, 'run-1', { text: 'tail' }),
+			completionPart(11, 'run-1', { text: 'end' }),
+			completionPart(0, 'run-1', { text: 'head' }),
+			completionPart(1, 'run-1', { text: 'mid' })
+		]);
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.text).toBe('headmidtailend');
+		expect(messages[0]?.sourceNumbers).toEqual([0, 1, 10, 11]);
+		expect(messages[0]?.streamIds).toEqual(['stream-0', 'stream-1', 'stream-10', 'stream-11']);
+		expect(
+			messages[0]?.parts.map((part) => (part.type === 'text' ? part.text : part.type))
+		).toEqual(['head', 'mid', 'tail', 'end']);
+	});
+
+	it('reattaches terminal tools persisted before the completion that ordered their calls', () => {
+		const messages = assembleTranscriptParts([
+			completionPart(0, 'run-1', { text: 'previous turn' }),
+			toolPart(1, 'run-1', [call('b', 1_100)]),
+			toolPart(2, 'run-1', [call('a', 1_200)]),
+			toolPart(3, 'run-1', [call('a'), result('a', 1_800)]),
+			completionPart(4, 'run-1', {
+				text: 'checking',
+				streamIds: ['stream-4'],
+				parts: [
+					{ type: 'reasoning', id: 'r', text: '' },
+					{ type: 'text', id: 't', text: 'checking' },
+					call('a'),
+					call('b')
+				]
+			}),
+			toolPart(5, 'run-1', [call('b'), result('b', 2_400)]),
+			completionPart(6, 'run-1', { text: 'answer', streamIds: ['stream-6'] })
+		]);
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.parts.map((part) => part.type)).toEqual([
+			'text',
+			'reasoning',
+			'text',
+			'tool-call',
+			'tool-result',
+			'tool-call',
+			'tool-result',
+			'text'
+		]);
+		expect(messages[0]?.parts[3]).toMatchObject({
+			type: 'tool-call',
+			callId: 'a',
+			startedAt: 1_200
+		});
+		expect(messages[0]?.parts[4]).toMatchObject({
+			type: 'tool-result',
+			callId: 'a',
+			completedAt: 1_800
+		});
+		expect(messages[0]?.parts[5]).toMatchObject({
+			type: 'tool-call',
+			callId: 'b',
+			startedAt: 1_100
+		});
+		expect(messages[0]?.parts[6]).toMatchObject({
+			type: 'tool-result',
+			callId: 'b',
+			completedAt: 2_400
+		});
+		expect(messages[0]?.text).toBe('previous turncheckinganswer');
+		expect(messages[0]?.streamIds).toEqual(['stream-0', 'stream-4', 'stream-6']);
+		expect(messages[0]?.sourceNumbers).toEqual([0, 1, 2, 3, 4, 5, 6]);
+	});
+
+	it('keeps a completion start time over an earlier placeholder', () => {
+		const messages = assembleTranscriptParts([
+			toolPart(1, 'run-1', [call('c1', 500)]),
+			completionPart(2, 'run-1', {
+				text: '',
+				parts: [{ ...call('c1'), startedAt: 700, input: {} }],
+				streamIds: ['s']
+			})
+		]);
+		expect(messages[0]?.parts[0]).toMatchObject({
+			type: 'tool-call',
+			callId: 'c1',
+			startedAt: 700
+		});
+	});
+
+	it('does not duplicate a terminal result that already followed its call', () => {
+		const messages = assembleTranscriptParts([
+			toolPart(1, 'run-1', [call('c1'), result('c1', 5_000)]),
+			toolPart(2, 'run-1', [call('c1'), result('c1', 9_000)])
+		]);
+		expect(messages[0]?.parts.map((part) => part.type)).toEqual(['tool-call', 'tool-result']);
+		expect(messages[0]?.parts[1]).toMatchObject({ completedAt: 5_000 });
+	});
+
+	it('marks a response fully loaded only when every contributing part is detailed', () => {
+		const light = completionPart(1, 'run-1', {
+			parts: [{ type: 'reasoning', id: 'r', text: '' }],
+			text: '',
+			detailsLoaded: false
+		});
+		const detailed = completionPart(1, 'run-1', {
+			parts: [{ type: 'reasoning', id: 'r', text: 'plan' }],
+			text: '',
+			detailsLoaded: true
+		});
+		const later = completionPart(2, 'run-1', { text: 'done', detailsLoaded: false });
+		const mixed = assembleTranscriptParts([detailed, later]);
+		expect(mixed[0]?.detailsLoaded).toBe(false);
+		expect(mixed[0]?.parts[0]).toMatchObject({ type: 'reasoning', text: 'plan' });
+		expect(assembleTranscriptParts([light, later])[0]?.detailsLoaded).toBe(false);
+		expect(
+			assembleTranscriptParts([
+				detailed,
+				completionPart(2, 'run-1', { text: 'done', detailsLoaded: true })
+			])[0]?.detailsLoaded
+		).toBe(true);
+	});
+
+	it('skips null projections and last-wins on duplicate numbers', () => {
+		const messages = assembleTranscriptParts([
+			{ number: 1, kind: 'completion', message: null },
+			completionPart(2, 'run-1', { text: 'old' }),
+			completionPart(2, 'run-1', { text: 'new' }),
+			promptPart(0)
+		]);
+		expect(messages.map((message) => message.text)).toEqual(['0', 'new']);
+		expect(messages[1]?.sourceNumbers).toEqual([2]);
+	});
+});

--- a/apps/web/src/lib/project/transcript-parts.ts
+++ b/apps/web/src/lib/project/transcript-parts.ts
@@ -1,0 +1,146 @@
+import type { AssistantPart } from '$convex/lib/assistantParts';
+import type { LocalTranscriptPart, ThreadMessage } from '$lib/types/sprocket';
+
+function cloneMessage(message: ThreadMessage): ThreadMessage {
+	return {
+		...message,
+		attachments: [...message.attachments],
+		parts: [...message.parts],
+		sourceNumbers: [...(message.sourceNumbers ?? [])],
+		streamIds: [...(message.streamIds ?? [])]
+	};
+}
+
+function applyCompletion(target: ThreadMessage, incoming: ThreadMessage) {
+	const callIds = new Set<string>();
+	for (const part of incoming.parts) {
+		if (part.type === 'tool-call') callIds.add(part.callId);
+	}
+	const placeholders = new Map<string, AssistantPart>();
+	const results = new Map<string, AssistantPart>();
+	const kept: AssistantPart[] = [];
+	for (const part of target.parts) {
+		if (part.type === 'tool-call' && callIds.has(part.callId)) {
+			placeholders.set(part.callId, part);
+			continue;
+		}
+		if (part.type === 'tool-result' && callIds.has(part.callId)) {
+			results.set(part.callId, part);
+			continue;
+		}
+		kept.push(part);
+	}
+	for (const part of incoming.parts) {
+		if (part.type === 'tool-result') results.delete(part.callId);
+	}
+	for (const part of incoming.parts) {
+		if (part.type === 'tool-call') {
+			const placeholder = placeholders.get(part.callId);
+			kept.push(
+				placeholder?.type === 'tool-call'
+					? {
+							...part,
+							startedAt: part.startedAt ?? placeholder.startedAt,
+							completedAt: part.completedAt ?? placeholder.completedAt
+						}
+					: part
+			);
+			const result = results.get(part.callId);
+			if (result) {
+				results.delete(part.callId);
+				kept.push(result);
+			}
+			continue;
+		}
+		kept.push(part);
+	}
+	target.parts = kept;
+	target.text += incoming.text;
+	target.sourceNumbers = [...(target.sourceNumbers ?? []), ...(incoming.sourceNumbers ?? [])];
+	target.streamIds = [...(target.streamIds ?? []), ...(incoming.streamIds ?? [])];
+}
+
+function applyTool(target: ThreadMessage, incoming: ThreadMessage, appliedTerminal: Set<string>) {
+	for (const part of incoming.parts) {
+		if (part.type !== 'tool-call') continue;
+		const index = target.parts.findIndex(
+			(item) => item.type === 'tool-call' && item.callId === part.callId
+		);
+		if (index >= 0) {
+			const existing = target.parts[index];
+			if (existing?.type === 'tool-call' && existing.startedAt == null && part.startedAt != null) {
+				target.parts[index] = { ...existing, startedAt: part.startedAt };
+			}
+		} else {
+			target.parts.push(part);
+		}
+	}
+	for (const part of incoming.parts) {
+		if (part.type !== 'tool-result') continue;
+		if (appliedTerminal.has(part.callId)) continue;
+		appliedTerminal.add(part.callId);
+		const resultIndex = target.parts.findIndex(
+			(item) => item.type === 'tool-result' && item.callId === part.callId
+		);
+		if (resultIndex >= 0) {
+			target.parts[resultIndex] = part;
+			continue;
+		}
+		const callIndex = target.parts.findIndex(
+			(item) => item.type === 'tool-call' && item.callId === part.callId
+		);
+		if (callIndex >= 0) {
+			target.parts.splice(callIndex + 1, 0, part);
+		} else {
+			target.parts.push(part);
+		}
+	}
+	target.sourceNumbers = [...(target.sourceNumbers ?? []), ...(incoming.sourceNumbers ?? [])];
+}
+
+function startResponse(kind: LocalTranscriptPart['kind'], message: ThreadMessage) {
+	const started = cloneMessage(message);
+	const appliedTerminal = new Set<string>();
+	if (kind === 'tool') {
+		for (const item of started.parts) {
+			if (item.type === 'tool-result') appliedTerminal.add(item.callId);
+		}
+	}
+	return { message: started, appliedTerminal };
+}
+
+function foldDetails(target: ThreadMessage, incoming: ThreadMessage) {
+	target.detailsLoaded = target.detailsLoaded === true && incoming.detailsLoaded === true;
+}
+
+export function assembleTranscriptParts(parts: readonly LocalTranscriptPart[]): ThreadMessage[] {
+	const byNumber = new Map<number, LocalTranscriptPart>();
+	for (const part of parts) byNumber.set(part.number, part);
+	const ordered = [...byNumber.values()].sort((left, right) => left.number - right.number);
+	const messages: ThreadMessage[] = [];
+	let open: ReturnType<typeof startResponse> | undefined;
+
+	const finish = () => {
+		if (open) messages.push(open.message);
+		open = undefined;
+	};
+
+	for (const part of ordered) {
+		if (!part.message) continue;
+		if (part.kind === 'prompt') {
+			finish();
+			messages.push(cloneMessage(part.message));
+			continue;
+		}
+		if (open && open.message._id === part.message._id) {
+			if (part.kind === 'completion') applyCompletion(open.message, part.message);
+			else applyTool(open.message, part.message, open.appliedTerminal);
+			foldDetails(open.message, part.message);
+			continue;
+		}
+		finish();
+		open = startResponse(part.kind, part.message);
+	}
+	finish();
+	return messages;
+}

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -222,7 +222,10 @@ export type DesktopApi = {
 	listProjectAttachments: () => Promise<ProjectAttachment[]>;
 	attachProject: (attachment: ProjectAttachmentRequest) => Promise<ProjectAttachment>;
 	runAgent: (request: AgentRunRequest) => Promise<AgentRunStart>;
-	fetchTranscriptPage: (request: TranscriptPageRequest) => Promise<LocalTranscriptPage>;
+	fetchTranscriptPage: (
+		request: TranscriptPageRequest,
+		signal?: AbortSignal
+	) => Promise<LocalTranscriptPage>;
 	fetchTranscriptDetails: (request: TranscriptDetailsRequest) => Promise<ThreadMessage>;
 	watchTranscript: (
 		request: TranscriptScopeRequest,

--- a/apps/web/src/lib/types/sprocket.ts
+++ b/apps/web/src/lib/types/sprocket.ts
@@ -130,12 +130,18 @@ export type LocalTranscriptAttachment = {
 	url?: string;
 };
 
+export type LocalTranscriptPart = {
+	number: number;
+	kind: 'prompt' | 'completion' | 'tool';
+	message: ThreadMessage | null;
+};
+
 export type LocalTranscriptPage = {
 	threadId: Id<'threadRecords'>;
 	totalParts: number;
 	historyFromNumber: number;
 	stale: boolean;
-	messages: ThreadMessage[];
+	parts: LocalTranscriptPart[];
 	nextBefore?: number;
 };
 
@@ -226,7 +232,10 @@ export type DesktopApi = {
 		request: TranscriptPageRequest,
 		signal?: AbortSignal
 	) => Promise<LocalTranscriptPage>;
-	fetchTranscriptDetails: (request: TranscriptDetailsRequest) => Promise<ThreadMessage>;
+	fetchTranscriptDetails: (
+		request: TranscriptDetailsRequest,
+		signal?: AbortSignal
+	) => Promise<LocalTranscriptPart[]>;
 	watchTranscript: (
 		request: TranscriptScopeRequest,
 		handlers: {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -554,7 +554,8 @@
 		const watchedThreadId = threadId;
 		const generation = replicaGeneration;
 		const history = new TranscriptHistory(
-			(request) => api.fetchTranscriptPage({ userId, threadId: watchedThreadId, ...request }),
+			(request) =>
+				api.fetchTranscriptPage({ userId, threadId: watchedThreadId, ...request }, ac.signal),
 			() => {
 				if (ac.signal.aborted || replicaGeneration !== generation) return;
 				replicaMessages = history.messages;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -511,6 +511,7 @@
 	let replicaError = $state<string | null>(null);
 	let replicaGeneration = 0;
 	let transcriptHistory: TranscriptHistory | null = null;
+	let transcriptAbort: AbortController | null = null;
 	let loadingOlderTranscript = $state(false);
 	const loadingTranscriptDetails = new SvelteMap<string, Promise<void>>();
 	let liveCompletion = $state<LiveCompletionOverlay | null>(null);
@@ -518,6 +519,8 @@
 
 	function showReplicaForThread(threadId: Id<'threadRecords'> | null) {
 		replicaGeneration += 1;
+		transcriptAbort?.abort();
+		transcriptAbort = null;
 		transcriptHistory?.stop();
 		transcriptHistory = null;
 		loadingOlderTranscript = false;
@@ -552,6 +555,7 @@
 		}
 		const ac = new AbortController();
 		const watchedThreadId = threadId;
+		transcriptAbort = ac;
 		const generation = replicaGeneration;
 		const history = new TranscriptHistory(
 			(request) =>
@@ -1335,6 +1339,7 @@
 		const threadId = currentThreadId;
 		const userId = getCurrentUserId();
 		const history = transcriptHistory;
+		const signal = transcriptAbort?.signal;
 		const generation = replicaGeneration;
 		if (
 			!api ||
@@ -1346,21 +1351,27 @@
 		) {
 			return;
 		}
-		const key = `${generation}:${message._id}:${message.sourceNumbers.join(',')}`;
+		const numbers = history.detailsNumbers(message);
+		if (!numbers.length) return;
+		const key = `${generation}:${message._id}`;
 		const pending = loadingTranscriptDetails.get(key);
-		if (pending) return pending;
-		const request = api
-			.fetchTranscriptDetails({
-				userId,
-				threadId,
-				numbers: message.sourceNumbers
-			})
-			.then((details) => {
+		if (pending) {
+			await pending;
+			if (replicaGeneration === generation) await loadTranscriptMessageDetails(message);
+			return;
+		}
+		const request = (async () => {
+			for (let offset = 0; offset < numbers.length; offset += 100) {
+				if (replicaGeneration !== generation || signal?.aborted) return;
+				const details = await api.fetchTranscriptDetails(
+					{ userId, threadId, numbers: numbers.slice(offset, offset + 100) },
+					signal
+				);
 				if (replicaGeneration === generation) history.applyDetails(details);
-			})
-			.finally(() => {
-				loadingTranscriptDetails.delete(key);
-			});
+			}
+		})().finally(() => {
+			loadingTranscriptDetails.delete(key);
+		});
 		loadingTranscriptDetails.set(key, request);
 		return request;
 	}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,8 +52,17 @@ export default defineConfig({
 				test: {
 					name: 'frontend',
 					include: ['src/**/*.test.{ts,js}'],
-					exclude: ['src/convex/**'],
+					exclude: ['src/convex/**', 'src/**/*.svelte.test.{ts,js}'],
 					environment: 'node'
+				}
+			},
+			{
+				extends: true,
+				resolve: { conditions: ['browser'] },
+				test: {
+					name: 'components',
+					include: ['src/**/*.svelte.test.{ts,js}'],
+					environment: 'jsdom'
 				}
 			}
 		]

--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@typescript/native": "npm:typescript@7.0.2",
         "convex-test": "^0.0.56",
         "eslint": "^10.0.0",
+        "jsdom": "^30.0.1",
         "svelte": "^5.55.5",
         "svelte-check": "^4.7.4",
         "tailwindcss": "^4.2.4",
@@ -1733,7 +1734,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.67.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.67.0", "@typescript-eslint/parser": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg=="],
 
-    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -1820,6 +1821,8 @@
     "@electron/fuses/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@electron/get/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
@@ -1924,8 +1927,6 @@
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "jsdom/undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -18,7 +18,8 @@ pub use run::{AgentRun, finalize_failed_start, run_agent, start_agent_run};
 pub use sprocket_convex::AuthTokenFetcher;
 pub use transcript::{
     RemoteTranscriptState, TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE, TranscriptMessage,
-    TranscriptPage, TranscriptPart, TranscriptStore, apply_remote_state, fetch_missing_parts,
-    message_page_start, parse_remote_parts,
+    TranscriptPage, TranscriptPart, TranscriptPartKind, TranscriptPartRecord, TranscriptPartsPage,
+    TranscriptState, TranscriptStore, apply_remote_state, fetch_missing_parts, message_page_start,
+    parse_remote_parts, parts_window,
 };
 pub use types::RunAgentRequest;

--- a/crates/sprocket-agent/src/transcript/mod.rs
+++ b/crates/sprocket-agent/src/transcript/mod.rs
@@ -4,11 +4,12 @@ mod sync;
 mod types;
 
 pub use history::{agent_history_from_parts, current_run_has_finished_turns};
-pub use store::{TranscriptStore, message_page_start};
+pub use store::{TranscriptStore, message_page_start, parts_window};
 pub use sync::{
     RemoteTranscriptState, apply_remote_state, fetch_missing_parts, fetch_parts_by_numbers,
     parse_remote_parts,
 };
 pub use types::{
     TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE, TranscriptMessage, TranscriptPage, TranscriptPart,
+    TranscriptPartKind, TranscriptPartRecord, TranscriptPartsPage, TranscriptState,
 };

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -9,7 +9,8 @@ use tokio::sync::Mutex;
 
 use super::types::{
     TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE, TranscriptMessage, TranscriptPage, TranscriptPart,
-    TranscriptPartKind, TranscriptState, UNKNOWN_RUN_STARTED_AT,
+    TranscriptPartKind, TranscriptPartRecord, TranscriptPartsPage, TranscriptState,
+    UNKNOWN_RUN_STARTED_AT,
 };
 
 fn safe_segment(value: &str) -> String {
@@ -281,6 +282,57 @@ impl TranscriptStore {
         })
     }
 
+    pub async fn parts_page(
+        &self,
+        user_id: &str,
+        thread_id: &str,
+        before: Option<u32>,
+        limit: Option<u32>,
+    ) -> anyhow::Result<TranscriptPartsPage> {
+        let state = self.load_state(user_id, thread_id).await?;
+        let (start, end_exclusive) = parts_window(state.visible_end_exclusive(), before, limit);
+        if start >= end_exclusive {
+            return Ok(TranscriptPartsPage {
+                thread_id: thread_id.to_string(),
+                total_parts: state.remote_total_parts,
+                history_from_number: state.history_from_number,
+                stale: state.stale,
+                parts: Vec::new(),
+                next_before: None,
+            });
+        }
+        let numbers: Vec<u32> = (start..end_exclusive).collect();
+        let parts = self.read_parts(user_id, thread_id, &numbers).await?;
+        anyhow::ensure!(
+            parts.len() == numbers.len(),
+            "incomplete transcript history"
+        );
+        Ok(TranscriptPartsPage {
+            thread_id: thread_id.to_string(),
+            total_parts: state.remote_total_parts,
+            history_from_number: state.history_from_number,
+            stale: state.stale,
+            parts: parts
+                .into_iter()
+                .map(|part| project_part(user_id, thread_id, part, false))
+                .collect(),
+            next_before: if start > 0 { Some(start) } else { None },
+        })
+    }
+
+    pub async fn has_complete_range(
+        &self,
+        user_id: &str,
+        thread_id: &str,
+        start: u32,
+        end_exclusive: u32,
+    ) -> anyhow::Result<bool> {
+        Ok(self
+            .missing_numbers(user_id, thread_id, start, end_exclusive)
+            .await?
+            .is_empty())
+    }
+
     pub async fn has_complete_message_page(
         &self,
         user_id: &str,
@@ -325,6 +377,24 @@ impl TranscriptStore {
             return Ok(None);
         }
         Ok(messages.pop())
+    }
+
+    pub async fn part_details(
+        &self,
+        user_id: &str,
+        thread_id: &str,
+        numbers: &[u32],
+    ) -> anyhow::Result<Option<Vec<TranscriptPartRecord>>> {
+        let parts = self.read_parts(user_id, thread_id, numbers).await?;
+        if parts.len() != numbers.len() {
+            return Ok(None);
+        }
+        Ok(Some(
+            parts
+                .into_iter()
+                .map(|part| project_part(user_id, thread_id, part, true))
+                .collect(),
+        ))
     }
 
     pub async fn missing_numbers(
@@ -530,6 +600,14 @@ impl TranscriptStore {
         }
         Ok(())
     }
+}
+
+pub fn parts_window(visible_end: u32, before: Option<u32>, limit: Option<u32>) -> (u32, u32) {
+    let limit = limit
+        .unwrap_or(TRANSCRIPT_PAGE_SIZE)
+        .clamp(1, TRANSCRIPT_CHUNK_SIZE);
+    let end_exclusive = before.unwrap_or(visible_end).min(visible_end);
+    (end_exclusive.saturating_sub(limit), end_exclusive)
 }
 
 pub fn message_page_start(
@@ -799,6 +877,26 @@ fn project_messages(
         }
     }
     messages
+}
+
+fn project_part(
+    user_id: &str,
+    thread_id: &str,
+    part: TranscriptPart,
+    include_details: bool,
+) -> TranscriptPartRecord {
+    let number = part.number;
+    let kind = part.kind;
+    let mut messages = project_messages(user_id, thread_id, vec![part], include_details);
+    debug_assert!(
+        messages.len() <= 1,
+        "a single transcript part should project to at most one message"
+    );
+    TranscriptPartRecord {
+        number,
+        kind,
+        message: messages.pop(),
+    }
 }
 
 fn json_str<'a>(item: &'a JsonValue, key: &str) -> Option<&'a str> {
@@ -1621,5 +1719,187 @@ mod tests {
                 .is_none()
         );
         let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[test]
+    fn parts_window_takes_a_numeric_slice_inside_five_hundred_parts() {
+        assert_eq!(parts_window(500, None, None), (460, 500));
+        assert_eq!(parts_window(500, Some(200), Some(40)), (160, 200));
+        assert_eq!(parts_window(500, Some(10), Some(40)), (0, 10));
+        assert_eq!(parts_window(100, Some(500), Some(200)), (0, 100));
+    }
+
+    #[tokio::test]
+    async fn cold_pages_fetch_only_requested_parts_of_a_five_hundred_part_response() {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-parts-window-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        store
+            .update_state("user", "thread", |state| state.remote_total_parts = 500)
+            .await
+            .unwrap();
+
+        let mut requests = Vec::new();
+        for before in [None, Some(488), None] {
+            let limit = if before.is_some() { 40 } else { 12 };
+            let (start, end) = parts_window(500, before, Some(limit));
+            crate::transcript::fetch_missing_parts(
+                &store,
+                "user",
+                "thread",
+                start,
+                end,
+                |numbers| {
+                    requests.push(numbers.clone());
+                    async move {
+                        Ok(numbers
+                            .into_iter()
+                            .map(|number| {
+                                completion_for_run(number, "span", &format!("part {number}"))
+                            })
+                            .collect())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+        }
+        assert_eq!(
+            requests,
+            vec![(488..500).collect::<Vec<_>>(), (448..488).collect()]
+        );
+        assert!(
+            store
+                .read_parts("user", "thread", &(0..448).collect::<Vec<_>>())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let page = store
+            .parts_page("user", "thread", Some(500), Some(12))
+            .await
+            .unwrap();
+        assert_eq!(page.total_parts, 500);
+        assert_eq!(page.parts.len(), 12);
+        assert_eq!(page.parts[0].number, 488);
+        assert_eq!(page.parts[11].number, 499);
+        assert_eq!(page.next_before, Some(488));
+        assert_eq!(page.parts[0].kind, TranscriptPartKind::Completion);
+        let message = page.parts[0].message.as_ref().unwrap();
+        assert_eq!(message.source_numbers, vec![488]);
+        assert_eq!(message.text, "part 488");
+        assert!(!message.details_loaded);
+
+        let older = store
+            .parts_page("user", "thread", page.next_before, Some(40))
+            .await
+            .unwrap();
+        assert_eq!(older.parts[0].number, 448);
+        assert_eq!(older.parts[39].number, 487);
+        assert_eq!(older.next_before, Some(448));
+
+        store
+            .update_state("user", "thread", |state| state.remote_total_parts = 501)
+            .await
+            .unwrap();
+        let frozen = store
+            .parts_page("user", "thread", Some(500), Some(12))
+            .await
+            .unwrap();
+        assert_eq!(frozen.parts, page.parts);
+
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn parts_page_errors_on_cache_holes_without_a_cursor() {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-parts-hole-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        let parts = (0..20)
+            .filter(|number| *number != 10)
+            .map(|number| prompt(number, "x"))
+            .collect::<Vec<_>>();
+        store.append_parts("user", "thread", &parts).await.unwrap();
+        store
+            .update_state("user", "thread", |state| state.remote_total_parts = 20)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .parts_page("user", "thread", Some(20), Some(10))
+                .await
+                .is_err()
+        );
+        assert!(
+            !store
+                .has_complete_range("user", "thread", 10, 20)
+                .await
+                .unwrap()
+        );
+
+        let complete = store
+            .parts_page("user", "thread", Some(10), Some(10))
+            .await
+            .unwrap();
+        assert_eq!(complete.parts.len(), 10);
+        assert_eq!(complete.parts[0].number, 0);
+        assert_eq!(complete.next_before, None);
+
+        tokio::fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn part_details_project_each_cached_part_with_hidden_payloads() {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-part-details-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        let mut empty_prompt = prompt(1, "hi");
+        empty_prompt.prompt = None;
+        store
+            .append_parts("user", "thread", &[completion(0), empty_prompt])
+            .await
+            .unwrap();
+        store
+            .update_state("user", "thread", |state| state.remote_total_parts = 2)
+            .await
+            .unwrap();
+
+        let page = store
+            .parts_page("user", "thread", None, Some(2))
+            .await
+            .unwrap();
+        assert_eq!(page.parts.len(), 2);
+        assert_eq!(page.parts[0].kind, TranscriptPartKind::Completion);
+        let light = page.parts[0].message.as_ref().unwrap();
+        assert!(!light.details_loaded);
+        assert_eq!(light.source_numbers, vec![0]);
+        assert_eq!(light.parts[0]["text"], "");
+        assert!(light.parts[1]["input"].is_null());
+        assert_eq!(page.parts[1].kind, TranscriptPartKind::Prompt);
+        assert!(page.parts[1].message.is_none());
+
+        let details = store
+            .part_details("user", "thread", &[0, 1])
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(details.len(), 2);
+        let detailed = details[0].message.as_ref().unwrap();
+        assert!(detailed.details_loaded);
+        assert_eq!(detailed.parts[0]["text"], "secret");
+        assert_eq!(detailed.parts[1]["input"]["cmd"], "pwd");
+        assert!(details[1].message.is_none());
+        assert!(
+            store
+                .part_details("user", "thread", &[0, 2])
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        tokio::fs::remove_dir_all(dir).await.unwrap();
     }
 }

--- a/crates/sprocket-agent/src/transcript/types.rs
+++ b/crates/sprocket-agent/src/transcript/types.rs
@@ -181,6 +181,26 @@ pub struct TranscriptPage {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct TranscriptPartsPage {
+    pub thread_id: String,
+    pub total_parts: u32,
+    pub history_from_number: u32,
+    pub stale: bool,
+    pub parts: Vec<TranscriptPartRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_before: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptPartRecord {
+    pub number: u32,
+    pub kind: TranscriptPartKind,
+    pub message: Option<TranscriptMessage>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct TranscriptMessage {
     pub id: String,
     pub thread_id: String,
@@ -247,5 +267,18 @@ mod tests {
             part.prompt.as_ref().map(|prompt| prompt.text.as_str()),
             Some("hi")
         );
+    }
+
+    #[test]
+    fn part_record_serializes_null_message() {
+        let json = serde_json::to_value(&TranscriptPartRecord {
+            number: 3,
+            kind: TranscriptPartKind::Tool,
+            message: None,
+        })
+        .unwrap();
+        assert_eq!(json["number"], 3);
+        assert_eq!(json["kind"], "tool");
+        assert!(json["message"].is_null());
     }
 }

--- a/crates/sprocket-server/src/routes/transcript.rs
+++ b/crates/sprocket-server/src/routes/transcript.rs
@@ -11,7 +11,7 @@ use axum::routing::post;
 use axum_extra::extract::CookieJar;
 use futures::stream::unfold;
 use serde::Deserialize;
-use sprocket_agent::{TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE};
+use sprocket_agent::{TRANSCRIPT_CHUNK_SIZE, TRANSCRIPT_PAGE_SIZE, parts_window};
 use tokio::sync::broadcast;
 
 use crate::AppState;
@@ -86,8 +86,10 @@ pub fn routes() -> axum::Router<AppState> {
     axum::Router::new()
         .route("/transcript/page", post(legacy_page_handler))
         .route("/transcript/messages", post(page_handler))
+        .route("/transcript/parts", post(parts_handler))
         .route("/transcript/watch", post(watch_handler))
         .route("/transcript/details", post(details_handler))
+        .route("/transcript/part-details", post(part_details_handler))
         .route("/transcript/clear", post(clear_handler))
         .route("/transcript/attachment", post(attachment_handler))
 }
@@ -128,16 +130,7 @@ async fn details_handler(
     Json(payload): Json<TranscriptDetailsRequest>,
 ) -> Result<Json<sprocket_agent::TranscriptMessage>, ApiError> {
     require_session_user(&state, &headers, &jar, &payload.user_id).await?;
-    if payload.numbers.is_empty() {
-        return Err(ApiError::bad_request(anyhow!(
-            "invalid transcript detail range"
-        )));
-    }
-    if payload.numbers.windows(2).any(|pair| pair[0] >= pair[1]) {
-        return Err(ApiError::bad_request(anyhow!(
-            "transcript detail numbers must be strictly increasing"
-        )));
-    }
+    require_transcript_numbers(&payload.numbers, None)?;
     let message = state
         .transcript
         .message_details(&payload.user_id, &payload.thread_id, &payload.numbers)
@@ -145,6 +138,42 @@ async fn details_handler(
         .map_err(|error| ApiError::internal_with("failed to read transcript details", error))?
         .ok_or_else(|| ApiError::bad_request(anyhow!("transcript message not found")))?;
     Ok(Json(message))
+}
+
+async fn part_details_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<TranscriptDetailsRequest>,
+) -> Result<Json<Vec<sprocket_agent::TranscriptPartRecord>>, ApiError> {
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
+    require_transcript_numbers(&payload.numbers, Some(TRANSCRIPT_CHUNK_SIZE as usize))?;
+    let records = state
+        .transcript
+        .part_details(&payload.user_id, &payload.thread_id, &payload.numbers)
+        .await
+        .map_err(|error| ApiError::internal_with("failed to read transcript part details", error))?
+        .ok_or_else(|| ApiError::bad_request(anyhow!("transcript parts not found")))?;
+    Ok(Json(records))
+}
+
+fn require_transcript_numbers(numbers: &[u32], max_len: Option<usize>) -> Result<(), ApiError> {
+    if numbers.is_empty() {
+        return Err(ApiError::bad_request(anyhow!(
+            "invalid transcript detail range"
+        )));
+    }
+    if max_len.is_some_and(|max| numbers.len() > max) {
+        return Err(ApiError::bad_request(anyhow!(
+            "request at most {TRANSCRIPT_CHUNK_SIZE} transcript parts"
+        )));
+    }
+    if numbers.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(ApiError::bad_request(anyhow!(
+            "transcript detail numbers must be strictly increasing"
+        )));
+    }
+    Ok(())
 }
 
 async fn require_user(state: &AppState, user_id: &str) -> Result<(), ApiError> {
@@ -174,36 +203,8 @@ async fn page_handler(
     Json(payload): Json<TranscriptPageRequest>,
 ) -> Result<Json<sprocket_agent::TranscriptPage>, ApiError> {
     require_session_user(&state, &headers, &jar, &payload.user_id).await?;
-    let mut transcript_state = state
-        .transcript
-        .load_state(&payload.user_id, &payload.thread_id)
-        .await
-        .map_err(|error| ApiError::internal_with("failed to read transcript state", error))?;
-    if transcript_state.visible_end_exclusive() == 0 {
-        let client = UserConvexClient::connect_with_fetcher(
-            &state.convex_deployment_url,
-            state
-                .native_auth
-                .auth_token_fetcher_for_user(payload.user_id.clone()),
-        )
-        .await
-        .map_err(|error| {
-            ApiError::internal_with("failed to connect while loading transcript", error)
-        })?;
-        let remote = client
-            .ensure_migrated(&payload.thread_id)
-            .await
-            .map_err(|error| ApiError::internal_with("failed to load transcript state", error))?;
-        transcript_state = sprocket_agent::apply_remote_state(
-            &state.transcript,
-            &payload.user_id,
-            &payload.thread_id,
-            &remote,
-            false,
-        )
-        .await
-        .map_err(|error| ApiError::internal_with("failed to save transcript state", error))?;
-    }
+    let transcript_state =
+        load_transcript_state(&state, &payload.user_id, &payload.thread_id).await?;
     let limit = payload
         .limit
         .unwrap_or(TRANSCRIPT_PAGE_SIZE)
@@ -277,6 +278,106 @@ async fn page_handler(
         .await
         .map_err(|error| ApiError::internal_with("failed to read transcript replica", error))?;
     Ok(Json(page))
+}
+
+async fn parts_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Json(payload): Json<TranscriptPageRequest>,
+) -> Result<Json<sprocket_agent::TranscriptPartsPage>, ApiError> {
+    require_session_user(&state, &headers, &jar, &payload.user_id).await?;
+    let transcript_state =
+        load_transcript_state(&state, &payload.user_id, &payload.thread_id).await?;
+    let (start, end) = parts_window(
+        transcript_state.visible_end_exclusive(),
+        payload.before,
+        payload.limit,
+    );
+    if start < end
+        && !state
+            .transcript
+            .has_complete_range(&payload.user_id, &payload.thread_id, start, end)
+            .await
+            .map_err(|error| ApiError::internal_with("failed to inspect transcript parts", error))?
+    {
+        let client = UserConvexClient::connect_with_fetcher(
+            &state.convex_deployment_url,
+            state
+                .native_auth
+                .auth_token_fetcher_for_user(payload.user_id.clone()),
+        )
+        .await
+        .map_err(|error| {
+            ApiError::internal_with("failed to connect while loading transcript parts", error)
+        })?;
+        crate::transcript_client::sync_range(
+            &state.transcript,
+            &client,
+            &payload.user_id,
+            &payload.thread_id,
+            start,
+            end,
+        )
+        .await
+        .map_err(|error| ApiError::internal_with("failed to load transcript parts", error))?;
+        if !state
+            .transcript
+            .has_complete_range(&payload.user_id, &payload.thread_id, start, end)
+            .await
+            .map_err(|error| ApiError::internal_with("failed to inspect transcript parts", error))?
+        {
+            return Err(ApiError::internal_with(
+                "incomplete transcript history",
+                anyhow!("transcript parts are not yet available; retry the page"),
+            ));
+        }
+    }
+
+    // A watch update during the fetch must not shift this page to uncached parts.
+    let page = state
+        .transcript
+        .parts_page(
+            &payload.user_id,
+            &payload.thread_id,
+            Some(end),
+            payload.limit,
+        )
+        .await
+        .map_err(|error| ApiError::internal_with("failed to read transcript replica", error))?;
+    Ok(Json(page))
+}
+
+async fn load_transcript_state(
+    state: &AppState,
+    user_id: &str,
+    thread_id: &str,
+) -> Result<sprocket_agent::TranscriptState, ApiError> {
+    let transcript_state = state
+        .transcript
+        .load_state(user_id, thread_id)
+        .await
+        .map_err(|error| ApiError::internal_with("failed to read transcript state", error))?;
+    if transcript_state.visible_end_exclusive() > 0 {
+        return Ok(transcript_state);
+    }
+    let client = UserConvexClient::connect_with_fetcher(
+        &state.convex_deployment_url,
+        state
+            .native_auth
+            .auth_token_fetcher_for_user(user_id.to_string()),
+    )
+    .await
+    .map_err(|error| {
+        ApiError::internal_with("failed to connect while loading transcript", error)
+    })?;
+    let remote = client
+        .ensure_migrated(thread_id)
+        .await
+        .map_err(|error| ApiError::internal_with("failed to load transcript state", error))?;
+    sprocket_agent::apply_remote_state(&state.transcript, user_id, thread_id, &remote, false)
+        .await
+        .map_err(|error| ApiError::internal_with("failed to save transcript state", error))
 }
 
 async fn watch_handler(
@@ -446,5 +547,15 @@ mod tests {
                 valid
             );
         }
+    }
+
+    #[test]
+    fn part_detail_numbers_are_capped_and_strictly_increasing() {
+        assert!(require_transcript_numbers(&[0, 1, 2], Some(100)).is_ok());
+        assert!(require_transcript_numbers(&[], Some(100)).is_err());
+        assert!(require_transcript_numbers(&[2, 1], Some(100)).is_err());
+        assert!(require_transcript_numbers(&[1, 1], Some(100)).is_err());
+        assert!(require_transcript_numbers(&(0..101).collect::<Vec<_>>(), Some(100)).is_err());
+        assert!(require_transcript_numbers(&(0..101).collect::<Vec<_>>(), None).is_ok());
     }
 }

--- a/crates/sprocket-server/src/transcript_watch.rs
+++ b/crates/sprocket-server/src/transcript_watch.rs
@@ -2,14 +2,12 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
-use sprocket_agent::{TRANSCRIPT_PAGE_SIZE, TranscriptStore, apply_remote_state};
+use sprocket_agent::{RemoteTranscriptState, TranscriptStore, apply_remote_state};
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use crate::native_auth::NativeAuthManager;
-use crate::transcript_client::{
-    UserConvexClient, decode_state_update, retry_after_failure, sync_range,
-};
+use crate::transcript_client::{UserConvexClient, decode_state_update, retry_after_failure};
 
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -239,61 +237,35 @@ async fn run_watch_loop(start: &WatchStart) -> anyhow::Result<()> {
     )
     .await?;
     let remote = client.ensure_migrated(&start.thread_id).await?;
+    apply_and_publish(start, &remote, false).await?;
+
+    let mut subscription = client.subscribe_state(&start.thread_id).await?;
+    while let Some(update) = subscription.next().await {
+        let remote = decode_state_update(update)?;
+        apply_and_publish(start, &remote, false).await?;
+    }
+    anyhow::bail!("transcript subscription ended")
+}
+
+async fn apply_and_publish(
+    start: &WatchStart,
+    remote: &RemoteTranscriptState,
+    stale: bool,
+) -> anyhow::Result<()> {
     apply_remote_state(
         &start.store,
         &start.user_id,
         &start.thread_id,
-        &remote,
-        false,
-    )
-    .await?;
-    let newest_start = remote.total_parts.saturating_sub(TRANSCRIPT_PAGE_SIZE);
-    sync_range(
-        &start.store,
-        &client,
-        &start.user_id,
-        &start.thread_id,
-        newest_start,
-        remote.total_parts,
+        remote,
+        stale,
     )
     .await?;
     let _ = start.events.send(TranscriptWatchEvent {
         event_type: "updated",
         total_parts: Some(remote.total_parts),
-        stale: false,
+        stale,
     });
-
-    let mut seen_total = remote.total_parts;
-    let mut subscription = client.subscribe_state(&start.thread_id).await?;
-    while let Some(update) = subscription.next().await {
-        let remote = decode_state_update(update)?;
-        apply_remote_state(
-            &start.store,
-            &start.user_id,
-            &start.thread_id,
-            &remote,
-            false,
-        )
-        .await?;
-        if remote.total_parts > seen_total {
-            sync_range(
-                &start.store,
-                &client,
-                &start.user_id,
-                &start.thread_id,
-                seen_total,
-                remote.total_parts,
-            )
-            .await?;
-        }
-        seen_total = remote.total_parts;
-        let _ = start.events.send(TranscriptWatchEvent {
-            event_type: "updated",
-            total_parts: Some(remote.total_parts),
-            stale: false,
-        });
-    }
-    anyhow::bail!("transcript subscription ended")
+    Ok(())
 }
 
 #[cfg(test)]
@@ -370,6 +342,57 @@ mod tests {
         assert_eq!(event.total_parts, Some(4));
         assert!(event.stale);
         drop(session);
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[tokio::test]
+    async fn watch_metadata_does_not_fetch_part_bodies() {
+        let dir =
+            std::env::temp_dir().join(format!("sprocket-watch-metadata-{}", uuid::Uuid::new_v4()));
+        let store = TranscriptStore::new(dir.clone());
+        let (events, mut rx) = broadcast::channel(8);
+        let start = WatchStart {
+            deployment_url: "https://example.convex.cloud".into(),
+            store: Arc::clone(&store),
+            native_auth: native_auth(),
+            user_id: "user".into(),
+            thread_id: "thread".into(),
+            events,
+        };
+        apply_and_publish(
+            &start,
+            &RemoteTranscriptState {
+                thread_id: "thread".into(),
+                total_parts: 500,
+                history_from_number: 0,
+                context_summary: None,
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        let event = rx.recv().await.expect("metadata update");
+        assert_eq!(event.total_parts, Some(500));
+        assert!(!event.stale);
+
+        let state = store.load_state("user", "thread").await.unwrap();
+        assert_eq!(state.remote_total_parts, 500);
+        assert!(state.downloaded_ranges.is_empty());
+        assert_eq!(
+            store
+                .missing_numbers("user", "thread", 0, 40)
+                .await
+                .unwrap(),
+            (0..40).collect::<Vec<_>>()
+        );
+        assert!(
+            store
+                .read_parts("user", "thread", &(0..40).collect::<Vec<_>>())
+                .await
+                .unwrap()
+                .is_empty()
+        );
         let _ = tokio::fs::remove_dir_all(dir).await;
     }
 }


### PR DESCRIPTION
## Summary

Page transcript history by numbered Convex parts instead of complete message bubbles. A single response can span hundreds of parts, so a message limit did not bound history downloads.

- Request 12 parts for the initial page and recent refreshes, and 40 parts for each older page. The server clamps every page to at most 100 parts and fetches only missing numbers in that window.
- Make transcript watches metadata-only. They no longer prefetch part bodies on open or after updates.
- Assemble partial responses across page boundaries, preserving tool ordering, timestamps, and previously loaded details. Reconnect catch-up uses the newest raw part number instead of the start of a response.
- Load older history only on upward scroll, wheel, touch, or keyboard demand. No paging button, loading text, or automatic viewport-fill loop. Preserve anchors within responses when older parts are prepended.
- Fetch details from the existing local cache in batches of at most 100 parts. Abort page and detail requests when leaving a thread.
- Preserve the released raw-page, message-page, and message-details endpoints. Record their removal gate in BACKWARDS_COMPATIBILITY.md. No stored-data format changes.

## Validation

- Frontend and component Vitest suites: 179 tests passed across 20 files. Follow-up viewport/disclosure tests also passed, bringing that component suite to 10 tests.
- Svelte check: 0 errors and 0 warnings.
- Changed-file ESLint, Oxlint, Rust formatting, and applicable non-build commit hooks passed.
- Rust transcript tests: 45 passed across the agent and server crates.
- Web production build passed.
- Regression coverage includes a cold 500-part response with exact fetch ranges, cache holes, cross-page tool ordering, detail upgrades, explicit paging, retries, cancellation, and same-response scroll anchoring.

Implemented in a separate worktree based on the latest main.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes transcript history from complete-message paging to bounded numbered-part paging and reconstructs partial responses across page boundaries.
- Adds part-bounded transcript page and detail endpoints while preserving released legacy endpoints.
- Makes transcript watches metadata-only and fetches missing part ranges on demand.
- Adds explicit upward-intent history loading, request cancellation, and intra-response scroll anchoring.
- Preserves work-disclosure identity as streamed or paged content changes.
- Expands frontend and Rust regression coverage for paging, reconstruction, retries, cancellation, and rendering state.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the previously reported transcript paging and disclosure-state issues are resolved and no new actionable failure remains.

The current implementation bounds transcript downloads by numbered parts, preserves response assembly and rendering state across page boundaries, supports explicit retry after failed older-page requests, and cancels obsolete requests when leaving a thread. All previous findings are resolved, retracted, or fully addressed by the current code and regression tests.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/lib/project/transcript-history.ts | Implements bounded part paging, response reconstruction, detail upgrades, retry state, and request cancellation. |
| crates/sprocket-agent/src/transcript/store.rs | Adds bounded numbered-part projection and cache-aware detail retrieval while retaining legacy projections. |
| crates/sprocket-server/src/routes/transcript.rs | Exposes authenticated part-page and part-detail routes alongside compatibility endpoints. |
| apps/web/src/lib/components/home/thread-transcript.svelte | Adds explicit upward-intent paging, finer scroll anchors, and stable work-section rendering keys. |
| apps/web/src/lib/chat/transcript-section-keys.ts | Reconciles work-section identities from their reasoning and tool members across transcript updates. |
| crates/sprocket-server/src/transcript_watch.rs | Changes transcript watches to propagate metadata without eagerly downloading part bodies. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Thread transcript
    participant History as TranscriptHistory
    participant Server as Local transcript API
    participant Store as Local part cache
    participant Convex as Convex transcript
    UI->>History: Initial refresh (12 parts)
    History->>Server: POST /transcript/parts
    Server->>Store: Read requested numbered window
    Store->>Convex: Fetch only missing numbers
    Convex-->>Store: Numbered transcript parts
    Store-->>Server: Bounded part page
    Server-->>History: Parts and nextBefore
    History->>History: Assemble partial responses
    History-->>UI: Render recent transcript
    UI->>History: Upward user intent
    History->>Server: Older page (40 parts)
    Server-->>History: Older numbered parts
    History->>History: Merge parts and preserve details
    History-->>UI: Prepend while restoring anchor
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(web): Keep disclosure identity attac..."](https://github.com/spikonado/sprocket/commit/537ac78c8608b953aaeda5d4fc711c644be241dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61174043)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Web application experience](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-application.md)
- Knowledge Base — [Chat, timeline, and artifacts UI](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-chat-and-artifacts.md)
- Knowledge Base — [Agent and workspace API routes](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-agent-workspace-routes.md)
- Knowledge Base — [Agent runtime](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/agent-runtime.md)
</details>


<!-- /greptile_comment -->