### PR TITLE
feat(ux): Add ways to update desktop app and CLI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -40,11 +40,11 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - run: bun run --cwd apps/web build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web
           path: apps/web/dist
@@ -73,8 +73,8 @@ jobs:
             electron_args: --win nsis --x64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -85,7 +85,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web
           path: apps/web/dist
@@ -168,7 +168,7 @@ jobs:
               }
             }
           '
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: desktop-${{ matrix.id }}
           path: |
@@ -183,10 +183,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: desktop-*
           path: release-assets

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.value }}
+      channel: ${{ steps.version.outputs.channel }}
     steps:
       - id: version
         name: Resolve version
@@ -29,6 +30,11 @@ jobs:
             exit 1
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
+          if [[ "$version" == *-canary.* ]]; then
+            echo "channel=canary" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=latest" >> "$GITHUB_OUTPUT"
+          fi
 
   web:
     needs: prepare
@@ -53,23 +59,18 @@ jobs:
           - id: linux-x64
             runner: ubuntu-latest
             electron_args: --linux AppImage --x64
-            artifact_glob: 'sprocket-desktop-*.AppImage'
           - id: linux-arm64
             runner: ubuntu-24.04-arm
             electron_args: --linux AppImage --arm64
-            artifact_glob: 'sprocket-desktop-*.AppImage'
           - id: darwin-arm64
             runner: macos-latest
-            electron_args: --mac dmg --arm64
-            artifact_glob: 'sprocket-desktop-*.dmg'
+            electron_args: --mac --arm64
           - id: darwin-x64
             runner: macos-15-intel
-            electron_args: --mac dmg --x64
-            artifact_glob: 'sprocket-desktop-*.dmg'
+            electron_args: --mac --x64
           - id: win32-x64
             runner: windows-2022
             electron_args: --win nsis --x64
-            artifact_glob: 'sprocket-desktop-*.exe'
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7.0.1
@@ -92,12 +93,14 @@ jobs:
         working-directory: apps/desktop
         shell: bash
         env:
+          CHANNEL: ${{ needs.prepare.outputs.channel }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           bun -e '
             const fs = require("node:fs");
             const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
             pkg.version = process.env.VERSION;
+            pkg.build.publish.channel = process.env.CHANNEL;
             fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, "\t")}\n`);
           '
       - name: Build Rust CLI
@@ -105,16 +108,73 @@ jobs:
         env:
           SPROCKET_VERSION: ${{ needs.prepare.outputs.version }}
         run: cargo build --locked --release -p sprocket-cli
+      - name: Load optional Apple API key
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_KEY_VALUE: ${{ secrets.APPLE_API_KEY }}
+          KEY_FILE: ${{ runner.temp }}/AuthKey.p8
+        run: |
+          if [[ -z "$APPLE_API_KEY_VALUE" ]]; then
+            exit 0
+          fi
+          node -e '
+            const fs = require("node:fs");
+            const value = process.env.APPLE_API_KEY_VALUE;
+            const compact = value.replace(/\s+/g, "");
+            const body = value.includes("BEGIN")
+              ? value
+              : Buffer.from(compact, "base64");
+            fs.writeFileSync(process.env.KEY_FILE, body);
+          '
+          chmod 600 "$KEY_FILE"
+          echo "APPLE_API_KEY=$KEY_FILE" >> "$GITHUB_ENV"
       - name: Package desktop installer
         working-directory: apps/desktop
         shell: bash
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          APPLE_API_ISSUER: ${{ runner.os == 'macOS' && secrets.APPLE_API_ISSUER || '' }}
+          APPLE_API_KEY_ID: ${{ runner.os == 'macOS' && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
+          APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ ((runner.os == 'macOS' && secrets.CSC_LINK != '') || (runner.os == 'Windows' && secrets.WIN_CSC_LINK != '')) && 'true' || 'false' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.CSC_KEY_PASSWORD || '' }}
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.CSC_LINK || '' }}
+          WIN_CSC_KEY_PASSWORD: ${{ runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
+          WIN_CSC_LINK: ${{ runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
         run: bunx electron-builder ${{ matrix.electron_args }} --publish never
+      - name: Drop builder debug files
+        working-directory: apps/desktop/dist
+        shell: bash
+        run: rm -f builder-debug.yml builder-effective-config.yaml
+      - name: Require updater artifacts
+        working-directory: apps/desktop/dist
+        shell: bash
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const files = fs.readdirSync(".");
+            const yml = files.filter((name) => name.endsWith(".yml") && !name.startsWith("builder"));
+            if (yml.length === 0) {
+              throw new Error("electron-builder did not write update metadata yml");
+            }
+            if (process.platform === "darwin") {
+              if (!files.some((name) => name.endsWith(".zip"))) {
+                throw new Error("macOS auto-update requires a zip artifact");
+              }
+              if (!files.some((name) => name.endsWith(".zip.blockmap"))) {
+                throw new Error("macOS auto-update requires a zip blockmap");
+              }
+            }
+          '
       - uses: actions/upload-artifact@v7
         with:
           name: desktop-${{ matrix.id }}
-          path: apps/desktop/dist/${{ matrix.artifact_glob }}
+          path: |
+            apps/desktop/dist/sprocket-desktop-*
+            apps/desktop/dist/*.yml
+            apps/desktop/dist/*.blockmap
           if-no-files-found: error
 
   publish:
@@ -123,19 +183,25 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
       - uses: actions/download-artifact@v8
         with:
           pattern: desktop-*
           path: release-assets
-          merge-multiple: true
+      - name: Merge updater metadata
+        shell: bash
+        run: bun apps/desktop/scripts/merge-update-metadata.mjs --input release-assets --output release-publish
       - name: Generate checksums
-        working-directory: release-assets
-        run: sha256sum sprocket-desktop-* | tee SHA256SUMS
+        working-directory: release-publish
+        run: sha256sum * | tee SHA256SUMS
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           prerelease: ${{ contains(github.ref_name, '-canary.') }}
           files: |
-            release-assets/sprocket-desktop-*
-            release-assets/SHA256SUMS
+            release-publish/sprocket-desktop-*
+            release-publish/*.yml
+            release-publish/SHA256SUMS
           fail_on_unmatched_files: true

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -6,6 +6,16 @@ a retired function name can disappear.
 
 Current as of 2026-09-07.
 
+## In-app updates
+
+The desktop preload's `updates` capability is optional so a newer web bundle can
+still run inside a released desktop shell. A missing capability hides the update
+action, without falling through to updating an unrelated npm installation.
+Browser clients also accept a 404 from `/api/update` as unsupported for released
+local servers. Remove these fallbacks when every supported desktop shell exposes
+`updates` and every supported local server implements `/api/update`. No stored
+data changes are required.
+
 ## Transcript projection API
 
 Attachment compatibility covers older stored schemas only. Older-client shims

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7812,6 +7812,7 @@ dependencies = [
  "gix",
  "hmac 0.13.0",
  "keyring",
+ "libc",
  "open",
  "reqwest 0.13.4",
  "serde",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ To always open a tab in your browser when using Sprocket, use the `--web` flag:
 sprocket --web
 ```
 
+### Updating
+
+When an update is available, an action appears above Settings. In the desktop
+app, click it to download the update, then choose **Restart to update** when
+active work has finished. Native macOS updates require a signed desktop build.
+
+For a supported global package-manager installation, use the same action in the
+browser app or run either command:
+
+```sh
+sprocket update
+sprocket upgrade
+```
+
+Both commands use the package manager that owns the installation and keep its
+release channel. Stable and canary installs only move forward. A `dev` install
+follows the current `dev` tag when the commit hash changes. Add `--check` to
+check without installing. After a browser-app update, stop the running server
+and launch Sprocket again to use the new version. Package updates do not restart
+or interrupt active agents automatically.
+
+For temporary runs, request the current release explicitly, for example
+`npx @spikonado/sprocket@latest`. Local project dependencies should be updated
+through that project's package manager, not converted into a global install.
+
 ### Workspaces
 
 Pass a directory to open or reconnect that workspace in a new thread:
@@ -63,6 +88,9 @@ Override with `SPROCKET_DATA_DIR`.
 
 | Command                     | Behavior                                                                       |
 | --------------------------- | ------------------------------------------------------------------------------ |
