### PR TITLE
fix(server): Revalidate mutable web assets after upgrades

### DIFF
--- a/crates/sprocket-server/src/static_files.rs
+++ b/crates/sprocket-server/src/static_files.rs
@@ -2,7 +2,7 @@ use std::path::{Component, Path, PathBuf};
 
 use axum::Router;
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderValue, Request, StatusCode, header::CACHE_CONTROL};
 use axum::response::{IntoResponse, Response};
 use tower::ServiceExt;
 use tower_http::services::{ServeDir, ServeFile};
@@ -32,18 +32,32 @@ async fn serve_static_request(
     assets: ServeDir,
 ) -> Response {
     let path = req.uri().path();
+    let immutable = path.starts_with("/_app/immutable/");
 
-    if path.starts_with("/_app/") {
-        return match assets.oneshot(req).await {
+    let mut response = if path.starts_with("/_app/") {
+        match assets.oneshot(req).await {
             Ok(response) => response.into_response(),
             Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
-        };
-    }
+        }
+    } else {
+        let file = resolve_static_file(dir, path).unwrap_or_else(|| index.to_path_buf());
+        serve_file(&file, req).await
+    };
 
-    match resolve_static_file(dir, path) {
-        Some(file_path) => serve_file(&file_path).await,
-        None => serve_file(index).await,
-    }
+    let cache_control =
+        if response.status().is_success() || response.status() == StatusCode::NOT_MODIFIED {
+            if immutable {
+                "public, max-age=31536000, immutable"
+            } else {
+                "no-cache"
+            }
+        } else {
+            "no-store"
+        };
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static(cache_control));
+    response
 }
 
 fn resolve_static_file(dir: &Path, path: &str) -> Option<PathBuf> {
@@ -75,45 +89,12 @@ fn resolve_static_file(dir: &Path, path: &str) -> Option<PathBuf> {
     None
 }
 
-async fn serve_file(path: &Path) -> Response {
-    match ServeFile::new(path).try_call(Request::new(())).await {
+async fn serve_file(path: &Path, req: Request<Body>) -> Response {
+    match ServeFile::new(path).try_call(req).await {
         Ok(response) => response.into_response(),
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolves_prerendered_html_routes() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../apps/web/dist");
-
-        if !dir.join("pair.html").exists() {
-            return;
-        }
-
-        assert_eq!(
-            resolve_static_file(&dir, "/pair"),
-            Some(dir.join("pair.html"))
-        );
-        assert_eq!(
-            resolve_static_file(&dir, "/callback"),
-            Some(dir.join("callback.html"))
-        );
-    }
-
-    #[test]
-    fn rejects_path_traversal_and_absolute_segments() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../apps/web/dist");
-
-        assert_eq!(resolve_static_file(&dir, "/../Cargo.toml"), None);
-        assert_eq!(resolve_static_file(&dir, "/foo/../../Cargo.toml"), None);
-        assert_eq!(resolve_static_file(&dir, "/./pair"), None);
-        // `C:` is a Prefix component only on Windows. On Unix it is a normal
-        // path segment, so drive-style rejection is Windows-only.
-        #[cfg(windows)]
-        assert_eq!(resolve_static_file(&dir, "/C:/Windows/win.ini"), None);
-    }
-}
+mod tests;

--- a/crates/sprocket-server/src/static_files/tests.rs
+++ b/crates/sprocket-server/src/static_files/tests.rs
@@ -1,0 +1,209 @@
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use axum::response::Response;
+use tower::ServiceExt;
+
+use super::{resolve_static_file, static_router};
+
+const INDEX: &str = "index-shell";
+const PAIR: &str = "pair-page";
+const CALLBACK: &str = "callback-page";
+const VERSION: &str = "{\"version\":\"test\"}";
+const ENV: &str = "window.env={}";
+const CHUNK: &str = "immutable-chunk";
+
+const NO_CACHE: &str = "no-cache";
+const IMMUTABLE: &str = "public, max-age=31536000, immutable";
+const NO_STORE: &str = "no-store";
+
+fn web_dist() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("_app/immutable")).unwrap();
+    std::fs::write(root.join("index.html"), INDEX).unwrap();
+    std::fs::write(root.join("pair.html"), PAIR).unwrap();
+    std::fs::write(root.join("callback.html"), CALLBACK).unwrap();
+    std::fs::write(root.join("_app/version.json"), VERSION).unwrap();
+    std::fs::write(root.join("_app/env.js"), ENV).unwrap();
+    std::fs::write(root.join("_app/immutable/chunk.js"), CHUNK).unwrap();
+    dir
+}
+
+fn fixture() -> (tempfile::TempDir, Router) {
+    let dir = web_dist();
+    let app = static_router(
+        dir.path().to_path_buf(),
+        Router::new()
+            .route("/ping", axum::routing::get(|| async { "pong" }))
+            .fallback(|| async { StatusCode::NOT_FOUND }),
+    );
+    (dir, app)
+}
+
+async fn call(app: &Router, request: Request<Body>) -> Response {
+    app.clone().oneshot(request).await.unwrap()
+}
+
+async fn body_bytes(response: Response) -> Vec<u8> {
+    axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .to_vec()
+}
+
+fn cache_control(response: &Response) -> &str {
+    response
+        .headers()
+        .get(header::CACHE_CONTROL)
+        .expect("Cache-Control")
+        .to_str()
+        .unwrap()
+}
+
+fn get(uri: &str) -> Request<Body> {
+    Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+#[test]
+fn resolves_prerendered_html_routes() {
+    let dist = web_dist();
+    let dir = dist.path();
+
+    assert_eq!(resolve_static_file(dir, "/"), Some(dir.join("index.html")));
+    assert_eq!(
+        resolve_static_file(dir, "/index.html"),
+        Some(dir.join("index.html"))
+    );
+    assert_eq!(
+        resolve_static_file(dir, "/pair"),
+        Some(dir.join("pair.html"))
+    );
+    assert_eq!(
+        resolve_static_file(dir, "/callback"),
+        Some(dir.join("callback.html"))
+    );
+    assert_eq!(resolve_static_file(dir, "/unknown"), None);
+}
+
+#[test]
+fn rejects_path_traversal_and_absolute_segments() {
+    let dist = web_dist();
+    let dir = dist.path();
+
+    assert_eq!(resolve_static_file(dir, "/../Cargo.toml"), None);
+    assert_eq!(resolve_static_file(dir, "/foo/../../Cargo.toml"), None);
+    assert_eq!(resolve_static_file(dir, "/./pair"), None);
+    // `C:` is a Prefix component only on Windows. On Unix it is a normal
+    // path segment, so drive-style rejection is Windows-only.
+    #[cfg(windows)]
+    assert_eq!(resolve_static_file(dir, "/C:/Windows/win.ini"), None);
+}
+
+#[tokio::test]
+async fn successful_static_responses_set_cache_control() {
+    let (_dir, app) = fixture();
+    let cases = [
+        ("/", INDEX, NO_CACHE),
+        ("/index.html", INDEX, NO_CACHE),
+        ("/pair", PAIR, NO_CACHE),
+        ("/callback", CALLBACK, NO_CACHE),
+        ("/unknown-spa-route", INDEX, NO_CACHE),
+        ("/_app/version.json", VERSION, NO_CACHE),
+        ("/_app/env.js", ENV, NO_CACHE),
+        ("/_app/immutable/chunk.js", CHUNK, IMMUTABLE),
+    ];
+
+    for (path, expected_body, policy) in cases {
+        let response = call(&app, get(path)).await;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        assert_eq!(cache_control(&response), policy, "{path}");
+        assert_eq!(
+            body_bytes(response).await,
+            expected_body.as_bytes(),
+            "{path}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn revalidation_returns_304_with_the_same_cache_policy() {
+    let (_dir, app) = fixture();
+    let cases = [
+        ("/", NO_CACHE),
+        ("/unknown-spa-route", NO_CACHE),
+        ("/_app/version.json", NO_CACHE),
+        ("/_app/immutable/chunk.js", IMMUTABLE),
+    ];
+
+    for (path, policy) in cases {
+        let first = call(&app, get(path)).await;
+        assert_eq!(first.status(), StatusCode::OK, "{path}");
+        assert_eq!(cache_control(&first), policy, "{path}");
+
+        let mut builder = Request::builder().uri(path);
+        if let Some(etag) = first.headers().get(header::ETAG).cloned() {
+            builder = builder.header(header::IF_NONE_MATCH, etag);
+        } else if let Some(last_modified) = first.headers().get(header::LAST_MODIFIED).cloned() {
+            builder = builder.header(header::IF_MODIFIED_SINCE, last_modified);
+        } else {
+            panic!("{path}: expected ETag or Last-Modified");
+        }
+
+        let response = call(&app, builder.body(Body::empty()).unwrap()).await;
+        assert_eq!(response.status(), StatusCode::NOT_MODIFIED, "{path}");
+        assert_eq!(cache_control(&response), policy, "{path}");
+        assert!(body_bytes(response).await.is_empty(), "{path}");
+    }
+}
+
+#[tokio::test]
+async fn head_responses_have_empty_bodies() {
+    let (_dir, app) = fixture();
+    let cases = [
+        ("/", NO_CACHE),
+        ("/unknown-spa-route", NO_CACHE),
+        ("/_app/immutable/chunk.js", IMMUTABLE),
+    ];
+
+    for (path, policy) in cases {
+        let response = call(
+            &app,
+            Request::builder()
+                .method("HEAD")
+                .uri(path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        assert_eq!(cache_control(&response), policy, "{path}");
+        assert!(body_bytes(response).await.is_empty(), "{path}");
+    }
+}
+
+#[tokio::test]
+async fn static_errors_use_no_store_and_missing_immutable_is_not_spa_html() {
+    let (_dir, app) = fixture();
+
+    for path in ["/_app/immutable/missing.js", "/_app/missing.js"] {
+        let response = call(&app, get(path)).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+        assert_eq!(cache_control(&response), NO_STORE, "{path}");
+        assert_ne!(body_bytes(response).await, INDEX.as_bytes(), "{path}");
+    }
+}
+
+#[tokio::test]
+async fn api_responses_do_not_get_static_cache_headers() {
+    let (_dir, app) = fixture();
+
+    let ok = call(&app, get("/api/ping")).await;
+    assert_eq!(ok.status(), StatusCode::OK);
+    assert!(ok.headers().get(header::CACHE_CONTROL).is_none());
+    assert_eq!(body_bytes(ok).await, b"pong");
+
+    let missing = call(&app, get("/api/missing")).await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    assert!(missing.headers().get(header::CACHE_CONTROL).is_none());
+}


### PR DESCRIPTION
## Summary

- Serve HTML, SPA fallbacks, and mutable assets such as `/_app/version.json` with `Cache-Control: no-cache`.
- Cache successful and 304 responses under `/_app/immutable/` for one year with `immutable`. Static errors use `no-store`, so missing chunks are not cached long term.
- Preserve the original request when serving individual files, allowing conditional GET and HEAD to work for HTML as well as assets.
- Replace frontend-build-dependent tests with temporary fixtures covering cache policies, revalidation, HEAD, missing chunks, route resolution, and API isolation.

## Why

The packaged server previously left static caching unspecified. Browsers could reuse old HTML that references an older frontend after a local-server upgrade. Investigation confirmed the installed npm packages matched the published release and contained the current frontend; browser caching remains a plausible cause of the reported version mismatch, not a proven one.

## Validation

- `nix develop -c cargo test --locked -p sprocket-server --quiet`: 87 tests passed.
- `nix develop -c prek run -a`: all checks passed.
- Two pre-PR reviews found no actionable issues.

## Scope

This fixes HTTP cache policy, not already-running tabs or old-client API compatibility. Existing tabs still need a reload after an incompatible server upgrade, and previously cached entry points may initially need a hard refresh.

Implemented and validated by Sprocket, an AI agent, on behalf of the repository owner.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds explicit caching policies to the packaged server’s static responses and preserves original request semantics when serving HTML and SPA fallbacks.
- Mutable HTML and `/_app` resources now require revalidation.
- Content-addressed immutable assets receive a one-year immutable policy.
- Static errors use `no-store`, while API responses remain unaffected.
- Temporary fixtures now cover cache headers, conditional requests, HEAD requests, missing assets, route resolution, and API isolation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

The cache policies align with mutable and content-addressed resource behavior, errors avoid persistent caching, original request forwarding enables the intended revalidation and HEAD semantics, and the added tests cover the affected routes.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-server/src/static_files.rs | Adds status- and path-aware static cache headers while forwarding original requests to preserve conditional GET and HEAD semantics. |
| crates/sprocket-server/src/static_files/tests.rs | Replaces frontend-build-dependent tests with temporary fixtures covering static routing and caching behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Request["Incoming request"] --> API{"Path under /api?"}
  API -->|Yes| ApiRouter["API router<br/>static cache policy unchanged"]
  API -->|No| Static{"Path under /_app/?"}
  Static -->|Yes| ServeDir["ServeDir"]
  Static -->|No| Resolve["Resolve HTML file<br/>or SPA index fallback"]
  Resolve --> ServeFile["ServeFile with original request"]
  ServeDir --> Status{"Successful or 304?"}
  ServeFile --> Status
  Status -->|No| NoStore["Cache-Control: no-store"]
  Status -->|Yes| Immutable{"Path under /_app/immutable/?"}
  Immutable -->|Yes| LongCache["public, max-age=31536000, immutable"]
  Immutable -->|No| Revalidate["Cache-Control: no-cache"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): Revalidate mutable web asse..."](https://github.com/spikonado/sprocket/commit/ffad851536ff914195913d4f31bc4f125472c2d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61412040)</sub>

<!-- /greptile_comment -->