### PR TITLE
refactor: Rename context compaction to handoff

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -229,7 +229,16 @@ migration runner, its cron, and both schema fields once both migrations report
 `success` and production scans find no remaining values. Historical documents
 in the now-unvalidated `threadMessages` table may be deleted independently.
 
-### 10. Legacy context compaction cutoff
+### 10. Context handoff and legacy compaction cutoff
+
+Active runtime and UI code use context handoff terminology. The gateway catalog
+and released context-budget API still use `autoCompactTokenLimit`; Rust maps it
+to `auto_handoff_token_limit`, and the UI maps it to `autoHandoffTokenLimit`.
+Rust serialization keeps the released wire name. Keep those boundary mappings
+until the gateway protocol and all supported context-budget consumers switch
+to a handoff-named field. Stored run snapshots keep the old optional field under
+the removal gate in section 5. This terminology change does not rewrite stored
+summaries, transcript cutoffs, or usage events.
 
 Released agents still call `saveContextCompaction`, which bills through the
 `compaction:` usage event and stores `contextSummaryThroughRunId` (last fully

--- a/apps/web/src/convex/agentRuntime.context.test.ts
+++ b/apps/web/src/convex/agentRuntime.context.test.ts
@@ -104,7 +104,7 @@ async function appendFinishedToolPart(
 }
 
 describe('agentRuntime context accounting', () => {
-	it('fences compaction and usage writes to the active claim', async () => {
+	it('fences legacy compaction and usage writes to the active claim', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const executionSecret = 'context-run-secret';
@@ -273,7 +273,7 @@ describe('agentRuntime context accounting', () => {
 		});
 	});
 
-	it('carries a compacted prefix into later runs without replaying covered history', async () => {
+	it('carries a legacy compacted prefix into later runs without replaying covered history', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const firstSecret = 'context-first-secret';

--- a/apps/web/src/convex/lib/uiModelCatalog.ts
+++ b/apps/web/src/convex/lib/uiModelCatalog.ts
@@ -8,14 +8,14 @@ export type CatalogModel = {
 	provider: string;
 	supportsImages: boolean;
 	contextWindowTokens: number;
-	autoCompactTokenLimit: number;
+	autoHandoffTokenLimit: number;
 	reasoningEfforts: readonly string[];
 	defaultReasoningEffort: string;
 	serviceTiers: readonly string[];
 	usagePolicy?: UsagePolicy;
 };
 
-/** Shape of `sprocket` from `GET /api/v1/models`. */
+/** UI catalog mapped from `sprocket` on `GET /api/v1/models`. */
 export type ModelCatalog = {
 	defaultModelId: string;
 	defaultReasoningEffort: string;

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -162,6 +162,7 @@ export default defineSchema({
 		completionTransport: v.optional(v.union(v.literal('convex-action'), v.literal('gateway'))),
 		gatewayProtocolVersion: v.optional(v.number()),
 		agentVersion: v.optional(v.string()),
+		// Historical catalog snapshot. Current inserts leave these unset.
 		contextWindowTokens: v.optional(v.number()),
 		autoCompactTokenLimit: v.optional(v.number()),
 		startedAt: v.number(),

--- a/apps/web/src/lib/chat/model-catalog.test.ts
+++ b/apps/web/src/lib/chat/model-catalog.test.ts
@@ -19,4 +19,16 @@ describe('gateway model catalog', () => {
 			'gpt-5.6-sol'
 		]);
 	});
+
+	it('maps gateway autoCompactTokenLimit onto autoHandoffTokenLimit', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => new Response(JSON.stringify(catalogFixture), { status: 200 }))
+		);
+		const catalog = await fetchGatewayModelCatalog('https://ai-gateway.spikonado.com');
+		expect(catalog.models.map((model) => model.autoHandoffTokenLimit)).toEqual(
+			catalogFixture.sprocket.models.map((model) => model.autoCompactTokenLimit)
+		);
+		expect(catalog.models[0]).not.toHaveProperty('autoCompactTokenLimit');
+	});
 });

--- a/apps/web/src/lib/chat/model-catalog.ts
+++ b/apps/web/src/lib/chat/model-catalog.ts
@@ -196,7 +196,7 @@ function catalogFromGatewayPayload(
 			provider: model.provider,
 			supportsImages: model.supportsImages,
 			contextWindowTokens: model.contextWindowTokens,
-			autoCompactTokenLimit: model.autoCompactTokenLimit,
+			autoHandoffTokenLimit: model.autoCompactTokenLimit,
 			reasoningEfforts: model.reasoningEfforts,
 			defaultReasoningEffort: model.defaultReasoningEffort,
 			serviceTiers: model.serviceTiers,

--- a/apps/web/src/lib/components/home/prompt-composer.svelte
+++ b/apps/web/src/lib/components/home/prompt-composer.svelte
@@ -60,7 +60,7 @@
 			inputTokens: number;
 			totalTokensProcessed: number;
 			contextWindowTokens: number;
-			autoCompactTokenLimit: number;
+			autoHandoffTokenLimit: number;
 		};
 		/** Project-path skill loader; cache invalidates when `workspacePath` changes. */
 		projectSkills?: {
@@ -216,9 +216,9 @@
 				)
 			: 0
 	);
-	const contextCompactPercent = $derived(
+	const contextHandoffPercent = $derived(
 		contextUsage.contextWindowTokens > 0
-			? Math.round((contextUsage.autoCompactTokenLimit / contextUsage.contextWindowTokens) * 100)
+			? Math.round((contextUsage.autoHandoffTokenLimit / contextUsage.contextWindowTokens) * 100)
 			: 0
 	);
 	const dollarQuery = $derived(getActiveDollarQuery(prompt, caretPosition));
@@ -834,8 +834,8 @@
 										<span>{formatTokens(contextUsage.totalTokensProcessed)}</span>
 									</div>
 									<p class="text-muted-foreground mt-4 text-[12px] leading-5">
-										Sprocket automatically compacts context at about {contextCompactPercent}% so
-										long-running work can continue.
+										At about {contextHandoffPercent}% of the context window, Sprocket writes a
+										handoff document and continues the work in a fresh context.
 									</p>
 								</div>
 							</div>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -545,7 +545,7 @@
 			inputTokens: currentActiveThread?.contextTokens ?? 0,
 			totalTokensProcessed: currentActiveThread ? currentActiveThread.totalTokensProcessed : 0,
 			contextWindowTokens: model?.contextWindowTokens ?? 0,
-			autoCompactTokenLimit: model?.autoCompactTokenLimit ?? 0
+			autoHandoffTokenLimit: model?.autoHandoffTokenLimit ?? 0
 		};
 	});
 	const currentLifecycle = $derived(dataForThread(lifecycleQuery.data, currentThreadId));

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -94,9 +94,9 @@ flow back through the executor job. Released agents that still call the public
 ## Main areas
 
 - `run.rs`: ownership, preparation, and finalization.
