### PR TITLE
fix(convex): Collapse duplicate browser session rows

### DIFF
--- a/apps/web/src/convex/browserSessions.test.ts
+++ b/apps/web/src/convex/browserSessions.test.ts
@@ -224,4 +224,45 @@ describe('browserSessions', () => {
 		expect(session?.browserbaseSessionId).toBe('bb-1');
 		expect(session?.runId).toBe(first.runId);
 	});
+
+	it('collapses duplicate session rows onto the latest startedAt', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId, runId, userId } = await seedRun(t, 'user_browser_dup');
+		await t.run(async (ctx) => {
+			await ctx.db.insert('browserSessions', {
+				threadId,
+				runId,
+				lastUsedRunId: runId,
+				userId,
+				browserbaseSessionId: 'bb-stale',
+				liveViewUrl: 'https://live.browserbase.test/stale',
+				startedAt: 1
+			});
+			await ctx.db.insert('browserSessions', {
+				threadId,
+				runId,
+				lastUsedRunId: runId,
+				userId,
+				browserbaseSessionId: 'bb-live',
+				liveViewUrl: 'https://live.browserbase.test/live',
+				startedAt: 2
+			});
+		});
+
+		const live = await asUser.query(api.browserSessions.liveViewForThread, { threadId });
+		expect(live).toMatchObject({
+			url: 'https://live.browserbase.test/live',
+			startedAt: 2
+		});
+
+		await t.mutation(internal.browserSessions.touchForThread, { threadId, runId });
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('browserSessions')
+				.withIndex('by_thread', (query) => query.eq('threadId', threadId))
+				.collect()
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.browserbaseSessionId).toBe('bb-live');
+	});
 });

--- a/apps/web/src/convex/browserSessions.ts
+++ b/apps/web/src/convex/browserSessions.ts
@@ -1,6 +1,12 @@
 import { v } from 'convex/values';
-import type { Id } from '@convex/_generated/dataModel';
-import { internalMutation, internalQuery, query } from '@convex/_generated/server';
+import type { Doc, Id } from '@convex/_generated/dataModel';
+import {
+	internalMutation,
+	internalQuery,
+	query,
+	type MutationCtx,
+	type QueryCtx
+} from '@convex/_generated/server';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import { getUserId } from '@convex/lib/auth';
 
@@ -25,14 +31,50 @@ const browserSessionDoc = v.object({
 	startedAt: v.number()
 });
 