+| `sprocket update`           | Update a global npm, bun, pnpm, or yarn install on the current channel.        |
+| `sprocket update --check`   | Report whether an update is available without installing.                      |
+| `sprocket upgrade`          | Alias for `update`.                                                            |
 | `sprocket serve`            | Run the local server in the foreground without launching a client.             |
 | `sprocket serve --api-only` | Serve only `/api`; intended for development (see [Development](#development)). |
 

--- a/README.md
+++ b/README.md
@@ -46,31 +46,6 @@ To always open a tab in your browser when using Sprocket, use the `--web` flag:
 sprocket --web
 ```
 
-### Updating
-
-When an update is available, an action appears above Settings. In the desktop
-app, click it to download the update, then choose **Restart to update** when
-active work has finished. Native macOS updates require a signed desktop build.
-
-For a supported global package-manager installation, use the same action in the
-browser app or run either command:
-
-```sh
-sprocket update
-sprocket upgrade
-```
-
-Both commands use the package manager that owns the installation and keep its
-release channel. Stable and canary installs only move forward. A `dev` install
-follows the current `dev` tag when the commit hash changes. Add `--check` to
-check without installing. After a browser-app update, stop the running server
-and launch Sprocket again to use the new version. Package updates do not restart
-or interrupt active agents automatically.
-
-For temporary runs, request the current release explicitly, for example
-`npx @spikonado/sprocket@latest`. Local project dependencies should be updated
-through that project's package manager, not converted into a global install.
-
 ### Workspaces
 
 Pass a directory to open or reconnect that workspace in a new thread:

--- a/apps/desktop/RELEASING.md
+++ b/apps/desktop/RELEASING.md
@@ -75,6 +75,19 @@ Windows SmartScreen warns on the unsigned NSIS installer.
 
 Linux AppImage updates do not need a signature for the GitHub provider.
 
+### Linux relaunch
+
+AppImage relaunch uses a detached shell that waits for the replacement process.
+NixOS `appimage-run` starts Bubblewrap with `--die-with-parent`, so launching the
+replacement directly from Electron would kill its launcher as the old app exits.
+The shell forwards the executable and arguments as positional parameters, not
+shell source, and exits when the replacement closes.
+
+Test updates with both the published filename and a custom name such as
+`sprocket.AppImage`. A custom name without a version number is preserved by
+`electron-updater`. Verify that the replacement opens and displays the new UI,
+not just that the update download finishes.
+
 ## Local package
 
 ```sh

--- a/apps/desktop/RELEASING.md
+++ b/apps/desktop/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing the Sprocket desktop app
+
+GitHub Releases at `spikonado/sprocket` are the desktop update feed.
+`electron-builder` 26 writes `app-update.yml` into each packaged app with that GitHub provider.
+Installed copies then fetch channel files (`latest.yml` / `canary.yml` and the platform suffixes) through `electron-updater` 6.
+
+Keep this packaging config on electron-builder 26 keys.
+`zip.writeUpdateInfo`, grouped `nativeModules`, and `electronGet` are not part of the 26.15 schema this repo uses.
+
+## Channels
+
+Push a tag.
+
+| Tag                                  | GitHub release            | Channel files                                                                |
+| ------------------------------------ | ------------------------- | ---------------------------------------------------------------------------- |
+| `vX.Y.Z`                             | Latest (not a prerelease) | `latest.yml`, `latest-mac.yml`, `latest-linux.yml`, `latest-linux-arm64.yml` |
+| `vX.Y.Z-canary.anything-can-go-here` | Prerelease                | `canary.yml`, `canary-mac.yml`, `canary-linux.yml`, `canary-linux-arm64.yml` |
+
+GitHub publishing does not infer the channel from the version on its own.
+The workflow writes `build.publish.channel` before `electron-builder` runs.
+
+Stable installs query `/releases/latest` and the `latest*` files.
+Canary installs (`*-canary.*`) set `allowPrerelease` and look for `canary*` files on the newest matching prerelease tag.
+
+`app-update.yml` does not contain `autoDownload` or `autoInstallOnAppQuit`.
+Those stay false in the packaged main process so a found update never downloads or installs until the UI asks.
+
+## Artifacts
+
+Each matrix leg builds with `--publish never`, then the publish job copies installers, zips, blockmaps, and yml into one directory.
+
+macOS ships both `dmg` (installer) and `zip` (Squirrel.Mac / `electron-updater`).
+The zip blockmap is required for differential downloads.
+
+`latest-mac.yml` / `canary-mac.yml` are the only names both Mac arches write.
+The publish job merges only the `files` list so both `x64` and `arm64` zips stay listed.
+Fields such as `releaseNotes`, `stagingPercentage`, and `isAdminRightsRequired` are kept when they match, or filled in from the arch that set them.
+A colliding installer, a different `version`, or a metadata entry with the same URL and a different checksum fails the job instead of keeping whichever arch finished last.
+The merge script refuses to write into a nonempty `--output` directory and will not delete that path.
+
+The publish job runs `bun install --frozen-lockfile` so the merge script can import `js-yaml`.
+Linux already uses `*-linux.yml` vs `*-linux-arm64.yml`, so those do not merge.
+
+## Signing and notarization
+
+macOS signing is optional in this workflow.
+GitHub-hosted Macs have unrelated identities, so `CSC_IDENTITY_AUTO_DISCOVERY` stays `false` until `CSC_LINK` is set.
+
+Set these repository secrets when you want signed, notarized Mac builds.
+
+| Secret             | Use                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `CSC_LINK`         | Base64-encoded Developer ID Application `.p12`, used only on macOS jobs                                            |
+| `CSC_KEY_PASSWORD` | Password for that `.p12`                                                                                           |
+| `APPLE_API_KEY`    | App Store Connect API `.p8` as PEM or base64. Written to a temp file because `@electron/notarize` 2.5 wants a path |
+| `APPLE_API_KEY_ID` | Key ID                                                                                                             |
+| `APPLE_API_ISSUER` | Issuer UUID                                                                                                        |
+
+Apple ID notarization is the fallback if the API key is unset. Set `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID` together.
+Do not set `APPLE_TEAM_ID` when using API key credentials. `@electron/notarize` rejects that mix.
+
+Windows signing uses `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD` on the Windows job only.
+`forceCodeSigning` stays false so a missing cert still produces installers.
+
+### Unsigned builds
+
+Without those secrets, CI still publishes installers.
+
+macOS Gatekeeper blocks first launch until the user opens the app from Finder.
+In-app Mac updates need a signed build. Leave `CSC_LINK` unset only when you are publishing installers that people will open from Finder, not update in place.
+Notarization does not run, so later macOS versions keep the unidentified-developer warning.
+
+Windows SmartScreen warns on the unsigned NSIS installer.
+`electron-updater` skips publisher checks when `app-update.yml` has no `publisherName`, which unsigned Windows builds will not have.
+
+Linux AppImage updates do not need a signature for the GitHub provider.
+
+## Local package
+
+```sh
+bun run build:release
+```
+
+Artifacts land in `apps/desktop/dist/` as `sprocket-desktop-*`.
+That command does not publish. Channel files appear locally when `build.publish` is present, which it is.

--- a/apps/desktop/main.mjs
+++ b/apps/desktop/main.mjs
@@ -6,7 +6,7 @@ import { spawn } from 'node:child_process';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { DEV_API_PORT, DEV_WEB_URL, INSTALLED_APP_PORT } from './local-config.mjs';
-import { DesktopUpdater, stopUpdateProcess } from './updater.mjs';
+import { createAppImageUpdater, DesktopUpdater, stopUpdateProcess } from './updater.mjs';
 
 const { app, BrowserWindow, dialog, Menu, ipcMain, shell } = electron;
 
@@ -31,7 +31,9 @@ let mainWindowRef = null;
 let serverReadyPromise = null;
 let isQuitting = false;
 const updates = new DesktopUpdater(
-	electronUpdater.autoUpdater,
+	process.platform === 'linux' && process.env.APPIMAGE
+		? createAppImageUpdater(electronUpdater.AppImageUpdater)
+		: electronUpdater.autoUpdater,
 	app.getVersion(),
 	app.isPackaged && (process.platform !== 'linux' || Boolean(process.env.APPIMAGE))
 );

--- a/apps/desktop/main.mjs
+++ b/apps/desktop/main.mjs
@@ -1,10 +1,12 @@
 import electron from 'electron';
+import electronUpdater from 'electron-updater';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { DEV_API_PORT, DEV_WEB_URL, INSTALLED_APP_PORT } from './local-config.mjs';
+import { DesktopUpdater, stopUpdateProcess } from './updater.mjs';
 
 const { app, BrowserWindow, dialog, Menu, ipcMain, shell } = electron;
 
@@ -28,6 +30,19 @@ let serverDesktopLoginCallbackUrl = null;
 let mainWindowRef = null;
 let serverReadyPromise = null;
 let isQuitting = false;
+const updates = new DesktopUpdater(
+	electronUpdater.autoUpdater,
+	app.getVersion(),
+	app.isPackaged && (process.platform !== 'linux' || Boolean(process.env.APPIMAGE))
+);
+let updateTimer = null;
+let updateConfirmationOpen = false;
+let shutdownPromise = null;
+updates.subscribe((state) => {
+	if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+		mainWindowRef.webContents.send('sprocket:update-state', state);
+	}
+});
 const initialWorkspaceLaunch = app.commandLine.getSwitchValue('sprocket-workspace').trim() || null;
 const pendingWorkspaceLaunches = initialWorkspaceLaunch ? [initialWorkspaceLaunch] : [];
 
@@ -257,6 +272,9 @@ async function startLocalServer() {
 		SPROCKET_DATA_DIR: dataDir,
 		SPROCKET_DESKTOP_BOOTSTRAP_TOKEN: desktopBootstrapToken
 	};
+	delete serverEnv.SPROCKET_UPDATE_NODE;
+	delete serverEnv.SPROCKET_UPDATE_SCRIPT;
+	delete serverEnv.SPROCKET_UPDATE_MANAGED;
 	if (staticDir) {
 		serverEnv.SPROCKET_STATIC_DIR = staticDir;
 	}
@@ -324,13 +342,13 @@ async function startLocalServer() {
 	return serverBaseUrl;
 }
 
-function stopLocalServer() {
-	if (!serverProcess || serverProcess.killed) {
-		return;
-	}
-
-	serverProcess.kill();
+async function stopServerBeforeUpdate() {
+	const child = serverProcess;
+	if (!child) return;
+	await stopUpdateProcess(child);
 	serverProcess = null;
+	serverBaseUrl = null;
+	serverReadyPromise = null;
 }
 
 function queueWorkspaceLaunch(workspacePath) {
@@ -470,6 +488,72 @@ ipcMain.handle('sprocket:take-workspace-launch', (event) => {
 	return pendingWorkspaceLaunches.shift() ?? null;
 });
 
+function requireUpdateRenderer(event) {
+	requireTrustedRenderer(event);
+	if (event.sender !== mainWindowRef?.webContents || event.senderFrame !== event.sender.mainFrame) {
+		throw new Error('Untrusted update request.');
+	}
+}
+
+ipcMain.handle('sprocket:get-update-state', (event) => {
+	requireUpdateRenderer(event);
+	return updates.getState();
+});
+
+ipcMain.handle('sprocket:download-update', (event) => {
+	requireUpdateRenderer(event);
+	void updates.download();
+	return updates.getState();
+});
+
+ipcMain.handle('sprocket:install-update', async (event) => {
+	requireUpdateRenderer(event);
+	if (updateConfirmationOpen || updates.getState().status !== 'downloaded') {
+		return updates.getState();
+	}
+	updateConfirmationOpen = true;
+	try {
+		const { response } = await dialog.showMessageBox(mainWindowRef, {
+			type: 'question',
+			buttons: ['Cancel', 'Restart and update'],
+			defaultId: 0,
+			cancelId: 0,
+			message: 'Restart Sprocket to install the update?',
+			detail: serverProcess
+				? 'This stops the local server and interrupts any agents it is running. Wait for active work to finish before restarting.'
+				: 'This restarts the desktop app. The local server was started separately and will keep running.'
+		});
+		if (response === 1 && !isQuitting) {
+			if (process.platform === 'darwin') {
+				// Squirrel validates the staged update asynchronously and may reject it without quitting.
+				updates.install();
+				return updates.getState();
+			}
+			isQuitting = true;
+			try {
+				await stopServerBeforeUpdate();
+				// AppImage can launch its replacement before the old Electron process exits.
+				app.releaseSingleInstanceLock();
+				if (!updates.install()) {
+					isQuitting = false;
+					if (!app.requestSingleInstanceLock()) {
+						app.quit();
+					} else {
+						serverReadyPromise = startLocalServer();
+						await serverReadyPromise;
+					}
+				}
+			} catch (error) {
+				isQuitting = false;
+				reportFatalError('Failed to install Sprocket update', error);
+			}
+		}
+		return updates.getState();
+	} finally {
+		updateConfirmationOpen = false;
+	}
+});
+
 function openWithXdgOpen(url) {
 	return new Promise((resolve, reject) => {
 		const systemOpeners = [
@@ -576,6 +660,9 @@ if (hasSingleInstanceLock) {
 	serverReadyPromise = app.whenReady().then(async () => {
 		Menu.setApplicationMenu(null);
 		await startLocalServer();
+		void updates.check();
+		updateTimer = setInterval(() => void updates.check(), 60 * 60 * 1000);
+		updateTimer.unref();
 	});
 
 	void serverReadyPromise
@@ -598,7 +685,21 @@ app.on('window-all-closed', () => {
 	}
 });
 
-app.on('before-quit', () => {
+app.on('before-quit', (event) => {
 	isQuitting = true;
-	stopLocalServer();
+	clearInterval(updateTimer);
+	if (!serverProcess) return;
+	event.preventDefault();
+	shutdownPromise ??= stopServerBeforeUpdate()
+		.then(() => {
+			if (process.platform === 'darwin' && updates.getState().status === 'installing') {
+				electronUpdater.autoUpdater.quitAndInstall();
+			} else {
+				app.quit();
+			}
+		})
+		.catch((error) => {
+			reportFatalError('Failed to stop Sprocket server', error);
+			app.exit(1);
+		});
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,10 +8,16 @@
 	"type": "module",
 	"main": "./main.mjs",
 	"desktopName": "com.spikonado.sprocket.desktop",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/spikonado/sprocket.git",
+		"directory": "apps/desktop"
+	},
 	"scripts": {
 		"dev": "cargo build -q -p sprocket-cli && node ./launch.cjs",
 		"build": "cargo build -p sprocket-cli",
-		"build:release": "cargo build --release -p sprocket-cli && electron-builder --publish never"
+		"build:release": "cargo build --release -p sprocket-cli && electron-builder --publish never",
+		"test": "node --test test/*.test.mjs"
 	},
 	"build": {
 		"appId": "com.spikonado.sprocket",
@@ -23,6 +29,7 @@
 		},
 		"files": [
 			"main.mjs",
+			"updater.mjs",
 			"preload.cjs",
 			"local-config.mjs",
 			"package.json"
@@ -44,6 +51,11 @@
 				]
 			}
 		],
+		"publish": {
+			"provider": "github",
+			"owner": "spikonado",
+			"repo": "sprocket"
+		},
 		"linux": {
 			"target": [
 				"AppImage"
@@ -54,7 +66,8 @@
 		},
 		"mac": {
 			"target": [
-				"dmg"
+				"dmg",
+				"zip"
 			],
 			"category": "public.app-category.developer-tools",
 			"forceCodeSigning": false,
@@ -72,8 +85,12 @@
 			"allowToChangeInstallationDirectory": true
 		}
 	},
+	"dependencies": {
+		"electron-updater": "^6.8.9"
+	},
 	"devDependencies": {
 		"electron": "^44.0.0",
-		"electron-builder": "^26.15.3"
+		"electron-builder": "^26.15.3",
+		"js-yaml": "^4.1.0"
 	}
 }

--- a/apps/desktop/preload.cjs
+++ b/apps/desktop/preload.cjs
@@ -1,6 +1,16 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('sprocketDesktopBridge', {
+	updates: {
+		getState: () => ipcRenderer.invoke('sprocket:get-update-state'),
+		download: () => ipcRenderer.invoke('sprocket:download-update'),
+		install: () => ipcRenderer.invoke('sprocket:install-update'),
+		onState: (callback) => {
+			const listener = (_event, state) => callback(state);
+			ipcRenderer.on('sprocket:update-state', listener);
+			return () => ipcRenderer.removeListener('sprocket:update-state', listener);
+		}
+	},
 	getLocalBootstrap: () => ipcRenderer.invoke('sprocket:get-local-bootstrap'),
 	takeWorkspaceLaunch: () => ipcRenderer.invoke('sprocket:take-workspace-launch'),
 	onWorkspaceLaunch: (callback) => {

--- a/apps/desktop/scripts/merge-update-metadata.mjs
+++ b/apps/desktop/scripts/merge-update-metadata.mjs
@@ -1,0 +1,332 @@
+import { createHash } from 'node:crypto';
+import { createReadStream, constants as fsConstants } from 'node:fs';
+import { copyFile, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { dump as dumpYaml, load as loadYaml } from 'js-yaml';
+
+const SKIP_NAMES = new Set(['builder-debug.yml', 'builder-effective-config.yaml']);
+const UPDATE_METADATA_NAME = /^(latest|alpha|beta|canary)(?:-linux(?:-arm64|-arm)?|-mac)?\.yml$/;
+const FILE_LIST_KEYS = new Set(['files', 'path', 'sha512', 'releaseDate']);
+const CORE_DUMP_KEYS = new Set(['version', 'files', 'path', 'sha512']);
+
+export function isUpdateMetadataName(name) {
+	return UPDATE_METADATA_NAME.test(name);
+}
+
+export function archHints(url) {
+	const hints = new Set();
+	if (/(?:^|[^a-z0-9])arm64(?:[^a-z0-9]|$)/i.test(url) || /aarch64/i.test(url)) {
+		hints.add('arm64');
+	} else if (/(?:^|[^a-z0-9])x64(?:[^a-z0-9]|$)/i.test(url) || /x86_64/i.test(url)) {
+		hints.add('x64');
+	} else if (/(?:^|[^a-z0-9])arm(?:[^a-z0-9]|$)/i.test(url)) {
+		hints.add('arm');
+	}
+	return hints;
+}
+
+function isPlainObject(value) {
+	return value !== null && value === Object(value) && !Array.isArray(value);
+}
+
+function reviveYamlValue(value) {
+	if (value instanceof Date) {
+		return value.toISOString();
+	}
+	if (Array.isArray(value)) {
+		return value.map(reviveYamlValue);
+	}
+	if (isPlainObject(value)) {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, nested]) => [key, reviveYamlValue(nested)])
+		);
+	}
+	return value;
+}
+
+function valuesEqual(left, right) {
+	if (Object.is(left, right)) {
+		return true;
+	}
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function parseUpdateInfoYaml(text, filePath = 'update.yml') {
+	let loaded;
+	try {
+		loaded = reviveYamlValue(loadYaml(text));
+	} catch (error) {
+		throw new Error(`${filePath} is not valid YAML: ${error.message}`);
+	}
+	if (!isPlainObject(loaded) || loaded.version == null || loaded.version === '') {
+		throw new Error(`${filePath} is not electron-builder update metadata.`);
+	}
+	if (!Array.isArray(loaded.files) || loaded.files.length === 0) {
+		throw new Error(`${filePath} is not electron-builder update metadata.`);
+	}
+	for (const file of loaded.files) {
+		if (!isPlainObject(file) || !file.url || !file.sha512) {
+			throw new Error(`${filePath} has an incomplete files entry.`);
+		}
+	}
+	return { ...loaded, version: String(loaded.version) };
+}
+
+function fileSortKey(file) {
+	const url = file.url;
+	if (url.endsWith('.zip')) {
+		return 0;
+	}
+	if (url.endsWith('.exe') || url.endsWith('.AppImage')) {
+		return 1;
+	}
+	return 2;
+}
+
+export function serializeUpdateInfoYaml(info) {
+	const files = [...info.files].sort((left, right) => fileSortKey(left) - fileSortKey(right));
+	const primary = files[0];
+	const document = {
+		version: info.version,
+		files,
+		path: info.path ?? primary.url,
+		sha512: info.sha512 ?? primary.sha512
+	};
+	for (const [key, value] of Object.entries(info)) {
+		if (CORE_DUMP_KEYS.has(key) || value === undefined) {
+			continue;
+		}
+		document[key] = value;
+	}
+	return dumpYaml(document, { lineWidth: -1, noRefs: true, quotingType: "'" });
+}
+
+function mergeFileEntry(existing, incoming, filePath) {
+	const merged = { ...existing };
+	for (const key of new Set([...Object.keys(existing), ...Object.keys(incoming)])) {
+		if (!(key in existing)) {
+			merged[key] = incoming[key];
+			continue;
+		}
+		if (!(key in incoming)) {
+			continue;
+		}
+		if (!valuesEqual(existing[key], incoming[key])) {
+			throw new Error(
+				`Refusing to overwrite ${existing.url} from ${filePath}. x64 and arm64 artifacts must both be kept.`
+			);
+		}
+	}
+	return merged;
+}
+
+function assertCompatibleMetadata(base, other, filePath) {
+	if (other.version !== base.version) {
+		throw new Error(
+			`Refusing to merge ${filePath} at version ${other.version} with ${base.version}.`
+		);
+	}
+	for (const key of new Set([...Object.keys(base), ...Object.keys(other)])) {
+		if (FILE_LIST_KEYS.has(key) || key === 'version') {
+			continue;
+		}
+		if (key in base && key in other && !valuesEqual(base[key], other[key])) {
+			throw new Error(`Refusing to merge ${filePath}: ${key} is not compatible.`);
+		}
+	}
+}
+
+export function mergeUpdateInfo(manifests) {
+	if (manifests.length === 0) {
+		throw new Error('No update metadata to merge.');
+	}
+	const base = { ...manifests[0].info };
+	const requiredArches = new Set();
+	const filesByUrl = new Map();
+
+	for (const { info, filePath } of manifests) {
+		assertCompatibleMetadata(base, info, filePath);
+		for (const [key, value] of Object.entries(info)) {
+			if (FILE_LIST_KEYS.has(key) || key === 'version' || value === undefined) {
+				continue;
+			}
+			if (!(key in base)) {
+				base[key] = value;
+			}
+		}
+		if (
+			info.releaseDate &&
+			(!base.releaseDate || String(info.releaseDate) > String(base.releaseDate))
+		) {
+			base.releaseDate = info.releaseDate;
+		}
+		for (const file of info.files) {
+			for (const arch of archHints(file.url)) {
+				requiredArches.add(arch);
+			}
+			const existing = filesByUrl.get(file.url);
+			filesByUrl.set(
+				file.url,
+				existing == null ? { ...file } : mergeFileEntry(existing, file, filePath)
+			);
+		}
+	}
+
+	const files = [...filesByUrl.values()];
+	const presentArches = new Set(files.flatMap((file) => [...archHints(file.url)]));
+	for (const arch of requiredArches) {
+		if (!presentArches.has(arch)) {
+			throw new Error(`Merged update metadata dropped the ${arch} artifact.`);
+		}
+	}
+
+	const zip = files.find((file) => file.url.endsWith('.zip')) ?? files[0];
+	return {
+		...base,
+		files,
+		path: zip.url,
+		sha512: zip.sha512
+	};
+}
+
+async function hashFile(file) {
+	const digest = createHash('sha256');
+	for await (const chunk of createReadStream(file)) {
+		digest.update(chunk);
+	}
+	return digest.digest('hex');
+}
+
+function isPathInside(inner, outer) {
+	const relative = path.relative(outer, inner);
+	return (
+		relative === '' ||
+		(relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+	);
+}
+
+async function listSources(input) {
+	const entries = await readdir(input, { withFileTypes: true });
+	const directories = entries
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(input, entry.name));
+	return directories.length > 0 ? directories.sort() : [input];
+}
+
+async function prepareOutputDirectory(input, output) {
+	const resolvedInput = path.resolve(input);
+	const resolvedOutput = path.resolve(output);
+	let inputStat;
+	try {
+		inputStat = await stat(resolvedInput);
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			throw new Error(`input does not exist: ${resolvedInput}`);
+		}
+		throw error;
+	}
+	if (!inputStat.isDirectory()) {
+		throw new Error('input must be a directory');
+	}
+	if (isPathInside(resolvedOutput, resolvedInput) || isPathInside(resolvedInput, resolvedOutput)) {
+		throw new Error('output must not overlap input');
+	}
+
+	let outputStat;
+	try {
+		outputStat = await stat(resolvedOutput);
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			await mkdir(resolvedOutput, { recursive: true });
+			return { resolvedInput, resolvedOutput };
+		}
+		throw error;
+	}
+	if (!outputStat.isDirectory()) {
+		throw new Error('output must be a directory');
+	}
+	const entries = await readdir(resolvedOutput);
+	if (entries.length > 0) {
+		throw new Error('output must be nonexistent or empty');
+	}
+	return { resolvedInput, resolvedOutput };
+}
+
+export async function mergeUpdateMetadata(input, output) {
+	const { resolvedInput, resolvedOutput } = await prepareOutputDirectory(input, output);
+	const planned = new Map();
+	const metadata = new Map();
+
+	for (const source of await listSources(resolvedInput)) {
+		for (const name of await readdir(source)) {
+			if (SKIP_NAMES.has(name)) {
+				continue;
+			}
+			const filePath = path.join(source, name);
+			if (!(await stat(filePath)).isFile()) {
+				continue;
+			}
+			if (isUpdateMetadataName(name)) {
+				const list = metadata.get(name) ?? [];
+				list.push({
+					filePath,
+					info: parseUpdateInfoYaml(await readFile(filePath, 'utf8'), filePath)
+				});
+				metadata.set(name, list);
+				continue;
+			}
+			const digest = await hashFile(filePath);
+			const existing = planned.get(name);
+			if (existing != null && existing.digest !== digest) {
+				throw new Error(
+					`Refusing to overwrite ${name}. Keep both ${existing.filePath} and ${filePath}.`
+				);
+			}
+			planned.set(name, { filePath, digest });
+		}
+	}
+
+	for (const [name, manifests] of metadata) {
+		const merged = mergeUpdateInfo(manifests);
+		await writeFile(path.join(resolvedOutput, name), serializeUpdateInfoYaml(merged), {
+			flag: 'wx'
+		});
+	}
+	await Promise.all(
+		[...planned.entries()].map(([name, file]) =>
+			copyFile(file.filePath, path.join(resolvedOutput, name), fsConstants.COPYFILE_EXCL)
+		)
+	);
+}
+
+function argumentsFrom(argv) {
+	const values = new Map();
+	for (let index = 0; index < argv.length; index += 2) {
+		const key = argv[index];
+		const value = argv[index + 1];
+		if (!key?.startsWith('--') || !value) {
+			throw new Error('usage: merge-update-metadata.mjs --input DIR --output DIR');
+		}
+		values.set(key.slice(2), value);
+	}
+	return values;
+}
+
+async function main() {
+	const args = argumentsFrom(process.argv.slice(2));
+	const input = args.get('input');
+	const output = args.get('output');
+	if (!input || !output) {
+		throw new Error('usage: merge-update-metadata.mjs --input DIR --output DIR');
+	}
+	await mergeUpdateMetadata(input, output);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main().catch((error) => {
+		console.error(error.message);
+		process.exitCode = 1;
+	});
+}

--- a/apps/desktop/test/appimage-relaunch.test.mjs
+++ b/apps/desktop/test/appimage-relaunch.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { execFile, spawn } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { createAppImageUpdater } from '../updater.mjs';
+
+const exec = promisify(execFile);
+const skipOnWindows = { skip: process.platform === 'win32' };
+const testFile = fileURLToPath(import.meta.url);
+const relaunchArgs = ['renamed AppImage', '$(exit 47)', '"; exit 48; #'];
+const rolePrefix = '--sprocket-appimage-role=';
+const originalPidPrefix = '--sprocket-original-pid=';
+
+function createTestUpdater(spawnLog) {
+	return createAppImageUpdater(
+		class {
+			spawnLog(...args) {
+				return spawnLog(...args);
+			}
+		}
+	);
+}
+
+function isAlive(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if (error.code === 'ESRCH') return false;
+		throw error;
+	}
+}
+
+function waitUntil(predicate, timeoutMs, message) {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error(message);
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+	}
+}
+
+function flagValue(prefix) {
+	const arg = process.argv.find((value) => value.startsWith(prefix));
+	return arg?.slice(prefix.length) ?? null;
+}
+
+function execEnv() {
+	const env = { ...process.env };
+	delete env.NODE_TEST_CONTEXT;
+	delete env.NODE_CHANNEL_FD;
+	return env;
+}
+
+const role = flagValue(rolePrefix);
+
+if (role === 'original-app') {
+	const updater = createTestUpdater((command, args) => {
+		const child = spawn(command, args, { detached: true, stdio: ['ignore', 'inherit', 'inherit'] });
+		child.unref();
+	});
+	updater.spawnLog(process.execPath, [
+		testFile,
+		`${rolePrefix}replacement`,
+		`${originalPidPrefix}${process.pid}`
+	]);
+	process.exit(0);
+}
+
+if (role === 'replacement') {
+	const originalParent = Number(flagValue(originalPidPrefix));
+	const parentAtStart = process.ppid;
+	waitUntil(() => !isAlive(originalParent), 4000, 'original app did not exit');
+	process.kill(parentAtStart, 0);
+	console.log(
+		JSON.stringify({
+			originalAlive: isAlive(originalParent),
+			originalParent,
+			parent: process.ppid,
+			parentAtStart
+		})
+	);
+	process.exit(0);
+}
+
+test('AppImage relaunch passes paths and arguments literally', skipOnWindows, async () => {
+	const updater = createTestUpdater((command, args, env) =>
+		exec(command, args, { env, timeout: 5000 })
+	);
+	const result = await updater.spawnLog(
+		process.execPath,
+		['-e', 'console.log(JSON.stringify(process.argv.slice(1)))', ...relaunchArgs],
+		process.env
+	);
+	assert.deepEqual(JSON.parse(result.stdout), relaunchArgs);
+});
+
+test(
+	'AppImage launcher retains a living parent after the old app exits',
+	skipOnWindows,
+	async () => {
+		const { stdout, stderr } = await exec(
+			process.execPath,
+			[testFile, `${rolePrefix}original-app`],
+			{
+				timeout: 5000,
+				env: execEnv()
+			}
+		);
+		assert.ok(stdout, stderr || 'replacement produced no output');
+		const result = JSON.parse(stdout);
+		assert.equal(result.originalAlive, false);
+		assert.equal(result.parent, result.parentAtStart);
+		assert.notEqual(result.parent, result.originalParent);
+		assert.ok(result.parent > 1);
+	}
+);

--- a/apps/desktop/test/merge-update-metadata.test.mjs
+++ b/apps/desktop/test/merge-update-metadata.test.mjs
@@ -1,0 +1,238 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import {
+	archHints,
+	isUpdateMetadataName,
+	mergeUpdateInfo,
+	mergeUpdateMetadata,
+	parseUpdateInfoYaml,
+	serializeUpdateInfoYaml
+} from '../scripts/merge-update-metadata.mjs';
+
+const SCRIPT = path.resolve(import.meta.dirname, '../scripts/merge-update-metadata.mjs');
+
+function macManifest(arch, extras = {}) {
+	const version = extras.version ?? '1.2.3';
+	return serializeUpdateInfoYaml({
+		version,
+		files: [
+			{
+				url: `sprocket-desktop-${version}-mac-${arch}.zip`,
+				sha512: `${arch}-zip-sha`,
+				size: arch === 'arm64' ? 10 : 11,
+				blockMapSize: 2
+			},
+			{
+				url: `sprocket-desktop-${version}-mac-${arch}.dmg`,
+				sha512: `${arch}-dmg-sha`,
+				size: arch === 'arm64' ? 20 : 21
+			}
+		],
+		path: `sprocket-desktop-${version}-mac-${arch}.zip`,
+		sha512: `${arch}-zip-sha`,
+		releaseDate: extras.releaseDate ?? '2026-09-07T00:00:00.000Z',
+		isAdminRightsRequired: extras.isAdminRightsRequired,
+		stagingPercentage: extras.stagingPercentage,
+		releaseNotes: extras.releaseNotes
+	});
+}
+
+test('names GitHub channel files and keeps x64 out of arm64 hints', () => {
+	assert.equal(isUpdateMetadataName('latest-mac.yml'), true);
+	assert.equal(isUpdateMetadataName('canary-linux-arm64.yml'), true);
+	assert.equal(isUpdateMetadataName('builder-debug.yml'), false);
+	assert.deepEqual([...archHints('sprocket-desktop-1.2.3-mac-arm64.zip')], ['arm64']);
+	assert.deepEqual([...archHints('sprocket-desktop-1.2.3-mac-x64.zip')], ['x64']);
+});
+
+test('merges per-arch files and keeps extra update fields', () => {
+	const merged = mergeUpdateInfo([
+		{
+			filePath: 'arm64/latest-mac.yml',
+			info: parseUpdateInfoYaml(
+				macManifest('arm64', {
+					isAdminRightsRequired: false,
+					releaseNotes: 'signed builds'
+				})
+			)
+		},
+		{
+			filePath: 'x64/latest-mac.yml',
+			info: parseUpdateInfoYaml(
+				macManifest('x64', {
+					releaseDate: '2026-09-07T01:00:00.000Z',
+					stagingPercentage: 25
+				})
+			)
+		}
+	]);
+	assert.equal(merged.version, '1.2.3');
+	assert.equal(merged.isAdminRightsRequired, false);
+	assert.equal(merged.stagingPercentage, 25);
+	assert.equal(merged.releaseNotes, 'signed builds');
+	assert.deepEqual(merged.files.map((file) => file.url).sort(), [
+		'sprocket-desktop-1.2.3-mac-arm64.dmg',
+		'sprocket-desktop-1.2.3-mac-arm64.zip',
+		'sprocket-desktop-1.2.3-mac-x64.dmg',
+		'sprocket-desktop-1.2.3-mac-x64.zip'
+	]);
+	assert.equal(merged.path.endsWith('.zip'), true);
+	assert.equal(merged.releaseDate, '2026-09-07T01:00:00.000Z');
+});
+
+test('refuses version, channel-field, and same-url checksum collisions', () => {
+	const arm64 = parseUpdateInfoYaml(
+		macManifest('arm64', { stagingPercentage: 10, releaseNotes: 'notes' })
+	);
+	assert.throws(
+		() =>
+			mergeUpdateInfo([
+				{ filePath: 'arm64.yml', info: arm64 },
+				{ filePath: 'other.yml', info: { ...arm64, version: '9.9.9' } }
+			]),
+		/version 9\.9\.9/
+	);
+	assert.throws(
+		() =>
+			mergeUpdateInfo([
+				{ filePath: 'arm64.yml', info: arm64 },
+				{
+					filePath: 'x64.yml',
+					info: parseUpdateInfoYaml(macManifest('x64', { stagingPercentage: 90 }))
+				}
+			]),
+		/stagingPercentage is not compatible/
+	);
+	assert.throws(
+		() =>
+			mergeUpdateInfo([
+				{ filePath: 'arm64.yml', info: { ...arm64, channel: 'latest' } },
+				{
+					filePath: 'x64.yml',
+					info: {
+						...parseUpdateInfoYaml(macManifest('x64')),
+						channel: 'canary'
+					}
+				}
+			]),
+		/channel is not compatible/
+	);
+	assert.throws(
+		() =>
+			mergeUpdateInfo([
+				{ filePath: 'first.yml', info: arm64 },
+				{
+					filePath: 'second.yml',
+					info: {
+						...arm64,
+						files: [{ url: arm64.files[0].url, sha512: 'different', size: 99 }]
+					}
+				}
+			]),
+		/Refusing to overwrite/
+	);
+});
+
+test('copies unique artifacts and merges colliding canary metadata', async () => {
+	const temporary = await mkdtemp(path.join(tmpdir(), 'sprocket-desktop-meta-'));
+	const input = path.join(temporary, 'input');
+	const output = path.join(temporary, 'output');
+	try {
+		await mkdir(path.join(input, 'desktop-darwin-arm64'), { recursive: true });
+		await mkdir(path.join(input, 'desktop-darwin-x64'), { recursive: true });
+		await mkdir(path.join(input, 'desktop-linux-x64'), { recursive: true });
+		await writeFile(
+			path.join(input, 'desktop-darwin-arm64/sprocket-desktop-1.2.3-mac-arm64.zip'),
+			'arm64-zip'
+		);
+		await writeFile(
+			path.join(input, 'desktop-darwin-x64/sprocket-desktop-1.2.3-mac-x64.zip'),
+			'x64-zip'
+		);
+		await writeFile(
+			path.join(input, 'desktop-linux-x64/sprocket-desktop-1.2.3-linux-x64.AppImage'),
+			'linux'
+		);
+		await writeFile(
+			path.join(input, 'desktop-darwin-arm64/canary-mac.yml'),
+			macManifest('arm64', { version: '1.2.3-canary.1', releaseNotes: 'canary' })
+		);
+		await writeFile(
+			path.join(input, 'desktop-darwin-x64/canary-mac.yml'),
+			macManifest('x64', { version: '1.2.3-canary.1', releaseNotes: 'canary' })
+		);
+		await writeFile(path.join(input, 'desktop-darwin-arm64/builder-debug.yml'), 'skip me');
+		await mergeUpdateMetadata(input, output);
+
+		const merged = parseUpdateInfoYaml(await readFile(path.join(output, 'canary-mac.yml'), 'utf8'));
+		assert.equal(merged.version, '1.2.3-canary.1');
+		assert.equal(merged.releaseNotes, 'canary');
+		assert.equal(
+			merged.files.some((file) => file.url.includes('arm64')),
+			true
+		);
+		assert.equal(
+			merged.files.some((file) => file.url.includes('x64')),
+			true
+		);
+		assert.equal(
+			await readFile(path.join(output, 'sprocket-desktop-1.2.3-mac-arm64.zip'), 'utf8'),
+			'arm64-zip'
+		);
+		assert.equal(
+			await readFile(path.join(output, 'sprocket-desktop-1.2.3-mac-x64.zip'), 'utf8'),
+			'x64-zip'
+		);
+		await assert.rejects(readFile(path.join(output, 'builder-debug.yml')));
+	} finally {
+		await rm(temporary, { recursive: true, force: true });
+	}
+});
+
+test('fails instead of overwriting colliding installers', async () => {
+	const temporary = await mkdtemp(path.join(tmpdir(), 'sprocket-desktop-collide-'));
+	try {
+		const input = path.join(temporary, 'input');
+		await mkdir(path.join(input, 'a'), { recursive: true });
+		await mkdir(path.join(input, 'b'), { recursive: true });
+		await writeFile(path.join(input, 'a/sprocket-desktop-1.2.3-mac-x64.zip'), 'one');
+		await writeFile(path.join(input, 'b/sprocket-desktop-1.2.3-mac-x64.zip'), 'two');
+		await assert.rejects(
+			mergeUpdateMetadata(input, path.join(temporary, 'output')),
+			/Refusing to overwrite sprocket-desktop-1\.2\.3-mac-x64\.zip/
+		);
+	} finally {
+		await rm(temporary, { recursive: true, force: true });
+	}
+});
+
+test('rejects a nonempty or overlapping output without deleting it', async () => {
+	const temporary = await mkdtemp(path.join(tmpdir(), 'sprocket-desktop-output-'));
+	try {
+		const input = path.join(temporary, 'input');
+		const output = path.join(temporary, 'output');
+		await mkdir(path.join(input, 'desktop-darwin-arm64'), { recursive: true });
+		await mkdir(output);
+		await writeFile(path.join(input, 'desktop-darwin-arm64/latest-mac.yml'), macManifest('arm64'));
+		await writeFile(path.join(output, 'keep-me'), 'sentinel');
+		await assert.rejects(mergeUpdateMetadata(input, output), /nonexistent or empty/);
+		assert.equal(await readFile(path.join(output, 'keep-me'), 'utf8'), 'sentinel');
+		await assert.rejects(
+			mergeUpdateMetadata(input, path.join(input, 'nested')),
+			/output must not overlap input/
+		);
+		assert.equal(await readFile(path.join(output, 'keep-me'), 'utf8'), 'sentinel');
+	} finally {
+		await rm(temporary, { recursive: true, force: true });
+	}
+});
+
+test('CLI requires input and output directories', () => {
+	const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /usage: merge-update-metadata\.mjs --input DIR --output DIR/);
+});

--- a/apps/desktop/test/updater.test.mjs
+++ b/apps/desktop/test/updater.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import { DesktopUpdater, stopUpdateProcess } from '../updater.mjs';
+
+class FakeUpdater extends EventEmitter {
+	checks = 0;
+	downloads = 0;
+	installs = 0;
+	checkForUpdates = async () => {
+		this.checks += 1;
+		this.emit('update-available', { version: '1.1.0' });
+	};
+	downloadUpdate = async () => {
+		this.downloads += 1;
+		this.emit('download-progress', { percent: 51.2 });
+		this.emit('update-downloaded', { version: '1.1.0' });
+	};
+	quitAndInstall(silent, relaunch) {
+		assert.equal(silent, false);
+		assert.equal(relaunch, undefined);
+		this.installs += 1;
+	}
+}
+
+test('checking never downloads or installs without an explicit action', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0', true);
+	assert.equal(native.autoDownload, false);
+	assert.equal(native.autoInstallOnAppQuit, false);
+	assert.equal(native.autoRunAppAfterInstall, true);
+	assert.equal(native.allowDowngrade, false);
+	assert.equal(native.disableWebInstaller, true);
+	assert.equal(native.allowPrerelease, false);
+	assert.equal(updates.install(), false);
+	await updates.download();
+	assert.equal(native.downloads, 0);
+	await updates.check();
+	assert.equal(updates.getState().status, 'available');
+	assert.equal(native.downloads, 0);
+	assert.equal(native.installs, 0);
+	await updates.download();
+	assert.equal(updates.getState().status, 'downloaded');
+	assert.equal(native.installs, 0);
+	await updates.check();
+	assert.equal(native.checks, 1);
+	assert.equal(updates.install(), true);
+	assert.equal(updates.install(), false);
+	assert.equal(native.installs, 1);
+});
+
+test('development and unpacked Linux builds cannot update', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '0.0.0', false);
+	await updates.check();
+	await updates.download();
+	assert.equal(updates.install(), false);
+	assert.equal(updates.getState().status, 'unavailable');
+	assert.equal(native.checks, 0);
+});
+
+test('concurrent clicks share a download and do not overwrite its state', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0', true);
+	let finish;
+	native.downloadUpdate = () => {
+		native.downloads += 1;
+		return new Promise((resolve) => {
+			finish = resolve;
+		});
+	};
+	await updates.check();
+	const first = updates.download();
+	await updates.download();
+	await updates.check();
+	assert.equal(updates.getState().status, 'downloading');
+	assert.equal(native.downloads, 1);
+	assert.equal(updates.install(), false);
+	native.emit('update-downloaded', { version: '1.1.0' });
+	finish();
+	await first;
+	assert.equal(updates.getState().status, 'downloaded');
+});
+
+test('download errors preserve the version and can be retried', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0', true);
+	await updates.check();
+	const download = native.downloadUpdate;
+	native.downloadUpdate = async () => {
+		throw new Error('Connection lost');
+	};
+	await updates.download();
+	assert.equal(updates.getState().error, 'Connection lost');
+	assert.equal(updates.getState().version, '1.1.0');
+	native.downloadUpdate = download;
+	await updates.download();
+	assert.equal(updates.getState().status, 'downloaded');
+	assert.equal(updates.getState().error, null);
+});
+
+test('failed background checks retry and subscribers can unsubscribe', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0-canary.1', true);
+	assert.equal(native.allowPrerelease, true);
+	const check = native.checkForUpdates;
+	const states = [];
+	const unsubscribe = updates.subscribe((state) => states.push(state.status));
+	native.checkForUpdates = async () => {
+		throw new Error('Offline');
+	};
+	await updates.check();
+	assert.equal(updates.getState().status, 'error');
+	assert.equal(updates.getState().version, null);
+	assert.deepEqual(states, ['checking', 'error']);
+	unsubscribe();
+	native.checkForUpdates = check;
+	await updates.check();
+	assert.equal(updates.getState().status, 'available');
+	assert.deepEqual(states, ['checking', 'error']);
+});
+
+test('an installer error emitted synchronously does not report a successful restart', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0', true);
+	await updates.check();
+	await updates.download();
+	native.quitAndInstall = () => native.emit('error', new Error('Installer could not start'));
+	assert.equal(updates.install(), false);
+	assert.equal(updates.getState().status, 'downloaded');
+});
+
+test('asynchronous Squirrel failures leave a retryable update', async () => {
+	const native = new FakeUpdater();
+	const updates = new DesktopUpdater(native, '1.0.0', true);
+	await updates.check();
+	await updates.download();
+	updates.install();
+	native.emit('error', new Error('Code signature invalid'));
+	assert.equal(updates.getState().status, 'downloaded');
+	assert.equal(updates.getState().version, '1.1.0');
+	assert.equal(updates.install(), true);
+	assert.equal(native.downloads, 1);
+});
+
+test('owned server shutdown is bounded even with long-lived connections', async () => {
+	const child = new EventEmitter();
+	child.exitCode = null;
+	child.signalCode = null;
+	const signals = [];
+	child.kill = (signal) => {
+		signals.push(signal);
+		if (signal === 'SIGKILL') child.emit('exit', null, signal);
+	};
+	await stopUpdateProcess(child, 1, 100);
+	assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+	assert.equal(child.listenerCount('exit'), 0);
+	assert.equal(child.listenerCount('error'), 0);
+});
+
+test('a graceful server exit is not force-killed', async () => {
+	const child = new EventEmitter();
+	child.exitCode = null;
+	child.signalCode = null;
+	const signals = [];
+	child.kill = (signal) => {
+		signals.push(signal);
+		child.emit('exit', 0, null);
+	};
+	await stopUpdateProcess(child, 1, 100);
+	assert.deepEqual(signals, ['SIGTERM']);
+});

