### PR TITLE
fix(convex): Collapse duplicate UI preference rows

### DIFF
--- a/apps/web/src/convex/uiPreferences.test.ts
+++ b/apps/web/src/convex/uiPreferences.test.ts
@@ -21,4 +21,25 @@ describe('theme preferences', () => {
 		expect(await alice.query(api.uiPreferences.getMine, {})).toMatchObject({ theme: 'light' });
 		await expect(t.query(api.uiPreferences.getMine, {})).rejects.toThrow('Authentication required');
 	});
+
+	it('collapses duplicate preference rows without throwing', async () => {
+		const t = initConvexTest();
+		const alice = t.withIdentity({ subject: 'alice_dup' });
+		await t.run(async (ctx) => {
+			await ctx.db.insert('uiPreferences', { userId: 'alice_dup', theme: 'light' });
+			await ctx.db.insert('uiPreferences', { userId: 'alice_dup', theme: 'dark' });
+		});
+		expect(await alice.query(api.uiPreferences.getMine, {})).toMatchObject({ theme: 'light' });
+
+		const updated = await alice.mutation(api.uiPreferences.setTheme, { theme: 'dark' });
+		expect(updated?.theme).toBe('dark');
+		const rows = await t.run(async (ctx) =>
+			ctx.db
+				.query('uiPreferences')
+				.withIndex('by_userId', (query) => query.eq('userId', 'alice_dup'))
+				.collect()
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.theme).toBe('dark');
+	});
 });

--- a/apps/web/src/convex/uiPreferences.ts
+++ b/apps/web/src/convex/uiPreferences.ts
@@ -1,20 +1,49 @@
-import { mutation, query } from '@convex/_generated/server';
+import { mutation, query, type MutationCtx, type QueryCtx } from '@convex/_generated/server';
 import { v } from 'convex/values';
+import type { Doc } from '@convex/_generated/dataModel';
 import { getUserId } from '@convex/lib/auth';
 import { unsupportedClient } from '@convex/lib/unsupportedClient';
 import schema from '@convex/schema';
 
 const vTheme = v.union(v.literal('light'), v.literal('dark'));
 
+async function listPreferences(
+	ctx: QueryCtx | MutationCtx,
+	userId: string
+): Promise<Doc<'uiPreferences'>[]> {
+	return await ctx.db
+		.query('uiPreferences')
+		.withIndex('by_userId', (query) => query.eq('userId', userId))
+		.collect();
+}
+
+/** Earliest row wins so concurrent first-theme writes converge. */
+function pickPreferences(rows: Array<Doc<'uiPreferences'>>): Doc<'uiPreferences'> | null {
+	if (rows.length === 0) return null;
+	return [...rows].sort(
+		(a, b) => a._creationTime - b._creationTime || a._id.localeCompare(b._id)
+	)[0];
+}
+
+async function getPreferencesExclusive(
+	ctx: MutationCtx,
+	userId: string
+): Promise<Doc<'uiPreferences'> | null> {
+	const rows = await listPreferences(ctx, userId);
+	const keep = pickPreferences(rows);
+	if (!keep) return null;
+	for (const row of rows) {
+		if (row._id !== keep._id) await ctx.db.delete('uiPreferences', row._id);
+	}
+	return keep;
+}
+
 export const getMine = query({
 	args: {},
 	returns: v.union(schema.doc('uiPreferences'), v.null()),
 	handler: async (ctx) => {
 		const userId = await getUserId(ctx);
-		return await ctx.db
-			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', userId))
-			.unique();
+		return pickPreferences(await listPreferences(ctx, userId));
 	}
 });
 
@@ -36,10 +65,7 @@ export const setTheme = mutation({
 	returns: v.union(schema.doc('uiPreferences'), v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
-		const existing = await ctx.db
-			.query('uiPreferences')
-			.withIndex('by_userId', (query) => query.eq('userId', userId))
-			.unique();
+		const existing = await getPreferencesExclusive(ctx, userId);
 
 		if (existing) {
 			await ctx.db.patch('uiPreferences', existing._id, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Concurrent first theme writes can insert two `uiPreferences` rows for the same user. Later `.unique()` reads then throw, so the theme query fails.

Reads now take the earliest row. Mutations delete the extras before patching.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a31f0f-ba32-4e9a-9eb3-5945ec017087&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes UI preference access tolerant of duplicate rows and repairs duplicates on the next theme mutation.
- Reads deterministically return the earliest preference row instead of throwing when duplicates exist.
- Theme writes retain the earliest row, delete extras, and apply the requested theme.
- Tests cover duplicate reads, mutation-driven collapse, and the resulting single-row state.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with duplicate preference reads and mutation cleanup behaving consistently with the intended one-row-per-user model.

The changed query no longer throws on duplicate rows, and the mutation atomically retains one deterministic row, removes extras, and applies the requested theme without introducing a conflicting writer path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/uiPreferences.ts | Deterministically selects the earliest preference row and atomically removes duplicates before theme updates. |
| apps/web/src/convex/uiPreferences.test.ts | Adds coverage proving duplicate reads succeed and a subsequent mutation collapses the rows. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A["Read preferences by authenticated user"] --> B{"Rows found?"}
  B -->|"None"| C["Return null or insert on mutation"]
  B -->|"One or more"| D["Select earliest row"]
  D --> E{"Query or mutation?"}
  E -->|"Query"| F["Return selected row"]
  E -->|"Mutation"| G["Delete duplicate rows"]
  G --> H["Patch selected row with requested theme"]
  H --> I["Return updated preference"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(convex): Collapse duplicate UI prefe..."](https://github.com/spikonado/sprocket/commit/9767c1294bf8b28bad134914cf3c4f1f34a65ed1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61210548)</sub>

**Context used:**

- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)

<!-- /greptile_comment -->