+async function listBrowserSessions(
+	ctx: QueryCtx | MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'browserSessions'>[]> {
+	return await ctx.db
+		.query('browserSessions')
+		.withIndex('by_thread', (query) => query.eq('threadId', threadId))
+		.collect();
+}
+
+/** Latest startedAt wins so a rotated session beats a leftover older row. */
+function pickBrowserSession(rows: Array<Doc<'browserSessions'>>): Doc<'browserSessions'> | null {
+	if (rows.length === 0) return null;
+	return [...rows].sort(
+		(a, b) => b.startedAt - a.startedAt || b._id.localeCompare(a._id)
+	)[0];
+}
+
+async function getBrowserSession(
+	ctx: QueryCtx | MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'browserSessions'> | null> {
+	return pickBrowserSession(await listBrowserSessions(ctx, threadId));
+}
+
+/** Mutation-only: collapse concurrent upsert races onto the latest session. */
+async function getBrowserSessionExclusive(
+	ctx: MutationCtx,
+	threadId: Id<'threadRecords'>
+): Promise<Doc<'browserSessions'> | null> {
+	const rows = await listBrowserSessions(ctx, threadId);
+	const keep = pickBrowserSession(rows);
+	if (!keep) return null;
+	for (const row of rows) {
+		if (row._id !== keep._id) await ctx.db.delete('browserSessions', row._id);
+	}
+	return keep;
+}
+
 export const getForThread = internalQuery({
 	args: { threadId: v.id('threadRecords'), userId: v.string() },
 	returns: v.union(browserSessionDoc, v.null()),
 	handler: async (ctx, args) => {
-		const session = await ctx.db
-			.query('browserSessions')
-			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
-			.first();
+		const session = await getBrowserSession(ctx, args.threadId);
 		return session?.userId === args.userId ? session : null;
 	}
 });
@@ -53,10 +95,7 @@ export const liveViewForThread = query({
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		const session = await ctx.db
-			.query('browserSessions')
-			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
-			.first();
+		const session = await getBrowserSession(ctx, args.threadId);
 		if (!session) return null;
 		return {
 			url: session.liveViewUrl ?? null,
@@ -67,8 +106,8 @@ export const liveViewForThread = query({
 });
 
 /** Record the live Browserbase session for a thread, replacing any prior one.
- * Transactional, so concurrent runs in a thread can't leave duplicate rows
- * pointing at different sessions. runId tracks which run (re)created it. */
+ * Concurrent upserts can still insert extras; mutations collapse them onto
+ * the latest row. runId tracks which run (re)created it. */
 export const upsertForThread = internalMutation({
 	args: {
 		threadId: v.id('threadRecords'),
@@ -79,10 +118,7 @@ export const upsertForThread = internalMutation({
 	},
 	returns: v.id('browserSessions'),
 	handler: async (ctx, args) => {
-		const existing = await ctx.db
-			.query('browserSessions')
-			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
-			.first();
+		const existing = await getBrowserSessionExclusive(ctx, args.threadId);
 		if (existing) {
 			// A rotated session must not keep the dead session's URL when its own
 			// live view URL is not known yet: patching undefined clears the field.
@@ -113,10 +149,7 @@ export const touchForThread = internalMutation({
 	args: { threadId: v.id('threadRecords'), runId: v.id('runs') },
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const existing = await ctx.db
-			.query('browserSessions')
-			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
-			.first();
+		const existing = await getBrowserSessionExclusive(ctx, args.threadId);
 		if (existing && existing.lastUsedRunId !== args.runId) {
 			await ctx.db.patch('browserSessions', existing._id, { lastUsedRunId: args.runId });
 		}
@@ -135,10 +168,7 @@ export const setLiveViewUrl = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const existing = await ctx.db
-			.query('browserSessions')
-			.withIndex('by_thread', (query) => query.eq('threadId', args.threadId))
-			.first();
+		const existing = await getBrowserSessionExclusive(ctx, args.threadId);
 		// The session may have rotated while the URL was being fetched; stamping
 		// the old session's URL onto the new row would point the live view at a
 		// dead browser.

--- a/apps/web/src/convex/browserSessions.ts
+++ b/apps/web/src/convex/browserSessions.ts
@@ -44,9 +44,7 @@ async function listBrowserSessions(
 /** Latest startedAt wins so a rotated session beats a leftover older row. */
 function pickBrowserSession(rows: Array<Doc<'browserSessions'>>): Doc<'browserSessions'> | null {
 	if (rows.length === 0) return null;
-	return [...rows].sort(
-		(a, b) => b.startedAt - a.startedAt || b._id.localeCompare(a._id)
-	)[0];
+	return [...rows].sort((a, b) => b.startedAt - a.startedAt || b._id.localeCompare(a._id))[0];
 }
 
 async function getBrowserSession(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Concurrent browser upserts can insert two `browserSessions` rows for the same thread. Reads used `.first()`, so the side panel live view could point at a dead Browserbase session.

Reads now take the latest `startedAt`. Mutations delete the extras before patching.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61210415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because duplicate cleanup can destroy a usable remote browser session when a newer duplicate is still unattached.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Newer Reservation Replaces Session** <a href="https://github.com/spikonado/sprocket/pull/317#discussion_r4015461384">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/web/src/convex/browserSessions.ts:35-37
When concurrent acquisition leaves an attached session beside a newer reservation that has not attached yet, this selection keeps the newer row solely because of `startedAt`. Exclusive lookup then deletes the usable attached row and schedules its remote session for closure before callers validate that the selected row has a `sessionId`. As a result, `setHumanControl` reports that the browser session ended, and the live view can point to an unusable reservation. Prefer an attached, non-closing, unexpired session when resolving duplicates, or validate the selected row before deleting the others.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details open><summary><h3>Summary</h3></summary>

This PR makes browser-session reads deterministic when duplicate rows exist and makes selected mutations collapse duplicates while closing detached remote sessions.
- Selects the row with the greatest `startedAt` for live-view reads.
- Deletes duplicate rows during exclusive mutation access.
- Updates human-control handling to use the shared cleanup path.
- Adds coverage for two fully attached duplicate rows.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A["Concurrent browser acquisitions"] --> B["Older row attaches to remote session"]
  A --> C["Newer reservation remains unattached"]
  B --> D["Select greatest startedAt"]
  C --> D
  D --> E["Keep newer unattached row"]
  D --> F["Delete older attached row"]
  F --> G["Schedule remote session closure"]
  E --> H["Caller validates sessionId"]
  H --> I["Mutation fails / live view lacks usable session"]
```
</details>

<sub>Reviews (4) · Last reviewed commit: ["fix(convex): handle duplicate sessions f..."](https://github.com/spikonado/sprocket/commit/54d4856691a0a9704346769c83c65d82a2c9760a)</sub>

<!-- /greptile_comment -->