### PR TITLE
fix(convex): Collapse duplicate transcript state rows

### DIFF
--- a/apps/web/src/convex/lib/transcriptParts.ts
+++ b/apps/web/src/convex/lib/transcriptParts.ts
@@ -106,7 +106,12 @@ export async function getTranscriptState(
 	ctx: MutationCtx | QueryCtx,
 	threadId: Id<'threadRecords'>
 ): Promise<Doc<'threadTranscriptStates'> | null> {
-	return pickTranscriptState(await listTranscriptStates(ctx, threadId));
+	const rows = await listTranscriptStates(ctx, threadId);
+	const keep = pickTranscriptState(rows);
+	if (!keep) return null;
+	const totalParts = Math.max(...rows.map((row) => row.totalParts));
+	if (keep.totalParts === totalParts) return keep;
+	return { ...keep, totalParts };
 }
 
 export async function getOrCreateTranscriptState(

--- a/apps/web/src/convex/lib/transcriptParts.ts
+++ b/apps/web/src/convex/lib/transcriptParts.ts
@@ -82,23 +82,48 @@ export function isTranscriptToolTerminalStatus(
 	return status === 'completed' || status === 'failed' || status === 'cancelled';
 }
 
+async function listTranscriptStates(
+	ctx: MutationCtx | QueryCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'threadTranscriptStates'>[]> {
+	return await ctx.db
+		.query('threadTranscriptStates')
+		.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+		.collect();
+}
+
+/** Earliest row wins so concurrent first-append duplicates converge. */
+function pickTranscriptState(
+	rows: Array<Doc<'threadTranscriptStates'>>
+): Doc<'threadTranscriptStates'> | null {
+	if (rows.length === 0) return null;
+	return [...rows].sort(
+		(a, b) => a._creationTime - b._creationTime || a._id.localeCompare(b._id)
+	)[0];
+}
+
 export async function getTranscriptState(
 	ctx: MutationCtx | QueryCtx,
 	threadId: Id<'threadRecords'>
 ): Promise<Doc<'threadTranscriptStates'> | null> {
-	return await ctx.db
-		.query('threadTranscriptStates')
-		.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
-		.unique();
+	return pickTranscriptState(await listTranscriptStates(ctx, threadId));
 }
 
 export async function getOrCreateTranscriptState(
 	ctx: MutationCtx,
 	args: { threadId: Id<'threadRecords'>; userId: string }
 ): Promise<Doc<'threadTranscriptStates'>> {
-	const existing = await getTranscriptState(ctx, args.threadId);
-	if (existing) {
-		return existing;
+	const rows = await listTranscriptStates(ctx, args.threadId);
+	const keep = pickTranscriptState(rows);
+	if (keep) {
+		const totalParts = Math.max(...rows.map((row) => row.totalParts));
+		if (keep.totalParts !== totalParts) {
+			await ctx.db.patch('threadTranscriptStates', keep._id, { totalParts });
+		}
+		for (const row of rows) {
+			if (row._id !== keep._id) await ctx.db.delete('threadTranscriptStates', row._id);
+		}
+		return (await ctx.db.get('threadTranscriptStates', keep._id)) ?? { ...keep, totalParts };
 	}
 	const stateId = await ctx.db.insert('threadTranscriptStates', {
 		threadId: args.threadId,

--- a/apps/web/src/convex/transcript.test.ts
+++ b/apps/web/src/convex/transcript.test.ts
@@ -736,3 +736,40 @@ describe('transcript attachment identity', () => {
 		expect(current.parts[0]?.prompt?.imageUploads[0]).not.toHaveProperty('imageUploadId');
 	});
 });
+
+describe('duplicate transcript state rows', () => {
+	it('reads and collapses extras without throwing', async () => {
+		const t = initConvexTest();
+		const { asUser, subject, threadId } = await seedOwnedThread(t, 'user_dup_transcript');
+		await t.run(async (ctx) => {
+			await ctx.db.insert('threadTranscriptStates', {
+				threadId,
+				userId: subject,
+				totalParts: 1
+			});
+			await ctx.db.insert('threadTranscriptStates', {
+				threadId,
+				userId: subject,
+				totalParts: 3
+			});
+		});
+
+		expect(await asUser.query(api.transcript.getState, { threadId })).toMatchObject({
+			threadId,
+			totalParts: 1
+		});
+
+		await asUser.mutation(api.transcript.ensureMigrated, { threadId });
+		expect(await asUser.query(api.transcript.getState, { threadId })).toMatchObject({
+			totalParts: 3
+		});
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('threadTranscriptStates')
+				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+				.collect()
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.totalParts).toBe(3);
+	});
+});

--- a/apps/web/src/convex/transcript.test.ts
+++ b/apps/web/src/convex/transcript.test.ts
@@ -756,7 +756,7 @@ describe('duplicate transcript state rows', () => {
 
 		expect(await asUser.query(api.transcript.getState, { threadId })).toMatchObject({
 			threadId,
-			totalParts: 1
+			totalParts: 3
 		});
 
 		await asUser.mutation(api.transcript.ensureMigrated, { threadId });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Concurrent first-time transcript writes can insert two `threadTranscriptStates` rows for the same thread. Later `.unique()` reads then throw, so `getState`, `getParts`, and context handoff fail for that thread.

Reads now take the earliest row. Mutations delete the extras and keep the highest `totalParts` so later appends do not reuse numbers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes transcript state access resilient to duplicate per-thread rows and preserves the highest observed part count during reads and mutation-driven cleanup.
- Replaces uniqueness-dependent state lookup with deterministic duplicate collection and selection.
- Overlays the maximum `totalParts` during reads.
- Consolidates duplicate rows during mutations while retaining the maximum counter.
- Adds coverage for duplicate reads, authoritative counters, and cleanup.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The transcript-state fix appears safe to merge, with the previously reported stale-counter behavior corrected and no new actionable defects identified.

Duplicate reads now expose the maximum observed `totalParts`, and mutations preserve that value while deleting extra state rows. The previous finding is resolved and no blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/lib/transcriptParts.ts | Deterministically handles duplicate transcript states, reports their maximum counter, and consolidates them on mutation. |
| apps/web/src/convex/transcript.test.ts | Verifies duplicate state reads expose the maximum counter and mutation cleanup leaves one authoritative row. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load transcript state rows by thread] --> B{Any rows?}
  B -- No --> C[Create state during mutation or return null during read]
  B -- Yes --> D[Select earliest row deterministically]
  D --> E[Calculate maximum totalParts]
  E --> F{Read or mutation?}
  F -- Read --> G[Return selected row with maximum counter]
  F -- Mutation --> H[Patch selected row if needed]
  H --> I[Delete duplicate rows]
  I --> J[Return consolidated state]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(convex): Overlay max transcript part..."](https://github.com/spikonado/sprocket/commit/4bddee714feb635cf5d2e81c40d733b79b447c51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61209913)</sub>

<!-- /greptile_comment -->