### PR TITLE
feat(agent-tools): Switch scrapes to Firecrawl for richer data

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -340,6 +340,13 @@ jobs and transcripts; remove it only after stored results and JSONL replicas
 have aged out or been migrated. The UI no longer displays a truncation badge,
 including for historical results.
 
+Firecrawl adds `summary` and media fields to new scrape results. Their stored
+validators remain optional so pre-Firecrawl transcript and executor rows still
+load. Remove that optionality only after those rows and local JSONL replicas
+have aged out or been rewritten. Current agents archive large scrapes as
+JSON and always keep the summary inline. Raw-markdown archive negotiation
+is not supported; deploy the updated client and backend together.
+
 Web image results store URL and image metadata, not bytes or local paths.
 History displays a notice rather than fetching the URL again. Local-path
 `parse_file` image results still replay from their existing local cache.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,6 @@
 	},
 	"dependencies": {
 		"@browserbasehq/stagehand": "^3.7.1",
-		"@context-dot-dev/convex": "^1.0.1",
 		"@convex-dev/action-retrier": "^0.3.1",
 		"@convex-dev/aggregate": "^0.2.2",
 		"@convex-dev/migrations": "^0.3.6",
@@ -23,6 +22,7 @@
 		"@convex-dev/workpool": "^0.4.10",
 		"@dodopayments/convex": "^0.2.15",
 		"@exalabs/convex-exa": "^0.1.1",
+		"@firecrawl/firecrawl-convex": "^0.1.1",
 		"@fontsource-variable/ibm-plex-sans": "^5.2.8",
 		"@fontsource/dm-sans": "^5.2.8",
 		"@fontsource/ibm-plex-mono": "^5.3.0",

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -187,7 +187,7 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  contextDev: import("@context-dot-dev/convex/_generated/component.js").ComponentApi<"contextDev">;
+  firecrawl: import("@firecrawl/firecrawl-convex/_generated/component.js").ComponentApi<"firecrawl">;
   exa: import("@exalabs/convex-exa/_generated/component.js").ComponentApi<"exa">;
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
   dodopayments: import("@dodopayments/convex/_generated/component.js").ComponentApi<"dodopayments">;

--- a/apps/web/src/convex/_generated/server.d.ts
+++ b/apps/web/src/convex/_generated/server.d.ts
@@ -33,11 +33,10 @@ type Env = {
   readonly BROWSERBASE_API_KEY: string | undefined;
   readonly BROWSERBASE_PROJECT_ID: string | undefined;
   readonly BROWSER_TASK_MODEL: string | undefined;
-  readonly CONTEXT_DEV_API_KEY: string;
   readonly DODO_PAYMENTS_API_KEY: string | undefined;
   readonly DODO_PAYMENTS_ENVIRONMENT: "live_mode" | "test_mode" | undefined;
   readonly EXA_API_KEY: string;
-  readonly FIRECRAWL_API_KEY: string | undefined;
+  readonly FIRECRAWL_API_KEY: string;
   readonly MODEL_GATEWAY_TOKEN_SECRET: string | undefined;
   readonly MODEL_GATEWAY_URL: string | undefined;
   readonly OPENAI_API_KEY: string | undefined;

--- a/apps/web/src/convex/convex.config.ts
+++ b/apps/web/src/convex/convex.config.ts
@@ -1,6 +1,6 @@
 import { defineApp } from 'convex/server';
 import { v } from 'convex/values';
-import contextDev from '@context-dot-dev/convex/convex.config';
+import firecrawl from '@firecrawl/firecrawl-convex/convex.config';
 import rateLimiter from '@convex-dev/rate-limiter/convex.config';
 import dodopayments from '@dodopayments/convex/convex.config';
 import exa from '@exalabs/convex-exa/convex.config';
@@ -12,9 +12,8 @@ import workpool from '@convex-dev/workpool/convex.config';
 
 const app = defineApp({
 	env: {
-		CONTEXT_DEV_API_KEY: v.string(),
 		EXA_API_KEY: v.string(),
-		FIRECRAWL_API_KEY: v.optional(v.string()),
+		FIRECRAWL_API_KEY: v.string(),
 		WORKOS_CLIENT_ID: v.string(),
 		OPENAI_API_KEY: v.optional(v.string()),
 		BROWSERBASE_API_KEY: v.optional(v.string()),
@@ -32,7 +31,7 @@ const app = defineApp({
 	}
 });
 
-app.use(contextDev, { env: { CONTEXT_DEV_API_KEY: app.env.CONTEXT_DEV_API_KEY } });
+app.use(firecrawl, { env: { FIRECRAWL_API_KEY: app.env.FIRECRAWL_API_KEY } });
 app.use(exa, { env: { EXA_API_KEY: app.env.EXA_API_KEY } });
 app.use(rateLimiter);
 app.use(dodopayments);

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -236,22 +236,35 @@ export const vCommandExecResult = v.object({
 	error: v.optional(v.string())
 });
 
-/** Stored scrape_url job result. Historical cloud rows include `truncated`. */
+const vScrapeMediaFields = {
+	summary: v.optional(v.string()),
+	images: v.optional(v.array(v.string())),
+	audio: v.optional(v.string()),
+	video: v.optional(v.string())
+};
+
+/** Stored scrape_url job result. Historical rows omit summary/media; cloud rows may include `truncated`. */
 export const vScrapeUrlResult = v.object({
 	url: v.string(),
 	markdown: v.string(),
-	truncated: v.optional(v.boolean())
+	truncated: v.optional(v.boolean()),
+	...vScrapeMediaFields
 });
 
-/** Local scrapeForTool transport. Long pages return a temporary download URL. */
+/** Local scrapeForTool transport. Oversized pages return a temporary JSON download URL. */
 export const vScrapeUrlTransport = v.union(
 	v.object({
 		url: v.string(),
-		markdown: v.string()
+		markdown: v.string(),
+		summary: v.string(),
+		images: v.array(v.string()),
+		audio: v.optional(v.string()),
+		video: v.optional(v.string())
 	}),
 	v.object({
 		url: v.string(),
-		markdownUrl: v.string()
+		summary: v.string(),
+		scrapeUrl: v.string()
 	})
 );
 

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import contextDevTest from '@context-dot-dev/convex/test';
+import firecrawlTest from '@firecrawl/firecrawl-convex/test';
 import rateLimiterTest from '@convex-dev/rate-limiter/test';
 import exaTest from '@exalabs/convex-exa/test';
 import migrationsTest from '@convex-dev/migrations/test';
@@ -39,7 +39,7 @@ export function initConvexTest(): ConvexTestInstance {
 	// TestConvex variance; the convex-test backend object is the same instance.
 	const backend = t as never;
 	rateLimiterTest.register(backend);
-	contextDevTest.register(backend);
+	firecrawlTest.register(backend);
 	exaTest.register(backend);
 	migrationsTest.register(backend);
 	aggregateTest.register(backend);

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -1,23 +1,66 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ContextDev } from '@context-dot-dev/convex';
+import { ConvexError } from 'convex/values';
+import { FirecrawlClient } from '@firecrawl/firecrawl-convex';
 import { api, internal } from '@convex/_generated/api';
 import { RUN_NO_LONGER_ACTIVE } from '@convex/lib/agentErrors';
 import { UNSUPPORTED_CLIENT_MESSAGE } from '@convex/lib/unsupportedClient';
 import {
-	isUnparseablePageFailure,
+	DEFAULT_SCRAPE_SUMMARY,
+	isCleanPageStatus,
+	localInlineFits,
 	scrapeHttpErrorStatus,
-	SCRAPE_MARKDOWN_MAX_CHARS,
-	SCRAPE_MARKDOWN_STORAGE_TTL_MS
+	SCRAPE_INLINE_MAX_CHARS,
+	SCRAPE_STORAGE_TTL_MS,
+	SCRAPE_TIMEOUT_MS,
+	summaryFitsTransport,
+	type ScrapedPage
 } from '@convex/webTools';
 import { initConvexTest, seedStartedWebJob, type ConvexTestInstance } from './test.setup';
 
-function mockScrapeMarkdown(markdown: string, url = 'https://example.com/page') {
-	return vi.spyOn(ContextDev.prototype, 'scrapeMarkdown').mockResolvedValue({
-		success: true,
-		url,
-		markdown,
-		metadata: { sourceUrl: url, finalUrl: url }
+const PAGE_URL = 'https://example.com/page';
+const AUDIO_URL = 'https://storage.googleapis.com/scrape/audio.mp3?X-Goog-Signature=sig';
+const VIDEO_URL = 'https://storage.googleapis.com/scrape/video.mp4?X-Goog-Signature=sig';
+
+function firecrawlApiError(status: number) {
+	return new ConvexError({
+		code: 'firecrawl_request_failed',
+		status,
+		path: '/v2/scrape',
+		message: `Firecrawl /v2/scrape failed (${status}): upstream`
 	});
+}
+
+function mockScrape(
+	document: {
+		markdown?: string;
+		summary?: string;
+		images?: string[];
+		audio?: string;
+		video?: string;
+		metadata?: { sourceURL?: string; url?: string; statusCode?: number };
+	},
+	url = PAGE_URL
+) {
+	return vi.spyOn(FirecrawlClient.prototype, 'scrape').mockResolvedValue({
+		markdown: document.markdown,
+		summary: document.summary,
+		images: document.images,
+		audio: document.audio,
+		video: document.video,
+		metadata: document.metadata ?? { sourceURL: url, statusCode: 200 }
+	});
+}
+
+function expectedScrapeArgs(url = PAGE_URL) {
+	return [
+		expect.anything(),
+		url,
+		{
+			formats: ['markdown', 'summary', 'images', 'audio', 'video'],
+			onlyMainContent: true,
+			timeout: SCRAPE_TIMEOUT_MS
+		}
+	] as const;
 }
 
 async function storageBlobs(t: ConvexTestInstance) {
@@ -28,44 +71,52 @@ beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
 
 describe('scrape HTTP failures', () => {
-	it('turns a Context.dev HTTP error into a readable message', () => {
+	it('reads Firecrawl API errors from ConvexError data', () => {
+		expect(scrapeHttpErrorStatus(firecrawlApiError(404))).toBe(404);
+		expect(scrapeHttpErrorStatus(firecrawlApiError(429))).toBe(429);
+	});
+
+	it('reads nested Firecrawl API errors from the message JSON', () => {
 		const error = new Error(
-			'Uncaught ConvexError: Uncaught ConvexError: {"message":"Target page returned a 404","status":404,"response":{"error_code":"NOT_FOUND"}}\n    at contextRequest (http.js:24:12)'
+			`Uncaught ConvexError: Uncaught ConvexError: ${JSON.stringify({
+				code: 'firecrawl_request_failed',
+				status: 403,
+				path: '/v2/scrape',
+				message: 'Firecrawl /v2/scrape failed (403): forbidden'
+			})}\n    at scrape (lib.js:24:12)`
 		);
-		expect(scrapeHttpErrorStatus(error)).toBe(404);
+		expect(scrapeHttpErrorStatus(error)).toBe(403);
 	});
 
 	it('ignores non-HTTP and malformed errors', () => {
 		expect(scrapeHttpErrorStatus(new Error('{"status":200}'))).toBeUndefined();
-		expect(scrapeHttpErrorStatus(new Error('Context.dev scrape failed.'))).toBeUndefined();
-	});
-});
-
-describe('unparseable page failures', () => {
-	it('recognizes component return-validation failures', () => {
-		const error = new Error(
-			'Uncaught ConvexError: ReturnsValidationError: Value does not match validator. Path: .values()'
+		expect(scrapeHttpErrorStatus(new Error('Firecrawl scrape timed out after 60000ms.'))).toBe(
+			undefined
 		);
-		expect(isUnparseablePageFailure(error)).toBe(true);
 	});
 
-	it('leaves timeouts and other failures alone', () => {
-		expect(isUnparseablePageFailure(new Error('Context.dev scrape timed out after 60000ms.'))).toBe(
-			false
-		);
-		expect(isUnparseablePageFailure(new Error('Run is no longer active.'))).toBe(false);
+	it('does not treat page metadata.statusCode as a Firecrawl API error', () => {
+		expect(scrapeHttpErrorStatus(new Error('This webpage returned a 404 error.'))).toBeUndefined();
+		expect(isCleanPageStatus(404)).toBe(false);
+		expect(isCleanPageStatus(200)).toBe(true);
+		expect(isCleanPageStatus(304)).toBe(true);
+		expect(isCleanPageStatus(301)).toBe(false);
 	});
 });
 
 describe('scrapeForTool auth', () => {
-	it('scrapes the URL from the authorized job payload', async () => {
+	it('scrapes the URL from the authorized job payload with the Firecrawl formats', async () => {
 		const t = initConvexTest();
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'local-scrape-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
-		const scrape = mockScrapeMarkdown('# Page');
+		const scrape = mockScrape({
+			markdown: '# Page',
+			summary: 'A page.',
+			images: ['https://example.com/a.png']
+		});
 		try {
 			expect(
 				await asUser.action(api.webTools.scrapeForTool, {
@@ -74,13 +125,13 @@ describe('scrapeForTool auth', () => {
 					jobId,
 					executionSecret
 				})
-			).toEqual({ url: 'https://example.com/page', markdown: '# Page' });
-			expect(scrape).toHaveBeenCalledWith(
-				expect.anything(),
-				expect.objectContaining({
-					params: expect.objectContaining({ url: 'https://example.com/page' })
-				})
-			);
+			).toEqual({
+				url: PAGE_URL,
+				markdown: '# Page',
+				summary: 'A page.',
+				images: ['https://example.com/a.png']
+			});
+			expect(scrape).toHaveBeenCalledWith(...expectedScrapeArgs());
 		} finally {
 			scrape.mockRestore();
 		}
@@ -108,7 +159,7 @@ describe('scrapeForTool auth', () => {
 		const { asUser, runId, claimId, jobId } = await seedStartedWebJob(t, {
 			executionSecret: 'scrape-auth-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
 		await expect(
 			asUser.action(api.webTools.scrapeForTool, {
@@ -162,7 +213,7 @@ describe('scrapeForTool auth', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'expired-scrape-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
 		await t.run(async (ctx) => {
 			await ctx.db.patch('runs', runId, { claimExpiresAt: Date.now() - 1 });
@@ -190,14 +241,14 @@ describe('scrapeForTool auth', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'settled-scrape-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
 		await asUser.mutation(api.executor.complete, {
 			runId,
 			claimId,
 			executionSecret,
 			jobId,
-			result: { url: 'https://example.com/page', markdown: 'done' }
+			result: { url: PAGE_URL, markdown: 'done', summary: 'Done.' }
 		});
 		await expect(
 			asUser.action(api.webTools.scrapeForTool, {
@@ -216,7 +267,7 @@ describe('stored scrape_url results', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'saved-path-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
 		await asUser.mutation(api.executor.complete, {
 			runId,
@@ -224,16 +275,17 @@ describe('stored scrape_url results', () => {
 			executionSecret,
 			jobId,
 			result: {
-				url: 'https://example.com/page',
+				url: PAGE_URL,
 				markdown: 'The scrape was saved to /tmp/scrape.md.'
 			}
 		});
 		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(job?.result).toEqual({
-			url: 'https://example.com/page',
+			url: PAGE_URL,
 			markdown: 'The scrape was saved to /tmp/scrape.md.'
 		});
 		expect(job?.result).not.toHaveProperty('truncated');
+		expect(job?.result).not.toHaveProperty('summary');
 	});
 
 	it('still accepts stored scrape results with truncated', async () => {
@@ -241,7 +293,7 @@ describe('stored scrape_url results', () => {
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'legacy-truncated-secret',
 			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
+			payload: { url: PAGE_URL }
 		});
 		await asUser.mutation(api.executor.complete, {
 			runId,
@@ -249,28 +301,63 @@ describe('stored scrape_url results', () => {
 			executionSecret,
 			jobId,
 			result: {
-				url: 'https://example.com/page',
+				url: PAGE_URL,
 				markdown: 'partial',
 				truncated: true
 			}
 		});
 		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(job?.result).toEqual({
-			url: 'https://example.com/page',
+			url: PAGE_URL,
 			markdown: 'partial',
 			truncated: true
 		});
 	});
+
+	it('accepts stored scrape results with additive summary and media', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'saved-media-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const result = {
+			url: PAGE_URL,
+			markdown: '# Page',
+			summary: 'A page.',
+			images: ['https://example.com/a.png'],
+			audio: AUDIO_URL,
+			video: VIDEO_URL
+		};
+		await asUser.mutation(api.executor.complete, {
+			runId,
+			claimId,
+			executionSecret,
+			jobId,
+			result
+		});
+		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(job?.result).toEqual(result);
+	});
 });
 
-async function scrapeLocalMarkdown(markdown: string, url = 'https://example.com/page') {
+async function scrapeLocalPage(
+	document: {
+		markdown?: string;
+		summary?: string;
+		images?: string[];
+		audio?: string;
+		video?: string;
+	},
+	url = PAGE_URL
+) {
 	const t = initConvexTest();
 	const seeded = await seedStartedWebJob(t, {
 		executionSecret: `local-md-${Math.random()}`,
 		kind: 'scrape_url',
 		payload: { url }
 	});
-	const scrape = mockScrapeMarkdown(markdown, url);
+	const scrape = mockScrape(document, url);
 	try {
 		const result = await seeded.asUser.action(api.webTools.scrapeForTool, {
 			runId: seeded.runId,
@@ -278,11 +365,67 @@ async function scrapeLocalMarkdown(markdown: string, url = 'https://example.com/
 			jobId: seeded.jobId,
 			executionSecret: seeded.executionSecret
 		});
-		return { t, result, scrapeCalls: scrape.mock.calls.length };
+		return { t, result, scrapeCalls: scrape.mock.calls.map((call) => [...call]) };
 	} finally {
 		scrape.mockRestore();
 	}
 }
+
+describe('scrape size budget', () => {
+	it('keeps short markdown plus media inline', () => {
+		expect(
+			localInlineFits({
+				url: PAGE_URL,
+				markdown: 'x'.repeat(SCRAPE_INLINE_MAX_CHARS - 1_000),
+				summary: 'Short page.',
+				images: ['https://example.com/a.png'],
+				audio: AUDIO_URL,
+				video: VIDEO_URL
+			})
+		).toBe(true);
+	});
+
+	it('spills when the images list alone exceeds the document budget', () => {
+		const page: ScrapedPage = {
+			url: PAGE_URL,
+			markdown: 'short',
+			summary: 'Short page.',
+			images: [`https://cdn.example.com/${'x'.repeat(SCRAPE_INLINE_MAX_CHARS)}.png`]
+		};
+		expect(localInlineFits(page)).toBe(false);
+		expect(summaryFitsTransport(page)).toBe(true);
+	});
+
+	it('spills at the inline limit even when markdown alone fits', () => {
+		const page: ScrapedPage = { url: PAGE_URL, markdown: '', summary: 'Summary', images: [] };
+		page.markdown = 'x'.repeat(SCRAPE_INLINE_MAX_CHARS - JSON.stringify(page).length);
+		expect(localInlineFits(page)).toBe(true);
+		page.images.push('https://example.com/a.png');
+		expect(localInlineFits(page)).toBe(false);
+	});
+
+	it('spills image arrays that exceed Convex array limits', () => {
+		expect(
+			localInlineFits({
+				url: PAGE_URL,
+				markdown: '',
+				summary: 'Summary',
+				images: Array(8_193).fill('')
+			})
+		).toBe(false);
+	});
+
+	it('rejects a summary that cannot fit the inline budget', async () => {
+		const page: ScrapedPage = {
+			url: PAGE_URL,
+			markdown: 'hi',
+			summary: 's'.repeat(SCRAPE_INLINE_MAX_CHARS),
+			images: []
+		};
+		expect(summaryFitsTransport(page)).toBe(false);
+		await expect(scrapeLocalPage(page)).rejects.toThrow('Scrape summary is too large.');
+	});
+});
 
 describe('scrapeForTool markdown transport', () => {
 	it('rejects markdown above the receiver byte limit without storing a blob', async () => {
@@ -292,7 +435,7 @@ describe('scrapeForTool markdown transport', () => {
 			kind: 'scrape_url',
 			payload: { url: 'https://example.com/page' }
 		});
-		const scrape = mockScrapeMarkdown(`${'é'.repeat(32 * 1024 * 1024)}x`);
+		const scrape = mockScrape({ markdown: `${'é'.repeat(32 * 1024 * 1024)}x` });
 		try {
 			await expect(
 				asUser.action(api.webTools.scrapeForTool, { runId, claimId, jobId, executionSecret })
@@ -303,56 +446,231 @@ describe('scrapeForTool markdown transport', () => {
 		}
 	});
 
-	it('accepts markdown exactly at the receiver byte limit', async () => {
-		const { t, result } = await scrapeLocalMarkdown('é'.repeat(32 * 1024 * 1024));
-		expect(result).toHaveProperty('markdownUrl');
+	it('accepts a JSON archive exactly at the receiver byte limit', async () => {
+		const page: ScrapedPage = { url: PAGE_URL, markdown: '', summary: 'Summary', images: [] };
+		page.markdown = 'x'.repeat(64 * 1024 * 1024 - JSON.stringify(page).length);
+		const { t, result } = await scrapeLocalPage(page);
+		expect(result).toHaveProperty('scrapeUrl');
 		const blobs = await storageBlobs(t);
 		expect(blobs).toHaveLength(1);
 		expect(blobs[0]?.size).toBe(64 * 1024 * 1024);
 	});
 
-	it('returns short markdown inline without truncated or storage', async () => {
-		const markdown = 'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS);
-		const { t, result, scrapeCalls } = await scrapeLocalMarkdown(markdown);
-		expect(result).toEqual({ url: 'https://example.com/page', markdown });
+	it('returns short markdown, summary, and media inline without truncated or storage', async () => {
+		const markdown = 'x'.repeat(SCRAPE_INLINE_MAX_CHARS - 1_000);
+		const { t, result, scrapeCalls } = await scrapeLocalPage({
+			markdown,
+			summary: 'A long but inline page.',
+			images: ['https://example.com/a.png'],
+			audio: AUDIO_URL,
+			video: VIDEO_URL
+		});
+		expect(result).toEqual({
+			url: PAGE_URL,
+			markdown,
+			summary: 'A long but inline page.',
+			images: ['https://example.com/a.png'],
+			audio: AUDIO_URL,
+			video: VIDEO_URL
+		});
 		expect(result).not.toHaveProperty('truncated');
-		expect(result).not.toHaveProperty('markdownUrl');
-		expect(scrapeCalls).toBe(1);
+		expect(result).not.toHaveProperty('scrapeUrl');
+		expect(scrapeCalls[0]).toEqual([...expectedScrapeArgs()]);
 		expect(await storageBlobs(t)).toEqual([]);
 	});
 
-	it('stores full long markdown bytes and returns markdownUrl', async () => {
-		const markdown = `${'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS)}é`;
-		const expectedBytes = new TextEncoder().encode(markdown);
-		const { t, result, scrapeCalls } = await scrapeLocalMarkdown(markdown);
+	it('uses an explicit default when Firecrawl omits summary', async () => {
+		const { result } = await scrapeLocalPage({ markdown: '# Page', images: [] });
 		expect(result).toEqual({
-			url: 'https://example.com/page',
-			markdownUrl: expect.any(String)
+			url: PAGE_URL,
+			markdown: '# Page',
+			summary: DEFAULT_SCRAPE_SUMMARY,
+			images: []
+		});
+	});
+
+	it('stores the full scrape JSON including all media and returns scrapeUrl', async () => {
+		const markdown = `${'x'.repeat(SCRAPE_INLINE_MAX_CHARS)}é`;
+		const images = ['https://example.com/a.png', 'https://example.com/b.png'];
+		const archive = {
+			url: PAGE_URL,
+			markdown,
+			summary: 'Huge page.',
+			images,
+			audio: AUDIO_URL,
+			video: VIDEO_URL
+		};
+		const expectedBytes = new TextEncoder().encode(JSON.stringify(archive));
+		const { t, result, scrapeCalls } = await scrapeLocalPage({
+			markdown,
+			summary: 'Huge page.',
+			images,
+			audio: AUDIO_URL,
+			video: VIDEO_URL
+		});
+		expect(result).toEqual({
+			url: PAGE_URL,
+			summary: 'Huge page.',
+			scrapeUrl: expect.any(String)
 		});
 		expect(result).not.toHaveProperty('truncated');
 		expect(result).not.toHaveProperty('markdown');
-		expect(scrapeCalls).toBe(1);
-		if (!('markdownUrl' in result)) throw new Error('expected markdownUrl');
+		expect(scrapeCalls[0]).toEqual([...expectedScrapeArgs()]);
+		if (!('scrapeUrl' in result)) throw new Error('expected scrapeUrl');
 		const blobs = await storageBlobs(t);
 		expect(blobs).toHaveLength(1);
 		expect(blobs[0]?.size).toBe(expectedBytes.byteLength);
-		const storedUrl = await t.run(async (ctx) => {
+		const stored = await t.run(async (ctx) => {
 			if (!blobs[0]) return null;
-			return await ctx.storage.getUrl(blobs[0]._id);
+			const blob = await ctx.storage.get(blobs[0]._id);
+			return {
+				url: await ctx.storage.getUrl(blobs[0]._id),
+				text: blob ? await new Response(blob).text() : null
+			};
 		});
-		expect(storedUrl).toBe(result.markdownUrl);
+		expect(stored?.url).toBe(result.scrapeUrl);
+		expect(stored?.text ? JSON.parse(stored.text) : null).toEqual(archive);
 	});
 
-	it('deletes stored markdown after one hour', async () => {
-		const markdown = `${'x'.repeat(SCRAPE_MARKDOWN_MAX_CHARS)}y`;
-		const { t } = await scrapeLocalMarkdown(markdown);
+	it('stores full image lists when media, not markdown, overflows the budget', async () => {
+		const images = [`https://cdn.example.com/${'x'.repeat(SCRAPE_INLINE_MAX_CHARS)}.png`];
+		const archive = {
+			url: PAGE_URL,
+			markdown: 'short',
+			summary: 'Images overflow.',
+			images
+		};
+		const expectedBytes = new TextEncoder().encode(JSON.stringify(archive));
+		const { t, result } = await scrapeLocalPage({
+			markdown: 'short',
+			summary: 'Images overflow.',
+			images
+		});
+		expect(result).toEqual({
+			url: PAGE_URL,
+			summary: 'Images overflow.',
+			scrapeUrl: expect.any(String)
+		});
+		const blobs = await storageBlobs(t);
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0]?.size).toBe(expectedBytes.byteLength);
+	});
+
+	it('deletes stored scrape JSON after one hour', async () => {
+		const markdown = `${'x'.repeat(SCRAPE_INLINE_MAX_CHARS)}y`;
+		const { t } = await scrapeLocalPage({ markdown, summary: 'Expires.' });
 		const blobs = await storageBlobs(t);
 		expect(blobs).toHaveLength(1);
 		const storageId = blobs[0]?._id;
 		expect(storageId).toBeDefined();
 		await t.finishAllScheduledFunctions(() => {
-			vi.advanceTimersByTime(SCRAPE_MARKDOWN_STORAGE_TTL_MS);
+			vi.advanceTimersByTime(SCRAPE_STORAGE_TTL_MS);
 		});
 		expect(await t.run(async (ctx) => ctx.db.system.get('_storage', storageId!))).toBeNull();
 	});
 });
+
+describe('scrape errors', () => {
+	it('rejects a missing Firecrawl API key without retrying', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'missing-key-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = vi.spyOn(FirecrawlClient.prototype, 'scrape').mockRejectedValue(
+			new ConvexError({
+				code: 'firecrawl_missing_api_key',
+				message: 'FIRECRAWL_API_KEY is not set for the Firecrawl component.'
+			})
+		);
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('FIRECRAWL_API_KEY is not configured.');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('maps Firecrawl API 404 to a non-retryable scrape failure', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'api-404-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = vi
+			.spyOn(FirecrawlClient.prototype, 'scrape')
+			.mockRejectedValue(firecrawlApiError(404));
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Firecrawl scrape failed (404).');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('maps page metadata.statusCode 404 separately from Firecrawl API errors', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'page-404-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = mockScrape({
+			markdown: 'missing',
+			summary: 'Not found.',
+			metadata: { sourceURL: PAGE_URL, statusCode: 404 }
+		});
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('This webpage returned a 404 error.');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects invalid Firecrawl documents', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'invalid-doc-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = vi.spyOn(FirecrawlClient.prototype, 'scrape').mockResolvedValue(
+			// SAFETY: Deliberately malformed provider data exercises runtime validation.
+			{ images: [1, 2, 3] } as never
+		);
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Firecrawl scrape returned an invalid response.');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+});
+

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -428,22 +428,49 @@ describe('scrape size budget', () => {
 });
 
 describe('scrapeForTool markdown transport', () => {
-	it('rejects markdown above the receiver byte limit without storing a blob', async () => {
-		const t = initConvexTest();
-		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
-			executionSecret: 'oversized-markdown-secret',
-			kind: 'scrape_url',
-			payload: { url: 'https://example.com/page' }
-		});
-		const scrape = mockScrape({ markdown: `${'é'.repeat(32 * 1024 * 1024)}x` });
-		try {
-			await expect(
-				asUser.action(api.webTools.scrapeForTool, { runId, claimId, jobId, executionSecret })
-			).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
-			expect(await storageBlobs(t)).toEqual([]);
-		} finally {
-			scrape.mockRestore();
+	it.each([undefined, 'json'] as const)(
+		'rejects oversized %s archives without storing a blob',
+		async (archiveFormat) => {
+			const t = initConvexTest();
+			const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+				executionSecret: 'oversized-markdown-secret',
+				kind: 'scrape_url',
+				payload: { url: 'https://example.com/page' }
+			});
+			const scrape = mockScrape({ markdown: `${'é'.repeat(32 * 1024 * 1024)}x` });
+			try {
+				await expect(
+					asUser.action(api.webTools.scrapeForTool, {
+						runId,
+						claimId,
+						jobId,
+						executionSecret,
+						archiveFormat
+					})
+				).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
+				expect(await storageBlobs(t)).toEqual([]);
+			} finally {
+				scrape.mockRestore();
+			}
 		}
+	);
+
+	it('counts JSON escaping toward the receiver byte limit', async () => {
+		await expect(
+			scrapeLocalPage({ markdown: '\n'.repeat(32 * 1024 * 1024), summary: 'Summary' })
+		).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
+	});
+
+	it('accepts raw markdown exactly at the receiver byte limit', async () => {
+		const { t, result } = await scrapeLocalPage(
+			{ markdown: 'é'.repeat(32 * 1024 * 1024) },
+			PAGE_URL,
+			null
+		);
+		expect(result).toHaveProperty('markdownUrl');
+		const blobs = await storageBlobs(t);
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0]?.size).toBe(64 * 1024 * 1024);
 	});
 
 	it('accepts a JSON archive exactly at the receiver byte limit', async () => {

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -428,49 +428,33 @@ describe('scrape size budget', () => {
 });
 
 describe('scrapeForTool markdown transport', () => {
-	it.each([undefined, 'json'] as const)(
-		'rejects oversized %s archives without storing a blob',
-		async (archiveFormat) => {
-			const t = initConvexTest();
-			const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
-				executionSecret: 'oversized-markdown-secret',
-				kind: 'scrape_url',
-				payload: { url: 'https://example.com/page' }
-			});
-			const scrape = mockScrape({ markdown: `${'é'.repeat(32 * 1024 * 1024)}x` });
-			try {
-				await expect(
-					asUser.action(api.webTools.scrapeForTool, {
-						runId,
-						claimId,
-						jobId,
-						executionSecret,
-						archiveFormat
-					})
-				).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
-				expect(await storageBlobs(t)).toEqual([]);
-			} finally {
-				scrape.mockRestore();
-			}
+	it('rejects oversized JSON archives without storing a blob', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'oversized-markdown-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' }
+		});
+		const scrape = mockScrape({ markdown: `${'é'.repeat(32 * 1024 * 1024)}x` });
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
+			expect(await storageBlobs(t)).toEqual([]);
+		} finally {
+			scrape.mockRestore();
 		}
-	);
+	});
 
 	it('counts JSON escaping toward the receiver byte limit', async () => {
 		await expect(
 			scrapeLocalPage({ markdown: '\n'.repeat(32 * 1024 * 1024), summary: 'Summary' })
 		).rejects.toThrow('Scrape exceeds the 64 MiB download limit.');
-	});
-
-	it('accepts raw markdown exactly at the receiver byte limit', async () => {
-		const { t, result } = await scrapeLocalPage(
-			{ markdown: 'é'.repeat(32 * 1024 * 1024) },
-			PAGE_URL,
-			null
-		);
-		expect(result).toHaveProperty('markdownUrl');
-		const blobs = await storageBlobs(t);
-		expect(blobs).toHaveLength(1);
-		expect(blobs[0]?.size).toBe(64 * 1024 * 1024);
 	});
 
 	it('accepts a JSON archive exactly at the receiver byte limit', async () => {
@@ -700,4 +684,3 @@ describe('scrape errors', () => {
 		}
 	});
 });
-

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -58,6 +58,8 @@ function expectedScrapeArgs(url = PAGE_URL) {
 		{
 			formats: ['markdown', 'summary', 'images', 'audio', 'video'],
 			onlyMainContent: true,
+			maxAge: 0,
+			storeInCache: false,
 			timeout: SCRAPE_TIMEOUT_MS
 		}
 	] as const;
@@ -105,7 +107,7 @@ describe('scrape HTTP failures', () => {
 });
 
 describe('scrapeForTool auth', () => {
-	it('scrapes the URL from the authorized job payload with the Firecrawl formats', async () => {
+	it('scrapes the authorized URL with Firecrawl cache reads and writes disabled', async () => {
 		const t = initConvexTest();
 		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
 			executionSecret: 'local-scrape-secret',

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -2,7 +2,7 @@
 
 import { ConvexError, v, type Infer } from 'convex/values';
 import { z } from 'zod';
-import { ContextDev } from '@context-dot-dev/convex';
+import { FirecrawlClient } from '@firecrawl/firecrawl-convex';
 import { ExaClient } from '@exalabs/convex-exa';
 import { action, internalAction, type ActionCtx } from '@convex/_generated/server';
 import { components, internal } from '@convex/_generated/api';
@@ -15,47 +15,133 @@ import { RUN_NO_LONGER_ACTIVE, toAgentToolConvexError } from '@convex/lib/agentE
 import { unsupportedClient } from '@convex/lib/unsupportedClient';
 import { NonRetryableError } from '@convex-dev/workpool';
 
-const contextDev = new ContextDev(components.contextDev);
+const firecrawl = new FirecrawlClient(components.firecrawl);
 const exa = new ExaClient(components.exa);
 
 const DEFAULT_SEARCH_RESULTS = 5;
 const MAX_SEARCH_RESULTS = 10;
-// Bounds inline markdown; Convex documents are capped at 1 MiB.
-export const SCRAPE_MARKDOWN_MAX_CHARS = 40_000;
-export const SCRAPE_MARKDOWN_STORAGE_TTL_MS = 60 * 60 * 1_000;
 const SCRAPE_MAX_BYTES = 64 * 1024 * 1024;
-const SCRAPE_MARKDOWN_BLOB_TYPE = 'text/markdown; charset=utf-8';
-const SCRAPE_TIMEOUT_MS = 60_000;
+export const SCRAPE_INLINE_MAX_CHARS = 40_000;
+export const SCRAPE_STORAGE_TTL_MS = 60 * 60 * 1_000;
+export const SCRAPE_TIMEOUT_MS = 60_000;
+export const SCRAPE_FORMATS = ['markdown', 'summary', 'images', 'audio', 'video'] as const;
+export const DEFAULT_SCRAPE_SUMMARY = 'No summary was returned for this page.';
+const SCRAPE_JSON_BLOB_TYPE = 'application/json; charset=utf-8';
+const CONVEX_ARRAY_MAX_LENGTH = 8_192;
 const SEARCH_RESULT_TEXT_MAX_CHARS = 2_000;
 const SEARCH_TIMEOUT_MS = 30_000;
+const SCRAPE_URL_SIZE_PLACEHOLDER = 'https://example.convex.cloud/api/storage/scrape.json';
 
 class WebToolTimeout extends Error {}
 
-// Context.dev validates its scrape result against a bounded-depth JSON schema,
-// so pages whose metadata nests deeper than the bound fail inside the component
-// before any content reaches us (#208).
-export function isUnparseablePageFailure(error: Error): boolean {
-	return error.message.includes('ReturnsValidationError');
-}
-
-const UNPARSEABLE_PAGE_ERROR = 'The webpage is too complex and could not be parsed as Markdown.';
 const UNCAUGHT_CONVEX_ERROR_PREFIX = 'Uncaught ConvexError: ';
+const firecrawlApiErrorSchema = z.object({
+	code: z.literal('firecrawl_request_failed'),
+	status: z.int().min(400).max(599)
+});
+const firecrawlMissingKeySchema = z.object({
+	code: z.literal('firecrawl_missing_api_key')
+});
 const scrapeHttpErrorSchema = z.object({ status: z.int().min(400).max(599) });
+const providerErrorSchema = z.union([
+	firecrawlApiErrorSchema,
+	firecrawlMissingKeySchema,
+	scrapeHttpErrorSchema
+]);
+type ProviderError = z.infer<typeof providerErrorSchema>;
+const firecrawlDocumentSchema = z.object({
+	markdown: z.string().nullish(),
+	summary: z.string().nullish(),
+	images: z.array(z.string()).nullish(),
+	audio: z.string().nullish(),
+	video: z.string().nullish(),
+	metadata: z
+		.object({
+			url: z.string().optional(),
+			sourceURL: z.string().optional(),
+			statusCode: z.number().optional(),
+			error: z.string().optional()
+		})
+		.passthrough()
+		.optional()
+});
 
-export function scrapeHttpErrorStatus(error: Error): number | undefined {
+export type ScrapedPage = {
+	url: string;
+	markdown: string;
+	summary: string;
+	images: string[];
+	audio?: string;
+	video?: string;
+};
+
+function convexErrorData(error: Error): ProviderError | undefined {
+	if (error instanceof ConvexError) {
+		return providerErrorSchema.safeParse(error.data).data;
+	}
 	let message = error.message.split('\n', 1)[0] ?? '';
 	while (message.startsWith(UNCAUGHT_CONVEX_ERROR_PREFIX)) {
 		message = message.slice(UNCAUGHT_CONVEX_ERROR_PREFIX.length);
 	}
-
-	let payload: unknown;
 	try {
-		payload = JSON.parse(message);
+		return providerErrorSchema.safeParse(JSON.parse(message)).data;
 	} catch {
 		return undefined;
 	}
-	const result = scrapeHttpErrorSchema.safeParse(payload);
+}
+
+/** Firecrawl API HTTP status, not the scraped page's `metadata.statusCode`. */
+export function scrapeHttpErrorStatus(error: Error): number | undefined {
+	const data = convexErrorData(error);
+	const firecrawlError = firecrawlApiErrorSchema.safeParse(data);
+	if (firecrawlError.success) {
+		return firecrawlError.data.status;
+	}
+	const result = scrapeHttpErrorSchema.safeParse(data);
 	return result.success ? result.data.status : undefined;
+}
+
+export function isCleanPageStatus(status: number): boolean {
+	return status === 304 || (status >= 200 && status < 300);
+}
+
+function isRetryableHttpStatus(status: number): boolean {
+	return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function throwHttpFailure(message: string, status: number, cause?: Error): never {
+	if (isRetryableHttpStatus(status)) {
+		throw new ConvexError(message);
+	}
+	throw new NonRetryableError(message, cause ? { cause } : undefined);
+}
+
+export function summaryFitsTransport(page: ScrapedPage): boolean {
+	return (
+		JSON.stringify({
+			url: page.url,
+			summary: page.summary,
+			scrapeUrl: SCRAPE_URL_SIZE_PLACEHOLDER
+		}).length <= SCRAPE_INLINE_MAX_CHARS
+	);
+}
+
+export function localInlineFits(page: ScrapedPage): boolean {
+	return (
+		page.images.length <= CONVEX_ARRAY_MAX_LENGTH &&
+		JSON.stringify(page).length <= SCRAPE_INLINE_MAX_CHARS
+	);
+}
+
+function rejectOversizedSummary(): never {
+	throw new NonRetryableError('Scrape summary is too large.');
+}
+
+function scrapeSummary(value: string | null | undefined): string {
+	if (value === undefined || value === null || value.trim() === '') {
+		return DEFAULT_SCRAPE_SUMMARY;
+	}
+	return value;
 }
 
 async function withTimeout<T>(label: string, timeoutMs: number, promise: Promise<T>): Promise<T> {
@@ -97,11 +183,6 @@ type PoolScrapeJob = {
 	payload: ExecutorJobPayload;
 } | null;
 
-type ScrapedPage = {
-	url: string;
-	markdown: string;
-};
-
 async function scrapeClaimedUrl(ctx: ActionCtx, job: PoolScrapeJob): Promise<ScrapedPage> {
 	if (!job || job.kind !== 'scrape_url') {
 		throw new NonRetryableError(RUN_NO_LONGER_ACTIVE);
@@ -120,58 +201,73 @@ async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPag
 		throw new NonRetryableError('Only http(s) URLs can be scraped.');
 	}
 
-	let response: Awaited<ReturnType<typeof contextDev.scrapeMarkdown>>;
+	let document: unknown;
 	try {
-		response = await withTimeout(
-			'Context.dev scrape',
+		document = await withTimeout(
+			'Firecrawl scrape',
 			SCRAPE_TIMEOUT_MS,
-			contextDev.scrapeMarkdown(ctx, {
-				params: {
-					url: url.toString(),
-					useMainContentOnly: true,
-					timeoutMS: SCRAPE_TIMEOUT_MS
-				}
+			firecrawl.scrape(ctx, url.toString(), {
+				formats: [...SCRAPE_FORMATS],
+				onlyMainContent: true,
+				timeout: SCRAPE_TIMEOUT_MS
 			})
 		);
 	} catch (error) {
 		if (error instanceof Error) {
+			if (firecrawlMissingKeySchema.safeParse(convexErrorData(error)).success) {
+				throw new NonRetryableError('FIRECRAWL_API_KEY is not configured.', { cause: error });
+			}
 			const status = scrapeHttpErrorStatus(error);
 			if (status !== undefined) {
-				const message = `This webpage returned a ${status} error.`;
-				if (status === 408 || status === 429 || status >= 500) {
-					throw new ConvexError(message);
-				}
-				throw new NonRetryableError(message, { cause: error });
-			}
-			if (isUnparseablePageFailure(error)) {
-				throw new NonRetryableError(UNPARSEABLE_PAGE_ERROR, { cause: error });
+				throwHttpFailure(`Firecrawl scrape failed (${status}).`, status, error);
 			}
 		}
 		throw error;
 	}
 
-	return { url: response.url, markdown: response.markdown };
+	const parsed = firecrawlDocumentSchema.safeParse(document);
+	if (!parsed.success) {
+		throw new NonRetryableError('Firecrawl scrape returned an invalid response.');
+	}
+
+	const statusCode = parsed.data.metadata?.statusCode;
+	if (statusCode !== undefined && !isCleanPageStatus(statusCode)) {
+		throwHttpFailure(`This webpage returned a ${statusCode} error.`, statusCode);
+	}
+
+	const page: ScrapedPage = {
+		url: parsed.data.metadata?.sourceURL ?? parsed.data.metadata?.url ?? url.toString(),
+		markdown: parsed.data.markdown ?? '',
+		summary: scrapeSummary(parsed.data.summary),
+		images: parsed.data.images ?? []
+	};
+	if (parsed.data.audio) page.audio = parsed.data.audio;
+	if (parsed.data.video) page.video = parsed.data.video;
+	return page;
 }
 
 async function localScrapeTransport(
 	ctx: ActionCtx,
 	page: ScrapedPage
 ): Promise<Infer<typeof vScrapeUrlTransport>> {
-	if (page.markdown.length <= SCRAPE_MARKDOWN_MAX_CHARS) {
-		return { url: page.url, markdown: page.markdown };
+	if (!summaryFitsTransport(page)) {
+		rejectOversizedSummary();
 	}
-	return { url: page.url, markdownUrl: await storeTemporaryMarkdown(ctx, page.markdown) };
+	if (localInlineFits(page)) {
+		return page;
+	}
+	return { url: page.url, summary: page.summary, scrapeUrl: await storeTemporaryScrape(ctx, page) };
 }
 
-async function storeTemporaryMarkdown(ctx: ActionCtx, markdown: string): Promise<string> {
-	const blob = new Blob([markdown], { type: SCRAPE_MARKDOWN_BLOB_TYPE });
+async function storeTemporaryScrape(ctx: ActionCtx, page: ScrapedPage): Promise<string> {
+	const blob = new Blob([JSON.stringify(page)], { type: SCRAPE_JSON_BLOB_TYPE });
 	if (blob.size > SCRAPE_MAX_BYTES) {
 		throw new NonRetryableError('Scrape exceeds the 64 MiB download limit.');
 	}
 	const storageId = await ctx.storage.store(blob);
 	try {
 		await ctx.scheduler.runAfter(
-			SCRAPE_MARKDOWN_STORAGE_TTL_MS,
+			SCRAPE_STORAGE_TTL_MS,
 			internal.webToolPool.deleteTemporaryStorage,
 			{ storageId }
 		);
@@ -179,12 +275,12 @@ async function storeTemporaryMarkdown(ctx: ActionCtx, markdown: string): Promise
 		await ctx.storage.delete(storageId);
 		throw error;
 	}
-	const markdownUrl = await ctx.storage.getUrl(storageId);
-	if (!markdownUrl) {
+	const scrapeUrl = await ctx.storage.getUrl(storageId);
+	if (!scrapeUrl) {
 		await ctx.storage.delete(storageId);
 		throw new Error('Stored scrape is unavailable.');
 	}
-	return markdownUrl;
+	return scrapeUrl;
 }
 
 async function runSearch(

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -209,6 +209,8 @@ async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPag
 			firecrawl.scrape(ctx, url.toString(), {
 				formats: [...SCRAPE_FORMATS],
 				onlyMainContent: true,
+				maxAge: 0,
+				storeInCache: false,
 				timeout: SCRAPE_TIMEOUT_MS
 			})
 		);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 		server: {
 			deps: {
 				inline: [
-					'@context-dot-dev/convex',
+					'@firecrawl/firecrawl-convex',
 					'@convex-dev/rate-limiter',
 					'@exalabs/convex-exa',
 					'@convex-dev/migrations',

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@browserbasehq/stagehand": "^3.7.1",
-        "@context-dot-dev/convex": "^1.0.1",
         "@convex-dev/action-retrier": "^0.3.1",
         "@convex-dev/aggregate": "^0.2.2",
         "@convex-dev/migrations": "^0.3.6",
@@ -41,6 +40,7 @@
         "@convex-dev/workpool": "^0.4.10",
         "@dodopayments/convex": "^0.2.15",
         "@exalabs/convex-exa": "^0.1.1",
+        "@firecrawl/firecrawl-convex": "^0.1.1",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@fontsource/dm-sans": "^5.2.8",
         "@fontsource/ibm-plex-mono": "^5.3.0",
@@ -147,8 +147,6 @@
     "@browserbasehq/stagehand": ["@browserbasehq/stagehand@3.7.1", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@anthropic-ai/sdk": "0.39.0", "@browserbasehq/sdk": "^2.14.0", "@google/genai": "^1.22.0", "@modelcontextprotocol/sdk": "^1.29.0", "ai": "^5.0.185", "devtools-protocol": "^0.0.1642743", "fetch-cookie": "^3.1.0", "openai": "^4.104.0", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "uuid": "^11.1.1", "ws": "^8.21.0", "zod-to-json-schema": "^3.25.0" }, "optionalDependencies": { "@ai-sdk/amazon-bedrock": "^3.0.73", "@ai-sdk/anthropic": "^2.0.81", "@ai-sdk/azure": "^2.0.109", "@ai-sdk/cerebras": "^1.0.25", "@ai-sdk/deepseek": "^1.0.23", "@ai-sdk/google": "^2.0.53", "@ai-sdk/google-vertex": "^3.0.70", "@ai-sdk/groq": "^2.0.24", "@ai-sdk/mistral": "^2.0.19", "@ai-sdk/openai": "^2.0.53", "@ai-sdk/perplexity": "^2.0.13", "@ai-sdk/togetherai": "^1.0.23", "@ai-sdk/xai": "^2.0.26", "bufferutil": "^4.0.9", "chrome-launcher": "^1.2.0", "ollama-ai-provider-v2": "^1.5.0" }, "peerDependencies": { "patchright-core": "^1.55.2", "playwright-core": "^1.55.1", "puppeteer-core": "^24.43.0", "zod": "^3.25.76 || ^4.2.0" }, "optionalPeers": ["patchright-core", "playwright-core", "puppeteer-core"] }, "sha512-vAuYSZWIhh3d76BxwppNVE3dB0ztEBLBi85G6TWulZNiebdWptNoANOMuprOB/cw5dE+80b/ZZQo4G33Pc9i6w=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
-
-    "@context-dot-dev/convex": ["@context-dot-dev/convex@1.0.1", "", { "peerDependencies": { "convex": ">=1.42.0" } }, "sha512-TMopb7CqtzsOgpUnRZ6E8KU9+ncsoyWW1P3NA11eC1LpaqKi+e3E3xWQqmBjT+24VQ0i6Zvz9JKMnYxCKRtluQ=="],
 
     "@convex-dev/action-retrier": ["@convex-dev/action-retrier@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-uji7ZV4GYN24fgnV9FrXABbq2mWCpcMohkEa2ie1zmD5S7ioSxNNBE0lNPB1jlMzICqWCTrbSTr68bgJPag6Ww=="],
 
@@ -277,6 +275,8 @@
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@firecrawl/firecrawl-convex": ["@firecrawl/firecrawl-convex@0.1.1", "", { "dependencies": { "convex-helpers": "^0.1.122" }, "peerDependencies": { "convex": "^1.43.0" } }, "sha512-fecepodOAcKLUKFD+4dyqRfU8ATn3y15nYtayyAmmQAV0FT/6sVwKNY0+rpq8/NKTLrEpuHr+cE0htNQ+ssU+g=="],
 
     "@fontsource-variable/ibm-plex-sans": ["@fontsource-variable/ibm-plex-sans@5.3.0", "", {}, "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ=="],
 

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -48,13 +48,22 @@ its `FIRECRAWL_API_KEY`; when it is not configured, the tool reports that hosted
 fallback is unavailable. Long parsed results include a preview and the path to
 the full text in the thread's `parse_file/` cache. Use `scrape_url` for http(s)
 URLs; `parse_file` rejects a `url` argument and URL-shaped paths.
+Hosted parsing still calls Firecrawl's Parse API directly because the official
+Convex component does not expose parsing.
 
 `scrape_url` fetches supported raster images in memory and returns their pixels
 to image-capable models. Images and short scrapes are not saved locally.
-Scrapes exceeding 40,000 characters are saved in full to the host's temporary
+Page scraping uses the official `@firecrawl/firecrawl-convex` component with
+`markdown`, `summary`, `images`, `audio`, and `video` formats. The backend needs
+`FIRECRAWL_API_KEY`; `CONTEXT_DEV_API_KEY` is no longer used. Audio and video are
+returned as provider URLs, not downloaded media files.
+
+Scrape outputs above 40,000 serialized characters are saved as JSON in the host's temporary
 directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
 `The scrape was saved to <file-path>.` These files have the operating system's
-temporary-file lifetime. Convex transfer copies expire after one hour.
+temporary-file lifetime. Convex transfer copies expire after one hour. The
+`summary` field remains inline in both short and saved results. Summaries that
+alone exceed the inline budget fail explicitly rather than being truncated.
 Rebuilt history keeps image metadata and asks the model to call
 the tool again if it needs the pixels. HTML uses the cloud scraper through an
 authenticated action. A HEAD request identifies image content types without
@@ -102,11 +111,10 @@ tool call is wrapped in a durable executor-job record and observes run
 cancellation while work is active.
 
 Command execution and patch operations both run with the local Sprocket
-process's permissions. Web search and scraping enqueue a Convex Workpool job
-(`webToolPool`) that runs Exa and Context.dev actions, keyed by deployment-side
-environment variables (`EXA_API_KEY`, `CONTEXT_DEV_API_KEY`); only the results
-flow back through the executor job. Released agents that still call the public
-`webTools` actions wait on that same job.
+process's permissions. Web search runs Exa through a Convex Workpool job.
+Current agents orchestrate scraping locally and call an authenticated Firecrawl
+action for pages. Released agents still use the cloud scrape workpool. Provider
+keys (`EXA_API_KEY`, `FIRECRAWL_API_KEY`) stay in the backend.
 
 ## Main areas
 

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -13,7 +13,7 @@ pub(super) async fn localize_scrape(
     saved_file: &mut Option<tempfile::NamedTempFile>,
 ) -> anyhow::Result<Value> {
     let fields = result.as_object_mut().context("invalid scrape response")?;
-    if let Some(download) = fields.remove("markdownUrl") {
+    if let Some(download) = fields.remove("scrapeUrl") {
         let url = reqwest::Url::parse(download.as_str().context("invalid scrape download URL")?)?;
         anyhow::ensure!(
             matches!(url.scheme(), "http" | "https"),
@@ -21,7 +21,7 @@ pub(super) async fn localize_scrape(
         );
         let temp = tempfile::Builder::new()
             .prefix("sprocket-scrape-")
-            .suffix(".md")
+            .suffix(".json")
             .tempfile()?;
         let temp = download_scrape(url, temp, cancellation).await?;
         fields.insert(
@@ -104,9 +104,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn short_scrapes_stay_inline_without_a_truncation_flag() {
+    async fn short_scrapes_preserve_summary_and_media_without_a_truncation_flag() {
         let result = localize_scrape(
-            json!({"url": "https://example.com", "markdown": "# Hello", "truncated": false}),
+            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3", "truncated": false}),
             &WorkspaceCancellation::new(),
             &mut None,
         )
@@ -114,17 +114,18 @@ mod tests {
         .unwrap();
         assert_eq!(
             result,
-            json!({"url": "https://example.com", "markdown": "# Hello"})
+            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3"})
         );
     }
 
     #[tokio::test]
-    async fn full_unicode_scrape_is_saved_and_only_the_notice_is_returned() {
-        let text = "é\n".repeat(40_001);
+    async fn full_scrape_is_saved_while_summary_stays_in_the_output() {
+        let scrape = json!({"markdown": "é\n".repeat(40_001), "summary": "Full summary", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3", "video": "https://example.com/video.mp4"});
+        let text = scrape.to_string();
         let url = serve(&text, text.len()).await;
         let mut saved_file = None;
         let result = localize_scrape(
-            json!({"url": "https://example.com", "markdownUrl": url.as_str()}),
+            json!({"url": "https://example.com", "scrapeUrl": url.as_str(), "summary": "Full summary"}),
             &WorkspaceCancellation::new(),
             &mut saved_file,
         )
@@ -138,11 +139,13 @@ mod tests {
             .strip_suffix('.')
             .unwrap();
         assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), text);
+        assert_eq!(result["summary"], "Full summary");
+        assert_eq!(std::path::Path::new(path).extension().unwrap(), "json");
         assert_eq!(
             std::path::Path::new(path).parent(),
             Some(std::env::temp_dir().as_path())
         );
-        assert!(result.get("markdownUrl").is_none());
+        assert!(result.get("scrapeUrl").is_none());
         assert!(result.get("truncated").is_none());
         tokio::fs::remove_file(path).await.unwrap();
     }


### PR DESCRIPTION
Step 3 of the URL-tool stack. #322 and #324 have merged; this PR now targets main.

## Changes
- Disable Firecrawl cache reads and writes with maxAge: 0 and storeInCache: false. Temporary transfer-blob expiry is unchanged; it is not a reusable scrape cache.
- Replace Context.dev with the official Firecrawl Convex component and request markdown, summary, images, audio, and video.
- Return short results inline. Save complete oversized results as JSON while keeping the summary inline.
- Remove archiveFormat negotiation and the raw-markdown download fallback on both client and server. Current clients consume JSON archives through scrapeUrl.
- Apply the 64 MiB transfer limit to the complete encoded JSON, including escaping and metadata.
- Keep historical result validators compatible with transcripts written before summary/media fields existed.

## Compatibility decision
The user also explicitly requested removing both localExecution and the asImage stored-payload field. Neither field exists on main; both were introduced in this unmerged stack. Do not restore either compatibility path.

The user explicitly requested removing older-client compatibility while retaining historical thread data support. The former archive-negotiation shim is intentionally removed. Deploy the updated client and backend together.

## Checks
- After removing the flags, the combined stack passes 187 Rust library tests, 68 targeted Convex tests, Convex codegen, Svelte/TypeScript checks, and full prek hooks.
- Cache-policy update: 31 webTools tests passed on this branch. The combined stack passes 68 targeted Convex tests, codegen, Svelte/TypeScript checks, and full prek hooks.
- Tests cover JSON escaping, exact archive byte boundaries, historical stored results, and provider failures.

FIRECRAWL_API_KEY is required. No paid Firecrawl requests were made.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.













<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces Context.dev scraping with the official Firecrawl Convex component and expands scrape results to include summaries and media.
- Disables Firecrawl cache reads and writes for scrape requests.
- Returns compact results inline and transfers oversized complete results as temporary JSON archives.
- Enforces transport limits against encoded JSON and preserves historical stored-result compatibility.
- Updates the Rust agent to localize JSON scrape archives while retaining summaries inline.
- Removes the transitional raw-Markdown archive protocol in favor of coordinated client/backend deployment.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no outstanding actionable findings.

The latest changes explicitly disable Firecrawl cache reads and writes, and the current implementation consistently validates and transports enriched scrape data without a demonstrated correctness or repository-rule violation. The prior compatibility finding was resolved, and coordinated client/backend deployment is now an explicit product decision.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Migrates page scraping to Firecrawl, validates provider responses, disables caching, and implements bounded inline or temporary JSON transport. |
| apps/web/src/convex/lib/validators.ts | Extends stored scrape validators compatibly while defining the new summary/media transport shapes. |
| crates/sprocket-agent/src/tools/scrape_files.rs | Downloads oversized scrape JSON archives into temporary files and preserves inline summaries. |
| apps/web/src/convex/webTools.test.ts | Covers provider failures, cache-disabling arguments, historical results, media fields, JSON size boundaries, and temporary storage cleanup. |
| apps/web/src/convex/convex.config.ts | Replaces the Context.dev component and environment configuration with the Firecrawl component. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant Convex as Convex webTools
    participant Firecrawl
    participant Storage as Temporary Storage

    Agent->>Convex: scrapeForTool(job credentials)
    Convex->>Firecrawl: "scrape(url, formats, maxAge=0, storeInCache=false)"
    Firecrawl-->>Convex: markdown, summary, images, audio, video
    alt Serialized result fits inline budget
        Convex-->>Agent: Complete inline scrape result
    else Result exceeds inline budget
        Convex->>Storage: Store complete JSON archive
        Storage-->>Convex: Temporary scrapeUrl
        Convex-->>Agent: summary + scrapeUrl
        Agent->>Storage: Download JSON archive
        Agent-->>Agent: Save temporary .json file
    end
```
</details>

<sub>Reviews (12): Last reviewed commit: ["fix(agent-tools): Disable Firecrawl scra..."](https://github.com/spikonado/sprocket/commit/3ff5c174e547911b3c577b3cf89ef180873f16ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61433157)</sub>

<!-- /greptile_comment -->