### PR TITLE
feat(agent-tools): Save oversized scrapes to temporary files

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -334,6 +334,12 @@ There is no execution-mode parameter or cloud-workpool scrape fallback.
 `web_search` still uses the workpool. Deploy the updated client and backend
 together.
 
+New scrape results omit `truncated` and save oversized content to a local
+temporary file. Stored validators retain the optional flag for old executor
+jobs and transcripts; remove it only after stored results and JSONL replicas
+have aged out or been migrated. The UI no longer displays a truncation badge,
+including for historical results.
+
 Web image results store URL and image metadata, not bytes or local paths.
 History displays a notice rather than fetching the URL again. Local-path
 `parse_file` image results still replay from their existing local cache.

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -236,11 +236,24 @@ export const vCommandExecResult = v.object({
 	error: v.optional(v.string())
 });
 
+/** Stored scrape_url job result. Historical cloud rows include `truncated`. */
 export const vScrapeUrlResult = v.object({
 	url: v.string(),
 	markdown: v.string(),
-	truncated: v.boolean()
+	truncated: v.optional(v.boolean())
 });
+
+/** Local scrapeForTool transport. Long pages return a temporary download URL. */
+export const vScrapeUrlTransport = v.union(
+	v.object({
+		url: v.string(),
+		markdown: v.string()
+	}),
+	v.object({
+		url: v.string(),
+		markdownUrl: v.string()
+	})
+);
 
 export const vWebImageResult = v.object({
 	outputType: v.literal('image'),

--- a/apps/web/src/convex/webToolPool.test.ts
+++ b/apps/web/src/convex/webToolPool.test.ts
@@ -57,8 +57,7 @@ describe('web tool workpool fencing', () => {
 		const { jobId } = await seedStartedWebJob(t, {
 			executionSecret: 'webpool-scrape-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/legacy' },
-			localExecution: true
+			payload: { url: 'https://example.com/legacy' }
 		});
 		const markdown = 'x'.repeat(40_000);
 		await t.run(async (ctx) => {

--- a/apps/web/src/convex/webToolPool.test.ts
+++ b/apps/web/src/convex/webToolPool.test.ts
@@ -52,22 +52,20 @@ describe('web tool workpool fencing', () => {
 		expect(after?.result).toMatchObject({ results: [{ url: 'https://example.com' }] });
 	});
 
-	it('stores legacy truncated scrape results from the cloud workpool', async () => {
+	it('reads historical truncated scrape results', async () => {
 		const t = initConvexTest();
-		const { runId, claimId, jobId } = await seedStartedWebJob(t, {
+		const { jobId } = await seedStartedWebJob(t, {
 			executionSecret: 'webpool-scrape-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/legacy' }
+			payload: { url: 'https://example.com/legacy' },
+			localExecution: true
 		});
 		const markdown = 'x'.repeat(40_000);
-		await t.mutation(internal.webToolPool.completeWebTool, {
-			// SAFETY: completeWebTool ignores workId and fences on job/claim state.
-			workId: 'work-scrape' as WorkId,
-			context: { jobId, runId, claimId },
-			result: {
-				kind: 'success',
-				returnValue: { url: 'https://example.com/legacy', markdown, truncated: true }
-			}
+		await t.run(async (ctx) => {
+			await ctx.db.patch('executorJobs', jobId, {
+				status: 'completed',
+				result: { url: 'https://example.com/legacy', markdown, truncated: true }
+			});
 		});
 		const after = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(after?.status).toBe('completed');

--- a/apps/web/src/convex/webToolPool.test.ts
+++ b/apps/web/src/convex/webToolPool.test.ts
@@ -51,6 +51,32 @@ describe('web tool workpool fencing', () => {
 		expect(after?.status).toBe('completed');
 		expect(after?.result).toMatchObject({ results: [{ url: 'https://example.com' }] });
 	});
+
+	it('stores legacy truncated scrape results from the cloud workpool', async () => {
+		const t = initConvexTest();
+		const { runId, claimId, jobId } = await seedStartedWebJob(t, {
+			executionSecret: 'webpool-scrape-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/legacy' }
+		});
+		const markdown = 'x'.repeat(40_000);
+		await t.mutation(internal.webToolPool.completeWebTool, {
+			// SAFETY: completeWebTool ignores workId and fences on job/claim state.
+			workId: 'work-scrape' as WorkId,
+			context: { jobId, runId, claimId },
+			result: {
+				kind: 'success',
+				returnValue: { url: 'https://example.com/legacy', markdown, truncated: true }
+			}
+		});
+		const after = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(after?.status).toBe('completed');
+		expect(after?.result).toEqual({
+			url: 'https://example.com/legacy',
+			markdown,
+			truncated: true
+		});
+	});
 });
 
 describe('local scrape_url dispatch', () => {
@@ -86,5 +112,33 @@ describe('local scrape_url dispatch', () => {
 		});
 		const stored = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(stored?.cloudWorkId).toEqual(expect.any(String));
+	});
+});
+
+describe('temporary scrape storage', () => {
+	it('deletes unregistered blobs and is a no-op after they are gone', async () => {
+		const t = initConvexTest();
+		const storageId = await t.run(async (ctx) => ctx.storage.store(new Blob(['scrape markdown'])));
+		expect(await t.mutation(internal.webToolPool.deleteTemporaryStorage, { storageId })).toBeNull();
+		expect(await t.run(async (ctx) => ctx.db.system.get('_storage', storageId))).toBeNull();
+		expect(await t.mutation(internal.webToolPool.deleteTemporaryStorage, { storageId })).toBeNull();
+	});
+
+	it('leaves registered attachments in place', async () => {
+		const t = initConvexTest();
+		const storageId = await t.run(async (ctx) => {
+			const storageId = await ctx.storage.store(new Blob(['attached']));
+			await ctx.db.insert('imageUploads', {
+				userId: 'owner',
+				storageId,
+				name: 'file.txt',
+				mediaType: 'text/plain',
+				size: 8,
+				attached: true
+			});
+			return storageId;
+		});
+		expect(await t.mutation(internal.webToolPool.deleteTemporaryStorage, { storageId })).toBeNull();
+		expect(await t.run(async (ctx) => ctx.db.system.get('_storage', storageId))).not.toBeNull();
 	});
 });

--- a/apps/web/src/convex/webToolPool.ts
+++ b/apps/web/src/convex/webToolPool.ts
@@ -10,6 +10,7 @@ import {
 import type { Doc, Id } from '@convex/_generated/dataModel';
 import { getExecutionRun } from '@convex/lib/auth';
 import { applyExecutorJobFailure, applyExecutorJobSuccess } from '@convex/lib/executorJobs';
+import { registeredParseStorage } from '@convex/lib/hostedParse';
 import { isSettledExecutorJobStatus } from '@convex/lib/runs';
 import { isRunFinalStatus, vExecutorJobPayload } from '@convex/lib/validators';
 import { ownsActiveRunClaim } from '@convex/lib/runLease';
@@ -176,6 +177,30 @@ export const completeWebTool = internalMutation({
 			error: args.result.error,
 			claimId: args.context.claimId
 		});
+		return null;
+	}
+});
+
+async function deleteUnregisteredStorage(
+	ctx: MutationCtx,
+	storageId: Id<'_storage'>
+): Promise<void> {
+	const attached = await ctx.db
+		.query('imageUploads')
+		.withIndex('by_storageId', (query) => query.eq('storageId', storageId))
+		.unique();
+	if (attached) return;
+	if (await registeredParseStorage(ctx, storageId)) return;
+	if (await ctx.db.system.get('_storage', storageId)) {
+		await ctx.storage.delete(storageId);
+	}
+}
+
+export const deleteTemporaryStorage = internalMutation({
+	args: { storageId: v.id('_storage') },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		await deleteUnregisteredStorage(ctx, args.storageId);
 		return null;
 	}
 });

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -360,4 +360,3 @@ describe('scrapeForTool markdown transport', () => {
 		expect(await t.run(async (ctx) => ctx.db.system.get('_storage', storageId!))).toBeNull();
 	});
 });
-

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -216,8 +216,7 @@ describe('stored scrape_url results', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'saved-path-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' },
-			localExecution: true
+			payload: { url: 'https://example.com/page' }
 		});
 		await asUser.mutation(api.executor.complete, {
 			runId,
@@ -242,8 +241,7 @@ describe('stored scrape_url results', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'legacy-truncated-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' },
-			localExecution: true
+			payload: { url: 'https://example.com/page' }
 		});
 		await asUser.mutation(api.executor.complete, {
 			runId,
@@ -270,8 +268,7 @@ async function scrapeLocalMarkdown(markdown: string, url = 'https://example.com/
 	const seeded = await seedStartedWebJob(t, {
 		executionSecret: `local-md-${Math.random()}`,
 		kind: 'scrape_url',
-		payload: { url },
-		localExecution: true
+		payload: { url }
 	});
 	const scrape = mockScrapeMarkdown(markdown, url);
 	try {
@@ -293,8 +290,7 @@ describe('scrapeForTool markdown transport', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'oversized-markdown-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' },
-			localExecution: true
+			payload: { url: 'https://example.com/page' }
 		});
 		const scrape = mockScrapeMarkdown(`${'é'.repeat(32 * 1024 * 1024)}x`);
 		try {

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -3,8 +3,26 @@ import { ContextDev } from '@context-dot-dev/convex';
 import { api, internal } from '@convex/_generated/api';
 import { RUN_NO_LONGER_ACTIVE } from '@convex/lib/agentErrors';
 import { UNSUPPORTED_CLIENT_MESSAGE } from '@convex/lib/unsupportedClient';
-import { isUnparseablePageFailure, scrapeHttpErrorStatus } from '@convex/webTools';
-import { initConvexTest, seedStartedWebJob } from './test.setup';
+import {
+	isUnparseablePageFailure,
+	scrapeHttpErrorStatus,
+	SCRAPE_MARKDOWN_MAX_CHARS,
+	SCRAPE_MARKDOWN_STORAGE_TTL_MS
+} from '@convex/webTools';
+import { initConvexTest, seedStartedWebJob, type ConvexTestInstance } from './test.setup';
+
+function mockScrapeMarkdown(markdown: string, url = 'https://example.com/page') {
+	return vi.spyOn(ContextDev.prototype, 'scrapeMarkdown').mockResolvedValue({
+		success: true,
+		url,
+		markdown,
+		metadata: { sourceUrl: url, finalUrl: url }
+	});
+}
+
+async function storageBlobs(t: ConvexTestInstance) {
+	return await t.run(async (ctx) => ctx.db.system.query('_storage').collect());
+}
 
 beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
@@ -47,12 +65,7 @@ describe('scrapeForTool auth', () => {
 			kind: 'scrape_url',
 			payload: { url: 'https://example.com/page' }
 		});
-		const scrape = vi.spyOn(ContextDev.prototype, 'scrapeMarkdown').mockResolvedValue({
-			success: true,
-			url: 'https://example.com/page',
-			markdown: '# Page',
-			metadata: { sourceUrl: 'https://example.com/page', finalUrl: 'https://example.com/page' }
-		});
+		const scrape = mockScrapeMarkdown('# Page');
 		try {
 			expect(
 				await asUser.action(api.webTools.scrapeForTool, {
@@ -61,7 +74,7 @@ describe('scrapeForTool auth', () => {
 					jobId,
 					executionSecret
 				})
-			).toEqual({ url: 'https://example.com/page', markdown: '# Page', truncated: false });
+			).toEqual({ url: 'https://example.com/page', markdown: '# Page' });
 			expect(scrape).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({
@@ -184,7 +197,7 @@ describe('scrapeForTool auth', () => {
 			claimId,
 			executionSecret,
 			jobId,
-			result: { url: 'https://example.com/page', markdown: 'done', truncated: false }
+			result: { url: 'https://example.com/page', markdown: 'done' }
 		});
 		await expect(
 			asUser.action(api.webTools.scrapeForTool, {
@@ -196,3 +209,128 @@ describe('scrapeForTool auth', () => {
 		).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
 	});
 });
+
+describe('stored scrape_url results', () => {
+	it('stores scrape results without truncated', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'saved-path-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' },
+			localExecution: true
+		});
+		await asUser.mutation(api.executor.complete, {
+			runId,
+			claimId,
+			executionSecret,
+			jobId,
+			result: {
+				url: 'https://example.com/page',
+				markdown: 'The scrape was saved to /tmp/scrape.md.'
+			}
+		});
+		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(job?.result).toEqual({
+			url: 'https://example.com/page',
+			markdown: 'The scrape was saved to /tmp/scrape.md.'
+		});
+		expect(job?.result).not.toHaveProperty('truncated');
+	});
+
+	it('still accepts stored scrape results with truncated', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'legacy-truncated-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' },
+			localExecution: true
+		});
+		await asUser.mutation(api.executor.complete, {
+			runId,
+			claimId,
+			executionSecret,
+			jobId,
+			result: {
+				url: 'https://example.com/page',
+				markdown: 'partial',
+				truncated: true
+			}
+		});
+		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(job?.result).toEqual({
+			url: 'https://example.com/page',
+			markdown: 'partial',
+			truncated: true
+		});
+	});
+});
+
+async function scrapeLocalMarkdown(markdown: string, url = 'https://example.com/page') {
+	const t = initConvexTest();
+	const seeded = await seedStartedWebJob(t, {
+		executionSecret: `local-md-${Math.random()}`,
+		kind: 'scrape_url',
+		payload: { url },
+		localExecution: true
+	});
+	const scrape = mockScrapeMarkdown(markdown, url);
+	try {
+		const result = await seeded.asUser.action(api.webTools.scrapeForTool, {
+			runId: seeded.runId,
+			claimId: seeded.claimId,
+			jobId: seeded.jobId,
+			executionSecret: seeded.executionSecret
+		});
+		return { t, result, scrapeCalls: scrape.mock.calls.length };
+	} finally {
+		scrape.mockRestore();
+	}
+}
+
+describe('scrapeForTool markdown transport', () => {
+	it('returns short markdown inline without truncated or storage', async () => {
+		const markdown = 'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS);
+		const { t, result, scrapeCalls } = await scrapeLocalMarkdown(markdown);
+		expect(result).toEqual({ url: 'https://example.com/page', markdown });
+		expect(result).not.toHaveProperty('truncated');
+		expect(result).not.toHaveProperty('markdownUrl');
+		expect(scrapeCalls).toBe(1);
+		expect(await storageBlobs(t)).toEqual([]);
+	});
+
+	it('stores full long markdown bytes and returns markdownUrl', async () => {
+		const markdown = `${'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS)}é`;
+		const expectedBytes = new TextEncoder().encode(markdown);
+		const { t, result, scrapeCalls } = await scrapeLocalMarkdown(markdown);
+		expect(result).toEqual({
+			url: 'https://example.com/page',
+			markdownUrl: expect.any(String)
+		});
+		expect(result).not.toHaveProperty('truncated');
+		expect(result).not.toHaveProperty('markdown');
+		expect(scrapeCalls).toBe(1);
+		if (!('markdownUrl' in result)) throw new Error('expected markdownUrl');
+		const blobs = await storageBlobs(t);
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0]?.size).toBe(expectedBytes.byteLength);
+		const storedUrl = await t.run(async (ctx) => {
+			if (!blobs[0]) return null;
+			return await ctx.storage.getUrl(blobs[0]._id);
+		});
+		expect(storedUrl).toBe(result.markdownUrl);
+	});
+
+	it('deletes stored markdown after one hour', async () => {
+		const markdown = `${'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS)}y`;
+		const { t } = await scrapeLocalMarkdown(markdown);
+		const blobs = await storageBlobs(t);
+		expect(blobs).toHaveLength(1);
+		const storageId = blobs[0]?._id;
+		expect(storageId).toBeDefined();
+		await t.finishAllScheduledFunctions(() => {
+			vi.advanceTimersByTime(SCRAPE_MARKDOWN_STORAGE_TTL_MS);
+		});
+		expect(await t.run(async (ctx) => ctx.db.system.get('_storage', storageId!))).toBeNull();
+	});
+});
+

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -288,6 +288,33 @@ async function scrapeLocalMarkdown(markdown: string, url = 'https://example.com/
 }
 
 describe('scrapeForTool markdown transport', () => {
+	it('rejects markdown above the receiver byte limit without storing a blob', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'oversized-markdown-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' },
+			localExecution: true
+		});
+		const scrape = mockScrapeMarkdown(`${'é'.repeat(32 * 1024 * 1024)}x`);
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, { runId, claimId, jobId, executionSecret })
+			).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
+			expect(await storageBlobs(t)).toEqual([]);
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('accepts markdown exactly at the receiver byte limit', async () => {
+		const { t, result } = await scrapeLocalMarkdown('é'.repeat(32 * 1024 * 1024));
+		expect(result).toHaveProperty('markdownUrl');
+		const blobs = await storageBlobs(t);
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0]?.size).toBe(64 * 1024 * 1024);
+	});
+
 	it('returns short markdown inline without truncated or storage', async () => {
 		const markdown = 'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS);
 		const { t, result, scrapeCalls } = await scrapeLocalMarkdown(markdown);

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -23,6 +23,7 @@ const MAX_SEARCH_RESULTS = 10;
 // Bounds inline markdown; Convex documents are capped at 1 MiB.
 export const SCRAPE_MARKDOWN_MAX_CHARS = 40_000;
 export const SCRAPE_MARKDOWN_STORAGE_TTL_MS = 60 * 60 * 1_000;
+const SCRAPE_MAX_BYTES = 64 * 1024 * 1024;
 const SCRAPE_MARKDOWN_BLOB_TYPE = 'text/markdown; charset=utf-8';
 const SCRAPE_TIMEOUT_MS = 60_000;
 const SEARCH_RESULT_TEXT_MAX_CHARS = 2_000;
@@ -163,9 +164,11 @@ async function localScrapeTransport(
 }
 
 async function storeTemporaryMarkdown(ctx: ActionCtx, markdown: string): Promise<string> {
-	const storageId = await ctx.storage.store(
-		new Blob([markdown], { type: SCRAPE_MARKDOWN_BLOB_TYPE })
-	);
+	const blob = new Blob([markdown], { type: SCRAPE_MARKDOWN_BLOB_TYPE });
+	if (blob.size > SCRAPE_MAX_BYTES) {
+		throw new NonRetryableError('Scrape exceeds the 64 MiB download limit.');
+	}
+	const storageId = await ctx.storage.store(blob);
 	try {
 		await ctx.scheduler.runAfter(
 			SCRAPE_MARKDOWN_STORAGE_TTL_MS,

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -7,7 +7,7 @@ import { ExaClient } from '@exalabs/convex-exa';
 import { action, internalAction, type ActionCtx } from '@convex/_generated/server';
 import { components, internal } from '@convex/_generated/api';
 import {
-	vScrapeUrlResult,
+	vScrapeUrlTransport,
 	vWebSearchResult,
 	type ExecutorJobPayload
 } from '@convex/lib/validators';
@@ -20,8 +20,10 @@ const exa = new ExaClient(components.exa);
 
 const DEFAULT_SEARCH_RESULTS = 5;
 const MAX_SEARCH_RESULTS = 10;
-// Bounds the persisted executor-job result; Convex documents are capped at 1 MiB.
-const SCRAPE_MARKDOWN_MAX_CHARS = 40_000;
+// Bounds inline markdown; Convex documents are capped at 1 MiB.
+export const SCRAPE_MARKDOWN_MAX_CHARS = 40_000;
+export const SCRAPE_MARKDOWN_STORAGE_TTL_MS = 60 * 60 * 1_000;
+const SCRAPE_MARKDOWN_BLOB_TYPE = 'text/markdown; charset=utf-8';
 const SCRAPE_TIMEOUT_MS = 60_000;
 const SEARCH_RESULT_TEXT_MAX_CHARS = 2_000;
 const SEARCH_TIMEOUT_MS = 30_000;
@@ -94,20 +96,19 @@ type PoolScrapeJob = {
 	payload: ExecutorJobPayload;
 } | null;
 
-async function scrapeClaimedUrl(
-	ctx: ActionCtx,
-	job: PoolScrapeJob
-): Promise<Infer<typeof vScrapeUrlResult>> {
+type ScrapedPage = {
+	url: string;
+	markdown: string;
+};
+
+async function scrapeClaimedUrl(ctx: ActionCtx, job: PoolScrapeJob): Promise<ScrapedPage> {
 	if (!job || job.kind !== 'scrape_url') {
 		throw new NonRetryableError(RUN_NO_LONGER_ACTIVE);
 	}
-	return await runScrape(ctx, scrapeUrlFromPayload(job.payload));
+	return await fetchScrape(ctx, scrapeUrlFromPayload(job.payload));
 }
 
-async function runScrape(
-	ctx: ActionCtx,
-	urlValue: string
-): Promise<Infer<typeof vScrapeUrlResult>> {
+async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPage> {
 	let url: URL;
 	try {
 		url = new URL(urlValue.trim());
@@ -148,12 +149,39 @@ async function runScrape(
 		throw error;
 	}
 
-	const truncated = response.markdown.length > SCRAPE_MARKDOWN_MAX_CHARS;
-	return {
-		url: response.url,
-		markdown: truncated ? response.markdown.slice(0, SCRAPE_MARKDOWN_MAX_CHARS) : response.markdown,
-		truncated
-	};
+	return { url: response.url, markdown: response.markdown };
+}
+
+async function localScrapeTransport(
+	ctx: ActionCtx,
+	page: ScrapedPage
+): Promise<Infer<typeof vScrapeUrlTransport>> {
+	if (page.markdown.length <= SCRAPE_MARKDOWN_MAX_CHARS) {
+		return { url: page.url, markdown: page.markdown };
+	}
+	return { url: page.url, markdownUrl: await storeTemporaryMarkdown(ctx, page.markdown) };
+}
+
+async function storeTemporaryMarkdown(ctx: ActionCtx, markdown: string): Promise<string> {
+	const storageId = await ctx.storage.store(
+		new Blob([markdown], { type: SCRAPE_MARKDOWN_BLOB_TYPE })
+	);
+	try {
+		await ctx.scheduler.runAfter(
+			SCRAPE_MARKDOWN_STORAGE_TTL_MS,
+			internal.webToolPool.deleteTemporaryStorage,
+			{ storageId }
+		);
+	} catch (error) {
+		await ctx.storage.delete(storageId);
+		throw error;
+	}
+	const markdownUrl = await ctx.storage.getUrl(storageId);
+	if (!markdownUrl) {
+		await ctx.storage.delete(storageId);
+		throw new Error('Stored scrape is unavailable.');
+	}
+	return markdownUrl;
 }
 
 async function runSearch(
@@ -254,11 +282,11 @@ export const scrapeForTool = action({
 		jobId: v.id('executorJobs'),
 		executionSecret: v.string()
 	},
-	returns: vScrapeUrlResult,
-	handler: async (ctx, args): Promise<Infer<typeof vScrapeUrlResult>> => {
+	returns: vScrapeUrlTransport,
+	handler: async (ctx, args): Promise<Infer<typeof vScrapeUrlTransport>> => {
 		try {
 			const job: PoolScrapeJob = await ctx.runQuery(internal.webToolPool.getLocalScrapeJob, args);
-			return await scrapeClaimedUrl(ctx, job);
+			return await localScrapeTransport(ctx, await scrapeClaimedUrl(ctx, job));
 		} catch (error) {
 			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}

--- a/apps/web/src/lib/chat/tool-summaries.ts
+++ b/apps/web/src/lib/chat/tool-summaries.ts
@@ -273,9 +273,6 @@ function summarizeWebToolResult(kind: string, result: JsonValue | undefined) {
 		const count = result.results.length;
 		return ` (${count} result${count === 1 ? '' : 's'})`;
 	}
-	if (kind === 'scrape_url' && isJsonObject(result) && result.truncated === true) {
-		return ' (truncated)';
-	}
 	return '';
 }
 

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -50,8 +50,12 @@ the full text in the thread's `parse_file/` cache. Use `scrape_url` for http(s)
 URLs; `parse_file` rejects a `url` argument and URL-shaped paths.
 
 `scrape_url` fetches supported raster images in memory and returns their pixels
-to image-capable models. It saves neither the image nor scraped markdown to a
-local file. Rebuilt history keeps image metadata and asks the model to call
+to image-capable models. Images and short scrapes are not saved locally.
+Scrapes exceeding 40,000 characters are saved in full to the host's temporary
+directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
+`The scrape was saved to <file-path>.` These files have the operating system's
+temporary-file lifetime. Convex transfer copies expire after one hour.
+Rebuilt history keeps image metadata and asks the model to call
 the tool again if it needs the pixels. HTML uses the cloud scraper through an
 authenticated action. A HEAD request identifies image content types without
 consuming page bodies. Image filename extensions cover servers without useful

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -8,6 +8,7 @@ mod mandates;
 mod parse_file;
 mod patch;
 mod questions;
+mod scrape_files;
 mod skills;
 mod web;
 

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -11,6 +10,7 @@ const MAX_SCRAPE_BYTES: u64 = 64 * 1024 * 1024;
 pub(super) async fn localize_scrape(
     mut result: Value,
     cancellation: &WorkspaceCancellation,
+    saved_file: &mut Option<tempfile::NamedTempFile>,
 ) -> anyhow::Result<Value> {
     let fields = result.as_object_mut().context("invalid scrape response")?;
     if let Some(download) = fields.remove("markdownUrl") {
@@ -23,11 +23,15 @@ pub(super) async fn localize_scrape(
             .prefix("sprocket-scrape-")
             .suffix(".md")
             .tempfile()?;
-        let path = download_scrape(url, temp, cancellation).await?;
+        let temp = download_scrape(url, temp, cancellation).await?;
         fields.insert(
             "markdown".into(),
-            Value::String(format!("The scrape was saved to {}.", path.display())),
+            Value::String(format!(
+                "The scrape was saved to {}.",
+                temp.path().display()
+            )),
         );
+        *saved_file = Some(temp);
     } else {
         anyhow::ensure!(
             fields.get("markdown").is_some_and(Value::is_string),
@@ -42,7 +46,7 @@ async fn download_scrape(
     url: reqwest::Url,
     temp: tempfile::NamedTempFile,
     cancellation: &WorkspaceCancellation,
-) -> anyhow::Result<PathBuf> {
+) -> anyhow::Result<tempfile::NamedTempFile> {
     let transfer = async {
         let client = reqwest::Client::builder()
             .no_proxy()
@@ -74,9 +78,7 @@ async fn download_scrape(
         _ = cancellation.cancelled() => return Err(WorkspaceOperationCancelled.into()),
         result = transfer => result.context("failed to save the scrape")?,
     }
-    let (file, path) = temp.keep().context("failed to keep the saved scrape")?;
-    drop(file);
-    Ok(path)
+    Ok(temp)
 }
 
 #[cfg(test)]
@@ -106,6 +108,7 @@ mod tests {
         let result = localize_scrape(
             json!({"url": "https://example.com", "markdown": "# Hello", "truncated": false}),
             &WorkspaceCancellation::new(),
+            &mut None,
         )
         .await
         .unwrap();
@@ -119,9 +122,11 @@ mod tests {
     async fn full_unicode_scrape_is_saved_and_only_the_notice_is_returned() {
         let text = "é\n".repeat(40_001);
         let url = serve(&text, text.len()).await;
+        let mut saved_file = None;
         let result = localize_scrape(
             json!({"url": "https://example.com", "markdownUrl": url.as_str()}),
             &WorkspaceCancellation::new(),
+            &mut saved_file,
         )
         .await
         .unwrap();
@@ -140,6 +145,19 @@ mod tests {
         assert!(result.get("markdownUrl").is_none());
         assert!(result.get("truncated").is_none());
         tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn successful_download_is_removed_unless_completion_is_accepted() {
+        let url = serve("scrape", 6).await;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+        let file = download_scrape(url, temp, &WorkspaceCancellation::new())
+            .await
+            .unwrap();
+        assert!(path.exists());
+        drop(file);
+        assert!(!path.exists());
     }
 
     #[tokio::test]

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -1,0 +1,176 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Context;
+use serde_json::Value;
+use sprocket_workspace::{WorkspaceCancellation, WorkspaceOperationCancelled};
+use tokio::io::AsyncWriteExt;
+
+const MAX_SCRAPE_BYTES: u64 = 64 * 1024 * 1024;
+
+pub(super) async fn localize_scrape(
+    mut result: Value,
+    cancellation: &WorkspaceCancellation,
+) -> anyhow::Result<Value> {
+    let fields = result.as_object_mut().context("invalid scrape response")?;
+    if let Some(download) = fields.remove("markdownUrl") {
+        let url = reqwest::Url::parse(download.as_str().context("invalid scrape download URL")?)?;
+        anyhow::ensure!(
+            matches!(url.scheme(), "http" | "https"),
+            "scrape download requires an http(s) URL"
+        );
+        let temp = tempfile::Builder::new()
+            .prefix("sprocket-scrape-")
+            .suffix(".md")
+            .tempfile()?;
+        let path = download_scrape(url, temp, cancellation).await?;
+        fields.insert(
+            "markdown".into(),
+            Value::String(format!("The scrape was saved to {}.", path.display())),
+        );
+    } else {
+        anyhow::ensure!(
+            fields.get("markdown").is_some_and(Value::is_string),
+            "scrape response is missing markdown"
+        );
+    }
+    fields.remove("truncated");
+    Ok(result)
+}
+
+async fn download_scrape(
+    url: reqwest::Url,
+    temp: tempfile::NamedTempFile,
+    cancellation: &WorkspaceCancellation,
+) -> anyhow::Result<PathBuf> {
+    let transfer = async {
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(60))
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .build()?;
+        let mut response = client.get(url).send().await?.error_for_status()?;
+        anyhow::ensure!(
+            response
+                .content_length()
+                .is_none_or(|size| size <= MAX_SCRAPE_BYTES),
+            "scrape exceeds the 64 MiB download limit"
+        );
+        let mut file = tokio::fs::File::from_std(temp.reopen()?);
+        let mut received = 0u64;
+        while let Some(chunk) = response.chunk().await? {
+            received = received.saturating_add(chunk.len() as u64);
+            anyhow::ensure!(
+                received <= MAX_SCRAPE_BYTES,
+                "scrape exceeds the 64 MiB download limit"
+            );
+            file.write_all(&chunk).await?;
+        }
+        file.flush().await?;
+        Ok::<_, anyhow::Error>(())
+    };
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(WorkspaceOperationCancelled.into()),
+        result = transfer => result.context("failed to save the scrape")?,
+    }
+    let (file, path) = temp.keep().context("failed to keep the saved scrape")?;
+    drop(file);
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::AsyncReadExt;
+
+    async fn serve(body: &str, declared_size: usize) -> reqwest::Url {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = reqwest::Url::parse(&format!("http://{}/scrape", listener.local_addr().unwrap()))
+            .unwrap();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {declared_size}\r\nConnection: close\r\n\r\n{body}"
+        );
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).await.unwrap();
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+        url
+    }
+
+    #[tokio::test]
+    async fn short_scrapes_stay_inline_without_a_truncation_flag() {
+        let result = localize_scrape(
+            json!({"url": "https://example.com", "markdown": "# Hello", "truncated": false}),
+            &WorkspaceCancellation::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            json!({"url": "https://example.com", "markdown": "# Hello"})
+        );
+    }
+
+    #[tokio::test]
+    async fn full_unicode_scrape_is_saved_and_only_the_notice_is_returned() {
+        let text = "é\n".repeat(40_001);
+        let url = serve(&text, text.len()).await;
+        let result = localize_scrape(
+            json!({"url": "https://example.com", "markdownUrl": url.as_str()}),
+            &WorkspaceCancellation::new(),
+        )
+        .await
+        .unwrap();
+        let path = result["markdown"]
+            .as_str()
+            .unwrap()
+            .strip_prefix("The scrape was saved to ")
+            .unwrap()
+            .strip_suffix('.')
+            .unwrap();
+        assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), text);
+        assert_eq!(
+            std::path::Path::new(path).parent(),
+            Some(std::env::temp_dir().as_path())
+        );
+        assert!(result.get("markdownUrl").is_none());
+        assert!(result.get("truncated").is_none());
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_or_incomplete_transfers_remove_partial_files() {
+        for declared_size in [MAX_SCRAPE_BYTES as usize + 1, 100] {
+            let url = serve("partial", declared_size).await;
+            let temp = tempfile::NamedTempFile::new().unwrap();
+            let path = temp.path().to_path_buf();
+            assert!(
+                download_scrape(url, temp, &WorkspaceCancellation::new())
+                    .await
+                    .is_err()
+            );
+            assert!(!path.exists());
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_transfers_remove_temporary_files() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+        let cancellation = WorkspaceCancellation::new();
+        cancellation.cancel();
+        let error = download_scrape(
+            reqwest::Url::parse("http://127.0.0.1:1").unwrap(),
+            temp,
+            &cancellation,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.is::<WorkspaceOperationCancelled>());
+        assert!(!path.exists());
+    }
+}

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -111,6 +111,7 @@ impl rig::tool::Tool for ScrapeUrlTool {
         let url = validate_web_url(&args.url).map_err(tool_error)?;
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         let mut image_output = None;
+        let image_result = &mut image_output;
         let result = execute_tool_job_with_id(
             &self.0.runtime,
             &self.0.run_id,
@@ -118,14 +119,14 @@ impl rig::tool::Tool for ScrapeUrlTool {
             Self::NAME,
             &self.0.tool_call_tracker,
             payload,
-            |cancellation, job_id| async {
+            |cancellation, job_id| async move {
                 let image = tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
                     result = fetch_web_image(url, self.0.supports_images) => result.map_err(tool_error)?,
                 };
                 if let Some((metadata, output)) = image {
-                    image_output = Some(output);
+                    *image_result = Some(output);
                     return Ok(metadata);
                 }
                 let action_args = BTreeMap::from([
@@ -133,7 +134,8 @@ impl rig::tool::Tool for ScrapeUrlTool {
                     ("claimId".to_string(), self.0.claim_id.clone().into()),
                     ("jobId".to_string(), job_id.into()),
                 ]);
-                run_convex_tool_action(&self.0.runtime, cancellation, "webTools:scrapeForTool", action_args).await
+                let result = run_convex_tool_action(&self.0.runtime, cancellation.clone(), "webTools:scrapeForTool", action_args).await?;
+                super::scrape_files::localize_scrape(result, &cancellation).await.map_err(tool_error)
             },
         )
         .await?;

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -112,6 +112,8 @@ impl rig::tool::Tool for ScrapeUrlTool {
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         let mut image_output = None;
         let image_result = &mut image_output;
+        let mut scrape_file = None;
+        let saved_file = &mut scrape_file;
         let result = execute_tool_job_with_id(
             &self.0.runtime,
             &self.0.run_id,
@@ -135,10 +137,13 @@ impl rig::tool::Tool for ScrapeUrlTool {
                     ("jobId".to_string(), job_id.into()),
                 ]);
                 let result = run_convex_tool_action(&self.0.runtime, cancellation.clone(), "webTools:scrapeForTool", action_args).await?;
-                super::scrape_files::localize_scrape(result, &cancellation).await.map_err(tool_error)
+                super::scrape_files::localize_scrape(result, &cancellation, saved_file).await.map_err(tool_error)
             },
         )
         .await?;
+        if let Some(file) = scrape_file.as_mut() {
+            file.disable_cleanup(true);
+        }
         Ok(image_output.unwrap_or_else(|| ToolOutput::json(result)))
     }
 }


### PR DESCRIPTION
Depends on #322. Step 2 of the URL-tool stack.

## Changes
- Save complete oversized scrapes in the agent host temporary directory and return a saved-file notice rather than truncated markdown.
- Reject transfer blobs larger than the agent's 64 MiB receiver limit before storage. Count encoded bytes, not characters, and accept exactly 64 MiB.
- Expire temporary cloud blobs after one hour. Retain local files only after executor completion is accepted; clean up failed or cancelled transfers.
- Remove the old cloud truncation response path. Keep optional truncated fields in stored validators for historical jobs and transcripts.

## Compatibility decision
The user also explicitly requested removing both localExecution and the asImage stored-payload field. Neither field exists on main; both were introduced in this unmerged stack. Do not restore either compatibility path.

Current clients only, as explicitly requested by the user. Historical transcripts and stored results must remain readable; older-client execution and transport behavior need not remain supported.

## Checks
- After removing the flags, the combined stack passes 187 Rust library tests, 68 targeted Convex tests, Convex codegen, Svelte/TypeScript checks, and full prek hooks.
- 36 targeted Convex tests and Convex codegen passed on this branch.
- Regression tests cover multibyte text, exact byte boundaries, and rejection without creating a storage blob.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.









<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces truncated oversized scrape responses with temporary-file delivery while preserving historical stored-result compatibility.
- Stores long scrape markdown in temporary Convex storage with a one-hour expiry.
- Enforces the agent receiver’s 64 MiB encoded-byte limit before creating storage blobs.
- Downloads oversized scrapes into agent-host temporary files and retains them only after executor completion succeeds.
- Removes the current truncation response and UI paths while retaining the optional stored validator field for historical data.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no outstanding findings.

No new changes were made after the previous review, both previous findings are resolved in the current code, and no repository-rule violations remain.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Adds inline-versus-temporary scrape transport, encoded-byte limit enforcement, and scheduled blob expiry. |
| apps/web/src/convex/webToolPool.ts | Adds idempotent cleanup for temporary storage while protecting registered attachments and parse storage. |
| crates/sprocket-agent/src/tools/scrape_files.rs | Downloads oversized scrapes into guarded temporary files with cancellation and receiver-size enforcement. |
| crates/sprocket-agent/src/tools/web.rs | Integrates scrape localization and retains local files only after executor completion is accepted. |
| apps/web/src/convex/lib/validators.ts | Separates current scrape transport validation from backward-compatible stored-result validation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant Convex as Convex scrape action
    participant Storage as Temporary blob storage
    participant Host as Agent host temp directory
    participant Executor

    Agent->>Convex: scrapeForTool
    Convex->>Convex: Fetch complete markdown
    alt Markdown ≤ 40,000 characters
        Convex-->>Agent: Inline markdown
    else "Markdown > 40,000 characters and ≤ 64 MiB"
        Convex->>Storage: Store complete markdown
        Convex->>Storage: Schedule deletion after one hour
        Convex-->>Agent: Temporary markdownUrl
        Agent->>Storage: Download with 64 MiB receiver limit
        Agent->>Host: Write NamedTempFile
        Agent->>Executor: Complete with saved-file notice
        alt Completion accepted
            Agent->>Host: Disable automatic cleanup
        else Failed, rejected, or cancelled
            Agent->>Host: Drop guard and remove file
        end
    else "Markdown > 64 MiB"
        Convex-->>Agent: Reject without storing blob
    end
```
</details>

<sub>Reviews (9): Last reviewed commit: ["test(agent-tools): Drop execution flags ..."](https://github.com/spikonado/sprocket/commit/50336e959b33205209bebb9eec13f841c5d152f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61427092)</sub>

<!-- /greptile_comment -->