-- `catalog.rs`: context window and auto-compact limits from `GET /api/v1/models`.
+- `catalog.rs`: context window and automatic context handoff limits from `GET /api/v1/models`.
 - `provider.rs`: gateway completion loop, transcript sink, and provider outcomes.
-- `compaction.rs`: hidden in-run `handoff_context` turn followed by a fresh agent context. Provider usage only.
+- `context_handoff.rs`: hidden in-run `handoff_context` turn followed by a fresh agent context. Provider usage only.
 - `tools/`: model tools and durable job coordination.
 - `convex.rs`: run-control communication.
 - `types.rs`: history and context wire types.

--- a/crates/sprocket-agent/src/catalog.rs
+++ b/crates/sprocket-agent/src/catalog.rs
@@ -49,7 +49,8 @@ struct GatewayCatalogModel {
     id: String,
     supports_images: bool,
     context_window_tokens: u64,
-    auto_compact_token_limit: u64,
+    #[serde(rename = "autoCompactTokenLimit")]
+    auto_handoff_token_limit: u64,
 }
 
 fn select_catalog_model(
@@ -71,7 +72,7 @@ fn select_catalog_model(
     Ok(CatalogModelCapabilities {
         context_budget: ContextBudget {
             context_window_tokens: model.context_window_tokens,
-            auto_compact_token_limit: model.auto_compact_token_limit,
+            auto_handoff_token_limit: model.auto_handoff_token_limit,
         },
         supports_images: model.supports_images,
     })
@@ -132,7 +133,7 @@ mod tests {
             select_catalog_model(catalog_payload(true), "gpt-5.6-sol").expect("vision model");
         assert!(vision.supports_images);
         assert_eq!(vision.context_budget.context_window_tokens, 272000);
-        assert_eq!(vision.context_budget.auto_compact_token_limit, 258000);
+        assert_eq!(vision.context_budget.auto_handoff_token_limit, 258000);
 
         let text = select_catalog_model(catalog_payload(true), "deepseek-v4-pro-0813")
             .expect("text model");

--- a/crates/sprocket-agent/src/context_handoff.rs
+++ b/crates/sprocket-agent/src/context_handoff.rs
@@ -11,7 +11,7 @@ use rig::tool::{Tool, ToolExecutionError};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub(crate) const HANDOFF_PROMPT: &str = "Your context is filled up; write a handoff document (to the `handoff_context` tool) summarising the current conversation so a fresh agent can continue the work. Do not duplicate content already captured in other artifacts (specs, plans, issues, commits, diffs). Reference them by path or URL instead. Redact any sensitive information, such as API keys, passwords, or personally identifiable information. The document should be a max of 20000 words. When that word limit feels constraining, try to focus more on the task being currently done.";
+pub(crate) const HANDOFF_PROMPT: &str = "Your context is filled up; write a handoff document (to the `handoff_context` tool) summarising the current conversation so a fresh agent can continue the work. Do not duplicate content already captured in other artifacts (specs, plans, issues, commits, diffs). Reference them by path or URL instead. Redact any sensitive information, such as API keys, passwords, or personally identifiable information.";
 const HANDOFF_REQUESTED: &str = "SPROCKET_CONTEXT_HANDOFF_REQUESTED";
 const MAX_COMPLETION_CALLS: usize = 1_000;
 

--- a/crates/sprocket-agent/src/context_handoff.rs
+++ b/crates/sprocket-agent/src/context_handoff.rs
@@ -17,7 +17,7 @@ const MAX_COMPLETION_CALLS: usize = 1_000;
 
 pub(crate) fn context_summary_text(summary: &str) -> String {
     format!(
-        "The conversation context was automatically handed off. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.\n\n<conversation_summary>\n{summary}\n</conversation_summary>"
+        "A handoff document was created automatically from the conversation context. Treat this document as authoritative, continue the current task from this state, and do not redo completed work.\n\n<handoff_document>\n{summary}\n</handoff_document>"
     )
 }
 

--- a/crates/sprocket-agent/src/context_handoff.rs
+++ b/crates/sprocket-agent/src/context_handoff.rs
@@ -11,13 +11,13 @@ use rig::tool::{Tool, ToolExecutionError};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub(crate) const HANDOFF_PROMPT: &str = "Your context is filled up; write a handoff document (to the `handoff_context` tool) summarising the current conversation so a fresh agent can continue the work. Do not duplicate content already captured in other artifacts (specs, plans, issues, commits, diffs). Reference them by path or URL instead. Redact any sensitive information, such as API keys, passwords, or personally identifiable information.";
+pub(crate) const HANDOFF_PROMPT: &str = "Your context is filled up; write a handoff document (to the `handoff_context` tool) summarising the current conversation so a fresh agent can continue the work. Do not duplicate content already captured in other artifacts (specs, plans, issues, commits, diffs). Reference them by path or URL instead. Redact any sensitive information, such as API keys, passwords, or personally identifiable information. The document should be a max of 20000 words. When that word limit feels constraining, try to focus more on the task being currently done.";
 const HANDOFF_REQUESTED: &str = "SPROCKET_CONTEXT_HANDOFF_REQUESTED";
 const MAX_COMPLETION_CALLS: usize = 1_000;
 
 pub(crate) fn context_summary_text(summary: &str) -> String {
     format!(
-        "The conversation context was automatically compacted. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.\n\n<conversation_summary>\n{summary}\n</conversation_summary>"
+        "The conversation context was automatically handed off. Treat this summary as authoritative, continue the current task from this state, and do not redo completed work.\n\n<conversation_summary>\n{summary}\n</conversation_summary>"
     )
 }
 
@@ -28,7 +28,7 @@ pub(crate) struct HandoffRequest {
 }
 
 #[derive(Default)]
-struct CompactionState {
+struct HandoffState {
     context_tokens: u64,
     first_call: bool,
     defer_prompt: bool,
@@ -38,7 +38,7 @@ struct CompactionState {
     calls: usize,
 }
 
-impl CompactionState {
+impl HandoffState {
     fn prepare(&mut self, event: CompletionCallEvent<'_>, limit: u64) -> CompletionCallAction {
         if self.writing {
             return CompletionCallAction::patch(
@@ -84,16 +84,16 @@ impl CompactionState {
 }
 
 #[derive(Clone)]
-pub(crate) struct ContextCompactionHook {
+pub(crate) struct ContextHandoffHook {
     token_limit: u64,
-    state: Arc<Mutex<CompactionState>>,
+    state: Arc<Mutex<HandoffState>>,
 }
 
-impl ContextCompactionHook {
+impl ContextHandoffHook {
     pub(crate) fn new(token_limit: u64, context_tokens: u64, defer_prompt: bool) -> Self {
         Self {
             token_limit,
-            state: Arc::new(Mutex::new(CompactionState {
+            state: Arc::new(Mutex::new(HandoffState {
                 context_tokens,
                 first_call: true,
                 defer_prompt,
@@ -133,7 +133,7 @@ impl ContextCompactionHook {
     pub(crate) fn restart(&self) {
         if let Ok(mut state) = self.state.lock() {
             let calls = state.calls;
-            *state = CompactionState {
+            *state = HandoffState {
                 calls,
                 ..Default::default()
             };
@@ -151,7 +151,7 @@ impl ContextCompactionHook {
     }
 }
 
-impl AgentHook for ContextCompactionHook {
+impl AgentHook for ContextHandoffHook {
     async fn on_completion_call(
         &self,
         _context: &HookContext,
@@ -217,7 +217,7 @@ fn context_tokens(usage: Usage) -> u64 {
 
 #[derive(Clone)]
 pub(crate) struct HandoffTool {
-    state: Arc<Mutex<CompactionState>>,
+    state: Arc<Mutex<HandoffState>>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -254,7 +254,7 @@ impl Tool for HandoffTool {
 }
 
 #[cfg(test)]
-#[path = "compaction_integration_tests.rs"]
+#[path = "context_handoff_integration_tests.rs"]
 mod integration_tests;
 
 #[cfg(test)]
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn missing_usage_preserves_the_last_observation_until_restart() {
-        let hook = ContextCompactionHook::new(100, 120, true);
+        let hook = ContextHandoffHook::new(100, 120, true);
         assert_eq!(hook.record_usage(Usage::default()), 0);
         assert_eq!(hook.state.lock().unwrap().context_tokens, 120);
         hook.restart();
@@ -288,7 +288,7 @@ mod tests {
     fn defers_the_new_prompt_without_putting_it_in_the_handoff_history() {
         let history = vec![Message::user("old work")];
         let prompt = Message::user("new task");
-        let mut state = CompactionState {
+        let mut state = HandoffState {
             context_tokens: 100,
             first_call: true,
             defer_prompt: true,
@@ -315,7 +315,7 @@ mod tests {
     fn mid_run_handoff_includes_the_pending_tool_result() {
         let history = vec![Message::user("old work")];
         let prompt = Message::user("tool result");
-        let mut state = CompactionState {
+        let mut state = HandoffState {
             context_tokens: 100,
             ..Default::default()
         };
@@ -337,7 +337,7 @@ mod tests {
     fn does_not_estimate_tokens_from_large_messages() {
         let history = vec![Message::user("x".repeat(100_000))];
         let prompt = Message::user("next");
-        let mut state = CompactionState::default();
+        let mut state = HandoffState::default();
         assert!(matches!(
             state.prepare(
                 CompletionCallEvent {
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn handoff_submission_requires_a_pending_request_and_nonempty_document() {
-        let mut state = CompactionState::default();
+        let mut state = HandoffState::default();
         assert!(state.submit("handoff".into()).is_err());
         state.writing = true;
         assert!(state.submit("  ".into()).is_err());

--- a/crates/sprocket-agent/src/context_handoff_integration_tests.rs
+++ b/crates/sprocket-agent/src/context_handoff_integration_tests.rs
@@ -1,4 +1,4 @@
-//! Rig runner compaction against a local Responses SSE fixture.
+//! Rig runner context handoff against a local Responses SSE fixture.
 
 use std::collections::VecDeque;
 use std::io::{Read, Write};
@@ -17,7 +17,7 @@ use rig::tool::{DynamicTool, Tool, ToolOutput};
 use serde_json::{Value as JsonValue, json};
 
 use super::{
-    ContextCompactionHook, HANDOFF_PROMPT, HANDOFF_REQUESTED, HandoffRequest, HandoffTool,
+    ContextHandoffHook, HANDOFF_PROMPT, HANDOFF_REQUESTED, HandoffRequest, HandoffTool,
     context_summary_text,
 };
 use crate::hooks::AGENT_TOOL_NAMES;
@@ -53,7 +53,7 @@ fn response_json(
     output_tokens: u64,
 ) -> JsonValue {
     let mut response = json!({
-        "id": "resp_compaction",
+        "id": "resp_context_handoff",
         "object": "response",
         "created_at": 0,
         "status": status,
@@ -355,7 +355,7 @@ fn stub_tool(name: &'static str) -> DynamicTool {
     )
 }
 
-fn test_agent(base_url: &str, hook: &ContextCompactionHook) -> rig::Agent {
+fn test_agent(base_url: &str, hook: &ContextHandoffHook) -> rig::Agent {
     let client = openai::Client::builder()
         .api_key("test-key")
         .base_url(base_url)
@@ -363,7 +363,7 @@ fn test_agent(base_url: &str, hook: &ContextCompactionHook) -> rig::Agent {
         .expect("openai responses client");
     let mut builder = client
         .agent(MODEL)
-        .preamble("compaction fixture")
+        .preamble("context handoff fixture")
         .tool(hook.tool());
     for name in AGENT_TOOL_NAMES {
         builder = builder.dynamic_tool(stub_tool(name));
@@ -471,7 +471,7 @@ fn cancelled_reason(error: StreamingError) -> String {
 
 async fn drive(
     agent: &rig::Agent,
-    hook: &ContextCompactionHook,
+    hook: &ContextHandoffHook,
     prompt: Message,
     history: Vec<Message>,
 ) -> DriveEnd {
@@ -512,18 +512,18 @@ async fn drive(
     };
     tokio::time::timeout(DRIVE_TIMEOUT, run)
         .await
-        .expect("rig compaction stream timed out")
+        .expect("rig context handoff stream timed out")
 }
 
-fn take_handoff(hook: &ContextCompactionHook) -> HandoffRequest {
+fn take_handoff(hook: &ContextHandoffHook) -> HandoffRequest {
     hook.take_request()
-        .expect("compaction hook should stash a handoff request")
+        .expect("context handoff hook should stash a handoff request")
 }
 
 #[tokio::test]
 async fn unsolicited_handoff_is_not_executed_or_emitted_as_a_tool_call() {
     let (base_url, server) = spawn_responses_sse(vec![handoff_document_sse(FIRST_SUMMARY)]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, 0, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, true);
     let agent = test_agent(&base_url, &hook);
     tokio::time::timeout(DRIVE_TIMEOUT, async {
         let mut stream = agent
@@ -562,7 +562,7 @@ async fn over_budget_turn_is_replaced_by_the_hidden_handoff_prompt() {
         handoff_document_sse(FIRST_SUMMARY),
         text_sse("continued from handoff", 4, 4),
     ]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, OVER_LIMIT, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true);
     let agent = test_agent(&base_url, &hook);
     let history = vec![Message::user(OLD_CONTEXT)];
     let prompt = Message::user(DEFERRED_PROMPT);
@@ -630,7 +630,7 @@ async fn over_budget_turn_is_replaced_by_the_hidden_handoff_prompt() {
     assert!(resume_input.contains(FIRST_SUMMARY));
     assert!(
         !resume_input.contains(OLD_CONTEXT),
-        "fresh runner must not replay pre-compaction history"
+        "fresh runner must not replay pre-handoff history"
     );
     assert!(
         !resume_input.contains(HANDOFF_PROMPT),
@@ -653,7 +653,7 @@ async fn mid_run_handoff_keeps_the_pending_tool_result() {
         exec_command_sse(80, 20),
         handoff_document_sse(FIRST_SUMMARY),
     ]);
-    let hook = ContextCompactionHook::new(50, 0, false);
+    let hook = ContextHandoffHook::new(50, 0, false);
     let agent = test_agent(&base_url, &hook);
     let history = vec![Message::user(OLD_CONTEXT)];
     let prompt = Message::user("run pwd");
@@ -723,13 +723,13 @@ async fn mid_run_handoff_keeps_the_pending_tool_result() {
 }
 
 #[tokio::test]
-async fn compaction_repeats_after_restart() {
+async fn context_handoff_repeats_after_restart() {
     let (base_url, server) = spawn_responses_sse(vec![
         handoff_document_sse(FIRST_SUMMARY),
         exec_command_sse(90, 20),
         handoff_document_sse(SECOND_SUMMARY),
     ]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, OVER_LIMIT, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true);
     let agent = test_agent(&base_url, &hook);
     let prompt = Message::user(DEFERRED_PROMPT);
 
@@ -778,7 +778,7 @@ async fn compaction_repeats_after_restart() {
             .history
             .iter()
             .any(|message| message_contains(message, OLD_CONTEXT)),
-        "second handoff must not revive the original pre-compaction context"
+        "second handoff must not revive the original pre-handoff context"
     );
 
     hook.start_handoff();
@@ -801,7 +801,7 @@ async fn compaction_repeats_after_restart() {
 #[tokio::test]
 async fn empty_handoff_document_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![handoff_document_sse("   ")]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -819,7 +819,7 @@ async fn empty_handoff_document_is_rejected() {
 #[tokio::test]
 async fn truncated_handoff_turn_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![truncated_handoff_sse()]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -834,7 +834,7 @@ async fn truncated_handoff_turn_is_rejected() {
 #[tokio::test]
 async fn text_only_handoff_turn_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![text_sse("I will summarise in prose", 8, 8)]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -849,7 +849,7 @@ async fn text_only_handoff_turn_is_rejected() {
 #[tokio::test]
 async fn two_handoff_tool_calls_are_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![two_tool_calls_sse()]);
-    let hook = ContextCompactionHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -1,6 +1,6 @@
 mod attachments;
 mod catalog;
-mod compaction;
+mod context_handoff;
 mod convex;
 mod hooks;
 mod live;

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -12,7 +12,7 @@ use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
 use sprocket_workspace::{CommandSessionManager, WorkspaceSkill};
 use tokio::time::{sleep, timeout};
 
-use crate::compaction::{ContextCompactionHook, HANDOFF_PROMPT, context_summary_text};
+use crate::context_handoff::{ContextHandoffHook, HANDOFF_PROMPT, context_summary_text};
 use crate::convex::RuntimeClient;
 use crate::hooks::{AgentPromptHook, GatewayRequestHook, ToolCallTracker};
 use crate::live::{
@@ -87,7 +87,7 @@ pub(crate) struct AgentProviderRequest {
     pub(crate) supports_images: bool,
     pub(crate) parse_file_cache_dir: PathBuf,
     pub(crate) context_tokens: u64,
-    pub(crate) defer_prompt_for_compaction: bool,
+    pub(crate) defer_prompt_for_context_handoff: bool,
 }
 
 pub(crate) enum AgentProviderResult {
@@ -162,10 +162,10 @@ where
         request.skills.clone(),
     );
     let session_shutdown = CommandSessionShutdown::new(tools.command_sessions.clone());
-    let compaction_hook = ContextCompactionHook::new(
-        request.context_budget.auto_compact_token_limit,
+    let context_handoff_hook = ContextHandoffHook::new(
+        request.context_budget.auto_handoff_token_limit,
         request.context_tokens,
-        request.defer_prompt_for_compaction,
+        request.defer_prompt_for_context_handoff,
     );
     let agent = completion_client
         .agent(model)
@@ -189,7 +189,7 @@ where
         .tool(tools.mandate_charge)
         .tool(tools.mandate_report)
         .tool(tools.parse_file)
-        .tool(compaction_hook.tool())
+        .tool(context_handoff_hook.tool())
         .build();
 
     eprintln!("sprocket-agent: built agent {}", request.run_id);
@@ -262,7 +262,7 @@ where
                 .max_turns(AGENT_MAX_TURNS)
                 .add_hook(prompt_hook.clone())
                 .add_hook(gateway_hook.clone())
-                .add_hook(compaction_hook.clone())
+                .add_hook(context_handoff_hook.clone())
                 .max_invalid_tool_call_retries(MAX_INVALID_TOOL_CALL_RETRIES)
                 .await;
             loop {
@@ -300,7 +300,7 @@ where
                         }
                     }
                     item = stream.next() => {
-                        let calls = compaction_hook.completion_calls();
+                        let calls = context_handoff_hook.completion_calls();
                         if calls != observed_calls {
                             if recorded_attempt == Some(transcript.attempt_seq) {
                                 if let Err(error) = transcript.advance_attempt().await {
@@ -312,10 +312,10 @@ where
                         match item {
                             Some(Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(_)))
                             | Some(Ok(rig::agent::MultiTurnStreamItem::FinalResponse(_)))
-                                if compaction_hook.is_writing() => {}
+                                if context_handoff_hook.is_writing() => {}
                             Some(Ok(rig::agent::MultiTurnStreamItem::CompletionCall(call))) => {
                                 recorded_attempt = Some(transcript.attempt_seq);
-                                let tokens = compaction_hook.record_usage(call.usage);
+                                let tokens = context_handoff_hook.record_usage(call.usage);
                                 if tokens == 0 {
                                     continue;
                                 }
@@ -368,8 +368,8 @@ where
                                 );
                             }
                             Some(Ok(rig::agent::MultiTurnStreamItem::ToolExecutionCommitted { .. })) => {
-                                if compaction_hook.is_writing() {
-                                    let Some(summary) = compaction_hook.take_summary() else {
+                                if context_handoff_hook.is_writing() {
+                                    let Some(summary) = context_handoff_hook.take_summary() else {
                                         break 'agent_run AgentProviderResult::Failed {
                                             text: streamed_text,
                                             error: anyhow!("Context handoff failed: no valid document was submitted."),
@@ -392,7 +392,7 @@ where
                                         Some(pending) => { history.push(handoff); pending }
                                         None => handoff,
                                     };
-                                    compaction_hook.restart();
+                                    context_handoff_hook.restart();
                                     final_text.clear();
                                     streamed_text.clear();
                                     completion_error = None;
@@ -410,15 +410,15 @@ where
                             | Some(Ok(rig::agent::MultiTurnStreamItem::ModelTurnRetried { .. }))
                             | Some(Ok(rig::agent::MultiTurnStreamItem::StreamUserItem(_))) => {}
                             Some(Err(error)) => {
-                                if let Some(handoff) = compaction_hook.take_request() {
+                                if let Some(handoff) = context_handoff_hook.take_request() {
                                     history = handoff.history;
                                     prompt = Message::user(HANDOFF_PROMPT);
                                     deferred_prompt = handoff.deferred_prompt;
                                     before_prompt = handoff.before_prompt;
-                                    compaction_hook.start_handoff();
+                                    context_handoff_hook.start_handoff();
                                     continue 'generations;
                                 }
-                                if compaction_hook.is_writing() {
+                                if context_handoff_hook.is_writing() {
                                     break 'agent_run AgentProviderResult::Failed {
                                         text: streamed_text,
                                         error: anyhow!("Context handoff failed. Retry to continue the conversation."),
@@ -444,7 +444,7 @@ where
                                 break 'agent_run result;
                             }
                             None => {
-                                if compaction_hook.is_writing() {
+                                if context_handoff_hook.is_writing() {
                                     break 'agent_run AgentProviderResult::Failed {
                                         text: streamed_text,
                                         error: anyhow!("Context handoff ended without submitting a document."),

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -758,7 +758,7 @@ async fn load_prior_history(
     )
     .await?;
     let state = store.load_state(user_id, thread_id).await?;
-    let current_run_was_compacted =
+    let current_run_had_context_handoff =
         if state.context_summary.is_some() && state.history_from_number > 0 {
             runtime
                 .transcript_parts_for_run(run_id, &[state.history_from_number - 1])
@@ -808,7 +808,7 @@ async fn load_prior_history(
             .map(prompt_text_with_attachments),
         messages: deserialize_agent_history(history)?,
         continue_from_finished_turns: context.run.continuation_of_run_id.is_some()
-            || current_run_was_compacted
+            || current_run_had_context_handoff
             || current_run_has_finished_turns(&parts, run_id),
     })
 }
@@ -970,7 +970,7 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
                         store.thread_dir(&context.run.user_id, &context.run.thread_id),
                     ),
                     context_tokens: context.context_tokens,
-                    defer_prompt_for_compaction: !prior_history.continue_from_finished_turns
+                    defer_prompt_for_context_handoff: !prior_history.continue_from_finished_turns
                         && context.run.continuation_of_run_id.is_none()
                         && request.continuation_of_run_id.is_none(),
                 },

--- a/crates/sprocket-agent/src/transcript/history.rs
+++ b/crates/sprocket-agent/src/transcript/history.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::compaction::context_summary_text;
+use crate::context_handoff::context_summary_text;
 use crate::reasoning::{opaque_encrypted, skip_reasoning_on_reload};
 use crate::transcript::types::{TranscriptPart, TranscriptPartKind, TranscriptToolBody};
 use crate::types::{
@@ -719,9 +719,9 @@ mod tests {
     }
 
     #[test]
-    fn compaction_reload_drops_all_loaded_reasoning_regardless_of_part_number() {
+    fn context_handoff_reload_drops_all_loaded_reasoning_regardless_of_part_number() {
         // A context summary is not proof the retained prefix is unchanged.
-        // In-flight old generations can commit later, and in-memory compaction
+        // In-flight old generations can commit later, and in-memory context handoff
         // can replace current-run text while historyFromNumber only drops the
         // prior run. Fail closed: drop every loaded reasoning item.
         let mut state = TranscriptState::new("user".into(), "thread".into());
@@ -769,7 +769,7 @@ mod tests {
     }
 
     #[test]
-    fn compaction_reload_keeps_text_while_dropping_reasoning() {
+    fn context_handoff_reload_keeps_text_while_dropping_reasoning() {
         let mut state = TranscriptState::new("user".into(), "thread".into());
         state.context_summary = Some("Prior work is done.".into());
         state.history_from_number = 1;

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -465,7 +465,7 @@ impl TranscriptStore {
         let limit = limit
             .unwrap_or(TRANSCRIPT_PAGE_SIZE)
             .clamp(1, TRANSCRIPT_CHUNK_SIZE);
-        // Compaction limits model context, not what the user may scroll back to.
+        // Context handoff limits model context, not what the user may scroll back to.
         let history_from = 0;
         let end_exclusive = before
             .unwrap_or_else(|| state.visible_end_exclusive())

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -83,8 +83,11 @@ pub struct RunContextResponse {
 pub struct ContextBudget {
     #[serde(deserialize_with = "deserialize_convex_u64")]
     pub context_window_tokens: u64,
-    #[serde(deserialize_with = "deserialize_convex_u64")]
-    pub auto_compact_token_limit: u64,
+    #[serde(
+        rename = "autoCompactTokenLimit",
+        deserialize_with = "deserialize_convex_u64"
+    )]
+    pub auto_handoff_token_limit: u64,
 }
 
 /// Live catalog fields for the selected model. Fetched once with the budget.
@@ -533,6 +536,24 @@ mod tests {
         assert_eq!(attachment.name, "robot.png");
         assert_eq!(attachment.size, 42);
         assert_eq!(attachment.storage_id, "storage_1");
+    }
+
+    #[test]
+    fn context_handoff_budget_preserves_the_released_wire_field() {
+        let budget: super::ContextBudget = serde_json::from_value(serde_json::json!({
+            "contextWindowTokens": 272000.0,
+            "autoCompactTokenLimit": 258000.0
+        }))
+        .expect("released context budget");
+
+        assert_eq!(budget.auto_handoff_token_limit, 258000);
+        assert_eq!(
+            serde_json::to_value(budget).expect("serialized context budget"),
+            serde_json::json!({
+                "contextWindowTokens": 272000,
+                "autoCompactTokenLimit": 258000
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep the original handoff-writing prompt, `HANDOFF_PROMPT`, unchanged.
- Describe the resumed context as an automatically created handoff document, enclosed in `<handoff_document>` tags, using the requested wrapper text.
- Rename the Rust module, hook, state, integration tests, runtime flags, internal budget fields, and UI terminology from context compaction to context handoff.
- Explain the handoff document and fresh context in the context-usage tooltip.
- Preserve gateway and released Convex wire names, stored fields, and legacy billing event names. Document their compatibility boundaries and removal gates.

The handoff-writing prompt matches main; the earlier word-limit addition was reverted at the user's request. The wrapper shown to the resumed agent is reworded. Handoff validation and persistence behavior are unchanged.

## Validation

- `cargo test -p sprocket-agent context_handoff`: 17 passed.
- `cargo test -p sprocket-agent`: 160 passed.
- Targeted Vitest run for model catalog, context accounting, and transcript tests with `--maxWorkers=1`: 35 passed. The first parallel run hit two 5-second timeouts during the cold Rust build; the single-worker rerun passed without changing test timeouts.
- `bun --env-file=.env.prod convex codegen`: passed with no generated changes.
- `prek run -a` applied Rust formatting; the subsequent commit-hook run passed all applicable checks, including cargo check, ESLint, Oxlint, Svelte check, Prettier, and Mermaid lint.
- Two pre-PR reviews completed. Clarified the tooltip based on the UI review.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently renames context compaction terminology to context handoff while preserving released gateway, Convex, storage, and billing compatibility boundaries.
- Maps the gateway’s `autoCompactTokenLimit` field to handoff-named internal and UI fields.
- Renames the Rust handoff module, hook, state, tests, flags, and related UI terminology.
- Presents resumed context as an automatically generated document enclosed in `<handoff_document>` tags.
- Documents the legacy names that must remain for backward compatibility.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule issues identified.

The terminology changes preserve compatibility mappings at external and stored-data boundaries, and the updated handoff wrapper is applied consistently to live and reloaded summaries.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/context_handoff.rs | Renames the handoff implementation and updates the shared resumed-context wrapper without changing validation or persistence behavior. |
| crates/sprocket-agent/src/provider.rs | Adopts handoff terminology throughout provider orchestration while retaining the existing lifecycle. |
| crates/sprocket-agent/src/types.rs | Renames the internal budget field while explicitly preserving the released serialized wire name. |
| crates/sprocket-agent/src/catalog.rs | Maps the legacy gateway catalog field to the handoff-named Rust field. |
| apps/web/src/lib/chat/model-catalog.ts | Maps the gateway compatibility field to the handoff-named UI catalog property. |
| apps/web/src/lib/components/home/prompt-composer.svelte | Updates context-usage terminology and explains that handoff continues work in a fresh context. |
| BACKWARDS_COMPATIBILITY.md | Documents retained wire, storage, API, and billing names and their removal gates. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Gateway["Gateway catalog<br/>autoCompactTokenLimit"] --> Mapping["Compatibility mapping"]
    Mapping --> Runtime["Rust runtime<br/>auto_handoff_token_limit"]
    Mapping --> UI["Web UI<br/>autoHandoffTokenLimit"]
    Runtime --> Writer["Handoff document generation"]
    Writer --> Wrapper["&lt;handoff_document&gt;"]
    Wrapper --> Fresh["Fresh agent context"]
    Persisted["Persisted legacy summary"] --> Wrapper
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): Describe resumed context as ..."](https://github.com/spikonado/sprocket/commit/d0f7cfe8a15ecf677fee494f154c30d35fa895cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61424191)</sub>

<!-- /greptile_comment -->