--- a/apps/desktop/updater.mjs
+++ b/apps/desktop/updater.mjs
@@ -1,0 +1,141 @@
+export class DesktopUpdater {
+	#updater;
+	#state;
+	#listeners = new Set();
+	#operation = null;
+	#enabled;
+
+	constructor(updater, currentVersion, enabled) {
+		this.#updater = updater;
+		this.#enabled = enabled;
+		this.#state = {
+			method: 'desktop',
+			status: enabled ? 'idle' : 'unavailable',
+			currentVersion,
+			version: null,
+			progress: null,
+			error: null
+		};
+		updater.autoDownload = false;
+		updater.autoInstallOnAppQuit = false;
+		updater.autoRunAppAfterInstall = true;
+		updater.allowDowngrade = false;
+		updater.disableWebInstaller = true;
+		updater.allowPrerelease = currentVersion.includes('-canary.');
+		updater.on('update-available', (info) => {
+			this.#setState({ status: 'available', version: info.version, error: null });
+		});
+		updater.on('update-not-available', () => {
+			this.#setState({ status: 'idle', version: null, error: null });
+		});
+		updater.on('download-progress', (progress) => {
+			this.#setState({ progress: Math.max(0, Math.min(100, Math.round(progress.percent))) });
+		});
+		updater.on('update-downloaded', (info) => {
+			this.#setState({ status: 'downloaded', version: info.version, progress: 100, error: null });
+		});
+		updater.on('error', (error) => this.#fail(error));
+	}
+
+	getState() {
+		return { ...this.#state };
+	}
+
+	subscribe(listener) {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	#setState(change) {
+		this.#state = { ...this.#state, ...change };
+		for (const listener of this.#listeners) listener(this.getState());
+	}
+
+	#fail(error) {
+		const installing = this.#state.status === 'installing';
+		this.#setState({
+			status: installing ? 'downloaded' : 'error',
+			error: error instanceof Error ? error.message : String(error),
+			progress: installing ? 100 : null
+		});
+	}
+
+	async #run(status, operation) {
+		this.#setState({ status, error: null, progress: null });
+		this.#operation = Promise.resolve().then(operation);
+		try {
+			await this.#operation;
+		} catch (error) {
+			this.#fail(error);
+		} finally {
+			this.#operation = null;
+		}
+		return this.getState();
+	}
+
+	async check() {
+		if (
+			!this.#enabled ||
+			this.#operation ||
+			['available', 'downloaded', 'installing'].includes(this.#state.status) ||
+			this.#state.version
+		) {
+			return this.getState();
+		}
+		return this.#run('checking', () => this.#updater.checkForUpdates());
+	}
+
+	async download() {
+		if (
+			!this.#enabled ||
+			this.#operation ||
+			!this.#state.version ||
+			!['available', 'error'].includes(this.#state.status)
+		) {
+			return this.getState();
+		}
+		return this.#run('downloading', () => this.#updater.downloadUpdate());
+	}
+
+	install() {
+		if (this.#state.status !== 'downloaded' || this.#operation) return false;
+		this.#setState({ status: 'installing', error: null });
+		try {
+			this.#updater.quitAndInstall(false);
+			return this.#state.status === 'installing';
+		} catch (error) {
+			this.#fail(error);
+			return false;
+		}
+	}
+}
+
+export function stopUpdateProcess(child, graceMs = 5_000, killWaitMs = 5_000) {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+	return new Promise((resolve, reject) => {
+		let timer;
+		const finish = (error) => {
+			clearTimeout(timer);
+			child.removeListener('exit', onExit);
+			child.removeListener('error', finish);
+			if (error) reject(error);
+			else resolve();
+		};
+		const onExit = () => finish();
+		child.once('exit', onExit);
+		child.once('error', finish);
+		timer = setTimeout(() => {
+			timer = setTimeout(() => finish(new Error('The local server did not stop.')), killWaitMs);
+			try {
+				child.kill('SIGKILL');
+			} catch (error) {
+				finish(error);
+			}
+		}, graceMs);
+		try {
+			child.kill('SIGTERM');
+		} catch (error) {
+			finish(error);
+		}
+	});
+}

--- a/apps/desktop/updater.mjs
+++ b/apps/desktop/updater.mjs
@@ -1,3 +1,17 @@
+export function createAppImageUpdater(AppImageUpdater) {
+	return new (class extends AppImageUpdater {
+		spawnLog(command, args = [], env, stdio) {
+			// appimage-run uses bwrap --die-with-parent. Keep its parent alive after Electron exits.
+			return super.spawnLog(
+				'/bin/sh',
+				['-c', '"$@" <&0 & child=$!; wait "$child"', 'sprocket-update-relaunch', command, ...args],
+				env,
+				stdio
+			);
+		}
+	})();
+}
+
 export class DesktopUpdater {
 	#updater;
 	#state;

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,6 +1,7 @@
 declare global {
 	interface Window {
 		sprocketDesktopBridge?: {
+			updates?: import('$lib/updates').DesktopUpdates;
 			getLocalBootstrap: () => Promise<{
 				httpBaseUrl: string;
 				desktopLoginCallbackUrl: string;

--- a/apps/web/src/lib/components/home/app-update.svelte
+++ b/apps/web/src/lib/components/home/app-update.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Download, LoaderCircle, RefreshCw } from '@lucide/svelte';
+	import { requestPackageUpdate, updateLabel, type UpdateState } from '$lib/updates';
+
+	let updateState = $state<UpdateState | null>(null);
+	let requestError = $state<string | null>(null);
+	let busy = $state(false);
+	let confirmInstall = $state(false);
+	let revision = 0;
+	const label = $derived(updateState ? updateLabel(updateState) : null);
+	const working = $derived(
+		busy || updateState?.status === 'downloading' || updateState?.status === 'installing'
+	);
+
+	function acceptUpdate(next: UpdateState | null) {
+		updateState = next;
+		if (next && ['downloading', 'downloaded', 'installing', 'installed'].includes(next.status)) {
+			requestError = null;
+		}
+	}
+
+	onMount(() => {
+		let disposed = false;
+		let polling = false;
+		let unsupported = false;
+		const bridge = window.sprocketDesktopBridge;
+		const updates = bridge?.updates;
+		const unsubscribe = updates?.onState((next) => {
+			revision += 1;
+			acceptUpdate(next);
+		});
+		async function refresh() {
+			if (polling || disposed || busy || unsupported || (bridge && !updates)) return;
+			polling = true;
+			const startedRevision = revision;
+			try {
+				const next = updates ? await updates.getState() : await requestPackageUpdate(false);
+				if (!disposed && revision === startedRevision) {
+					acceptUpdate(next);
+					unsupported = next === null || next.status === 'unavailable';
+				}
+			} catch {
+				// Background checks must not interrupt work when the server or registry is offline.
+			} finally {
+				polling = false;
+			}
+		}
+		void refresh();
+		const timer = setInterval(() => void refresh(), 5_000);
+		return () => {
+			disposed = true;
+			clearInterval(timer);
+			unsubscribe?.();
+		};
+	});
+
+	async function update() {
+		if (!updateState || working) return;
+		if (updateState.method === 'package' && !confirmInstall) {
+			confirmInstall = true;
+			return;
+		}
+		confirmInstall = false;
+		const startedRevision = ++revision;
+		busy = true;
+		requestError = null;
+		try {
+			const updates = window.sprocketDesktopBridge?.updates;
+			if (updateState.method === 'desktop' && updates) {
+				const next = await (updateState.status === 'downloaded'
+					? updates.install()
+					: updates.download());
+				if (revision === startedRevision) acceptUpdate(next);
+			} else if (updateState.method === 'package') {
+				acceptUpdate(await requestPackageUpdate(true));
+			}
+		} catch (error) {
+			requestError = error instanceof Error ? error.message : String(error);
+		} finally {
+			busy = false;
+		}
+	}
+</script>
+
+{#if label && updateState}
+	<div class="mb-1" aria-live="polite">
+		<button
+			type="button"
+			class="text-foreground hover:bg-hover-fill flex min-h-9 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-[13px] font-medium tracking-[-0.02em] transition disabled:cursor-default disabled:opacity-70"
+			disabled={working || updateState.status === 'installed'}
+			onclick={() => void update()}
+			title={updateState.version ? `Sprocket ${updateState.version}` : undefined}
+			aria-busy={working}
+		>
+			{#if working}
+				<LoaderCircle class="size-4 shrink-0 animate-spin" aria-hidden="true" />
+			{:else if updateState.status === 'downloaded'}
+				<RefreshCw class="size-4 shrink-0" aria-hidden="true" />
+			{:else}
+				<Download class="size-4 shrink-0" aria-hidden="true" />
+			{/if}
+			<span>{label}</span>
+		</button>
+		{#if confirmInstall}
+			<div class="text-muted-foreground px-2 pb-2 text-xs">
+				<p>
+					Install {updateState.version} using your package manager? Restart Sprocket from your terminal
+					afterward to use the new version.
+				</p>
+				<p class="mt-1">
+					On Windows, a locked executable may require stopping Sprocket and running
+					<code>sprocket update</code> instead.
+				</p>
+				<div class="mt-2 flex gap-3">
+					<button type="button" class="text-foreground underline" onclick={() => void update()}
+						>Install update</button
+					>
+					<button type="button" class="underline" onclick={() => (confirmInstall = false)}
+						>Cancel</button
+					>
+				</div>
+			</div>
+		{/if}
+		{#if updateState.status === 'installed'}
+			<p class="text-muted-foreground px-2 pb-2 text-xs">
+				Wait for active agents to finish, then stop Sprocket in your terminal and launch it again.
+			</p>
+		{/if}
+		{#if requestError || updateState.error}
+			<p class="text-destructive px-2 pb-2 text-xs break-words" role="alert">
+				{requestError || updateState.error}
+			</p>
+		{/if}
+	</div>
+{/if}

--- a/apps/web/src/lib/components/home/project-sidebar.svelte
+++ b/apps/web/src/lib/components/home/project-sidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Archive, ChevronRight, Folder, FolderOpen, Settings, SquarePen } from '@lucide/svelte';
 	import BrandMark from '$lib/components/brand-mark.svelte';
+	import AppUpdate from '$lib/components/home/app-update.svelte';
 	import SidebarTopActions from '$lib/components/home/sidebar-top-actions.svelte';
 	import type { Id } from '$convex/_generated/dataModel';
 	import type { SprocketTheme } from '$lib/theme';
@@ -424,6 +425,7 @@
 		</div>
 
 		<div class="px-3.5 pt-2 pb-4">
+			<AppUpdate />
 			<button type="button" class={sidebarActionButtonClass} onclick={onOpenSettings}>
 				<Settings class={sidebarActionIconClass} aria-hidden="true" />
 				Settings

--- a/apps/web/src/lib/updates.test.ts
+++ b/apps/web/src/lib/updates.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { requestPackageUpdate, updateLabel, updateStateSchema, type UpdateState } from './updates';
+
+afterEach(() => vi.unstubAllGlobals());
+
+function state(status: UpdateState['status'], version: string | null = '1.1.0'): UpdateState {
+	return { status, version, method: 'desktop', currentVersion: '1.0.0', error: null };
+}
+
+describe('update action', () => {
+	it('stays hidden until an update is known, including background failures', () => {
+		for (const status of ['idle', 'unavailable', 'checking', 'error'] as const) {
+			expect(updateLabel(state(status, null))).toBeNull();
+		}
+		expect(updateLabel(state('available'))).toBe('Update available');
+		expect(updateLabel(state('error'))).toBe('Retry update');
+	});
+
+	it('distinguishes download, restart, and package install completion', () => {
+		expect(updateLabel({ ...state('downloading'), progress: 42 })).toBe('Downloading… 42%');
+		expect(updateLabel(state('downloaded'))).toBe('Restart to update');
+		expect(updateLabel({ ...state('installed'), method: 'package' })).toBe('Update installed');
+	});
+
+	it('rejects an unrelated or incompatible local server response', () => {
+		expect(updateStateSchema.safeParse({ status: 'ok' }).success).toBe(false);
+		expect(updateStateSchema.safeParse(state('available')).success).toBe(true);
+	});
+});
+
+describe('package update requests', () => {
+	it('shows the server explanation when an install is rejected', async () => {
+		vi.stubGlobal('window', { location: { origin: 'http://127.0.0.1:1234' } });
+		vi.stubGlobal('fetch', async () =>
+			Response.json({ error: 'Updates must be installed from this machine.' }, { status: 403 })
+		);
+		await expect(requestPackageUpdate(true)).rejects.toThrow(
+			'Updates must be installed from this machine.'
+		);
+	});
+
+	it('treats a missing route on an older server as unsupported only for checks', async () => {
+		vi.stubGlobal('window', { location: { origin: 'http://127.0.0.1:1234' } });
+		vi.stubGlobal('fetch', async () => new Response('', { status: 404 }));
+		expect(await requestPackageUpdate(false)).toBeNull();
+		await expect(requestPackageUpdate(true)).rejects.toThrow('Update request failed (404)');
+	});
+
+	it('uses a credentialed POST for installation and validates its response', async () => {
+		vi.stubGlobal('window', { location: { origin: 'http://127.0.0.1:1234' } });
+		const fetcher = vi
+			.fn()
+			.mockResolvedValue(Response.json({ ...state('installed'), method: 'package' }));
+		vi.stubGlobal('fetch', fetcher);
+		expect((await requestPackageUpdate(true))?.status).toBe('installed');
+		expect(fetcher).toHaveBeenCalledWith(
+			'http://127.0.0.1:1234/api/update/install',
+			expect.objectContaining({
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+	});
+});

--- a/apps/web/src/lib/updates.ts
+++ b/apps/web/src/lib/updates.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { resolveLocalApiBaseUrl } from '$lib/local/client';
+
+export const updateStateSchema = z.object({
+	method: z.enum(['desktop', 'package']),
+	status: z.enum([
+		'unavailable',
+		'idle',
+		'checking',
+		'available',
+		'downloading',
+		'downloaded',
+		'installing',
+		'installed',
+		'error'
+	]),
+	currentVersion: z.string(),
+	version: z.string().nullable(),
+	progress: z.number().nullable().optional(),
+	error: z.string().nullable(),
+	message: z.string().nullable().optional()
+});
+
+export type UpdateState = z.infer<typeof updateStateSchema>;
+
+export type DesktopUpdates = {
+	getState: () => Promise<UpdateState>;
+	download: () => Promise<UpdateState>;
+	install: () => Promise<UpdateState>;
+	onState: (callback: (state: UpdateState) => void) => () => void;
+};
+
+export function updateLabel(state: UpdateState): string | null {
+	switch (state.status) {
+		case 'available':
+			return 'Update available';
+		case 'downloading':
+			return state.progress == null ? 'Downloading update…' : `Downloading… ${state.progress}%`;
+		case 'downloaded':
+			return 'Restart to update';
+		case 'installing':
+			return 'Installing update…';
+		case 'installed':
+			return 'Update installed';
+		case 'error':
+			return state.version ? 'Retry update' : null;
+		default:
+			return null;
+	}
+}
+
+export async function requestPackageUpdate(install: boolean): Promise<UpdateState | null> {
+	const baseUrl = resolveLocalApiBaseUrl();
+	if (!baseUrl) return null;
+	const response = await fetch(`${baseUrl}/api/update${install ? '/install' : ''}`, {
+		method: install ? 'POST' : 'GET',
+		credentials: 'include',
+		headers: { 'content-type': 'application/json' },
+		signal: AbortSignal.timeout(30_000)
+	});
+	if (!install && response.status === 404) return null;
+	if (!response.ok) {
+		const error = z
+			.object({ error: z.string() })
+			.safeParse(await response.json().catch(() => null));
+		throw new Error(
+			error.success ? error.data.error : `Update request failed (${response.status}). Try again.`
+		);
+	}
+	return updateStateSchema.parse(await response.json());
+}

--- a/bun.lock
+++ b/bun.lock
@@ -18,9 +18,13 @@
     "apps/desktop": {
       "name": "@sprocket/desktop",
       "version": "0.0.0",
+      "dependencies": {
+        "electron-updater": "^6.8.9",
+      },
       "devDependencies": {
         "electron": "^44.0.0",
         "electron-builder": "^26.15.3",
+        "js-yaml": "^4.1.0",
       },
     },
     "apps/web": {
@@ -988,6 +992,8 @@
 
     "electron-publish": ["electron-publish@26.15.3", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "aws4": "^1.13.2", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q=="],
 
+    "electron-updater": ["electron-updater@6.8.9", "", { "dependencies": { "builder-util-runtime": "9.7.0", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig=="],
+
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -1324,6 +1330,10 @@
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
@@ -1592,7 +1602,7 @@
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
-    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
@@ -1687,6 +1697,8 @@
     "thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
+
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
 
     "tinybench": ["tinybench@6.1.4", "", {}, "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ=="],
 
@@ -1822,6 +1834,8 @@
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
+    "@electron/get/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "@electron/get/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
@@ -1860,6 +1874,8 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "@vitest/mocker/magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -1869,8 +1885,6 @@
     "app-builder-lib/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
-
-    "app-builder-lib/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
@@ -1910,6 +1924,8 @@
 
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
+    "eslint-plugin-svelte/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -1926,6 +1942,8 @@
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "global-agent/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
@@ -1934,9 +1952,15 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "node-abi/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "node-api-version/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "node-gyp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "node-gyp/undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
@@ -1956,6 +1980,8 @@
 
     "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "simple-update-notifier/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "svelte-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -1963,6 +1989,8 @@
     "svelte-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "svelte-eslint-parser/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 

--- a/crates/sprocket-server/Cargo.toml
+++ b/crates/sprocket-server/Cargo.toml
@@ -38,6 +38,9 @@ url = "2.5.8"
 uuid = { version = "1.21.0", features = ["v4"] }
 workos = "3.4.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.186"
+
 [build-dependencies]
 dotenvy = "0.15.7"
 

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -4,7 +4,7 @@ use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, header};
 use axum_extra::extract::CookieJar;
 use cookie::{Cookie, SameSite};
 use hmac::{Hmac, KeyInit, Mac};
@@ -342,15 +342,78 @@ struct PersistedSessionRecord {
 }
 
 pub fn extract_session_token(headers: &HeaderMap, jar: &CookieJar) -> Option<String> {
-    if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION)
-        && let Ok(value) = auth_header.to_str()
-        && let Some(token) = value.strip_prefix("Bearer ")
-    {
-        return Some(token.trim().to_string());
+    if let Some(token) = bearer_token(headers) {
+        return Some(token);
     }
 
     jar.get(SESSION_COOKIE_NAME)
         .map(|cookie| cookie.value().to_string())
+}
+
+pub(crate) fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+pub(crate) fn origin_matches_host(headers: &HeaderMap) -> bool {
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Ok(url) = url::Url::parse(origin) else {
+        return false;
+    };
+    matches!(url.scheme(), "http" | "https") && origin == format!("{}://{host}", url.scheme())
+}
+
+pub(crate) fn origin_host_is_loopback(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Ok(url) = url::Url::parse(origin) else {
+        return false;
+    };
+    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"))
+}
+
+pub(crate) fn cookie_request_is_csrf_safe(headers: &HeaderMap) -> bool {
+    bearer_token(headers).is_some() || origin_matches_host(headers)
+}
+
+pub(crate) fn cookie_get_is_csrf_safe(headers: &HeaderMap) -> bool {
+    if bearer_token(headers).is_some() {
+        return true;
+    }
+    match headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        None => true,
+        Some(_) => origin_matches_host(headers),
+    }
+}
+
+pub(crate) fn cookie_request_is_loopback_csrf_safe(headers: &HeaderMap) -> bool {
+    cookie_request_is_csrf_safe(headers)
+        && (bearer_token(headers).is_some() || origin_host_is_loopback(headers))
 }
 
 pub async fn require_session(
@@ -588,5 +651,41 @@ mod tests {
         assert!(!host_supports_loopback_desktop_login("[::]"));
         assert!(!host_supports_loopback_desktop_login("::1"));
         assert!(!host_supports_loopback_desktop_login("192.168.1.10"));
+    }
+
+    #[test]
+    fn origin_matching_rejects_cross_origin_and_missing_headers() {
+        let mut headers = HeaderMap::new();
+        assert!(!origin_matches_host(&headers));
+        assert!(!origin_host_is_loopback(&headers));
+        headers.insert(header::HOST, "127.0.0.1:7731".parse().unwrap());
+        assert!(!origin_matches_host(&headers));
+        assert!(cookie_get_is_csrf_safe(&headers));
+        assert!(!cookie_request_is_csrf_safe(&headers));
+        headers.insert(header::ORIGIN, "http://127.0.0.1:7731".parse().unwrap());
+        assert!(origin_matches_host(&headers));
+        assert!(origin_host_is_loopback(&headers));
+        assert!(cookie_get_is_csrf_safe(&headers));
+        assert!(cookie_request_is_csrf_safe(&headers));
+        assert!(cookie_request_is_loopback_csrf_safe(&headers));
+
+        headers.insert(header::ORIGIN, "https://attacker.example".parse().unwrap());
+        assert!(!origin_matches_host(&headers));
+        assert!(!cookie_get_is_csrf_safe(&headers));
+        assert!(!cookie_request_is_csrf_safe(&headers));
+
+        headers.insert(header::ORIGIN, "null".parse().unwrap());
+        assert!(!cookie_get_is_csrf_safe(&headers));
+
+        headers.insert(header::HOST, "192.168.1.10:7731".parse().unwrap());
+        headers.insert(header::ORIGIN, "http://192.168.1.10:7731".parse().unwrap());
+        assert!(origin_matches_host(&headers));
+        assert!(cookie_request_is_csrf_safe(&headers));
+        assert!(!origin_host_is_loopback(&headers));
+        assert!(!cookie_request_is_loopback_csrf_safe(&headers));
+
+        headers.insert(header::AUTHORIZATION, "Bearer secret".parse().unwrap());
+        assert!(cookie_request_is_csrf_safe(&headers));
+        assert!(cookie_request_is_loopback_csrf_safe(&headers));
     }
 }

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod machine_identity;
 mod machines;
 mod native_auth;
+mod package_update;
 mod project_attachments;
 pub mod repo_env;
 mod routes;
@@ -97,6 +98,56 @@ pub struct AppState {
     pub web_ui_enabled: bool,
     pub desktop_bootstrap_token: Option<Arc<Mutex<Option<String>>>>,
     pub(crate) machine_identity: Arc<machine_identity::MachineIdentity>,
+    pub package_updates: Arc<package_update::PackageUpdateManager>,
+}
+
+#[cfg(test)]
+impl AppState {
+    pub(crate) fn for_test(
+        auth: Arc<auth::AuthState>,
+        native_auth: Arc<native_auth::NativeAuthManager>,
+        data_dir: PathBuf,
+        loopback_desktop_login_supported: bool,
+        package_updates: Arc<package_update::PackageUpdateManager>,
+    ) -> Self {
+        let project_attachments =
+            project_attachments::ProjectAttachmentStore::new(data_dir.clone());
+        let transcript = TranscriptStore::new(data_dir.join("transcripts"));
+        let transcript_watchers = TranscriptWatchers::new(
+            "https://example.convex.cloud".to_string(),
+            transcript.clone(),
+            Arc::clone(&native_auth),
+        );
+        let thread_cache = thread_sync::ThreadCacheSync::new(
+            "https://example.convex.cloud".to_string(),
+            thread_cache::ThreadCacheStore::new(data_dir.clone()),
+            Arc::clone(&native_auth),
+        );
+        let machine_identity =
+            Arc::new(machine_identity::MachineIdentity::load(&data_dir).expect("machine identity"));
+        Self {
+            auth,
+            native_auth: Arc::clone(&native_auth),
+            project_attachments,
+            transcript,
+            transcript_watchers,
+            thread_cache,
+            machines: machines::MachineManager::new(
+                "https://example.convex.cloud".to_string(),
+                Arc::clone(&native_auth),
+                Arc::clone(&machine_identity),
+            ),
+            live_completions: Arc::new(LiveCompletionHub::new()),
+            http_base_url: "http://127.0.0.1:7731".to_string(),
+            desktop_login_callback_url: auth::desktop_login_callback_url(7731),
+            loopback_desktop_login_supported,
+            convex_deployment_url: "https://example.convex.cloud".to_string(),
+            web_ui_enabled: true,
+            desktop_bootstrap_token: None,
+            machine_identity,
+            package_updates,
+        }
+    }
 }
 
 pub fn build_router(state: AppState, static_dir: Option<PathBuf>) -> Router {
@@ -108,6 +159,7 @@ pub fn build_router(state: AppState, static_dir: Option<PathBuf>) -> Router {
         .merge(routes::agent::routes())
         .merge(routes::transcript::routes())
         .merge(routes::threads::routes())
+        .merge(routes::update::routes())
         .fallback(api_not_found)
         .with_state(state);
 
@@ -173,6 +225,7 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         web_ui_enabled,
         desktop_bootstrap_token,
         machine_identity,
+        package_updates: package_update::PackageUpdateManager::from_env(),
     };
 
     let startup = StartupInfo {

--- a/crates/sprocket-server/src/package_update.rs
+++ b/crates/sprocket-server/src/package_update.rs
@@ -1,0 +1,1100 @@
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::sync::{Mutex, watch};
+
+const SUCCESS_CHECK_TTL: Duration = Duration::from_secs(60 * 60);
+const FAILED_CHECK_TTL: Duration = Duration::from_secs(5 * 60);
+const CHECK_TIMEOUT: Duration = Duration::from_secs(60);
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const MAX_HELPER_STREAM_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UpdateStatus {
+    Unavailable,
+    Idle,
+    Available,
+    Installing,
+    Installed,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UpdateMethod {
+    Package,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageUpdateSnapshot {
+    pub status: UpdateStatus,
+    pub current_version: String,
+    pub version: Option<String>,
+    pub error: Option<String>,
+    pub method: UpdateMethod,
+    pub message: Option<String>,
+}
+
+impl PackageUpdateSnapshot {
+    fn unavailable() -> Self {
+        Self {
+            status: UpdateStatus::Unavailable,
+            current_version: String::new(),
+            version: None,
+            error: None,
+            method: UpdateMethod::Package,
+            message: None,
+        }
+    }
+
+    fn error(current_version: String, version: Option<String>, message: impl Into<String>) -> Self {
+        let error = message.into();
+        Self {
+            status: UpdateStatus::Error,
+            current_version,
+            version,
+            error: Some(error.clone()),
+            method: UpdateMethod::Package,
+            message: Some(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UpdateCommand {
+    node: PathBuf,
+    script: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HelperAction {
+    Check,
+    Install,
+}
+
+impl HelperAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Check => "check",
+            Self::Install => "install",
+        }
+    }
+}
+
+struct RunningOp {
+    action: HelperAction,
+    wait: watch::Receiver<Option<PackageUpdateSnapshot>>,
+}
+
+struct Inner {
+    snapshot: PackageUpdateSnapshot,
+    last_check_at: Option<Instant>,
+    last_check_failed: bool,
+    installed: bool,
+    pending_install: bool,
+    running: Option<RunningOp>,
+}
+
+pub struct PackageUpdateManager {
+    command: Option<UpdateCommand>,
+    success_ttl: Duration,
+    failure_ttl: Duration,
+    check_timeout: Duration,
+    install_timeout: Duration,
+    inner: Mutex<Inner>,
+}
+
+impl PackageUpdateManager {
+    pub fn from_env() -> Arc<Self> {
+        Arc::new(Self::new(
+            parse_update_command_from_env(),
+            SUCCESS_CHECK_TTL,
+            FAILED_CHECK_TTL,
+            CHECK_TIMEOUT,
+            INSTALL_TIMEOUT,
+        ))
+    }
+
+    pub fn disabled() -> Arc<Self> {
+        Arc::new(Self::new(
+            None,
+            SUCCESS_CHECK_TTL,
+            FAILED_CHECK_TTL,
+            CHECK_TIMEOUT,
+            INSTALL_TIMEOUT,
+        ))
+    }
+
+    fn new(
+        command: Option<UpdateCommand>,
+        success_ttl: Duration,
+        failure_ttl: Duration,
+        check_timeout: Duration,
+        install_timeout: Duration,
+    ) -> Self {
+        let snapshot = if command.is_some() {
+            PackageUpdateSnapshot {
+                status: UpdateStatus::Idle,
+                current_version: String::new(),
+                version: None,
+                error: None,
+                method: UpdateMethod::Package,
+                message: None,
+            }
+        } else {
+            PackageUpdateSnapshot::unavailable()
+        };
+        Self {
+            command,
+            success_ttl,
+            failure_ttl,
+            check_timeout,
+            install_timeout,
+            inner: Mutex::new(Inner {
+                snapshot,
+                last_check_at: None,
+                last_check_failed: false,
+                installed: false,
+                pending_install: false,
+                running: None,
+            }),
+        }
+    }
+
+    pub async fn status(self: &Arc<Self>) -> PackageUpdateSnapshot {
+        let mut inner = self.inner.lock().await;
+        if self.command.is_none() {
+            return PackageUpdateSnapshot::unavailable();
+        }
+        if inner.installed {
+            return inner.snapshot.clone();
+        }
+        if let Some(running) = &inner.running {
+            if running.action == HelperAction::Install || inner.pending_install {
+                return inner.snapshot.clone();
+            }
+            let mut wait = running.wait.clone();
+            drop(inner);
+            return wait_for_snapshot(&mut wait).await;
+        }
+        if cache_is_fresh(&inner, self.success_ttl, self.failure_ttl) {
+            return inner.snapshot.clone();
+        }
+        let wait = self.start_locked(&mut inner, HelperAction::Check);
+        drop(inner);
+        wait_for_snapshot(&mut wait.clone()).await
+    }
+
+    pub async fn install(self: &Arc<Self>) -> PackageUpdateSnapshot {
+        let mut inner = self.inner.lock().await;
+        if self.command.is_none() {
+            return PackageUpdateSnapshot::unavailable();
+        }
+        if inner.installed {
+            return inner.snapshot.clone();
+        }
+        if let Some(running) = &inner.running {
+            if running.action == HelperAction::Install || inner.pending_install {
+                return inner.snapshot.clone();
+            }
+            inner.pending_install = true;
+            mark_installing(&mut inner.snapshot);
+            return inner.snapshot.clone();
+        }
+        self.start_locked(&mut inner, HelperAction::Install);
+        inner.snapshot.clone()
+    }
+
+    fn start_locked(
+        self: &Arc<Self>,
+        inner: &mut Inner,
+        action: HelperAction,
+    ) -> watch::Receiver<Option<PackageUpdateSnapshot>> {
+        let (tx, rx) = watch::channel(None);
+        if action == HelperAction::Install {
+            mark_installing(&mut inner.snapshot);
+        }
+        inner.running = Some(RunningOp {
+            action,
+            wait: rx.clone(),
+        });
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let snapshot = manager.run_helper(action).await;
+            let mut inner = manager.inner.lock().await;
+            inner.apply_result(action, snapshot);
+            inner.running = None;
+            let follow_with_install = action == HelperAction::Check
+                && inner.pending_install
+                && !inner.installed
+                && inner.snapshot.status != UpdateStatus::Unavailable;
+            inner.pending_install = false;
+            if follow_with_install {
+                manager.start_locked(&mut inner, HelperAction::Install);
+            }
+            let completed = inner.snapshot.clone();
+            drop(inner);
+            let _ = tx.send(Some(completed));
+        });
+        rx
+    }
+
+    async fn run_helper(&self, action: HelperAction) -> PackageUpdateSnapshot {
+        let Some(command) = &self.command else {
+            return PackageUpdateSnapshot::unavailable();
+        };
+        let previous = self.inner.lock().await.snapshot.clone();
+        let limit = match action {
+            HelperAction::Check => self.check_timeout,
+            HelperAction::Install => self.install_timeout,
+        };
+        let mut child = match spawn_helper(command, action) {
+            Ok(child) => child,
+            Err(error) => {
+                return PackageUpdateSnapshot::error(
+                    previous.current_version,
+                    previous.version,
+                    format!("failed to start update helper: {error}"),
+                );
+            }
+        };
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        #[cfg(unix)]
+        let mut process_group = UpdateProcessGroup(child.id());
+        let output = collect_helper_output(&mut child, stdout, stderr, limit).await;
+        #[cfg(unix)]
+        {
+            process_group.0 = None;
+        }
+        match output {
+            Ok((status, stdout, stderr)) => {
+                if stdout.truncated || stderr.truncated {
+                    return PackageUpdateSnapshot::error(
+                        previous.current_version,
+                        previous.version,
+                        "update helper output exceeded the size limit",
+                    );
+                }
+                parse_helper_output(&stdout.bytes, &stderr.bytes, status.success(), &previous)
+            }
+            Err(HelperCollectError::Wait(error)) => PackageUpdateSnapshot::error(
+                previous.current_version,
+                previous.version,
+                format!("failed to wait for update helper: {error}"),
+            ),
+            Err(HelperCollectError::TimedOut) => PackageUpdateSnapshot::error(
+                previous.current_version,
+                previous.version,
+                "update helper timed out",
+            ),
+        }
+    }
+}
+
+impl Inner {
+    fn apply_result(&mut self, action: HelperAction, snapshot: PackageUpdateSnapshot) {
+        let mut snapshot = snapshot;
+        if snapshot.current_version.is_empty() && !self.snapshot.current_version.is_empty() {
+            snapshot.current_version = self.snapshot.current_version.clone();
+        }
+        if snapshot.status == UpdateStatus::Error && snapshot.version.is_none() {
+            snapshot.version = self.snapshot.version.clone();
+        }
+        if snapshot.status == UpdateStatus::Installed {
+            self.installed = true;
+        }
+        if action == HelperAction::Check || snapshot.status == UpdateStatus::Error {
+            self.last_check_at = Some(Instant::now());
+            self.last_check_failed = snapshot.status == UpdateStatus::Error;
+        } else if snapshot.status == UpdateStatus::Installed {
+            self.last_check_at = Some(Instant::now());
+            self.last_check_failed = false;
+        }
+        self.snapshot = snapshot;
+    }
+}
+
+fn cache_is_fresh(inner: &Inner, success_ttl: Duration, failure_ttl: Duration) -> bool {
+    let Some(last_check_at) = inner.last_check_at else {
+        return false;
+    };
+    let ttl = if inner.last_check_failed {
+        failure_ttl
+    } else {
+        success_ttl
+    };
+    last_check_at.elapsed() < ttl
+}
+
+async fn wait_for_snapshot(
+    wait: &mut watch::Receiver<Option<PackageUpdateSnapshot>>,
+) -> PackageUpdateSnapshot {
+    loop {
+        if let Some(snapshot) = wait.borrow().clone() {
+            return snapshot;
+        }
+        if wait.changed().await.is_err() {
+            return PackageUpdateSnapshot::error(String::new(), None, "update helper task ended");
+        }
+    }
+}
+
+fn parse_update_command_from_env() -> Option<UpdateCommand> {
+    parse_update_command(
+        std::env::var("SPROCKET_UPDATE_NODE").ok().as_deref(),
+        std::env::var("SPROCKET_UPDATE_SCRIPT").ok().as_deref(),
+    )
+}
+
+fn parse_update_command(node: Option<&str>, script: Option<&str>) -> Option<UpdateCommand> {
+    let node = node.map(str::trim).filter(|value| !value.is_empty())?;
+    let script = script.map(str::trim).filter(|value| !value.is_empty())?;
+    let node = PathBuf::from(node);
+    let script = PathBuf::from(script);
+    if !node.is_absolute() || !script.is_absolute() {
+        tracing::warn!(
+            "SPROCKET_UPDATE_NODE and SPROCKET_UPDATE_SCRIPT must be absolute paths; package updates disabled"
+        );
+        return None;
+    }
+    Some(UpdateCommand { node, script })
+}
+
+fn mark_installing(snapshot: &mut PackageUpdateSnapshot) {
+    snapshot.status = UpdateStatus::Installing;
+    snapshot.error = None;
+    snapshot.message = None;
+}
+
+enum HelperCollectError {
+    TimedOut,
+    Wait(std::io::Error),
+}
+
+#[cfg(unix)]
+struct UpdateProcessGroup(Option<u32>);
+
+#[cfg(unix)]
+impl Drop for UpdateProcessGroup {
+    fn drop(&mut self) {
+        if let Some(pid) = self.0 {
+            // SAFETY: the update helper owns this group; canceling its task must also stop its children.
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+        }
+    }
+}
+
+async fn collect_helper_output(
+    child: &mut tokio::process::Child,
+    stdout: Option<tokio::process::ChildStdout>,
+    stderr: Option<tokio::process::ChildStderr>,
+    limit: Duration,
+) -> Result<(std::process::ExitStatus, LimitedOutput, LimitedOutput), HelperCollectError> {
+    let pid = child.id();
+    let mut stdout_task = tokio::spawn(read_limited(stdout, MAX_HELPER_STREAM_BYTES));
+    let mut stderr_task = tokio::spawn(read_limited(stderr, MAX_HELPER_STREAM_BYTES));
+    let collect = async {
+        let status = child.wait().await.map_err(HelperCollectError::Wait)?;
+        let stdout = (&mut stdout_task).await.unwrap_or_default();
+        let stderr = (&mut stderr_task).await.unwrap_or_default();
+        Ok((status, stdout, stderr))
+    };
+    let error = match tokio::time::timeout(limit, collect).await {
+        Ok(Ok(output)) => return Ok(output),
+        Ok(Err(error)) => error,
+        Err(_) => HelperCollectError::TimedOut,
+    };
+    kill_helper(child, pid).await;
+    stdout_task.abort();
+    stderr_task.abort();
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+    Err(error)
+}
+
+fn spawn_helper(
+    command: &UpdateCommand,
+    action: HelperAction,
+) -> std::io::Result<tokio::process::Child> {
+    let mut process = Command::new(&command.node);
+    process
+        .arg(&command.script)
+        .arg(action.as_str())
+        .env("SPROCKET_UPDATE_MANAGED", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    process.process_group(0);
+    process.spawn()
+}
+
+async fn kill_helper(child: &mut tokio::process::Child, pid: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(pid) = pid {
+        // SAFETY: spawn_helper makes the child the leader of its own process group.
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
+    }
+    #[cfg(windows)]
+    if let (Some(pid), Some(system_root)) = (pid, std::env::var_os("SystemRoot")) {
+        let mut killer = Command::new(PathBuf::from(system_root).join("System32/taskkill.exe"));
+        killer
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let _ = tokio::time::timeout(Duration::from_secs(5), killer.status()).await;
+    }
+    let _ = child.start_kill();
+}
+
+#[derive(Default)]
+struct LimitedOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+async fn read_limited<R>(pipe: Option<R>, max_bytes: usize) -> LimitedOutput
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let Some(mut pipe) = pipe else {
+        return LimitedOutput::default();
+    };
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match pipe.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if bytes.len() + n > max_bytes {
+                    bytes.extend_from_slice(&buf[..max_bytes.saturating_sub(bytes.len())]);
+                    return LimitedOutput {
+                        bytes,
+                        truncated: true,
+                    };
+                }
+                bytes.extend_from_slice(&buf[..n]);
+            }
+            Err(_) => break,
+        }
+    }
+    LimitedOutput {
+        bytes,
+        truncated: false,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HelperJson {
+    status: String,
+    current_version: String,
+    version: Option<String>,
+    error: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+fn parse_helper_output(
+    stdout: &[u8],
+    stderr: &[u8],
+    exit_ok: bool,
+    previous: &PackageUpdateSnapshot,
+) -> PackageUpdateSnapshot {
+    let stdout = String::from_utf8_lossy(stdout);
+    let trimmed = stdout.trim();
+    match serde_json::from_str::<HelperJson>(trimmed) {
+        Ok(json) => {
+            let snapshot = json.into_snapshot();
+            if !exit_ok && snapshot.status != UpdateStatus::Error {
+                PackageUpdateSnapshot::error(
+                    snapshot.current_version,
+                    snapshot.version,
+                    "update helper exited with an error",
+                )
+            } else {
+                snapshot
+            }
+        }
+        Err(_) => {
+            let stderr = String::from_utf8_lossy(stderr);
+            let detail = if !exit_ok {
+                if stderr.trim().is_empty() {
+                    "update helper exited with an error".to_string()
+                } else {
+                    format!(
+                        "update helper exited with an error: {}",
+                        truncate_chars(stderr.trim(), 500)
+                    )
+                }
+            } else {
+                "update helper returned invalid JSON".to_string()
+            };
+            PackageUpdateSnapshot::error(
+                previous.current_version.clone(),
+                previous.version.clone(),
+                detail,
+            )
+        }
+    }
+}
+
+impl HelperJson {
+    fn into_snapshot(self) -> PackageUpdateSnapshot {
+        let version = self
+            .version
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let status = match self.status.trim() {
+            "unavailable" => UpdateStatus::Unavailable,
+            "idle" => UpdateStatus::Idle,
+            "available" => UpdateStatus::Available,
+            "installed" => UpdateStatus::Installed,
+            "error" => UpdateStatus::Error,
+            "downloading" | "installing" => {
+                return PackageUpdateSnapshot::error(
+                    self.current_version,
+                    version,
+                    "update helper exited before the install finished",
+                );
+            }
+            _ => {
+                return PackageUpdateSnapshot::error(
+                    self.current_version,
+                    version,
+                    format!("update helper returned unknown status '{}'", self.status),
+                );
+            }
+        };
+        if matches!(status, UpdateStatus::Available | UpdateStatus::Installed) && version.is_none()
+        {
+            return PackageUpdateSnapshot::error(
+                self.current_version,
+                None,
+                "update helper omitted the update version",
+            );
+        }
+        let error = self.error.filter(|value| !value.is_empty()).or_else(|| {
+            (status == UpdateStatus::Error).then(|| "The package update failed.".to_string())
+        });
+        PackageUpdateSnapshot {
+            status,
+            current_version: self.current_version,
+            version,
+            error,
+            method: UpdateMethod::Package,
+            message: self.message.filter(|value| !value.is_empty()),
+        }
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+impl PackageUpdateManager {
+    fn with_helper(node: PathBuf, script: PathBuf) -> Arc<Self> {
+        Self::with_helper_and_timeouts(
+            node,
+            script,
+            SUCCESS_CHECK_TTL,
+            FAILED_CHECK_TTL,
+            CHECK_TIMEOUT,
+            INSTALL_TIMEOUT,
+        )
+    }
+
+    pub(crate) fn with_helper_and_timeouts(
+        node: PathBuf,
+        script: PathBuf,
+        success_ttl: Duration,
+        failure_ttl: Duration,
+        check_timeout: Duration,
+        install_timeout: Duration,
+    ) -> Arc<Self> {
+        Arc::new(Self::new(
+            Some(UpdateCommand { node, script }),
+            success_ttl,
+            failure_ttl,
+            check_timeout,
+            install_timeout,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helper_success_requires_a_version_and_successful_exit() {
+        let previous = PackageUpdateSnapshot::unavailable();
+        for (json, exit_ok) in [
+            (
+                r#"{"status":"installed","currentVersion":"1.0.0","version":"1.1.0"}"#,
+                false,
+            ),
+            (r#"{"status":"installed","currentVersion":"1.0.0"}"#, true),
+            (r#"{"status":"available","currentVersion":"1.0.0"}"#, true),
+        ] {
+            let snapshot = parse_helper_output(json.as_bytes(), b"", exit_ok, &previous);
+            assert_eq!(snapshot.status, UpdateStatus::Error);
+            assert!(snapshot.error.is_some());
+        }
+    }
+
+    #[test]
+    fn missing_or_relative_env_disables_updates() {
+        let root = std::env::current_dir().unwrap();
+        let node = root.join("node").display().to_string();
+        let script = root.join("update-api.js").display().to_string();
+        assert!(parse_update_command(None, None).is_none());
+        assert!(parse_update_command(Some(&node), None).is_none());
+        assert!(parse_update_command(Some(""), Some(&script)).is_none());
+        assert!(parse_update_command(Some("node"), Some(&script)).is_none());
+        assert!(parse_update_command(Some(&node), Some("update-api.js")).is_none());
+        assert!(parse_update_command(Some(&node), Some(&script)).is_some());
+        assert!(
+            parse_update_command(Some(&format!("  {node}  ")), Some(&format!("  {script}  ")))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn helper_json_maps_known_statuses() {
+        let previous = PackageUpdateSnapshot::unavailable();
+        let snapshot = parse_helper_output(
+            br#"{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}"#,
+            b"",
+            true,
+            &previous,
+        );
+        assert_eq!(snapshot.status, UpdateStatus::Idle);
+        let snapshot = parse_helper_output(
+            br#"{"status":"available","currentVersion":"1.0.0","version":"1.1.0","error":null,"method":"package"}"#,
+            b"",
+            true,
+            &previous,
+        );
+        assert_eq!(snapshot.status, UpdateStatus::Available);
+        let snapshot = parse_helper_output(
+            br#"{"status":"installed","currentVersion":"1.1.0","version":"1.1.0","error":null,"method":"package"}"#,
+            b"",
+            true,
+            &previous,
+        );
+        assert_eq!(snapshot.status, UpdateStatus::Installed);
+        let snapshot = parse_helper_output(
+            br#"{"status":"downloading","currentVersion":"1.0.0","version":"1.1.0","error":null,"method":"package"}"#,
+            b"",
+            true,
+            &previous,
+        );
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert_eq!(snapshot.version.as_deref(), Some("1.1.0"));
+    }
+
+    #[test]
+    fn helper_parse_error_keeps_previous_version() {
+        let previous = PackageUpdateSnapshot {
+            status: UpdateStatus::Available,
+            current_version: "1.0.0".to_string(),
+            version: Some("1.1.0".to_string()),
+            error: None,
+            method: UpdateMethod::Package,
+            message: None,
+        };
+        let snapshot = parse_helper_output(b"not-json", b"boom", false, &previous);
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert_eq!(snapshot.current_version, "1.0.0");
+        assert_eq!(snapshot.version.as_deref(), Some("1.1.0"));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod process_tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(prefix: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_helper(dir: &Path, body: &str) -> (PathBuf, PathBuf) {
+        let script = dir.join("update-api.sh");
+        fs::write(&script, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        (PathBuf::from("/bin/sh"), script)
+    }
+
+    async fn wait_until_settled(manager: &Arc<PackageUpdateManager>) -> PackageUpdateSnapshot {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = manager.status().await;
+            if snapshot.status != UpdateStatus::Installing {
+                return snapshot;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return snapshot;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_manager_never_spawns() {
+        let dir = TempDir::new("sprocket-update-disabled");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"echo spawned >> "$(dirname "$0")/calls"
+echo '{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}'"#,
+        );
+        let _ = (node, script);
+        let manager = PackageUpdateManager::disabled();
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Unavailable);
+        assert_eq!(snapshot.method, UpdateMethod::Package);
+        assert!(!dir.path().join("calls").exists());
+        let snapshot = manager.install().await;
+        assert_eq!(snapshot.status, UpdateStatus::Unavailable);
+        assert!(!dir.path().join("calls").exists());
+    }
+
+    #[tokio::test]
+    async fn check_uses_fixed_helper_args() {
+        let dir = TempDir::new("sprocket-update-check-args");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+echo '{"status":"available","currentVersion":"1.0.0","version":"1.1.0","error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Available);
+        assert_eq!(snapshot.current_version, "1.0.0");
+        assert_eq!(snapshot.version.as_deref(), Some("1.1.0"));
+        assert_eq!(snapshot.method, UpdateMethod::Package);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("calls")).unwrap(),
+            "check\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_uses_fixed_helper_args_and_persists() {
+        let dir = TempDir::new("sprocket-update-install-args");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+echo '{"status":"installed","currentVersion":"1.1.0","version":"1.1.0","error":null,"method":"package","message":"restart required"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let snapshot = manager.install().await;
+        assert_eq!(snapshot.status, UpdateStatus::Installing);
+        let snapshot = wait_until_settled(&manager).await;
+        assert_eq!(snapshot.status, UpdateStatus::Installed);
+        assert_eq!(snapshot.current_version, "1.1.0");
+        assert_eq!(snapshot.message.as_deref(), Some("restart required"));
+        let again = manager.status().await;
+        assert_eq!(again.status, UpdateStatus::Installed);
+        let install_again = manager.install().await;
+        assert_eq!(install_again.status, UpdateStatus::Installed);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("calls")).unwrap(),
+            "install\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_checks_are_cached() {
+        let dir = TempDir::new("sprocket-update-cache-ok");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf x >> "$(dirname "$0")/calls"
+echo '{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper_and_timeouts(
+            node,
+            script,
+            Duration::from_millis(250),
+            Duration::from_millis(250),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        );
+        assert_eq!(manager.status().await.status, UpdateStatus::Idle);
+        assert_eq!(manager.status().await.status, UpdateStatus::Idle);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "x");
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(manager.status().await.status, UpdateStatus::Idle);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "xx");
+    }
+
+    #[tokio::test]
+    async fn failed_checks_are_cached_briefly() {
+        let dir = TempDir::new("sprocket-update-cache-err");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf x >> "$(dirname "$0")/calls"
+echo '{"status":"error","currentVersion":"1.0.0","version":null,"error":"registry down","method":"package"}'
+exit 1"#,
+        );
+        let manager = PackageUpdateManager::with_helper_and_timeouts(
+            node,
+            script,
+            Duration::from_secs(60),
+            Duration::from_millis(250),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        );
+        let first = manager.status().await;
+        assert_eq!(first.status, UpdateStatus::Error);
+        assert_eq!(first.error.as_deref(), Some("registry down"));
+        assert_eq!(manager.status().await.status, UpdateStatus::Error);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "x");
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(manager.status().await.status, UpdateStatus::Error);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "xx");
+    }
+
+    #[tokio::test]
+    async fn concurrent_checks_share_one_helper() {
+        let dir = TempDir::new("sprocket-update-concurrent");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf x >> "$(dirname "$0")/calls"
+sleep 0.3
+echo '{"status":"available","currentVersion":"1.0.0","version":"1.2.0","error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let a = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.status().await })
+        };
+        let b = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.status().await })
+        };
+        let a = a.await.unwrap();
+        let b = b.await.unwrap();
+        assert_eq!(a.status, UpdateStatus::Available);
+        assert_eq!(b.status, UpdateStatus::Available);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "x");
+    }
+
+    #[tokio::test]
+    async fn dropped_status_waiter_does_not_start_another_helper() {
+        let dir = TempDir::new("sprocket-update-disconnect");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf x >> "$(dirname "$0")/calls"
+sleep 0.4
+echo '{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let dropped = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.status().await })
+        };
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        dropped.abort();
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Idle);
+        assert_eq!(fs::read_to_string(dir.path().join("calls")).unwrap(), "x");
+    }
+
+    #[tokio::test]
+    async fn status_during_install_returns_installing_without_a_second_spawn() {
+        let dir = TempDir::new("sprocket-update-installing");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+sleep 0.4
+echo '{"status":"installed","currentVersion":"1.1.0","version":"1.1.0","error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let snapshot = manager.install().await;
+        assert_eq!(snapshot.status, UpdateStatus::Installing);
+        assert_eq!(manager.status().await.status, UpdateStatus::Installing);
+        let installed = wait_until_settled(&manager).await;
+        assert_eq!(installed.status, UpdateStatus::Installed);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("calls")).unwrap(),
+            "install\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_installs_coalesce_instead_of_rerunning() {
+        let dir = TempDir::new("sprocket-update-coalesce");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+sleep 0.3
+echo '{"status":"error","currentVersion":"1.0.0","version":null,"error":"failed","method":"package"}'
+exit 1"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let first = manager.install().await;
+        let second = manager.install().await;
+        assert_eq!(first.status, UpdateStatus::Installing);
+        assert_eq!(second.status, UpdateStatus::Installing);
+        let settled = wait_until_settled(&manager).await;
+        assert_eq!(settled.status, UpdateStatus::Error);
+        assert_eq!(
+            fs::read_to_string(dir.path().join("calls")).unwrap(),
+            "install\n"
+        );
+        let retry = manager.install().await;
+        assert_eq!(retry.status, UpdateStatus::Installing);
+        let _ = wait_until_settled(&manager).await;
+        assert_eq!(
+            fs::read_to_string(dir.path().join("calls")).unwrap(),
+            "install\ninstall\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_error_preserves_available_version() {
+        let dir = TempDir::new("sprocket-update-keep-version");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"if [ "$1" = check ]; then
+  echo '{"status":"available","currentVersion":"1.0.0","version":"1.1.0","error":null,"method":"package"}'
+else
+  echo '{"status":"error","currentVersion":"1.0.0","version":null,"error":"npm failed","method":"package"}'
+  exit 1
+fi"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let checked = manager.status().await;
+        assert_eq!(checked.status, UpdateStatus::Available);
+        assert_eq!(checked.version.as_deref(), Some("1.1.0"));
+        let installing = manager.install().await;
+        assert_eq!(installing.status, UpdateStatus::Installing);
+        assert_eq!(installing.version.as_deref(), Some("1.1.0"));
+        let failed = wait_until_settled(&manager).await;
+        assert_eq!(failed.status, UpdateStatus::Error);
+        assert_eq!(failed.version.as_deref(), Some("1.1.0"));
+        assert_eq!(failed.current_version, "1.0.0");
+    }
+
+    #[tokio::test]
+    async fn timeout_covers_orphans_holding_stdout() {
+        let dir = TempDir::new("sprocket-update-orphan-pipe");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"(sleep 5) >&1 &
+echo '{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}'
+exit 0"#,
+        );
+        let manager = PackageUpdateManager::with_helper_and_timeouts(
+            node,
+            script,
+            SUCCESS_CHECK_TTL,
+            FAILED_CHECK_TTL,
+            Duration::from_millis(200),
+            Duration::from_millis(200),
+        );
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert_eq!(snapshot.error.as_deref(), Some("update helper timed out"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_without_json_becomes_error() {
+        let dir = TempDir::new("sprocket-update-bad-exit");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"echo boom >&2
+exit 2"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert!(
+            snapshot
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("update helper exited with an error")
+        );
+    }
+
+    #[tokio::test]
+    async fn helper_timeout_becomes_error() {
+        let dir = TempDir::new("sprocket-update-timeout");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"sleep 5
+echo '{"status":"idle","currentVersion":"1.0.0","version":null,"error":null,"method":"package"}'"#,
+        );
+        let manager = PackageUpdateManager::with_helper_and_timeouts(
+            node,
+            script,
+            SUCCESS_CHECK_TTL,
+            FAILED_CHECK_TTL,
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+        );
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert_eq!(snapshot.error.as_deref(), Some("update helper timed out"));
+    }
+
+    #[tokio::test]
+    async fn oversized_helper_output_becomes_error() {
+        let dir = TempDir::new("sprocket-update-overflow");
+        let (node, script) = write_helper(
+            dir.path(),
+            r#"dd if=/dev/zero bs=1024 count=128 2>/dev/null"#,
+        );
+        let manager = PackageUpdateManager::with_helper(node, script);
+        let snapshot = manager.status().await;
+        assert_eq!(snapshot.status, UpdateStatus::Error);
+        assert_eq!(
+            snapshot.error.as_deref(),
+            Some("update helper output exceeded the size limit")
+        );
+    }
+}

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -10,7 +10,8 @@ use serde::Deserialize;
 
 use crate::auth::{
     AuthSessionResponse, AuthState, BootstrapRequest, BootstrapResponse, DesktopLoginStartResponse,
-    extract_session_token, peer_may_complete_desktop_login_callback, require_session,
+    extract_session_token, origin_host_is_loopback, origin_matches_host,
+    peer_may_complete_desktop_login_callback, require_session,
 };
 use crate::native_auth::{NativeLoginFlow, NativeLoginStart, NativeLoginStatus};
 use crate::routes::api_error::ApiError;
@@ -374,24 +375,7 @@ async fn native_session_token_response(
 }
 
 fn is_loopback_same_origin(headers: &HeaderMap) -> bool {
-    let Some(host) = headers
-        .get(header::HOST)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return false;
-    };
-    let Some(origin) = headers
-        .get(header::ORIGIN)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return false;
-    };
-    let Ok(url) = url::Url::parse(origin) else {
-        return false;
-    };
-    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "[::1]"))
-        && matches!(url.scheme(), "http" | "https")
-        && origin == format!("{}://{host}", url.scheme())
+    origin_matches_host(headers) && origin_host_is_loopback(headers)
 }
 
 fn desktop_bootstrap_response(state: &AppState) -> Json<DesktopBootstrapResponse> {
@@ -469,7 +453,6 @@ mod tests {
 
     use super::*;
     use crate::auth;
-    use crate::project_attachments::ProjectAttachmentStore;
 
     async fn test_state(loopback_supported: bool) -> (AppState, String, String) {
         let temp_dir =
@@ -477,51 +460,19 @@ mod tests {
         let auth = auth::AuthState::load(&temp_dir).expect("auth state");
         let credential = auth.pairing_credential().to_string();
         let (_, session_token) = auth.bootstrap(&credential).await.expect("bootstrap");
-
-        let project_attachments = ProjectAttachmentStore::new(temp_dir.clone());
-        let transcript = sprocket_agent::TranscriptStore::new(temp_dir.join("transcripts"));
         let native_auth = crate::native_auth::NativeAuthManager::configured_for_test(
             crate::native_auth::NativeAuthConfig {
                 workos_client_id: "client_test".to_string(),
             },
             auth::desktop_login_callback_url(7731),
         );
-        let transcript_watchers = crate::transcript_watch::TranscriptWatchers::new(
-            "https://example.convex.cloud".to_string(),
-            transcript.clone(),
-            Arc::clone(&native_auth),
-        );
-        let thread_cache = crate::thread_sync::ThreadCacheSync::new(
-            "https://example.convex.cloud".to_string(),
-            crate::thread_cache::ThreadCacheStore::new(temp_dir.clone()),
-            Arc::clone(&native_auth),
-        );
-
-        let machine_identity = Arc::new(
-            crate::machine_identity::MachineIdentity::load(&temp_dir).expect("machine identity"),
-        );
-        let state = AppState {
+        let state = AppState::for_test(
             auth,
-            native_auth: Arc::clone(&native_auth),
-            project_attachments,
-            transcript,
-            transcript_watchers,
-            thread_cache,
-            machines: crate::machines::MachineManager::new(
-                "https://example.convex.cloud".to_string(),
-                Arc::clone(&native_auth),
-                Arc::clone(&machine_identity),
-            ),
-            live_completions: Arc::new(sprocket_agent::LiveCompletionHub::new()),
-            http_base_url: "http://127.0.0.1:7731".to_string(),
-            desktop_login_callback_url: auth::desktop_login_callback_url(7731),
-            loopback_desktop_login_supported: loopback_supported,
-            convex_deployment_url: "https://example.convex.cloud".to_string(),
-            web_ui_enabled: true,
-            desktop_bootstrap_token: None,
-            machine_identity,
-        };
-
+            native_auth,
+            temp_dir,
+            loopback_supported,
+            crate::package_update::PackageUpdateManager::disabled(),
+        );
         (state, session_token, credential)
     }
 

--- a/crates/sprocket-server/src/routes/mod.rs
+++ b/crates/sprocket-server/src/routes/mod.rs
@@ -6,4 +6,5 @@ pub mod config;
 pub mod health;
 pub mod threads;
 pub mod transcript;
+pub mod update;
 pub mod workspace;

--- a/crates/sprocket-server/src/routes/update.rs
+++ b/crates/sprocket-server/src/routes/update.rs
@@ -1,0 +1,514 @@
+use std::net::SocketAddr;
+
+use axum::Json;
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum_extra::extract::CookieJar;
+
+use crate::AppState;
+use crate::auth::{cookie_get_is_csrf_safe, cookie_request_is_loopback_csrf_safe, require_session};
+use crate::package_update::PackageUpdateSnapshot;
+use crate::routes::api_error::ApiError;
+
+pub fn routes() -> axum::Router<AppState> {
+    axum::Router::new()
+        .route("/update", get(status))
+        .route("/update/install", post(install))
+}
+
+async fn status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> Result<Response, ApiError> {
+    require_update_read(&state, &headers, &jar).await?;
+    Ok(update_response(state.package_updates.status().await))
+}
+
+async fn install(
+    State(state): State<AppState>,
+    peer: Result<ConnectInfo<SocketAddr>, axum::extract::rejection::ExtensionRejection>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> Result<Response, ApiError> {
+    let peer = peer.ok().map(|ConnectInfo(peer)| peer);
+    require_update_install(&state, peer, &headers, &jar).await?;
+    Ok(update_response(state.package_updates.install().await))
+}
+
+async fn require_update_read(
+    state: &AppState,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+) -> Result<(), ApiError> {
+    require_session(&state.auth, headers, jar)
+        .await
+        .map_err(|_| ApiError::authentication_required())?;
+    if !cookie_get_is_csrf_safe(headers) {
+        return Err(cross_origin_rejected());
+    }
+    Ok(())
+}
+
+async fn require_update_install(
+    state: &AppState,
+    peer: Option<SocketAddr>,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+) -> Result<(), ApiError> {
+    require_session(&state.auth, headers, jar)
+        .await
+        .map_err(|_| ApiError::authentication_required())?;
+    if !peer.is_some_and(|peer| peer.ip().is_loopback())
+        || !cookie_request_is_loopback_csrf_safe(headers)
+    {
+        return Err(ApiError::with_status(
+            StatusCode::FORBIDDEN,
+            anyhow::anyhow!("package updates can only be installed from this machine"),
+        ));
+    }
+    Ok(())
+}
+
+fn cross_origin_rejected() -> ApiError {
+    ApiError::with_status(
+        StatusCode::FORBIDDEN,
+        anyhow::anyhow!("cross-origin request rejected"),
+    )
+}
+
+fn update_response(snapshot: PackageUpdateSnapshot) -> Response {
+    let mut response = Json(snapshot).into_response();
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::auth;
+    use crate::package_update::PackageUpdateManager;
+
+    async fn test_state(package_updates: Arc<PackageUpdateManager>) -> (AppState, String) {
+        let temp_dir =
+            std::env::temp_dir().join(format!("sprocket-update-route-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let auth = auth::AuthState::load(&temp_dir).expect("auth state");
+        let credential = auth.pairing_credential().to_string();
+        let (_, session_token) = auth.bootstrap(&credential).await.expect("bootstrap");
+        let native_auth = crate::native_auth::NativeAuthManager::configured_for_test(
+            crate::native_auth::NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            auth::desktop_login_callback_url(7731),
+        );
+        let state = AppState::for_test(auth, native_auth, temp_dir, true, package_updates);
+        (state, session_token)
+    }
+
+    fn router(state: AppState) -> axum::Router {
+        crate::build_router(state, None)
+    }
+
+    async fn read_json(response: axum::http::Response<Body>) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    fn session_cookie(session_token: &str) -> String {
+        format!("{}={session_token}", crate::SESSION_COOKIE_NAME)
+    }
+
+    fn loopback_peer() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 54321)
+    }
+
+    fn lan_peer() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)), 54321)
+    }
+
+    fn with_peer(mut request: Request<Body>, peer: SocketAddr) -> Request<Body> {
+        request.extensions_mut().insert(ConnectInfo(peer));
+        request
+    }
+
+    fn status_request(session_token: Option<&str>, origin: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("/api/update")
+            .header(header::HOST, "127.0.0.1:7731");
+        if let Some(origin) = origin {
+            request = request.header(header::ORIGIN, origin);
+        }
+        if let Some(session_token) = session_token {
+            request = request.header(header::COOKIE, session_cookie(session_token));
+        }
+        request.body(Body::empty()).unwrap()
+    }
+
+    fn install_request(
+        session_token: Option<&str>,
+        origin: Option<&str>,
+        body: &'static str,
+    ) -> Request<Body> {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/api/update/install")
+            .header(header::HOST, "127.0.0.1:7731")
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(origin) = origin {
+            request = request.header(header::ORIGIN, origin);
+        }
+        if let Some(session_token) = session_token {
+            request = request.header(header::COOKIE, session_cookie(session_token));
+        }
+        request.body(Body::from(body)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn update_status_requires_session_and_rejects_hostile_origin() {
+        let (state, session_token) = test_state(PackageUpdateManager::disabled()).await;
+        let app = router(state);
+
+        let unauthenticated = app
+            .clone()
+            .oneshot(status_request(None, Some("http://127.0.0.1:7731")))
+            .await
+            .unwrap();
+        assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+        let missing_origin = app
+            .clone()
+            .oneshot(status_request(Some(&session_token), None))
+            .await
+            .unwrap();
+        assert_eq!(missing_origin.status(), StatusCode::OK);
+        assert_eq!(missing_origin.headers()[header::CACHE_CONTROL], "no-store");
+        let payload = read_json(missing_origin).await;
+        assert_eq!(payload["status"], "unavailable");
+        assert_eq!(payload["method"], "package");
+
+        let cross_origin = app
+            .clone()
+            .oneshot(status_request(
+                Some(&session_token),
+                Some("https://attacker.example"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(cross_origin.status(), StatusCode::FORBIDDEN);
+
+        let ok = app
+            .oneshot(status_request(
+                Some(&session_token),
+                Some("http://127.0.0.1:7731"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::OK);
+        let payload = read_json(ok).await;
+        assert_eq!(payload["status"], "unavailable");
+    }
+
+    #[tokio::test]
+    async fn install_requires_session_loopback_and_same_origin() {
+        let (state, session_token) = test_state(PackageUpdateManager::disabled()).await;
+        let app = router(state);
+
+        let unauthenticated = app
+            .clone()
+            .oneshot(with_peer(
+                install_request(None, Some("http://127.0.0.1:7731"), "{}"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+        let missing_origin = app
+            .clone()
+            .oneshot(with_peer(
+                install_request(Some(&session_token), None, "{}"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(missing_origin.status(), StatusCode::FORBIDDEN);
+
+        let cross_origin = app
+            .clone()
+            .oneshot(with_peer(
+                install_request(Some(&session_token), Some("https://attacker.example"), "{}"),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(cross_origin.status(), StatusCode::FORBIDDEN);
+
+        let lan = app
+            .oneshot(with_peer(
+                install_request(Some(&session_token), Some("http://127.0.0.1:7731"), "{}"),
+                lan_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(lan.status(), StatusCode::FORBIDDEN);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod process_tests {
+    use std::fs;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::auth;
+    use crate::package_update::PackageUpdateManager;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let path =
+                std::env::temp_dir().join(format!("sprocket-update-route-{}", Uuid::new_v4()));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_helper(dir: &Path, body: &str) -> Arc<PackageUpdateManager> {
+        let script = dir.join("update-api.sh");
+        fs::write(&script, format!("#!/bin/sh\nset -eu\n{body}\n")).unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        PackageUpdateManager::with_helper_and_timeouts(
+            PathBuf::from("/bin/sh"),
+            script,
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        )
+    }
+
+    async fn test_state(package_updates: Arc<PackageUpdateManager>) -> (AppState, String, TempDir) {
+        let temp_dir = TempDir::new();
+        let auth = auth::AuthState::load(&temp_dir.0).expect("auth state");
+        let credential = auth.pairing_credential().to_string();
+        let (_, session_token) = auth.bootstrap(&credential).await.expect("bootstrap");
+        let native_auth = crate::native_auth::NativeAuthManager::configured_for_test(
+            crate::native_auth::NativeAuthConfig {
+                workos_client_id: "client_test".to_string(),
+            },
+            auth::desktop_login_callback_url(7731),
+        );
+        let state =
+            AppState::for_test(auth, native_auth, temp_dir.0.clone(), true, package_updates);
+        (state, session_token, temp_dir)
+    }
+
+    fn router(state: AppState) -> axum::Router {
+        crate::build_router(state, None)
+    }
+
+    async fn read_json(response: axum::http::Response<Body>) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    fn session_cookie(session_token: &str) -> String {
+        format!("{}={session_token}", crate::SESSION_COOKIE_NAME)
+    }
+
+    fn loopback_peer() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 54321)
+    }
+
+    fn with_peer(mut request: Request<Body>, peer: SocketAddr) -> Request<Body> {
+        request.extensions_mut().insert(ConnectInfo(peer));
+        request
+    }
+
+    fn status_request(session_token: Option<&str>, origin: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("/api/update")
+            .header(header::HOST, "127.0.0.1:7731");
+        if let Some(origin) = origin {
+            request = request.header(header::ORIGIN, origin);
+        }
+        if let Some(session_token) = session_token {
+            request = request.header(header::COOKIE, session_cookie(session_token));
+        }
+        request.body(Body::empty()).unwrap()
+    }
+
+    fn install_request(
+        session_token: Option<&str>,
+        origin: Option<&str>,
+        body: &'static str,
+    ) -> Request<Body> {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/api/update/install")
+            .header(header::HOST, "127.0.0.1:7731")
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(origin) = origin {
+            request = request.header(header::ORIGIN, origin);
+        }
+        if let Some(session_token) = session_token {
+            request = request.header(header::COOKIE, session_cookie(session_token));
+        }
+        request.body(Body::from(body)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn bearer_status_skips_origin_and_does_not_install() {
+        let helper_dir = TempDir::new();
+        let manager = write_helper(
+            &helper_dir.0,
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+echo '{"status":"available","currentVersion":"1.0.0","version":"1.1.0","error":null,"method":"package"}'"#,
+        );
+        let (state, session_token, _dir) = test_state(manager).await;
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/update")
+                    .header(header::HOST, "127.0.0.1:7731")
+                    .header(header::AUTHORIZATION, format!("Bearer {session_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = read_json(response).await;
+        assert_eq!(payload["status"], "available");
+        assert_eq!(
+            fs::read_to_string(helper_dir.0.join("calls")).unwrap(),
+            "check\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_starts_without_using_request_body_and_returns_installing() {
+        let helper_dir = TempDir::new();
+        let manager = write_helper(
+            &helper_dir.0,
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+while [ ! -f "$(dirname "$0")/finish" ]; do sleep 0.02; done
+echo '{"status":"installed","currentVersion":"1.1.0","version":"1.1.0","error":null,"method":"package"}'"#,
+        );
+        let (state, session_token, _dir) = test_state(Arc::clone(&manager)).await;
+        let app = router(state);
+
+        let ok = app
+            .clone()
+            .oneshot(with_peer(
+                install_request(
+                    Some(&session_token),
+                    Some("http://127.0.0.1:7731"),
+                    r#"{"command":"rm -rf /","args":["--force"]}"#,
+                ),
+                loopback_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), StatusCode::OK);
+        let payload = read_json(ok).await;
+        assert_eq!(payload["status"], "installing");
+
+        let status = app
+            .oneshot(status_request(Some(&session_token), None))
+            .await
+            .unwrap();
+        assert_eq!(status.status(), StatusCode::OK);
+        let payload = read_json(status).await;
+        assert_eq!(payload["status"], "installing");
+        finish_install(&manager, &helper_dir.0).await;
+        assert_eq!(
+            fs::read_to_string(helper_dir.0.join("calls")).unwrap(),
+            "install\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_post_coalesces_one_install() {
+        let helper_dir = TempDir::new();
+        let manager = write_helper(
+            &helper_dir.0,
+            r#"printf '%s\n' "$1" >> "$(dirname "$0")/calls"
+while [ ! -f "$(dirname "$0")/finish" ]; do sleep 0.02; done
+echo '{"status":"error","currentVersion":"1.0.0","version":null,"error":"failed","method":"package"}'
+exit 1"#,
+        );
+        let (state, session_token, _dir) = test_state(Arc::clone(&manager)).await;
+        let app = router(state);
+        let first = app.clone().oneshot(with_peer(
+            install_request(Some(&session_token), Some("http://127.0.0.1:7731"), "{}"),
+            loopback_peer(),
+        ));
+        let second = app.oneshot(with_peer(
+            install_request(Some(&session_token), Some("http://127.0.0.1:7731"), "{}"),
+            loopback_peer(),
+        ));
+        let (first, second) = tokio::join!(first, second);
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(read_json(first).await["status"], "installing");
+        assert_eq!(read_json(second).await["status"], "installing");
+        finish_install(&manager, &helper_dir.0).await;
+        assert_eq!(
+            fs::read_to_string(helper_dir.0.join("calls")).unwrap(),
+            "install\n"
+        );
+    }
+
+    async fn finish_install(manager: &Arc<PackageUpdateManager>, directory: &Path) {
+        fs::write(directory.join("finish"), "").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while manager.status().await.status == crate::package_update::UpdateStatus::Installing {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("update helper did not finish");
+    }
+}

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -62,3 +62,14 @@ Install the newest development build with:
 ```sh
 npx @spikonado/sprocket@dev --web
 ```
+
+## Updating published installs
+
+`sprocket update` and `sprocket upgrade` follow the dist-tag that matches the
+installed version: `latest`, `canary`, or `dev`. Stable and canary installs only
+move forward, so an older tag is left alone. A `dev` install follows the current
+`dev` tag whenever the commit hash changes.
+
+Only a global npm, bun, pnpm, or yarn copy of `@spikonado/sprocket` can be
+updated this way. After the package manager finishes, stop Sprocket and launch
+it again. The running process does not reload itself.

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -73,3 +73,6 @@ move forward, so an older tag is left alone. A `dev` install follows the current
 Only a global npm, bun, pnpm, or yarn copy of `@spikonado/sprocket` can be
 updated this way. After the package manager finishes, stop Sprocket and launch
 it again. The running process does not reload itself.
+
+Custom `npm_config_registry` or `NPM_CONFIG_REGISTRY` overrides must use HTTPS.
+Update checks reject registry redirects rather than allow a downgrade to HTTP.

--- a/npm/sprocket/bin/sprocket.js
+++ b/npm/sprocket/bin/sprocket.js
@@ -2,4 +2,4 @@
 
 import { launch } from '../lib/launcher.js';
 
-launch(process.argv.slice(2));
+await launch(process.argv.slice(2));

--- a/npm/sprocket/lib/launcher.js
+++ b/npm/sprocket/lib/launcher.js
@@ -2,7 +2,8 @@ import { spawnSync } from 'node:child_process';
 import { accessSync, chmodSync, constants, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+
+import { createHost, parseUpdateArgs, runUpdateCli, UPDATE_API_FILENAME } from './update.js';
 
 const require = createRequire(import.meta.url);
 
@@ -74,20 +75,45 @@ export function run(binary, args, options = {}) {
 	return result.status ?? 1;
 }
 
-export function launch(args) {
+export function nativeChildEnvironment(env, staticDir, updateNode, updateScript) {
+	const next = {
+		...env,
+		SPROCKET_STATIC_DIR: env.SPROCKET_STATIC_DIR || staticDir,
+		SPROCKET_UPDATE_NODE: updateNode,
+		SPROCKET_UPDATE_SCRIPT: updateScript
+	};
+	delete next.SPROCKET_UPDATE_MANAGED;
+	return next;
+}
+
+export async function launch(args, options = {}) {
+	const env = { ...(options.env ?? process.env) };
+	delete env.SPROCKET_UPDATE_MANAGED;
+	const parsed = parseUpdateArgs(args);
+	if (parsed.kind !== 'none') {
+		const code = await runUpdateCli(parsed, options.host ?? createHost({ env }));
+		process.exitCode = code;
+		return code;
+	}
+
 	try {
-		const packageRoot = path.dirname(fileURLToPath(import.meta.url));
-		const staticDir = path.resolve(packageRoot, '../web');
-		const binary = resolveNativeBinary();
-		ensureExecutable(binary);
+		const libDir = options.libDir ?? import.meta.dirname;
+		const staticDir = path.resolve(libDir, '../web');
+		const binary = (options.resolveBinary ?? resolveNativeBinary)();
+		(options.ensureExecutable ?? ensureExecutable)(binary);
 		process.exitCode = run(binary, args, {
-			env: {
-				...process.env,
-				SPROCKET_STATIC_DIR: process.env.SPROCKET_STATIC_DIR || staticDir
-			}
+			env: nativeChildEnvironment(
+				env,
+				staticDir,
+				options.execPath ?? process.execPath,
+				path.resolve(libDir, UPDATE_API_FILENAME)
+			),
+			spawn: options.spawn
 		});
+		return process.exitCode;
 	} catch (error) {
 		console.error(`sprocket: ${error.message}`);
 		process.exitCode = 1;
+		return 1;
 	}
 }

--- a/npm/sprocket/lib/update-api.js
+++ b/npm/sprocket/lib/update-api.js
@@ -1,0 +1,5 @@
+import { runUpdateApi } from './update.js';
+
+const { exitCode, payload } = await runUpdateApi(process.argv[2]);
+process.stdout.write(`${JSON.stringify(payload)}\n`);
+process.exitCode = exitCode;

--- a/npm/sprocket/lib/update.js
+++ b/npm/sprocket/lib/update.js
@@ -641,11 +641,21 @@ export async function runUpdateCli(parsed, host = createHost()) {
 }
 
 export function registryUrl(env = {}) {
-	const value = asText(env.npm_config_registry).trim();
-	if (/^https?:\/\//i.test(value) && !/\s/.test(value)) {
-		return value.replace(/\/$/, '');
+	const values = [env.npm_config_registry, env.NPM_CONFIG_REGISTRY]
+		.map((value) => asText(value).trim())
+		.filter(Boolean);
+	for (const value of values) {
+		let url;
+		try {
+			url = new URL(value);
+		} catch {
+			throw new Error('Package updates require a valid HTTPS npm registry URL.');
+		}
+		if (url.protocol !== 'https:' || /\s/.test(value) || url.search || url.hash) {
+			throw new Error('Package updates require a valid HTTPS npm registry URL.');
+		}
 	}
-	return DEFAULT_REGISTRY;
+	return values[0]?.replace(/\/$/, '') ?? DEFAULT_REGISTRY;
 }
 
 export function channelManifestUrl(registry, channel, name = PACKAGE_NAME) {
@@ -710,6 +720,7 @@ async function fetchChannelVersion(host, channel, currentVersion) {
 	let response;
 	try {
 		response = await host.fetch(url, {
+			redirect: 'error',
 			headers: {
 				accept: 'application/json',
 				'user-agent': `sprocket/${currentVersion || '0'}`

--- a/npm/sprocket/lib/update.js
+++ b/npm/sprocket/lib/update.js
@@ -1,0 +1,1025 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { promises as fsPromises, readFileSync, realpathSync, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const PACKAGE_NAME = '@spikonado/sprocket';
+export const UPDATE_API_FILENAME = 'update-api.js';
+export const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+export const RELAUNCH_MESSAGE =
+	'Wait for active agents to finish, then stop Sprocket and launch it again.';
+export const UNSUPPORTED_MESSAGE =
+	'This copy of Sprocket was not installed globally with npm, bun, pnpm, or yarn, so it cannot be updated in place.';
+
+const STABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+const CANARY_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+-canary\.[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/;
+const DEV_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9a-f]{40}$/;
+const NUMERIC_IDENTIFIER = /^[0-9]+$/;
+const QUERY_TIMEOUT_MS = 10_000;
+const INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15_000;
+const KILL_WAIT_MS = 5_000;
+const OUTPUT_LIMIT = 1_000_000;
+
+export const PACKAGE_ROOT = path.resolve(import.meta.dirname, '..');
+
+const HELP = `Usage: sprocket update [--check]
+
+Update a global ${PACKAGE_NAME} install.
+
+  --check   Report whether an update is available, without installing
+
+\`sprocket upgrade\` is the same command.
+
+Updates stay on the current channel: latest, canary, or dev.
+Only global installs from npm, bun, pnpm, or yarn can be updated this way.
+`;
+
+const MANAGERS = [
+	{
+		name: 'bun',
+		queryArgs: ['pm', 'bin', '--global'],
+		installArgs: (version) => ['add', '--global', packageSpec(version)],
+		globalRoot(queryStdout) {
+			const binDir = firstAbsolutePath(queryStdout);
+			return binDir ? path.resolve(binDir, '..', 'install', 'global', 'node_modules') : '';
+		}
+	},
+	{
+		name: 'pnpm',
+		queryArgs: ['root', '-g'],
+		installArgs: (version) => ['add', '--global', packageSpec(version)],
+		globalRoot(queryStdout) {
+			return firstAbsolutePath(queryStdout);
+		}
+	},
+	{
+		name: 'yarn',
+		queryArgs: ['global', 'dir'],
+		installArgs: (version) => ['global', 'add', packageSpec(version)],
+		globalRoot(queryStdout) {
+			const dir = firstAbsolutePath(queryStdout);
+			return dir ? path.join(dir, 'node_modules') : '';
+		}
+	},
+	{
+		name: 'npm',
+		queryArgs: ['root', '-g'],
+		installArgs: (version) => ['install', '--global', packageSpec(version)],
+		globalRoot(queryStdout) {
+			return firstAbsolutePath(queryStdout);
+		}
+	}
+];
+
+export function packageSpec(version) {
+	return `${PACKAGE_NAME}@${version}`;
+}
+
+export function asText(value) {
+	if (value == null) {
+		return '';
+	}
+	return `${value}`;
+}
+
+export function parseVersionField(value) {
+	const text = asText(value).trim();
+	if (!text || text.length > 128) {
+		return '';
+	}
+	return text;
+}
+
+export function releaseChannel(version) {
+	const text = asText(version);
+	if (text.includes('-canary.')) {
+		return 'canary';
+	}
+	if (text.includes('-dev.')) {
+		return 'dev';
+	}
+	return 'latest';
+}
+
+export function isAllowedVersion(version, channel) {
+	const text = parseVersionField(version);
+	if (!text) {
+		return false;
+	}
+	if (channel === 'canary') {
+		return CANARY_VERSION.test(text);
+	}
+	if (channel === 'dev') {
+		return DEV_VERSION.test(text);
+	}
+	return STABLE_VERSION.test(text);
+}
+
+export function compareReleaseVersions(left, right) {
+	const parsedLeft = parseComparable(left);
+	const parsedRight = parseComparable(right);
+	if (!parsedLeft || !parsedRight) {
+		return null;
+	}
+	for (let index = 0; index < 3; index += 1) {
+		if (parsedLeft.core[index] < parsedRight.core[index]) {
+			return -1;
+		}
+		if (parsedLeft.core[index] > parsedRight.core[index]) {
+			return 1;
+		}
+	}
+	return comparePrerelease(parsedLeft.pre, parsedRight.pre);
+}
+
+export function channelUpdate(currentVersion, registryVersion) {
+	if (currentVersion === registryVersion) {
+		return { status: 'idle' };
+	}
+	if (releaseChannel(currentVersion) === 'dev') {
+		return { status: 'available', version: registryVersion };
+	}
+	const comparison = compareReleaseVersions(registryVersion, currentVersion);
+	if (comparison == null) {
+		throw new Error('Could not compare the installed version with the registry version.');
+	}
+	if (comparison <= 0) {
+		return { status: 'idle' };
+	}
+	return { status: 'available', version: registryVersion };
+}
+
+export function makePayload(fields) {
+	return {
+		status: fields.status,
+		currentVersion: fields.currentVersion,
+		version: fields.version ?? null,
+		error: fields.error ?? null,
+		method: 'package',
+		message: fields.message ?? null
+	};
+}
+
+export function parseUpdateArgs(args) {
+	const command = args[0];
+	if (command !== 'update' && command !== 'upgrade') {
+		return { kind: 'none' };
+	}
+	let check = false;
+	for (const arg of args.slice(1)) {
+		if (arg === '--help' || arg === '-h') {
+			return { kind: 'help' };
+		}
+		if (arg === '--check') {
+			check = true;
+			continue;
+		}
+		return { kind: 'invalid', error: `Unknown option '${arg}'.` };
+	}
+	return { kind: 'run', check };
+}
+
+export function globalPackageDir(globalRoot) {
+	return path.join(globalRoot, '@spikonado', 'sprocket');
+}
+
+export function isManagedUpdate(env = {}) {
+	return asText(env.SPROCKET_UPDATE_MANAGED) === '1';
+}
+
+export function taskkillPath(env = {}) {
+	const root = asText(env.SystemRoot || env.SYSTEMROOT);
+	if (!path.win32.isAbsolute(root))
+		throw new Error('SystemRoot is unavailable; cannot stop the update process tree.');
+	return path.win32.join(root, 'System32', 'taskkill.exe');
+}
+
+export function timeoutRecoveryMessage(lockPath) {
+	return `Timed out while installing the update. Confirm no package manager is still running, delete ${lockPath}, then retry.`;
+}
+
+export function updateLockPath(host, globalRoot) {
+	const resolved = path.resolve(globalPackageDir(globalRoot));
+	const identity = host.platform === 'win32' ? resolved.toLowerCase() : resolved;
+	const id = createHash('sha256').update(identity).digest('hex').slice(0, 16);
+	return path.join(host.tmpdir(), `sprocket-update-${id}.lock`);
+}
+
+export function waitForClose(child, deadlineMs) {
+	return new Promise((resolve, reject) => {
+		if (child.exitCode != null || child.signalCode != null) {
+			resolve();
+			return;
+		}
+		const finish = () => {
+			clearTimeout(timer);
+			child.off?.('error', fail);
+			resolve();
+		};
+		const fail = (error) => {
+			clearTimeout(timer);
+			child.off?.('close', finish);
+			reject(error);
+		};
+		const timer = setTimeout(() => {
+			child.off?.('close', finish);
+			child.off?.('error', fail);
+			reject(new Error('process did not exit'));
+		}, deadlineMs);
+		if (child.once) {
+			child.once('close', finish);
+			child.once('error', fail);
+			return;
+		}
+		if (child.on) {
+			child.on('close', finish);
+			child.on('error', fail);
+			return;
+		}
+		clearTimeout(timer);
+		resolve();
+	});
+}
+
+export async function killProcessTree(child, platform = process.platform, extras = {}) {
+	const pid = child?.pid;
+	if (pid == null || pid <= 0) {
+		return;
+	}
+	const deadlineMs = extras.deadlineMs ?? KILL_WAIT_MS;
+	if (platform === 'win32') {
+		const spawnImpl = extras.spawn ?? spawn;
+		const killer = spawnImpl(
+			extras.taskkillPath ?? taskkillPath(extras.env),
+			['/PID', String(pid), '/T', '/F'],
+			{
+				shell: false,
+				windowsHide: true,
+				stdio: 'ignore',
+				timeout: deadlineMs,
+				killSignal: 'SIGKILL'
+			}
+		);
+		await Promise.all([waitForClose(killer, deadlineMs), waitForClose(child, deadlineMs)]);
+		if (killer.exitCode !== 0) throw new Error('taskkill could not stop the update process tree.');
+		return;
+	}
+	try {
+		process.kill(-pid, 'SIGKILL');
+	} catch {
+		try {
+			child.kill('SIGKILL');
+		} catch {
+			try {
+				process.kill(pid, 'SIGKILL');
+			} catch {
+				// The process already exited.
+			}
+		}
+	}
+}
+
+export function createRunCommand(spawnImpl, treeKiller = killProcessTree, selfKill) {
+	const killHelperGroup = selfKill ?? ((groupPid) => process.kill(groupPid, 'SIGKILL'));
+	return function runCommand(command, args, options = {}) {
+		return new Promise((resolve) => {
+			let settled = false;
+			let timingOut = false;
+			let timer;
+			let stdout = '';
+			let stderr = '';
+			const platform = options.platform ?? process.platform;
+			const managed = isManagedUpdate(options.env);
+			const killWaitMs = options.killWaitMs ?? KILL_WAIT_MS;
+			const done = (result) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				clearTimeout(timer);
+				resolve(result);
+			};
+
+			let child;
+			try {
+				child = spawnImpl(command, args, {
+					cwd: options.cwd,
+					env: options.env,
+					shell: false,
+					windowsHide: true,
+					detached: platform !== 'win32' && !managed,
+					stdio: ['ignore', 'pipe', 'pipe']
+				});
+			} catch (error) {
+				done({
+					status: 1,
+					stdout: '',
+					stderr: publicError(error),
+					error,
+					timedOut: false
+				});
+				return;
+			}
+
+			child.stdout?.setEncoding('utf8');
+			child.stderr?.setEncoding('utf8');
+			child.stdout?.on('data', (chunk) => {
+				stdout = appendBounded(stdout, chunk);
+			});
+			child.stderr?.on('data', (chunk) => {
+				stderr = appendBounded(stderr, chunk);
+			});
+			child.on('error', (error) => {
+				if (timingOut) return;
+				done({
+					status: 1,
+					stdout,
+					stderr: appendBounded(stderr, publicError(error)),
+					error,
+					timedOut: false
+				});
+			});
+			child.on('close', (status) => {
+				if (!timingOut) done({ status: status ?? 1, stdout, stderr, timedOut: false });
+			});
+
+			if (options.timeout) {
+				timer = setTimeout(() => {
+					void finishTimeout();
+				}, options.timeout);
+			}
+
+			async function finishTimeout() {
+				if (settled) {
+					return;
+				}
+				timingOut = true;
+				if (managed && platform !== 'win32') {
+					try {
+						killHelperGroup(-process.pid);
+					} catch {
+						// Tests inject a no-op killer; production SIGKILL does not return.
+					}
+					done({
+						status: 1,
+						stdout,
+						stderr: appendBounded(stderr, 'Timed out.'),
+						timedOut: true,
+						uncertain: true
+					});
+					return;
+				}
+				let uncertain = false;
+				try {
+					await treeKiller(child, platform, {
+						spawn: spawnImpl,
+						env: options.env,
+						deadlineMs: killWaitMs
+					});
+				} catch {
+					uncertain = true;
+				}
+				child.stdout?.destroy();
+				child.stderr?.destroy();
+				try {
+					await waitForClose(child, killWaitMs);
+				} catch {
+					uncertain = true;
+				}
+				done({
+					status: 1,
+					stdout,
+					stderr: appendBounded(stderr, 'Timed out.'),
+					timedOut: true,
+					uncertain
+				});
+			}
+		});
+	};
+}
+
+export function createHost(overrides = {}) {
+	const env = overrides.env ?? process.env;
+	const platform = overrides.platform ?? process.platform;
+	const execPath = overrides.execPath ?? process.execPath;
+	const packageRoot = overrides.packageRoot ?? PACKAGE_ROOT;
+	const readFile = overrides.readFile ?? ((file, encoding) => readFileSync(file, encoding));
+	const isFile = overrides.isFile ?? defaultIsFile;
+	const host = {
+		env,
+		platform,
+		execPath,
+		pid: overrides.pid ?? process.pid,
+		packageRoot,
+		currentVersion: overrides.currentVersion,
+		tmpdir: overrides.tmpdir ?? (() => os.tmpdir()),
+		homedir: overrides.homedir ?? (() => os.homedir()),
+		fetch: overrides.fetch ?? globalThis.fetch.bind(globalThis),
+		runCommand: overrides.runCommand ?? createRunCommand(overrides.spawn ?? spawn),
+		isFile,
+		readFile,
+		realpath: overrides.realpath ?? defaultRealpath,
+		findExecutable:
+			overrides.findExecutable ?? ((name) => findExecutable(name, env, platform, isFile)),
+		open: overrides.open ?? ((file, flags) => fsPromises.open(file, flags)),
+		unlink: overrides.unlink ?? ((file) => fsPromises.unlink(file)),
+		writeStdout: overrides.writeStdout ?? ((text) => process.stdout.write(text)),
+		writeStderr: overrides.writeStderr ?? ((text) => process.stderr.write(text))
+	};
+	if (host.currentVersion === undefined) {
+		host.currentVersion = readCurrentVersion(host);
+	}
+	return host;
+}
+
+export function readCurrentVersion(host) {
+	const configured = parseVersionField(host.currentVersion);
+	if (configured) {
+		return configured;
+	}
+	try {
+		const manifest = JSON.parse(host.readFile(path.join(host.packageRoot, 'package.json'), 'utf8'));
+		return parseVersionField(manifest?.version);
+	} catch {
+		return '';
+	}
+}
+
+export async function detectInstall(host) {
+	const packageRoot = path.resolve(host.packageRoot);
+	for (const manager of MANAGERS) {
+		const invocation = resolveManagerInvocation(manager.name, host);
+		if (!invocation) {
+			continue;
+		}
+		const globalRoot = await queryGlobalRoot(manager, invocation, host);
+		if (!globalRoot) {
+			continue;
+		}
+		if (isExactGlobalPackage(packageRoot, globalRoot, host)) {
+			return {
+				supported: true,
+				manager: manager.name,
+				command: invocation.command,
+				argsPrefix: invocation.argsPrefix,
+				globalRoot,
+				installArgs: manager.installArgs
+			};
+		}
+	}
+	return { supported: false };
+}
+
+export async function checkForUpdate(host) {
+	const currentVersion = readCurrentVersion(host);
+	const install = await detectInstall(host);
+	if (!install.supported) {
+		return makePayload({
+			status: 'unavailable',
+			currentVersion,
+			message: UNSUPPORTED_MESSAGE
+		});
+	}
+	const channel = releaseChannel(currentVersion);
+	const registryVersion = await fetchChannelVersion(host, channel, currentVersion);
+	const decision = channelUpdate(currentVersion, registryVersion);
+	if (decision.status === 'idle') {
+		return makePayload({ status: 'idle', currentVersion });
+	}
+	return makePayload({
+		status: 'available',
+		currentVersion,
+		version: decision.version
+	});
+}
+
+export async function installUpdate(host) {
+	const currentVersion = readCurrentVersion(host);
+	const detected = await detectInstall(host);
+	if (!detected.supported) {
+		return makePayload({
+			status: 'unavailable',
+			currentVersion,
+			message: UNSUPPORTED_MESSAGE
+		});
+	}
+	const lockPath = updateLockPath(host, detected.globalRoot);
+	try {
+		return await withUpdateLock(host, lockPath, async () => {
+			const checked = await checkForUpdate(host);
+			if (checked.status !== 'available') {
+				return { payload: checked };
+			}
+			const install = await detectInstall(host);
+			if (!install.supported) {
+				return {
+					payload: makePayload({
+						status: 'unavailable',
+						currentVersion,
+						message: UNSUPPORTED_MESSAGE
+					})
+				};
+			}
+			if (!isAllowedVersion(checked.version, releaseChannel(currentVersion))) {
+				return {
+					payload: makePayload({
+						status: 'error',
+						currentVersion,
+						version: checked.version,
+						error: 'Refusing to install a version that failed validation.'
+					})
+				};
+			}
+			if (updateLockPath(host, install.globalRoot) !== lockPath) {
+				throw new Error('The installation location changed during the update check. Try again.');
+			}
+			const result = await host.runCommand(
+				install.command,
+				[...install.argsPrefix, ...install.installArgs(checked.version)],
+				{
+					cwd: host.homedir(),
+					env: host.env,
+					platform: host.platform,
+					timeout: INSTALL_TIMEOUT_MS
+				}
+			);
+			if (result.timedOut || result.uncertain) {
+				return {
+					retainLock: true,
+					payload: makePayload({
+						status: 'error',
+						currentVersion,
+						version: checked.version,
+						error: timeoutRecoveryMessage(lockPath)
+					})
+				};
+			}
+			if ((result.status ?? 1) !== 0) {
+				return {
+					payload: makePayload({
+						status: 'error',
+						currentVersion,
+						version: checked.version,
+						error: installFailureMessage(
+							`${result.stderr ?? ''}\n${result.stdout ?? ''}`,
+							host.platform
+						)
+					})
+				};
+			}
+			return {
+				payload: makePayload({
+					status: 'installed',
+					currentVersion,
+					version: checked.version,
+					message: RELAUNCH_MESSAGE
+				})
+			};
+		});
+	} catch (error) {
+		return makePayload({
+			status: 'error',
+			currentVersion,
+			error: publicError(error)
+		});
+	}
+}
+
+export async function runUpdateApi(command, host = createHost()) {
+	const currentVersion = readCurrentVersion(host);
+	try {
+		if (command !== 'check' && command !== 'install') {
+			return {
+				exitCode: 1,
+				payload: makePayload({
+					status: 'error',
+					currentVersion,
+					error: 'Usage: check or install.'
+				})
+			};
+		}
+		const payload = command === 'check' ? await checkForUpdate(host) : await installUpdate(host);
+		return {
+			exitCode: payload.status === 'error' ? 1 : 0,
+			payload
+		};
+	} catch (error) {
+		return {
+			exitCode: 1,
+			payload: makePayload({
+				status: 'error',
+				currentVersion,
+				error: publicError(error)
+			})
+		};
+	}
+}
+
+export async function runUpdateCli(parsed, host = createHost()) {
+	if (parsed.kind === 'help') {
+		host.writeStdout(HELP);
+		return 0;
+	}
+	if (parsed.kind === 'invalid') {
+		host.writeStderr(`sprocket: ${parsed.error}\nTry \`sprocket update --help\`.\n`);
+		return 1;
+	}
+	try {
+		const payload = parsed.check ? await checkForUpdate(host) : await installUpdate(host);
+		if (payload.status === 'error') {
+			host.writeStderr(`sprocket: ${payload.error}\n`);
+			return 1;
+		}
+		host.writeStdout(formatCli(payload, parsed.check));
+		return payload.status === 'unavailable' ? 1 : 0;
+	} catch (error) {
+		host.writeStderr(`sprocket: ${publicError(error)}\n`);
+		return 1;
+	}
+}
+
+export function registryUrl(env = {}) {
+	const value = asText(env.npm_config_registry).trim();
+	if (/^https?:\/\//i.test(value) && !/\s/.test(value)) {
+		return value.replace(/\/$/, '');
+	}
+	return DEFAULT_REGISTRY;
+}
+
+export function channelManifestUrl(registry, channel, name = PACKAGE_NAME) {
+	const base = registry.replace(/\/$/, '');
+	const encodedName = encodeURIComponent(name);
+	return `${base}/${encodedName}/${encodeURIComponent(channel)}`;
+}
+
+export async function withUpdateLock(host, lockPath, operation) {
+	let handle;
+	try {
+		handle = await host.open(lockPath, 'wx');
+	} catch (error) {
+		if (error?.code === 'EEXIST') {
+			throw new Error(
+				`Another Sprocket update is already running. If it is not, delete ${lockPath} and retry.`
+			);
+		}
+		if (error?.code === 'EACCES' || error?.code === 'EPERM') {
+			throw new Error(`Cannot write the update lock at ${lockPath}. Check permissions and retry.`);
+		}
+		throw error;
+	}
+	let retainLock = false;
+	try {
+		await handle.writeFile(String(host.pid));
+		const outcome = await operation();
+		retainLock = outcome?.retainLock === true;
+		return outcome?.payload ?? outcome;
+	} finally {
+		await handle.close().catch(() => {});
+		if (!retainLock) {
+			await host.unlink(lockPath).catch(() => {});
+		}
+	}
+}
+
+function formatCli(payload, check) {
+	if (payload.status === 'unavailable') {
+		return `${payload.message ?? UNSUPPORTED_MESSAGE}\n`;
+	}
+	if (payload.status === 'idle') {
+		return `Sprocket ${payload.currentVersion} is up to date (${releaseChannel(payload.currentVersion)} channel).\n`;
+	}
+	if (payload.status === 'available') {
+		const lines = [
+			`Sprocket ${payload.version} is available (currently ${payload.currentVersion}).`
+		];
+		if (check) {
+			lines.push('Run `sprocket update` to install it.');
+		}
+		return `${lines.join('\n')}\n`;
+	}
+	if (payload.status === 'installed') {
+		return `Updated Sprocket to ${payload.version}.\n${payload.message ?? RELAUNCH_MESSAGE}\n`;
+	}
+	return '';
+}
+
+async function fetchChannelVersion(host, channel, currentVersion) {
+	const url = channelManifestUrl(registryUrl(host.env), channel);
+	let response;
+	try {
+		response = await host.fetch(url, {
+			headers: {
+				accept: 'application/json',
+				'user-agent': `sprocket/${currentVersion || '0'}`
+			},
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+		});
+	} catch {
+		throw new Error('Could not reach the npm registry. Try again.');
+	}
+	if (!response.ok) {
+		throw new Error(`npm registry returned HTTP ${response.status}.`);
+	}
+	let body;
+	try {
+		body = await response.json();
+	} catch {
+		throw new Error('npm registry returned an invalid package document.');
+	}
+	const version = parseVersionField(body?.version);
+	if (!isAllowedVersion(version, channel)) {
+		throw new Error(`npm dist-tag '${channel}' does not point at a valid ${channel} release.`);
+	}
+	return version;
+}
+
+function isExactGlobalPackage(packageRoot, globalRoot, host) {
+	const expected = globalPackageDir(globalRoot);
+	const actual = pathIdentities(host, packageRoot);
+	for (const candidate of pathIdentities(host, expected)) {
+		if (actual.has(candidate)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function pathIdentities(host, file) {
+	const identities = new Set([normalizePath(file, host.platform)]);
+	identities.add(normalizePath(tryRealpath(host, file), host.platform));
+	return identities;
+}
+
+function normalizePath(file, platform) {
+	const resolved = path.resolve(file);
+	return platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function resolveManagerInvocation(manager, host) {
+	const execDir = path.dirname(host.execPath);
+	const execBase = path.basename(host.execPath, '.exe').toLowerCase();
+	if (manager === 'bun' && execBase === 'bun') {
+		return { command: host.execPath, argsPrefix: [] };
+	}
+	if (manager === 'npm') {
+		const npmCli = path.join(execDir, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+		if (host.isFile(npmCli)) {
+			return { command: host.execPath, argsPrefix: [npmCli] };
+		}
+		const npmExecPath = asText(host.env.npm_execpath);
+		if (
+			npmExecPath &&
+			isAbsolutePath(npmExecPath, host.platform) &&
+			host.isFile(npmExecPath) &&
+			/npm-cli\.js$/i.test(npmExecPath)
+		) {
+			return { command: host.execPath, argsPrefix: [npmExecPath] };
+		}
+	}
+	const found = host.findExecutable(manager);
+	if (!found) {
+		return null;
+	}
+	return spawnPlan(found, manager, host);
+}
+
+function spawnPlan(binary, manager, host) {
+	if (/\.(cjs|js|mjs)$/i.test(binary)) {
+		return { command: host.execPath, argsPrefix: [binary] };
+	}
+	if (host.platform === 'win32' && /\.(cmd|bat)$/i.test(binary)) {
+		const jsCli = jsCliBesideShim(binary, manager, host);
+		if (jsCli) {
+			return { command: host.execPath, argsPrefix: [jsCli] };
+		}
+		return null;
+	}
+	return { command: binary, argsPrefix: [] };
+}
+
+function jsCliBesideShim(binary, manager, host) {
+	const dir = path.dirname(binary);
+	const candidates =
+		manager === 'npm'
+			? [path.join(dir, 'node_modules', 'npm', 'bin', 'npm-cli.js'), path.join(dir, 'npm-cli.js')]
+			: manager === 'pnpm'
+				? [path.join(dir, 'pnpm.cjs'), path.join(dir, 'node_modules', 'pnpm', 'bin', 'pnpm.cjs')]
+				: manager === 'yarn'
+					? [path.join(dir, 'yarn.js'), path.join(dir, 'node_modules', 'yarn', 'bin', 'yarn.js')]
+					: [];
+	return candidates.find((candidate) => host.isFile(candidate));
+}
+
+async function queryGlobalRoot(manager, invocation, host) {
+	const result = await host.runCommand(
+		invocation.command,
+		[...invocation.argsPrefix, ...manager.queryArgs],
+		{
+			cwd: host.homedir(),
+			env: {
+				...host.env,
+				COREPACK_ENABLE_NETWORK: '0',
+				COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+			},
+			platform: host.platform,
+			timeout: QUERY_TIMEOUT_MS
+		}
+	);
+	if ((result.status ?? 1) !== 0) {
+		return '';
+	}
+	const globalRoot = manager.globalRoot(result.stdout ?? '');
+	if (!globalRoot || globalRoot.includes('\0')) {
+		return '';
+	}
+	return path.resolve(globalRoot);
+}
+
+function parseComparable(version) {
+	const text = asText(version);
+	if (STABLE_VERSION.test(text)) {
+		const [major, minor, patch] = text.split('.');
+		return { core: [Number(major), Number(minor), Number(patch)], pre: [] };
+	}
+	if (!CANARY_VERSION.test(text)) {
+		return null;
+	}
+	const marker = '-canary.';
+	const index = text.indexOf(marker);
+	const [major, minor, patch] = text.slice(0, index).split('.');
+	return {
+		core: [Number(major), Number(minor), Number(patch)],
+		pre: ['canary', ...text.slice(index + marker.length).split('.')]
+	};
+}
+
+function comparePrerelease(left, right) {
+	if (left.length === 0 && right.length === 0) {
+		return 0;
+	}
+	if (left.length === 0) {
+		return 1;
+	}
+	if (right.length === 0) {
+		return -1;
+	}
+	const length = Math.max(left.length, right.length);
+	for (let index = 0; index < length; index += 1) {
+		if (index >= left.length) {
+			return -1;
+		}
+		if (index >= right.length) {
+			return 1;
+		}
+		const comparison = compareIdentifier(left[index], right[index]);
+		if (comparison !== 0) {
+			return comparison;
+		}
+	}
+	return 0;
+}
+
+function compareIdentifier(left, right) {
+	const leftNumeric = NUMERIC_IDENTIFIER.test(left);
+	const rightNumeric = NUMERIC_IDENTIFIER.test(right);
+	if (leftNumeric && rightNumeric) {
+		const delta = Number(left) - Number(right);
+		if (delta < 0) {
+			return -1;
+		}
+		if (delta > 0) {
+			return 1;
+		}
+		return 0;
+	}
+	if (leftNumeric) {
+		return -1;
+	}
+	if (rightNumeric) {
+		return 1;
+	}
+	if (left < right) {
+		return -1;
+	}
+	if (left > right) {
+		return 1;
+	}
+	return 0;
+}
+
+function installFailureMessage(output, platform) {
+	if (isWindowsBusyExecutable(output, platform)) {
+		return 'Windows cannot replace Sprocket while it is running. Stop Sprocket, then run `sprocket update` again.';
+	}
+	const lines = output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const useful = lines
+		.filter((line) => /npm ERR!|error|ERR!|EACCES|EPERM|EBUSY|denied|ELIFECYCLE/i.test(line))
+		.slice(-5);
+	const detail = useful.join(' ') || 'the package manager failed';
+	return `Failed to install the update: ${sanitize(detail)}`;
+}
+
+export function isWindowsBusyExecutable(output, platform) {
+	if (platform !== 'win32') {
+		return false;
+	}
+	return (
+		/sprocket\.exe/i.test(output) &&
+		/(?:EBUSY|EPERM|EACCES|being used by another process|resource busy|locked)/i.test(output)
+	);
+}
+
+function publicError(error) {
+	if (error instanceof Error) {
+		return sanitize(error.message);
+	}
+	return sanitize(asText(error));
+}
+
+function sanitize(text) {
+	return asText(text).replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function isAbsolutePath(file, platform) {
+	if (platform === 'win32') {
+		return path.win32.isAbsolute(file) || /^[a-zA-Z]:[\\/]/.test(file) || file.startsWith('\\\\');
+	}
+	return path.isAbsolute(file);
+}
+
+function findExecutable(name, env, platform, isFile) {
+	const pathValue = asText(env.PATH || env.Path || env.path);
+	const directories = pathValue.split(path.delimiter);
+	const extensions =
+		platform === 'win32'
+			? asText(env.PATHEXT || '.EXE;.CMD;.BAT;.COM')
+					.split(';')
+					.filter(Boolean)
+			: [''];
+	for (const directory of directories) {
+		if (!directory || !isAbsolutePath(directory, platform)) {
+			continue;
+		}
+		if (platform === 'win32') {
+			const exact = path.join(directory, name);
+			if (isFile(exact)) {
+				return exact;
+			}
+			for (const extension of extensions) {
+				const candidate = path.join(directory, name + extension);
+				if (isFile(candidate)) {
+					return candidate;
+				}
+			}
+			continue;
+		}
+		const candidate = path.join(directory, name);
+		if (isFile(candidate)) {
+			return candidate;
+		}
+	}
+	return undefined;
+}
+
+function defaultIsFile(file) {
+	try {
+		return statSync(file).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function defaultRealpath(file) {
+	return realpathSync(file);
+}
+
+function tryRealpath(host, file) {
+	try {
+		return host.realpath(file);
+	} catch {
+		return file;
+	}
+}
+
+function firstAbsolutePath(text) {
+	for (const line of asText(text).split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.includes('\0')) {
+			continue;
+		}
+		if (path.isAbsolute(trimmed) || /^[a-zA-Z]:[\\/]/.test(trimmed) || trimmed.startsWith('\\\\')) {
+			return trimmed;
+		}
+	}
+	return '';
+}
+
+function appendBounded(previous, chunk) {
+	const next = previous + chunk;
+	return next.length > OUTPUT_LIMIT ? next.slice(next.length - OUTPUT_LIMIT) : next;
+}

--- a/npm/sprocket/test/launcher.test.js
+++ b/npm/sprocket/test/launcher.test.js
@@ -4,7 +4,14 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { ensureExecutable, nativePackage, run } from '../lib/launcher.js';
+import {
+	ensureExecutable,
+	launch,
+	nativeChildEnvironment,
+	nativePackage,
+	run
+} from '../lib/launcher.js';
+import { createHost } from '../lib/update.js';
 
 test('selects the native package for supported platforms', () => {
 	assert.deepEqual(nativePackage('linux', 'x64'), [
@@ -52,4 +59,66 @@ test('runs the native executable with unchanged arguments and environment', () =
 		options: { stdio: 'inherit', env: expectedEnv }
 	});
 	assert.equal(status, 0);
+});
+
+test('overrides inherited update helper environment for the native child', async () => {
+	let invocation;
+	await launch(['--web'], {
+		env: {
+			SPROCKET_STATIC_DIR: '/tmp/web',
+			SPROCKET_UPDATE_NODE: '/evil/node',
+			SPROCKET_UPDATE_SCRIPT: '/evil/update-api.js',
+			SPROCKET_UPDATE_MANAGED: '1'
+		},
+		execPath: '/usr/bin/node',
+		libDir: '/pkg/lib',
+		resolveBinary: () => '/tmp/sprocket',
+		ensureExecutable: () => {},
+		spawn(binary, args, options) {
+			invocation = { binary, args, options };
+			return { status: 0 };
+		}
+	});
+	assert.equal(invocation.options.env.SPROCKET_UPDATE_NODE, '/usr/bin/node');
+	assert.equal(
+		invocation.options.env.SPROCKET_UPDATE_SCRIPT,
+		path.resolve('/pkg/lib', 'update-api.js')
+	);
+	assert.equal(invocation.options.env.SPROCKET_STATIC_DIR, '/tmp/web');
+	assert.equal(Object.hasOwn(invocation.options.env, 'SPROCKET_UPDATE_MANAGED'), false);
+});
+
+test('update and upgrade do not spawn the native binary', async () => {
+	let stdout = '';
+	const code = await launch(['upgrade', '--help'], {
+		host: createHost({
+			writeStdout(text) {
+				stdout += text;
+			},
+			writeStderr() {}
+		}),
+		spawn() {
+			throw new Error('native binary should not run');
+		}
+	});
+	assert.equal(code, 0);
+	assert.match(stdout, /sprocket update/);
+});
+
+test('native child environment always overwrites helper paths', () => {
+	const env = nativeChildEnvironment(
+		{
+			SPROCKET_STATIC_DIR: '/custom/web',
+			SPROCKET_UPDATE_NODE: '/evil/node',
+			SPROCKET_UPDATE_SCRIPT: '/evil/update-api.js',
+			SPROCKET_UPDATE_MANAGED: '1'
+		},
+		'/pkg/web',
+		'/usr/bin/node',
+		'/pkg/lib/update-api.js'
+	);
+	assert.equal(env.SPROCKET_STATIC_DIR, '/custom/web');
+	assert.equal(env.SPROCKET_UPDATE_NODE, '/usr/bin/node');
+	assert.equal(env.SPROCKET_UPDATE_SCRIPT, '/pkg/lib/update-api.js');
+	assert.equal(Object.hasOwn(env, 'SPROCKET_UPDATE_MANAGED'), false);
 });

--- a/npm/sprocket/test/managed-group-helper.mjs
+++ b/npm/sprocket/test/managed-group-helper.mjs
@@ -1,0 +1,18 @@
+import { spawn } from 'node:child_process';
+import { createRunCommand } from '../lib/update.js';
+
+const pidFile = process.argv[2];
+const nested = [
+	'const {spawn}=require("node:child_process");',
+	'const {writeFileSync}=require("node:fs");',
+	'const g=spawn(process.execPath,["-e","setInterval(()=>{},6e4)"],{stdio:"ignore"});',
+	'writeFileSync(process.env.SPROCKET_TEST_PID_FILE,String(g.pid));',
+	'setInterval(()=>{},6e4);'
+].join('');
+
+const runCommand = createRunCommand(spawn);
+await runCommand(process.execPath, ['-e', nested], {
+	env: { ...process.env, SPROCKET_UPDATE_MANAGED: '1', SPROCKET_TEST_PID_FILE: pidFile },
+	timeout: 500,
+	platform: process.platform
+});

--- a/npm/sprocket/test/npm-packages.test.js
+++ b/npm/sprocket/test/npm-packages.test.js
@@ -64,6 +64,8 @@ test('assembles version-matched root and native packages', async () => {
 		);
 		assert.equal(rootManifest.engines.node, sourceManifest.engines.node);
 		await access(path.join(output, 'sprocket/bin/sprocket.js'), constants.X_OK);
+		await access(path.join(output, 'sprocket/lib/update-api.js'));
+		await access(path.join(output, 'sprocket/lib/update.js'));
 		await access(path.join(output, 'linux-x64-gnu/bin/sprocket'), constants.X_OK);
 	} finally {
 		await rm(temporary, { recursive: true, force: true });

--- a/npm/sprocket/test/update.test.js
+++ b/npm/sprocket/test/update.test.js
@@ -96,6 +96,26 @@ async function waitForFile(file) {
 	throw new Error(`missing ${file}`);
 }
 
+async function waitForProcessToStop(pid) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		try {
+			process.kill(pid, 0);
+			if (process.platform === 'linux') {
+				const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+				// A killed orphan may still have a PID until the runner's init reaps it.
+				if (['Z', 'X'].includes(stat[stat.lastIndexOf(')') + 2])) {
+					return;
+				}
+			}
+		} catch (error) {
+			if (error.code === 'ESRCH' || error.code === 'ENOENT') return;
+			throw error;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	assert.fail(`process ${pid} is still running`);
+}
+
 function testHost(options = {}) {
 	const commands = [];
 	const fetched = [];
@@ -786,8 +806,6 @@ test(
 				[path.resolve(import.meta.dirname, 'managed-group-helper.mjs'), pidFile],
 				{ detached: true, stdio: 'ignore' }
 			);
-			await waitForFile(pidFile);
-			const grandchildPid = Number(readFileSync(pidFile, 'utf8').trim());
 			await new Promise((resolve, reject) => {
 				const timer = setTimeout(() => reject(new Error('helper did not exit')), 5000);
 				helper.once('close', () => {
@@ -795,15 +813,10 @@ test(
 					resolve();
 				});
 			});
+			await waitForFile(pidFile);
+			const grandchildPid = Number(readFileSync(pidFile, 'utf8').trim());
 			assert.equal(Number.isInteger(grandchildPid) && grandchildPid > 0, true);
-			let alive = false;
-			try {
-				process.kill(grandchildPid, 0);
-				alive = true;
-			} catch {
-				alive = false;
-			}
-			assert.equal(alive, false);
+			await waitForProcessToStop(grandchildPid);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}
@@ -846,13 +859,28 @@ test('ignores relative PATH entries and relative npm_execpath', async () => {
 	assert.equal(install.command, '/usr/bin/npm');
 });
 
-test('uses npm_config_registry when it is an http URL', () => {
+test('accepts HTTPS registry URLs and rejects insecure or malformed overrides', () => {
 	assert.equal(registryUrl({}), 'https://registry.npmjs.org');
 	assert.equal(
 		registryUrl({ npm_config_registry: 'https://example.invalid/npm/' }),
 		'https://example.invalid/npm'
 	);
-	assert.equal(registryUrl({ npm_config_registry: 'file:///tmp' }), 'https://registry.npmjs.org');
+	assert.equal(
+		registryUrl({ NPM_CONFIG_REGISTRY: 'https://example.invalid/npm/' }),
+		'https://example.invalid/npm'
+	);
+	for (const value of ['http://example.invalid', 'file:///tmp', 'not a URL', 'https://host/?q=1']) {
+		assert.throws(() => registryUrl({ npm_config_registry: value }), /HTTPS/);
+		assert.throws(() => registryUrl({ NPM_CONFIG_REGISTRY: value }), /HTTPS/);
+	}
+	assert.throws(
+		() =>
+			registryUrl({
+				npm_config_registry: 'https://registry.npmjs.org',
+				NPM_CONFIG_REGISTRY: 'http://example.invalid'
+			}),
+		/HTTPS/
+	);
 	assert.equal(
 		channelManifestUrl('https://registry.npmjs.org', 'latest'),
 		'https://registry.npmjs.org/%40spikonado%2Fsprocket/latest'
@@ -861,6 +889,32 @@ test('uses npm_config_registry when it is an http URL', () => {
 		channelManifestUrl('https://registry.npmjs.org', 'canary'),
 		'https://registry.npmjs.org/%40spikonado%2Fsprocket/canary'
 	);
+});
+
+test('insecure registry overrides cannot fetch a version or run an install', async () => {
+	const { host, commands, fetched } = testHost({
+		env: { PATH: '/usr/bin', npm_config_registry: 'http://example.invalid' },
+		executables: { npm: '/usr/bin/npm' }
+	});
+	const result = await installUpdate(host);
+	assert.equal(result.status, 'error');
+	assert.match(result.error, /HTTPS/);
+	assert.equal(fetched.length, 0);
+	assert.equal(
+		commands.some(({ args }) => isInstallArgs(args)),
+		false
+	);
+});
+
+test('registry checks disallow redirects rather than risk an HTTP downgrade', async () => {
+	const { host } = testHost({
+		executables: { npm: '/usr/bin/npm' },
+		fetch: async (_url, options) => {
+			assert.equal(options.redirect, 'error');
+			return jsonResponse(versionDoc('0.3.5'));
+		}
+	});
+	assert.equal((await checkForUpdate(host)).status, 'available');
 });
 
 test('update-api.js prints only JSON and rejects unknown commands', () => {

--- a/npm/sprocket/test/update.test.js
+++ b/npm/sprocket/test/update.test.js
@@ -1,0 +1,891 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, promises as fsPromises, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+import {
+	PACKAGE_NAME,
+	RELAUNCH_MESSAGE,
+	UNSUPPORTED_MESSAGE,
+	channelManifestUrl,
+	channelUpdate,
+	checkForUpdate,
+	compareReleaseVersions,
+	createHost,
+	createRunCommand,
+	detectInstall,
+	globalPackageDir,
+	installUpdate,
+	isAllowedVersion,
+	isWindowsBusyExecutable,
+	killProcessTree,
+	makePayload,
+	parseUpdateArgs,
+	registryUrl,
+	releaseChannel,
+	runUpdateApi,
+	runUpdateCli,
+	taskkillPath,
+	timeoutRecoveryMessage,
+	updateLockPath
+} from '../lib/update.js';
+
+const DEV_SHA = '0123456789abcdef0123456789abcdef01234567';
+const DEV_SHA_HIGH = 'f'.repeat(40);
+const DEV_SHA_LOW = '0'.repeat(40);
+const NPM_CLI = '/usr/bin/node_modules/npm/bin/npm-cli.js';
+const NPM_ROOT = '/usr/local/lib/node_modules';
+const NPM_PACKAGE = `${NPM_ROOT}/@spikonado/sprocket`;
+
+function jsonResponse(body, status = 200) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		async json() {
+			return body;
+		}
+	};
+}
+
+function versionDoc(version) {
+	return { name: PACKAGE_NAME, version };
+}
+
+function managerOf(command, args) {
+	if (args.some((arg) => /npm-cli\.js$/i.test(arg)) || /(?:^|[/\\])npm(?:\.cmd)?$/i.test(command)) {
+		return 'npm';
+	}
+	if (
+		args.some((arg) => /pnpm\.cjs$/i.test(arg)) ||
+		/(?:^|[/\\])pnpm(?:\.cmd|\.exe)?$/i.test(command)
+	) {
+		return 'pnpm';
+	}
+	if (
+		args.some((arg) => /yarn\.js$/i.test(arg)) ||
+		/(?:^|[/\\])yarn(?:\.cmd|\.exe)?$/i.test(command)
+	) {
+		return 'yarn';
+	}
+	if (/(?:^|[/\\])bun(?:\.exe)?$/i.test(command) || args.includes('pm')) {
+		return 'bun';
+	}
+	return 'unknown';
+}
+
+function isInstallArgs(args) {
+	return (
+		(args.includes('install') && args.includes('--global')) ||
+		(args.includes('add') && args.includes('--global')) ||
+		(args.includes('global') && args.includes('add'))
+	);
+}
+
+async function waitForFile(file) {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		try {
+			readFileSync(file);
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	throw new Error(`missing ${file}`);
+}
+
+function testHost(options = {}) {
+	const commands = [];
+	const fetched = [];
+	const lockFiles = options.lockFiles ?? new Map();
+	let releaseInstall;
+	const installHold = options.holdInstall
+		? new Promise((resolve) => {
+				releaseInstall = resolve;
+			})
+		: null;
+
+	const host = createHost({
+		platform: options.platform ?? 'linux',
+		execPath: options.execPath ?? '/usr/bin/node',
+		packageRoot: options.packageRoot ?? NPM_PACKAGE,
+		currentVersion: options.currentVersion ?? '0.3.4',
+		pid: options.pid ?? 1001,
+		env: options.env ?? { PATH: '/usr/bin' },
+		tmpdir: options.tmpdir ?? (() => '/tmp'),
+		homedir: options.homedir ?? (() => '/home/user'),
+		isFile: options.isFile ?? ((file) => file === NPM_CLI || Boolean(options.files?.[file])),
+		findExecutable: options.findExecutable ?? ((name) => options.executables?.[name]),
+		realpath: options.realpath ?? ((file) => file),
+		fetch:
+			options.fetch ??
+			(async (url) => {
+				fetched.push(String(url));
+				return jsonResponse(options.manifest ?? versionDoc('0.3.5'));
+			}),
+		runCommand: async (command, args, spawnOptions) => {
+			commands.push({ command, args, options: spawnOptions });
+			if (options.runCommand) {
+				return options.runCommand(command, args, spawnOptions);
+			}
+			if (args.includes('pm') && args.includes('bin')) {
+				return options.bunBin
+					? { status: 0, stdout: options.bunBin, stderr: '' }
+					: { status: 1, stdout: '', stderr: 'not bun' };
+			}
+			if (args.includes('global') && args.includes('dir') && !args.includes('add')) {
+				return options.yarnDir
+					? { status: 0, stdout: options.yarnDir, stderr: '' }
+					: { status: 1, stdout: '', stderr: 'not yarn' };
+			}
+			if (args.includes('root') && args.includes('-g')) {
+				const manager = managerOf(command, args);
+				const stdout = manager === 'pnpm' ? options.pnpmRoot : (options.npmRoot ?? NPM_ROOT);
+				return stdout
+					? { status: 0, stdout, stderr: '' }
+					: { status: 1, stdout: '', stderr: 'no root' };
+			}
+			if (isInstallArgs(args)) {
+				if (installHold) {
+					await installHold;
+				}
+				return options.install ?? { status: 0, stdout: '', stderr: '' };
+			}
+			return { status: 1, stdout: '', stderr: 'unexpected command' };
+		},
+		open:
+			options.open ??
+			(async (file, flags) => {
+				if (flags === 'wx' && lockFiles.has(file)) {
+					const error = new Error('EEXIST');
+					error.code = 'EEXIST';
+					throw error;
+				}
+				lockFiles.set(file, '');
+				return {
+					writeFile: async (contents) => {
+						lockFiles.set(file, String(contents));
+					},
+					close: async () => {}
+				};
+			}),
+		unlink:
+			options.unlink ??
+			(async (file) => {
+				lockFiles.delete(file);
+			}),
+		readFile:
+			options.readFile ??
+			((file) => {
+				if (lockFiles.has(file)) {
+					return lockFiles.get(file);
+				}
+				const error = new Error('ENOENT');
+				error.code = 'ENOENT';
+				throw error;
+			}),
+		writeStdout: options.writeStdout ?? (() => {}),
+		writeStderr: options.writeStderr ?? (() => {})
+	});
+
+	return { host, commands, fetched, lockFiles, releaseInstall };
+}
+
+test('maps installed versions onto latest, canary, and dev channels', () => {
+	assert.equal(releaseChannel('0.3.4'), 'latest');
+	assert.equal(releaseChannel('0.3.4-canary.1'), 'canary');
+	assert.equal(releaseChannel(`0.3.4-dev.${DEV_SHA}`), 'dev');
+});
+
+test('accepts only registry versions that match the release channel', () => {
+	assert.equal(isAllowedVersion('0.3.5', 'latest'), true);
+	assert.equal(isAllowedVersion('0.3.5-canary.1', 'latest'), false);
+	assert.equal(isAllowedVersion('0.3.5; rm -rf /', 'latest'), false);
+	assert.equal(isAllowedVersion('--prefix=/tmp', 'latest'), false);
+	assert.equal(isAllowedVersion('0.3.5-canary.1', 'canary'), true);
+	assert.equal(isAllowedVersion(`0.3.5-dev.${DEV_SHA}`, 'dev'), true);
+	assert.equal(isAllowedVersion('0.3.5-dev.abc', 'dev'), false);
+});
+
+test('stable and canary updates move forward only', () => {
+	assert.equal(compareReleaseVersions('0.3.5', '0.3.4') > 0, true);
+	assert.equal(compareReleaseVersions('0.3.4', '0.4.0') > 0, false);
+	assert.equal(compareReleaseVersions('0.3.4-canary.10', '0.3.4-canary.2') > 0, true);
+	assert.equal(channelUpdate('0.4.0', '0.3.5').status, 'idle');
+	assert.equal(channelUpdate('0.3.4-canary.10', '0.3.4-canary.2').status, 'idle');
+	assert.equal(channelUpdate('0.3.4', '0.3.5').status, 'available');
+});
+
+test('dev updates follow a changed commit hash without ordering the hash', () => {
+	const current = `0.3.5-dev.${DEV_SHA_HIGH}`;
+	const tagged = `0.3.4-dev.${DEV_SHA_LOW}`;
+	assert.equal(channelUpdate(current, tagged).status, 'available');
+	assert.equal(channelUpdate(current, current).status, 'idle');
+});
+
+test('parses update, upgrade, --check, and help', () => {
+	assert.deepEqual(parseUpdateArgs(['serve']), { kind: 'none' });
+	assert.deepEqual(parseUpdateArgs(['update']), { kind: 'run', check: false });
+	assert.deepEqual(parseUpdateArgs(['upgrade', '--check']), { kind: 'run', check: true });
+	assert.equal(parseUpdateArgs(['update', '--help']).kind, 'help');
+	assert.equal(parseUpdateArgs(['update', '--force']).kind, 'invalid');
+});
+
+test('detects a global npm install from the exact package path', async () => {
+	const { host } = testHost();
+	const install = await detectInstall(host);
+	assert.equal(install.supported, true);
+	assert.equal(install.manager, 'npm');
+});
+
+test('does not treat a nested global dependency as this install', async () => {
+	const { host, commands } = testHost({
+		packageRoot: `${NPM_ROOT}/other-tool/node_modules/@spikonado/sprocket`
+	});
+	const install = await detectInstall(host);
+	assert.equal(install.supported, false);
+	assert.equal(
+		commands.some((command) => isInstallArgs(command.args)),
+		false
+	);
+});
+
+test('does not treat a local or npx copy as updatable just because npm is on PATH', async () => {
+	for (const packageRoot of [
+		'/home/user/app/node_modules/@spikonado/sprocket',
+		'/home/user/.npm/_npx/a1b2/node_modules/@spikonado/sprocket'
+	]) {
+		const { host, commands } = testHost({
+			packageRoot,
+			executables: { npm: '/usr/bin/npm' },
+			isFile: () => false,
+			npmRoot: NPM_ROOT
+		});
+		const install = await detectInstall(host);
+		assert.equal(install.supported, false, packageRoot);
+		assert.equal(
+			commands.some((command) => isInstallArgs(command.args)),
+			false
+		);
+	}
+});
+
+test('detects global bun, pnpm, and yarn installs from their own prefix queries', async () => {
+	const bun = await detectInstall(
+		testHost({
+			execPath: '/home/user/.bun/bin/bun',
+			packageRoot: '/home/user/.bun/install/global/node_modules/@spikonado/sprocket',
+			bunBin: '/home/user/.bun/bin',
+			isFile: () => false
+		}).host
+	);
+	assert.equal(bun.supported, true);
+	assert.equal(bun.manager, 'bun');
+
+	const physical =
+		'/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@spikonado+sprocket@0.3.4/node_modules/@spikonado/sprocket';
+	const logical = '/home/user/.local/share/pnpm/global/5/node_modules/@spikonado/sprocket';
+	const pnpm = await detectInstall(
+		testHost({
+			packageRoot: physical,
+			executables: { pnpm: '/usr/bin/pnpm' },
+			pnpmRoot: '/home/user/.local/share/pnpm/global/5/node_modules',
+			isFile: () => false,
+			realpath: (file) => (file === logical ? physical : file)
+		}).host
+	);
+	assert.equal(pnpm.supported, true);
+	assert.equal(pnpm.manager, 'pnpm');
+
+	const yarn = await detectInstall(
+		testHost({
+			packageRoot: '/home/user/.config/yarn/global/node_modules/@spikonado/sprocket',
+			executables: { yarn: '/usr/bin/yarn' },
+			yarnDir: '/home/user/.config/yarn/global',
+			isFile: () => false
+		}).host
+	);
+	assert.equal(yarn.supported, true);
+	assert.equal(yarn.manager, 'yarn');
+});
+
+test('does not install with bun just because bun is on PATH for an npm global', async () => {
+	const { host, commands } = testHost({
+		executables: { bun: '/usr/bin/bun' },
+		bunBin: '/home/user/.bun/bin'
+	});
+	const payload = await installUpdate(host);
+	assert.equal(payload.status, 'installed');
+	const install = commands.find((command) => isInstallArgs(command.args));
+	assert.equal(install.command, '/usr/bin/node');
+	assert.ok(install.args.includes(NPM_CLI));
+	assert.ok(install.args.includes(`${PACKAGE_NAME}@0.3.5`));
+	assert.ok(!install.args.includes(`${PACKAGE_NAME}@latest`));
+});
+
+test('check reports unavailable, idle, and available without installing', async () => {
+	const unavailable = await checkForUpdate(
+		testHost({
+			packageRoot: '/tmp/project/node_modules/@spikonado/sprocket',
+			isFile: () => false
+		}).host
+	);
+	assert.equal(unavailable.status, 'unavailable');
+	assert.equal(unavailable.method, 'package');
+	assert.equal(unavailable.version, null);
+	assert.equal(unavailable.error, null);
+	assert.equal(unavailable.message, UNSUPPORTED_MESSAGE);
+
+	const idle = await checkForUpdate(
+		testHost({
+			manifest: versionDoc('0.3.4')
+		}).host
+	);
+	assert.equal(idle.status, 'idle');
+	assert.equal(idle.version, null);
+
+	const { host, commands, fetched } = testHost();
+	const available = await checkForUpdate(host);
+	assert.equal(available.status, 'available');
+	assert.equal(available.version, '0.3.5');
+	assert.equal(available.currentVersion, '0.3.4');
+	assert.equal(
+		commands.some((command) => isInstallArgs(command.args)),
+		false
+	);
+	assert.match(fetched[0], /\/latest$/);
+});
+
+test('does not offer a stable or canary downgrade when the installed version is newer', async () => {
+	const stable = await checkForUpdate(
+		testHost({
+			currentVersion: '0.4.0',
+			manifest: versionDoc('0.3.5')
+		}).host
+	);
+	assert.equal(stable.status, 'idle');
+
+	const canary = await checkForUpdate(
+		testHost({
+			currentVersion: '0.3.4-canary.10',
+			manifest: versionDoc('0.3.4-canary.2')
+		}).host
+	);
+	assert.equal(canary.status, 'idle');
+});
+
+test('install re-checks and stays idle when the channel is already current', async () => {
+	const { host, commands } = testHost({
+		manifest: versionDoc('0.3.4')
+	});
+	const payload = await installUpdate(host);
+	assert.equal(payload.status, 'idle');
+	assert.equal(
+		commands.some((command) => isInstallArgs(command.args)),
+		false
+	);
+});
+
+test('install returns installed with a relaunch message and keeps the running version', async () => {
+	const payload = await installUpdate(testHost().host);
+	assert.equal(payload.status, 'installed');
+	assert.equal(payload.currentVersion, '0.3.4');
+	assert.equal(payload.version, '0.3.5');
+	assert.equal(payload.method, 'package');
+	assert.equal(payload.message, RELAUNCH_MESSAGE);
+	assert.equal(payload.error, null);
+});
+
+test('follows canary and dev dist-tags for those installs', async () => {
+	const canaryVersion = '0.3.5-canary.9';
+	const canary = await checkForUpdate(
+		testHost({
+			currentVersion: '0.3.4-canary.1',
+			manifest: versionDoc(canaryVersion)
+		}).host
+	);
+	assert.equal(canary.version, canaryVersion);
+
+	const tagged = `0.3.4-dev.${DEV_SHA_LOW}`;
+	const dev = await checkForUpdate(
+		testHost({
+			currentVersion: `0.3.5-dev.${DEV_SHA_HIGH}`,
+			manifest: versionDoc(tagged)
+		}).host
+	);
+	assert.equal(dev.status, 'available');
+	assert.equal(dev.version, tagged);
+});
+
+test('rejects a channel manifest that is missing or malformed', async () => {
+	const malformed = await runUpdateApi(
+		'check',
+		testHost({
+			manifest: versionDoc('0.3.5;touch /tmp/pwned')
+		}).host
+	);
+	assert.equal(malformed.exitCode, 1);
+	assert.equal(malformed.payload.status, 'error');
+
+	const missing = await runUpdateApi(
+		'check',
+		testHost({
+			fetch: async () => jsonResponse({}, 404)
+		}).host
+	);
+	assert.equal(missing.payload.status, 'error');
+	assert.match(missing.payload.error, /HTTP 404/);
+});
+
+test('explains a Windows lock on the running native executable', async () => {
+	assert.equal(
+		isWindowsBusyExecutable('EBUSY unlink sprocket.exe resource busy or locked', 'win32'),
+		true
+	);
+	const payload = await installUpdate(
+		testHost({
+			platform: 'win32',
+			install: {
+				status: 1,
+				stdout: '',
+				stderr: 'npm ERR! code EBUSY\nnpm ERR! syscall unlink\nnpm ERR! path C:\\npm\\sprocket.exe'
+			}
+		}).host
+	);
+	assert.equal(payload.status, 'error');
+	assert.match(payload.error, /Windows cannot replace Sprocket while it is running/);
+});
+
+test('package manager commands never use a shell and detach on unix', async () => {
+	let spawnOptions;
+	const runCommand = createRunCommand((command, args, options) => {
+		spawnOptions = options;
+		return {
+			stdout: { setEncoding() {}, on() {}, destroy() {} },
+			stderr: { setEncoding() {}, on() {}, destroy() {} },
+			on(event, handler) {
+				if (event === 'close') {
+					queueMicrotask(() => handler(0));
+				}
+			}
+		};
+	});
+	await runCommand('/usr/bin/npm', ['install', '--global', `${PACKAGE_NAME}@0.3.5`], {
+		cwd: '/home/user',
+		platform: 'linux'
+	});
+	assert.equal(spawnOptions.shell, false);
+	assert.equal(spawnOptions.detached, true);
+	assert.equal(spawnOptions.timeout, undefined);
+	assert.deepEqual(spawnOptions.stdio, ['ignore', 'pipe', 'pipe']);
+});
+
+test('managed unix children stay in the helper process group', async () => {
+	let spawnOptions;
+	const selfKills = [];
+	const runCommand = createRunCommand(
+		(command, args, options) => {
+			spawnOptions = options;
+			return {
+				pid: 99,
+				stdout: { setEncoding() {}, on() {}, destroy() {} },
+				stderr: { setEncoding() {}, on() {}, destroy() {} },
+				on() {}
+			};
+		},
+		async () => {},
+		(pid) => {
+			selfKills.push(pid);
+		}
+	);
+	const result = await runCommand(
+		'/usr/bin/npm',
+		['install', '--global', `${PACKAGE_NAME}@0.3.5`],
+		{
+			env: { SPROCKET_UPDATE_MANAGED: '1' },
+			platform: 'linux',
+			timeout: 20,
+			killWaitMs: 20
+		}
+	);
+	assert.equal(spawnOptions.detached, false);
+	assert.equal(result.timedOut, true);
+	assert.deepEqual(selfKills, [-process.pid]);
+});
+
+test('command timeout kills the process tree and closes pipes', async () => {
+	const killed = [];
+	const stdout = {
+		setEncoding() {},
+		on() {},
+		destroy() {
+			this.destroyed = true;
+		}
+	};
+	const stderr = {
+		setEncoding() {},
+		on() {},
+		destroy() {
+			this.destroyed = true;
+		}
+	};
+	const child = {
+		pid: 4321,
+		stdout,
+		stderr,
+		on() {}
+	};
+	const runCommand = createRunCommand(
+		() => child,
+		(target, platform) => {
+			killed.push({ pid: target.pid, platform });
+		}
+	);
+	const result = await runCommand('npm', ['install', '--global', `${PACKAGE_NAME}@0.3.5`], {
+		platform: 'linux',
+		timeout: 20,
+		killWaitMs: 20
+	});
+	assert.equal(result.timedOut, true);
+	assert.deepEqual(killed, [{ pid: 4321, platform: 'linux' }]);
+	assert.equal(stdout.destroyed, true);
+	assert.equal(stderr.destroyed, true);
+});
+
+test('JSON helper returns exactly the documented payload shape', async () => {
+	const { exitCode, payload } = await runUpdateApi('check', testHost().host);
+	assert.equal(exitCode, 0);
+	assert.deepEqual(Object.keys(payload).sort(), [
+		'currentVersion',
+		'error',
+		'message',
+		'method',
+		'status',
+		'version'
+	]);
+	assert.equal(payload.method, 'package');
+	assert.equal(payload.status, 'available');
+
+	const invalid = await runUpdateApi('download', testHost().host);
+	assert.equal(invalid.exitCode, 1);
+	assert.equal(invalid.payload.status, 'error');
+});
+
+test('upgrade --check is the same as update --check', async () => {
+	let stdout = '';
+	const host = testHost({
+		writeStdout(text) {
+			stdout += text;
+		}
+	}).host;
+	const code = await runUpdateCli(parseUpdateArgs(['upgrade', '--check']), host);
+	assert.equal(code, 0);
+	assert.match(stdout, /0\.3\.5 is available/);
+});
+
+test('CLI help does not query the registry', async () => {
+	let stdout = '';
+	let fetched = false;
+	const host = testHost({
+		fetch: async () => {
+			fetched = true;
+			return jsonResponse(versionDoc('0.3.5'));
+		},
+		writeStdout(text) {
+			stdout += text;
+		}
+	}).host;
+	assert.equal(await runUpdateCli(parseUpdateArgs(['update', '--help']), host), 0);
+	assert.match(stdout, /sprocket update/);
+	assert.equal(fetched, false);
+});
+
+test('refuses to install when the lock cannot be created', async () => {
+	const { host, commands } = testHost({
+		open: async () => {
+			const error = new Error('denied');
+			error.code = 'EACCES';
+			throw error;
+		}
+	});
+	const payload = await installUpdate(host);
+	assert.equal(payload.status, 'error');
+	assert.match(payload.error, /Cannot write the update lock/);
+	assert.equal(
+		commands.some((command) => isInstallArgs(command.args)),
+		false
+	);
+});
+
+test('does not steal an existing lock even if its pid looks dead', async () => {
+	const { host, lockFiles, commands } = testHost({ pid: 1001 });
+	lockFiles.set(updateLockPath(host, NPM_ROOT), '9999');
+	const payload = await installUpdate(host);
+	assert.equal(payload.status, 'error');
+	assert.match(payload.error, /already running/);
+	assert.match(payload.error, /delete/);
+	assert.equal(
+		commands.some((command) => isInstallArgs(command.args)),
+		false
+	);
+});
+
+test('serializes concurrent installs with a lock outside the replaced package tree', async () => {
+	const scratch = mkdtempSync(path.join(tmpdir(), 'sprocket-lock-'));
+	try {
+		const shared = {
+			tmpdir: () => scratch,
+			open: (file, flags) => fsPromises.open(file, flags),
+			unlink: (file) => fsPromises.unlink(file),
+			readFile: (file, encoding) => readFileSync(file, encoding)
+		};
+		const first = testHost({ ...shared, pid: 7001, holdInstall: true });
+		const second = testHost({ ...shared, pid: 7002 }).host;
+		const firstResultPromise = installUpdate(first.host);
+		const lockPath = updateLockPath(first.host, NPM_ROOT);
+		await waitForFile(lockPath);
+		assert.equal(path.dirname(lockPath), scratch);
+		const secondResult = await installUpdate(second);
+		assert.equal(secondResult.status, 'error');
+		assert.match(secondResult.error, /already running/);
+		assert.match(secondResult.error, /delete/);
+		first.releaseInstall();
+		assert.equal((await firstResultPromise).status, 'installed');
+	} finally {
+		rmSync(scratch, { recursive: true, force: true });
+	}
+});
+
+test('lock identity follows the logical global package dir across pnpm versions', () => {
+	const globalRoot = '/home/user/.local/share/pnpm/global/5/node_modules';
+	const host = testHost({
+		packageRoot: `${globalRoot}/.pnpm/@spikonado+sprocket@0.3.4/node_modules/@spikonado/sprocket`
+	}).host;
+	const later = testHost({
+		packageRoot: `${globalRoot}/.pnpm/@spikonado+sprocket@0.3.5/node_modules/@spikonado/sprocket`
+	}).host;
+	assert.equal(globalPackageDir(globalRoot), path.join(globalRoot, '@spikonado', 'sprocket'));
+	assert.equal(updateLockPath(host, globalRoot), updateLockPath(later, globalRoot));
+	assert.notEqual(updateLockPath(host, globalRoot), updateLockPath(host, NPM_ROOT));
+});
+
+test('retains the update lock after a timed-out install', async () => {
+	const { host, lockFiles } = testHost({
+		install: { status: 1, timedOut: true, stdout: '', stderr: 'Timed out.' }
+	});
+	const lockPath = updateLockPath(host, NPM_ROOT);
+	const payload = await installUpdate(host);
+	assert.equal(payload.status, 'error');
+	assert.equal(payload.error, timeoutRecoveryMessage(lockPath));
+	assert.equal(lockFiles.has(lockPath), true);
+});
+
+test('windows killer uses System32 taskkill.exe, waits, and does not unref', async () => {
+	const calls = [];
+	let closeKiller;
+	let closeChild;
+	const killer = {
+		unref() {
+			calls.push('unref');
+		},
+		once(event, handler) {
+			if (event === 'close') {
+				closeKiller = () => {
+					killer.exitCode = 0;
+					handler(0);
+				};
+			}
+		}
+	};
+	const child = {
+		pid: 42,
+		once(event, handler) {
+			if (event === 'close') {
+				closeChild = () => handler(1);
+			}
+		}
+	};
+	const pending = killProcessTree(child, 'win32', {
+		env: { SystemRoot: 'C:\\Windows' },
+		deadlineMs: 1000,
+		spawn(command, args, options) {
+			calls.push({ command, args, options });
+			queueMicrotask(() => {
+				closeKiller();
+				closeChild();
+			});
+			return killer;
+		}
+	});
+	await pending;
+	assert.equal(calls[0].command, taskkillPath({ SystemRoot: 'C:\\Windows' }));
+	assert.deepEqual(calls[0].args, ['/PID', '42', '/T', '/F']);
+	assert.equal(calls[0].options.shell, false);
+	assert.equal(calls.includes('unref'), false);
+});
+
+test('a child closing during timeout does not release the update before its killer finishes', async () => {
+	const child = new EventEmitter();
+	child.pid = 42;
+	let releaseKiller;
+	const killerFinished = new Promise((resolve) => {
+		releaseKiller = resolve;
+	});
+	let notifyStarted;
+	const killerStarted = new Promise((resolve) => {
+		notifyStarted = resolve;
+	});
+	const runCommand = createRunCommand(
+		() => child,
+		async () => {
+			child.exitCode = 1;
+			child.emit('close', 1);
+			notifyStarted();
+			await killerFinished;
+		}
+	);
+	let settled = false;
+	const pending = runCommand('npm', [], { platform: 'win32', timeout: 1 }).then((result) => {
+		settled = true;
+		return result;
+	});
+	await killerStarted;
+	assert.equal(settled, false);
+	releaseKiller();
+	assert.equal((await pending).timedOut, true);
+});
+
+test('a missing Windows taskkill reports failure without an unhandled error', async () => {
+	const child = new EventEmitter();
+	child.pid = 42;
+	child.exitCode = 1;
+	const killer = new EventEmitter();
+	await assert.rejects(
+		killProcessTree(child, 'win32', {
+			env: { SystemRoot: 'C:\\Windows' },
+			spawn() {
+				queueMicrotask(() => killer.emit('error', new Error('taskkill missing')));
+				return killer;
+			}
+		}),
+		/taskkill missing/
+	);
+});
+
+test(
+	'managed helper timeout kills grandchild processes',
+	{ skip: process.platform === 'win32' },
+	async () => {
+		const directory = mkdtempSync(path.join(tmpdir(), 'sprocket-managed-'));
+		const pidFile = path.join(directory, 'grandchild.pid');
+		try {
+			const helper = spawn(
+				process.execPath,
+				[path.resolve(import.meta.dirname, 'managed-group-helper.mjs'), pidFile],
+				{ detached: true, stdio: 'ignore' }
+			);
+			await waitForFile(pidFile);
+			const grandchildPid = Number(readFileSync(pidFile, 'utf8').trim());
+			await new Promise((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error('helper did not exit')), 5000);
+				helper.once('close', () => {
+					clearTimeout(timer);
+					resolve();
+				});
+			});
+			assert.equal(Number.isInteger(grandchildPid) && grandchildPid > 0, true);
+			let alive = false;
+			try {
+				process.kill(grandchildPid, 0);
+				alive = true;
+			} catch {
+				alive = false;
+			}
+			assert.equal(alive, false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}
+);
+
+test('ignores relative PATH entries and relative npm_execpath', async () => {
+	const files = new Set([
+		'node_modules/.bin/npm',
+		'node_modules/npm/bin/npm-cli.js',
+		'/usr/bin/npm'
+	]);
+	const commands = [];
+	const host = createHost({
+		platform: 'linux',
+		execPath: '/usr/bin/node',
+		packageRoot: NPM_PACKAGE,
+		currentVersion: '0.3.4',
+		env: {
+			PATH: 'node_modules/.bin:/usr/bin',
+			npm_execpath: 'node_modules/npm/bin/npm-cli.js'
+		},
+		isFile: (file) => files.has(file),
+		tmpdir: () => '/tmp',
+		homedir: () => '/home/user',
+		realpath: (file) => file,
+		runCommand: async (command, args) => {
+			commands.push({ command, args });
+			if (args.includes('root') && args.includes('-g')) {
+				assert.equal(command, '/usr/bin/npm');
+				return { status: 0, stdout: NPM_ROOT, stderr: '' };
+			}
+			return { status: 1, stdout: '', stderr: '' };
+		},
+		writeStdout() {},
+		writeStderr() {}
+	});
+	const install = await detectInstall(host);
+	assert.equal(install.supported, true);
+	assert.equal(install.command, '/usr/bin/npm');
+});
+
+test('uses npm_config_registry when it is an http URL', () => {
+	assert.equal(registryUrl({}), 'https://registry.npmjs.org');
+	assert.equal(
+		registryUrl({ npm_config_registry: 'https://example.invalid/npm/' }),
+		'https://example.invalid/npm'
+	);
+	assert.equal(registryUrl({ npm_config_registry: 'file:///tmp' }), 'https://registry.npmjs.org');
+	assert.equal(
+		channelManifestUrl('https://registry.npmjs.org', 'latest'),
+		'https://registry.npmjs.org/%40spikonado%2Fsprocket/latest'
+	);
+	assert.equal(
+		channelManifestUrl('https://registry.npmjs.org', 'canary'),
+		'https://registry.npmjs.org/%40spikonado%2Fsprocket/canary'
+	);
+});
+
+test('update-api.js prints only JSON and rejects unknown commands', () => {
+	const result = spawnSync(
+		process.execPath,
+		[path.resolve(import.meta.dirname, '../lib/update-api.js'), 'nope'],
+		{ encoding: 'utf8' }
+	);
+	assert.equal(result.status, 1);
+	const payload = JSON.parse(result.stdout);
+	assert.equal(payload.status, 'error');
+	assert.equal(payload.method, 'package');
+	const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+	assert.equal(payload.currentVersion, manifest.version);
+	assert.equal(payload.version, null);
+	assert.equal(payload.error.length > 0, true);
+});
+
+test('payload helper always includes method package', () => {
+	assert.deepEqual(makePayload({ status: 'idle', currentVersion: '1.0.0' }), {
+		status: 'idle',
+		currentVersion: '1.0.0',
+		version: null,
+		error: null,
+		method: 'package',
+		message: null
+	});
+});


### PR DESCRIPTION
## Summary
- Add an update action above Settings, with explicit download and restart confirmation for packaged desktop apps.
- Support browser-initiated global npm, bun, pnpm, and yarn updates, plus `sprocket update`, `sprocket update --check`, and the `sprocket upgrade` alias.
- Authenticate and restrict installation requests, coalesce concurrent operations, and bound helper execution and process-tree shutdown.
- Publish desktop updater metadata and macOS zip artifacts, merge multi-architecture metadata, and document signing and compatibility requirements.

## Validation
- Rebased onto current main and re-ran the full Bun tests, Svelte check, Oxlint, 106 Rust server tests, and the CLI test successfully.
- All 45 npm tests pass after the review fixes. Formatting, workflow schema checks, and frozen lockfile installation pass.
- CI build, Bun tests, full Cargo tests, cross-platform checks, Prek, and CodeQL passed. Convex Preview is blocked by the team deployment quota of 40. No deployments were deleted.
- Linux test releases v0.90.0 and v0.90.1 are published for x86_64 and arm64 at https://github.com/Amronos/sprocket-update-test/releases . The app has a separate identity, local data directory, server port, updater cache, and release feed.
- macOS requires a signed install/update smoke test. No production release or package installation was performed.







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds authenticated package-manager updates and native desktop update support, including release metadata generation and explicit download/install controls.
- Adds browser and CLI flows for checking and installing global package updates.
- Integrates Electron’s updater with guarded IPC, confirmation, server shutdown, and AppImage relaunch handling.
- Extends the desktop release workflow to publish per-channel update metadata and macOS ZIP artifacts.
- Adds tests and release documentation for update orchestration and metadata merging.
- The latest revision pins release-workflow actions and removes part of the user-facing update documentation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the remaining finding is a non-blocking user-documentation regression for temporary and local installations.

The native and package-manager update paths include the expected authentication, transport restrictions, operation coalescing, and shutdown controls. Previous security and workflow findings were fixed, while the macOS installer concern was correctly conceded. The only accepted new issue is that deleting the README’s Updating section leaves users of the documented `npx` workflow without the instructions needed to obtain future versions correctly.

**Files Needing Attention:** README.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| npm/sprocket/lib/update.js | Implements channel-aware global package updates with registry validation, bounded execution, and coalescing. |
| crates/sprocket-server/src/package_update.rs | Adds authenticated server-side package-update orchestration and managed helper execution. |
| apps/desktop/main.mjs | Connects the native updater to trusted renderer IPC and coordinates confirmation, shutdown, installation, and relaunch. |
| apps/desktop/updater.mjs | Encapsulates desktop updater state, concurrent operations, process-tree shutdown, and AppImage relaunch behavior. |
| apps/desktop/scripts/merge-update-metadata.mjs | Safely merges architecture-specific update metadata while rejecting incompatible manifests and artifact collisions. |
| .github/workflows/desktop-release.yml | Builds and publishes signed or unsigned desktop artifacts with pinned actions and channel-specific updater metadata. |
| README.md | Documents the new CLI commands, but the latest revision removes guidance needed by temporary and local-install users. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    UI[Web or desktop update action] --> Mode{Desktop bridge available?}
    Mode -->|Yes| IPC[Trusted Electron IPC]
    IPC --> Check[Check native release feed]
    Check --> Download[Explicit download]
    Download --> Confirm[Restart confirmation]
    Confirm --> Shutdown[Stop owned local server]
    Shutdown --> Install[Install and relaunch desktop app]

    Mode -->|No| API[Authenticated local update API]
    API --> Detect[Detect owning global package manager]
    Detect --> Channel[Resolve current release channel]
    Channel --> Package[Run bounded package-manager update]
    Package --> Restart[User restarts running server]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 46 ([link](https://github.com/spikonado/sprocket/blob/f9480b297a094fe8417a1fd8ec55468a5a526304/README.md#L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Temporary Update Guidance Removed**

   Removing the Updating section leaves the documented `npx @spikonado/sprocket` workflow without explaining that `sprocket update` only handles global installations. Users may therefore expect the command to update a temporary run, but must instead request `npx @spikonado/sprocket@latest`. The removed section was also the only user-facing guidance telling users to update local project dependencies through that project's package manager rather than treating them as global installs. Please restore this guidance near the command table or the “Run without installing” instructions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 46

   Comment:
   **Temporary Update Guidance Removed**

   Removing the Updating section leaves the documented `npx @spikonado/sprocket` workflow without explaining that `sprocket update` only handles global installations. Users may therefore expect the command to update a temporary run, but must instead request `npx @spikonado/sprocket@latest`. The removed section was also the only user-facing guidance telling users to update local project dependencies through that project's package manager rather than treating them as global installs. Please restore this guidance near the command table or the “Run without installing” instructions.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:46
**Temporary Update Guidance Removed**

Removing the Updating section leaves the documented `npx @spikonado/sprocket` workflow without explaining that `sprocket update` only handles global installations. Users may therefore expect the command to update a temporary run, but must instead request `npx @spikonado/sprocket@latest`. The removed section was also the only user-facing guidance telling users to update local project dependencies through that project's package manager rather than treating them as global installs. Please restore this guidance near the command table or the “Run without installing” instructions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["docs: Remove README updating section"](https://github.com/spikonado/sprocket/commit/f9480b297a094fe8417a1fd8ec55468a5a526304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61220555)</sub>

<!-- /greptile_comment -->