### PR TITLE
feat(agent-tools): Add screenshot_url with Firecrawl

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -446,15 +446,6 @@ route is a one-shot command-time relay, not a replacement subscription. Move
 lifecycle reads behind Rust only if Rust gains an equivalent ordered reactive
 stream.
 
-## Historical web image results
-
-Web image results now store a local file path alongside their metadata. The
-path remains optional in Convex for stored results from before local image
-persistence. Those images cannot be recovered from metadata, so history reports
-them as unavailable without fetching the URL again. Make the path required
-once no stored web image results lack it. There are no image bytes to migrate
-for those records.
-
 ## Removal checklist
 
 1. Confirm the gate with prod numbers (schema) or an explicit decision that

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -351,6 +351,10 @@ Web image results store URL and image metadata, not bytes or local paths.
 History displays a notice rather than fetching the URL again. Local-path
 `parse_file` image results still replay from their existing local cache.
 
+`screenshot_url` is an additive tool kind using the same image metadata result
+shape. It stores the target page URL for explicit re-capture, never the expiring
+provider URL. No stored-row migration is needed.
+
 ### Local sessions created before account binding
 
 Persisted local sessions created before native WorkOS account binding have no

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -446,6 +446,15 @@ route is a one-shot command-time relay, not a replacement subscription. Move
 lifecycle reads behind Rust only if Rust gains an equivalent ordered reactive
 stream.
 
+## Historical web image results
+
+Web image results now store a local file path alongside their metadata. The
+path remains optional in Convex for stored results from before local image
+persistence. Those images cannot be recovered from metadata, so history reports
+them as unavailable without fetching the URL again. Make the path required
+once no stored web image results lack it. There are no image bytes to migrate
+for those records.
+
 ## Removal checklist
 
 1. Confirm the gate with prod numbers (schema) or an explicit decision that

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -186,6 +186,56 @@ describe('executor', () => {
 		expect(job?.result).not.toHaveProperty('path');
 	});
 
+	it('persists screenshot_url image metadata without file bytes', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'screenshot-image-secret';
+		const claimId = 'claim-screenshot';
+		const { runId } = await createQueuedRun(
+			t,
+			asUser,
+			threadId,
+			'screenshot-image',
+			executionSecret,
+			'Capture this page'
+		);
+		await asUser.mutation(api.agentRuntime.start, { runId, claimId, executionSecret });
+		const { jobId } = await asUser.mutation(api.agentRuntime.beginToolJob, {
+			runId,
+			claimId,
+			executionSecret,
+			kind: 'screenshot_url',
+			payload: { url: 'https://example.com/page' }
+		});
+		await expect(
+			asUser.mutation(api.executor.complete, {
+				runId,
+				claimId,
+				executionSecret,
+				jobId,
+				result: {
+					outputType: 'image',
+					url: 'https://example.com/page',
+					mediaType: 'image/png',
+					byteSize: 80,
+					width: 1280,
+					height: 720
+				}
+			})
+		).resolves.toBe(true);
+		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(job?.result).toEqual({
+			outputType: 'image',
+			url: 'https://example.com/page',
+			mediaType: 'image/png',
+			byteSize: 80,
+			width: 1280,
+			height: 720
+		});
+		expect(job?.result).not.toHaveProperty('path');
+		expect(job?.result).not.toHaveProperty('screenshotUrl');
+	});
+
 	it('completes the active job and releases the run back to running', async () => {
 		const t = initConvexTest();
 		const { asUser, runId, jobId, claimId, executionSecret } = await seedRunWithJob(t, {

--- a/apps/web/src/convex/executor.test.ts
+++ b/apps/web/src/convex/executor.test.ts
@@ -137,104 +137,55 @@ describe('executor', () => {
 		}
 	);
 
-	it('persists scrape_url image metadata without file bytes', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-		const executionSecret = 'scrape-image-secret';
-		const claimId = 'claim-image';
-		const { runId } = await createQueuedRun(
-			t,
-			asUser,
-			threadId,
-			'scrape-image',
-			executionSecret,
-			'Read this image'
-		);
-		await asUser.mutation(api.agentRuntime.start, { runId, claimId, executionSecret });
-		const { jobId } = await asUser.mutation(api.agentRuntime.beginToolJob, {
-			runId,
-			claimId,
-			executionSecret,
-			kind: 'scrape_url',
-			payload: { url: 'https://example.com/pic.png' }
-		});
-		await expect(
-			asUser.mutation(api.executor.complete, {
+	it.each(['scrape_url', 'screenshot_url'] as const)(
+		'persists %s local image references without file bytes',
+		async (kind) => {
+			const t = initConvexTest();
+			const { asUser, threadId } = await seedOwnedThread(t);
+			const executionSecret = 'web-image-secret';
+			const claimId = 'claim-image';
+			const result = {
+				outputType: 'image' as const,
+				url: 'https://example.com/image',
+				path: '/threads/thread/parse_file/image.png',
+				mediaType: 'image/png',
+				byteSize: 80,
+				width: 1280,
+				height: 720
+			};
+			const { runId } = await createQueuedRun(
+				t,
+				asUser,
+				threadId,
+				'web-image',
+				executionSecret,
+				'Read this image'
+			);
+			await asUser.mutation(api.agentRuntime.start, { runId, claimId, executionSecret });
+			const { jobId } = await asUser.mutation(api.agentRuntime.beginToolJob, {
 				runId,
 				claimId,
 				executionSecret,
-				jobId,
-				result: {
-					outputType: 'image',
-					url: 'https://example.com/pic.png',
-					mediaType: 'image/png',
-					byteSize: 80,
-					width: 1,
-					height: 1
-				}
-			})
-		).resolves.toBe(true);
-		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
-		expect(job?.result).toEqual({
-			outputType: 'image',
-			url: 'https://example.com/pic.png',
-			mediaType: 'image/png',
-			byteSize: 80,
-			width: 1,
-			height: 1
-		});
-		expect(job?.result).not.toHaveProperty('path');
-	});
-
-	it('persists screenshot_url image metadata without file bytes', async () => {
-		const t = initConvexTest();
-		const { asUser, threadId } = await seedOwnedThread(t);
-		const executionSecret = 'screenshot-image-secret';
-		const claimId = 'claim-screenshot';
-		const { runId } = await createQueuedRun(
-			t,
-			asUser,
-			threadId,
-			'screenshot-image',
-			executionSecret,
-			'Capture this page'
-		);
-		await asUser.mutation(api.agentRuntime.start, { runId, claimId, executionSecret });
-		const { jobId } = await asUser.mutation(api.agentRuntime.beginToolJob, {
-			runId,
-			claimId,
-			executionSecret,
-			kind: 'screenshot_url',
-			payload: { url: 'https://example.com/page' }
-		});
-		await expect(
-			asUser.mutation(api.executor.complete, {
-				runId,
-				claimId,
-				executionSecret,
-				jobId,
-				result: {
-					outputType: 'image',
-					url: 'https://example.com/page',
-					mediaType: 'image/png',
-					byteSize: 80,
-					width: 1280,
-					height: 720
-				}
-			})
-		).resolves.toBe(true);
-		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
-		expect(job?.result).toEqual({
-			outputType: 'image',
-			url: 'https://example.com/page',
-			mediaType: 'image/png',
-			byteSize: 80,
-			width: 1280,
-			height: 720
-		});
-		expect(job?.result).not.toHaveProperty('path');
-		expect(job?.result).not.toHaveProperty('screenshotUrl');
-	});
+				kind,
+				payload: { url: result.url }
+			});
+			await expect(
+				asUser.mutation(api.executor.complete, {
+					runId,
+					claimId,
+					executionSecret,
+					jobId,
+					result
+				})
+			).resolves.toBe(true);
+			const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+			expect(job?.result).toEqual(result);
+			const parts = await asUser.query(api.transcript.getParts, { threadId, numbers: [0, 1, 2] });
+			expect(parts.parts.find((part) => part.tool?.status === 'completed')?.tool?.output).toEqual(
+				result
+			);
+		}
+	);
 
 	it('completes the active job and releases the run back to running', async () => {
 		const t = initConvexTest();

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -281,7 +281,7 @@ export const vScreenshotUrlTransport = v.object({
 export const vWebImageResult = v.object({
 	outputType: v.literal('image'),
 	url: v.string(),
-	path: v.optional(v.string()),
+	path: v.string(),
 	mediaType: v.string(),
 	byteSize: v.number(),
 	width: v.number(),

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -48,6 +48,9 @@ export const vScrapeUrlPayload = v.object({
 	url: v.string()
 });
 
+/** screenshot_url job payload. */
+export const vScreenshotUrlPayload = vScrapeUrlPayload.pick('url');
+
 export const vWebSearchPayload = v.object({
 	query: v.string(),
 	numResults: v.optional(v.number())
@@ -195,6 +198,7 @@ export const vExecutorJobPayload = v.union(
 	vExecCommandPayload,
 	vReadSkillPayload,
 	vScrapeUrlPayload,
+	vScreenshotUrlPayload,
 	vWebSearchPayload,
 	vWriteStdinPayload,
 	vAddArtifactPayload,
@@ -267,6 +271,12 @@ export const vScrapeUrlTransport = v.union(
 		scrapeUrl: v.string()
 	})
 );
+
+/** Local screenshotForTool transport. `url` is the page; `screenshotUrl` is the provider image. */
+export const vScreenshotUrlTransport = v.object({
+	url: v.string(),
+	screenshotUrl: v.string()
+});
 
 export const vWebImageResult = v.object({
 	outputType: v.literal('image'),
@@ -497,6 +507,7 @@ export const vExecutorJobKind = v.union(
 	v.literal('read_skill'),
 	v.literal('parse_file'),
 	v.literal('scrape_url'),
+	v.literal('screenshot_url'),
 	v.literal('web_search'),
 	v.literal('write_stdin'),
 	v.literal('add_artifact'),

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -281,6 +281,7 @@ export const vScreenshotUrlTransport = v.object({
 export const vWebImageResult = v.object({
 	outputType: v.literal('image'),
 	url: v.string(),
+	path: v.optional(v.string()),
 	mediaType: v.string(),
 	byteSize: v.number(),
 	width: v.number(),

--- a/apps/web/src/convex/test.setup.ts
+++ b/apps/web/src/convex/test.setup.ts
@@ -173,7 +173,7 @@ export async function seedStartedWebJob(
 	t: ConvexTestInstance,
 	options: {
 		executionSecret: string;
-		kind: 'web_search' | 'scrape_url';
+		kind: 'web_search' | 'scrape_url' | 'screenshot_url';
 		payload: { query: string } | { url: string };
 		prompt?: string;
 		claimId?: string;

--- a/apps/web/src/convex/webToolPool.test.ts
+++ b/apps/web/src/convex/webToolPool.test.ts
@@ -112,6 +112,76 @@ describe('local scrape_url dispatch', () => {
 	});
 });
 
+describe('local screenshot_url dispatch', () => {
+	it('never enqueues screenshot_url in the cloud workpool', async () => {
+		const t = initConvexTest();
+		const { jobId, runId, claimId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'screenshot-dispatch-secret',
+			kind: 'screenshot_url',
+			payload: { url: 'https://example.com/page' }
+		});
+		const stored = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(stored?.cloudWorkId).toBeUndefined();
+		expect(stored?.status).toBe('claimed');
+		expect(stored?.kind).toBe('screenshot_url');
+
+		expect(
+			await t.query(internal.webToolPool.getLocalScreenshotJob, {
+				runId,
+				claimId,
+				jobId,
+				executionSecret
+			})
+		).toEqual({
+			kind: 'screenshot_url',
+			payload: { url: 'https://example.com/page' }
+		});
+		expect(
+			await t.query(internal.webToolPool.getLocalScrapeJob, {
+				runId,
+				claimId,
+				jobId,
+				executionSecret
+			})
+		).toBeNull();
+		expect(
+			await t.query(internal.webToolPool.getWebToolJob, {
+				runId,
+				claimId,
+				jobId
+			})
+		).toBeNull();
+	});
+
+	it('does not return scrape jobs from getLocalScreenshotJob', async () => {
+		const t = initConvexTest();
+		const { jobId, runId, claimId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'scrape-not-screenshot-secret',
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' }
+		});
+		expect(
+			await t.query(internal.webToolPool.getLocalScreenshotJob, {
+				runId,
+				claimId,
+				jobId,
+				executionSecret
+			})
+		).toBeNull();
+		expect(
+			await t.query(internal.webToolPool.getLocalScrapeJob, {
+				runId,
+				claimId,
+				jobId,
+				executionSecret
+			})
+		).toEqual({
+			kind: 'scrape_url',
+			payload: { url: 'https://example.com/page' }
+		});
+	});
+});
+
 describe('temporary scrape storage', () => {
 	it('deletes unregistered blobs and is a no-op after they are gone', async () => {
 		const t = initConvexTest();

--- a/apps/web/src/convex/webToolPool.ts
+++ b/apps/web/src/convex/webToolPool.ts
@@ -126,27 +126,59 @@ export const getWebToolJob = internalQuery({
 	}
 });
 
-export const getLocalScrapeJob = internalQuery({
+const vLocalJobArgs = {
+	...vWebToolContext.fields,
+	executionSecret: v.string()
+};
+
+async function claimedLocalWebJob<K extends 'scrape_url' | 'screenshot_url'>(
+	ctx: QueryCtx,
 	args: {
-		...vWebToolContext.fields,
-		executionSecret: v.string()
+		jobId: Id<'executorJobs'>;
+		runId: Id<'runs'>;
+		claimId: string;
+		executionSecret: string;
 	},
+	kind: K
+): Promise<{ kind: K; payload: Doc<'executorJobs'>['payload'] } | null> {
+	await getExecutionRun(ctx, args.runId, args.executionSecret);
+	const active = await claimedJobForActiveRun(ctx, args);
+	if (
+		!active ||
+		active.job.kind !== kind ||
+		active.job.status !== 'claimed' ||
+		active.job.cloudWorkId !== undefined
+	) {
+		return null;
+	}
+	return { kind, payload: active.job.payload };
+}
+
+export const getLocalScrapeJob = internalQuery({
+	args: vLocalJobArgs,
 	returns: v.union(
 		v.null(),
-		v.object({ kind: v.literal('scrape_url'), payload: vExecutorJobPayload })
+		v.object({
+			kind: v.literal('scrape_url'),
+			payload: vExecutorJobPayload
+		})
 	),
 	handler: async (ctx, args) => {
-		await getExecutionRun(ctx, args.runId, args.executionSecret);
-		const active = await claimedJobForActiveRun(ctx, args);
-		if (
-			!active ||
-			active.job.kind !== 'scrape_url' ||
-			active.job.status !== 'claimed' ||
-			active.job.cloudWorkId !== undefined
-		) {
-			return null;
-		}
-		return { kind: active.job.kind, payload: active.job.payload };
+		return await claimedLocalWebJob(ctx, args, 'scrape_url');
+	}
+});
+
+export const getLocalScreenshotJob = internalQuery({
+	args: vLocalJobArgs,
+	returns: v.union(
+		v.null(),
+		v.object({
+			kind: v.literal('screenshot_url'),
+			payload: vExecutorJobPayload
+		})
+	),
+	handler: async (ctx, args) => {
+		return await claimedLocalWebJob(ctx, args, 'screenshot_url');
 	}
 });
 

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -20,6 +20,7 @@ import { initConvexTest, seedStartedWebJob, type ConvexTestInstance } from './te
 const PAGE_URL = 'https://example.com/page';
 const AUDIO_URL = 'https://storage.googleapis.com/scrape/audio.mp3?X-Goog-Signature=sig';
 const VIDEO_URL = 'https://storage.googleapis.com/scrape/video.mp4?X-Goog-Signature=sig';
+const SCREENSHOT_URL = 'https://storage.googleapis.com/firecrawl/shot.png?X-Goog-Signature=sig';
 
 function firecrawlApiError(status: number) {
 	return new ConvexError({
@@ -37,6 +38,7 @@ function mockScrape(
 		images?: string[];
 		audio?: string;
 		video?: string;
+		screenshot?: string;
 		metadata?: { sourceURL?: string; url?: string; statusCode?: number };
 	},
 	url = PAGE_URL
@@ -47,6 +49,7 @@ function mockScrape(
 		images: document.images,
 		audio: document.audio,
 		video: document.video,
+		screenshot: document.screenshot,
 		metadata: document.metadata ?? { sourceURL: url, statusCode: 200 }
 	});
 }
@@ -58,6 +61,19 @@ function expectedScrapeArgs(url = PAGE_URL) {
 		{
 			formats: ['markdown', 'summary', 'images', 'audio', 'video'],
 			onlyMainContent: true,
+			maxAge: 0,
+			storeInCache: false,
+			timeout: SCRAPE_TIMEOUT_MS
+		}
+	] as const;
+}
+
+function expectedScreenshotArgs(url = PAGE_URL) {
+	return [
+		expect.anything(),
+		url,
+		{
+			formats: ['screenshot'],
 			maxAge: 0,
 			storeInCache: false,
 			timeout: SCRAPE_TIMEOUT_MS
@@ -208,6 +224,29 @@ describe('scrapeForTool auth', () => {
 				executionSecret
 			})
 		).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+	});
+
+	it('rejects screenshot_url jobs before calling Firecrawl', async () => {
+		const t = initConvexTest();
+		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
+			executionSecret: 'screenshot-as-scrape-secret',
+			kind: 'screenshot_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.scrapeForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
 	});
 
 	it('rejects an expired claim', async () => {
@@ -684,5 +723,397 @@ describe('scrape errors', () => {
 		} finally {
 			scrape.mockRestore();
 		}
+	});
+});
+
+const screenshotImageResult = {
+	outputType: 'image' as const,
+	url: PAGE_URL,
+	mediaType: 'image/png',
+	byteSize: 80,
+	width: 1280,
+	height: 720
+};
+
+async function screenshotToolArgs(options: {
+	executionSecret: string;
+	kind?: 'screenshot_url' | 'scrape_url' | 'web_search';
+	payload?: { url: string } | { query: string };
+}) {
+	const t = initConvexTest();
+	const seeded = await seedStartedWebJob(t, {
+		executionSecret: options.executionSecret,
+		kind: options.kind ?? 'screenshot_url',
+		payload: options.payload ?? { url: PAGE_URL }
+	});
+	return { t, ...seeded };
+}
+
+describe('screenshotForTool', () => {
+	it('requests a viewport screenshot and returns the page URL, not the signed image URL', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'screenshot-format-secret'
+		});
+		const scrape = mockScrape({
+			screenshot: SCREENSHOT_URL,
+			metadata: { sourceURL: PAGE_URL, url: SCREENSHOT_URL, statusCode: 200 }
+		});
+		try {
+			expect(
+				await asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).toEqual({ url: PAGE_URL, screenshotUrl: SCREENSHOT_URL });
+			expect(scrape).toHaveBeenCalledWith(...expectedScreenshotArgs());
+			expect(scrape.mock.calls[0]?.[2]).not.toEqual(
+				expect.objectContaining({ formats: [{ type: 'screenshot', fullPage: true }] })
+			);
+			expect(await storageBlobs(t)).toEqual([]);
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('keeps the requested page URL when Firecrawl metadata only repeats the screenshot URL', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'screenshot-page-url-secret'
+		});
+		const scrape = mockScrape({
+			screenshot: SCREENSHOT_URL,
+			metadata: { url: SCREENSHOT_URL, statusCode: 200 }
+		});
+		try {
+			expect(
+				await asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).toEqual({ url: PAGE_URL, screenshotUrl: SCREENSHOT_URL });
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects a wrong execution secret before calling Firecrawl', async () => {
+		const { asUser, runId, claimId, jobId } = await screenshotToolArgs({
+			executionSecret: 'screenshot-auth-secret'
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret: 'wrong-secret'
+				})
+			).rejects.toThrow('Run not found.');
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects an expired claim before calling Firecrawl', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'expired-screenshot-secret'
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch('runs', runId, { claimExpiresAt: Date.now() - 1 });
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+			expect(
+				await t.query(internal.webToolPool.getLocalScreenshotJob, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).toBeNull();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects a cancelled run before calling Firecrawl', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'cancelled-screenshot-secret'
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch('runs', runId, { cancellationRequestedAt: Date.now() });
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects scrape_url jobs before calling Firecrawl', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'scrape-as-screenshot-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects web_search jobs before calling Firecrawl', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'search-as-screenshot-secret',
+			kind: 'web_search',
+			payload: { query: 'sprocket' }
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects a non-http target URL before calling Firecrawl', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'ftp-screenshot-secret',
+			payload: { url: 'ftp://example.com' }
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Only http(s) URLs can be scraped.');
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects cloud-enqueued scrape jobs before calling Firecrawl', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'cloud-scrape-as-screenshot-secret',
+			kind: 'scrape_url',
+			payload: { url: PAGE_URL }
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch('executorJobs', jobId, { cloudWorkId: 'historical-cloud-work' });
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects a screenshot job that has a cloud work id before calling Firecrawl', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'cloud-id-screenshot-secret'
+		});
+		await t.run(async (ctx) => {
+			await ctx.db.patch('executorJobs', jobId, { cloudWorkId: 'work-screenshot' });
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('rejects a settled screenshot job before calling Firecrawl', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'settled-screenshot-secret'
+		});
+		await asUser.mutation(api.executor.complete, {
+			runId,
+			claimId,
+			executionSecret,
+			jobId,
+			result: screenshotImageResult
+		});
+		const scrape = mockScrape({ screenshot: SCREENSHOT_URL });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow(RUN_NO_LONGER_ACTIVE);
+			expect(scrape).not.toHaveBeenCalled();
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it.each([undefined, '', '   '])(
+		'rejects a missing screenshot (%j) without storing bytes',
+		async (screenshot) => {
+			const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+				executionSecret: `missing-screenshot-${String(screenshot)}-secret`
+			});
+			const scrape = mockScrape(screenshot === undefined ? { markdown: '# Page' } : { screenshot });
+			try {
+				await expect(
+					asUser.action(api.webTools.screenshotForTool, {
+						runId,
+						claimId,
+						jobId,
+						executionSecret
+					})
+				).rejects.toThrow('Firecrawl screenshot is unavailable.');
+				expect(scrape).toHaveBeenCalledWith(...expectedScreenshotArgs());
+				expect(await storageBlobs(t)).toEqual([]);
+			} finally {
+				scrape.mockRestore();
+			}
+		}
+	);
+
+	it('rejects a non-http screenshot URL', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'invalid-screenshot-url-secret'
+		});
+		const scrape = mockScrape({ screenshot: 'data:image/png;base64,abc' });
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Firecrawl screenshot returned an invalid URL.');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('maps page metadata.statusCode 404 separately from Firecrawl API errors', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'screenshot-page-404-secret'
+		});
+		const scrape = mockScrape({
+			screenshot: SCREENSHOT_URL,
+			metadata: { sourceURL: PAGE_URL, statusCode: 404 }
+		});
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('This webpage returned a 404 error.');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('maps Firecrawl API 404 to a non-retryable failure', async () => {
+		const { asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'screenshot-api-404-secret'
+		});
+		const scrape = vi
+			.spyOn(FirecrawlClient.prototype, 'scrape')
+			.mockRejectedValue(firecrawlApiError(404));
+		try {
+			await expect(
+				asUser.action(api.webTools.screenshotForTool, {
+					runId,
+					claimId,
+					jobId,
+					executionSecret
+				})
+			).rejects.toThrow('Firecrawl scrape failed (404).');
+		} finally {
+			scrape.mockRestore();
+		}
+	});
+
+	it('stores screenshot image metadata with the page URL and without file bytes', async () => {
+		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
+			executionSecret: 'saved-screenshot-secret'
+		});
+		await asUser.mutation(api.executor.complete, {
+			runId,
+			claimId,
+			executionSecret,
+			jobId,
+			result: screenshotImageResult
+		});
+		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
+		expect(job?.result).toEqual(screenshotImageResult);
+		expect(job?.result).not.toHaveProperty('path');
+		expect(job?.result).not.toHaveProperty('screenshotUrl');
+		expect(await storageBlobs(t)).toEqual([]);
 	});
 });

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -729,6 +729,7 @@ describe('scrape errors', () => {
 const screenshotImageResult = {
 	outputType: 'image' as const,
 	url: PAGE_URL,
+	path: '/threads/thread/parse_file/screenshot.png',
 	mediaType: 'image/png',
 	byteSize: 80,
 	width: 1280,
@@ -1099,7 +1100,7 @@ describe('screenshotForTool', () => {
 		}
 	});
 
-	it('stores screenshot image metadata with the page URL and without file bytes', async () => {
+	it('stores a local screenshot reference with the page URL and without file bytes', async () => {
 		const { t, asUser, runId, claimId, jobId, executionSecret } = await screenshotToolArgs({
 			executionSecret: 'saved-screenshot-secret'
 		});
@@ -1112,7 +1113,6 @@ describe('screenshotForTool', () => {
 		});
 		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(job?.result).toEqual(screenshotImageResult);
-		expect(job?.result).not.toHaveProperty('path');
 		expect(job?.result).not.toHaveProperty('screenshotUrl');
 		expect(await storageBlobs(t)).toEqual([]);
 	});

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -2,12 +2,13 @@
 
 import { ConvexError, v, type Infer } from 'convex/values';
 import { z } from 'zod';
-import { FirecrawlClient } from '@firecrawl/firecrawl-convex';
+import { FirecrawlClient, type ScrapeOptions } from '@firecrawl/firecrawl-convex';
 import { ExaClient } from '@exalabs/convex-exa';
 import { action, internalAction, type ActionCtx } from '@convex/_generated/server';
 import { components, internal } from '@convex/_generated/api';
 import {
 	vScrapeUrlTransport,
+	vScreenshotUrlTransport,
 	vWebSearchResult,
 	type ExecutorJobPayload
 } from '@convex/lib/validators';
@@ -25,6 +26,7 @@ export const SCRAPE_INLINE_MAX_CHARS = 40_000;
 export const SCRAPE_STORAGE_TTL_MS = 60 * 60 * 1_000;
 export const SCRAPE_TIMEOUT_MS = 60_000;
 export const SCRAPE_FORMATS = ['markdown', 'summary', 'images', 'audio', 'video'] as const;
+export const SCREENSHOT_FORMATS = ['screenshot'] as const;
 export const DEFAULT_SCRAPE_SUMMARY = 'No summary was returned for this page.';
 const SCRAPE_JSON_BLOB_TYPE = 'application/json; charset=utf-8';
 const CONVEX_ARRAY_MAX_LENGTH = 8_192;
@@ -55,6 +57,7 @@ const firecrawlDocumentSchema = z.object({
 	images: z.array(z.string()).nullish(),
 	audio: z.string().nullish(),
 	video: z.string().nullish(),
+	screenshot: z.string().nullish(),
 	metadata: z
 		.object({
 			url: z.string().optional(),
@@ -65,6 +68,7 @@ const firecrawlDocumentSchema = z.object({
 		.passthrough()
 		.optional()
 });
+type FirecrawlDocument = z.infer<typeof firecrawlDocumentSchema>;
 
 export type ScrapedPage = {
 	url: string;
@@ -164,7 +168,7 @@ type WebSearchJobArgs = {
 	numResults?: number;
 };
 
-function scrapeUrlFromPayload(payload: ExecutorJobPayload): string {
+function urlFromPayload(payload: ExecutorJobPayload): string {
 	if (!('url' in payload)) return '';
 	return payload.url;
 }
@@ -178,19 +182,17 @@ function webSearchFromPayload(payload: ExecutorJobPayload): WebSearchJobArgs {
 	return { query, numResults: payload.numResults };
 }
 
-type PoolScrapeJob = {
-	kind: 'web_search' | 'scrape_url';
+type LocalScrapeJob = {
+	kind: 'scrape_url';
 	payload: ExecutorJobPayload;
 } | null;
 
-async function scrapeClaimedUrl(ctx: ActionCtx, job: PoolScrapeJob): Promise<ScrapedPage> {
-	if (!job || job.kind !== 'scrape_url') {
-		throw new NonRetryableError(RUN_NO_LONGER_ACTIVE);
-	}
-	return await fetchScrape(ctx, scrapeUrlFromPayload(job.payload));
-}
+type LocalScreenshotJob = {
+	kind: 'screenshot_url';
+	payload: ExecutorJobPayload;
+} | null;
 
-async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPage> {
+function requireHttpUrl(urlValue: string): URL {
 	let url: URL;
 	try {
 		url = new URL(urlValue.trim());
@@ -200,15 +202,21 @@ async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPag
 	if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 		throw new NonRetryableError('Only http(s) URLs can be scraped.');
 	}
+	return url;
+}
 
+async function requestFirecrawlScrape(
+	ctx: ActionCtx,
+	url: URL,
+	options: ScrapeOptions
+): Promise<FirecrawlDocument> {
 	let document: unknown;
 	try {
 		document = await withTimeout(
 			'Firecrawl scrape',
 			SCRAPE_TIMEOUT_MS,
 			firecrawl.scrape(ctx, url.toString(), {
-				formats: [...SCRAPE_FORMATS],
-				onlyMainContent: true,
+				...options,
 				maxAge: 0,
 				storeInCache: false,
 				timeout: SCRAPE_TIMEOUT_MS
@@ -226,26 +234,72 @@ async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPag
 		}
 		throw error;
 	}
-
 	const parsed = firecrawlDocumentSchema.safeParse(document);
 	if (!parsed.success) {
 		throw new NonRetryableError('Firecrawl scrape returned an invalid response.');
 	}
-
 	const statusCode = parsed.data.metadata?.statusCode;
 	if (statusCode !== undefined && !isCleanPageStatus(statusCode)) {
 		throwHttpFailure(`This webpage returned a ${statusCode} error.`, statusCode);
 	}
+	return parsed.data;
+}
 
+async function scrapeClaimedUrl(ctx: ActionCtx, job: LocalScrapeJob): Promise<ScrapedPage> {
+	if (!job || job.kind !== 'scrape_url') {
+		throw new NonRetryableError(RUN_NO_LONGER_ACTIVE);
+	}
+	return await fetchScrape(ctx, urlFromPayload(job.payload));
+}
+
+async function screenshotClaimedUrl(
+	ctx: ActionCtx,
+	job: LocalScreenshotJob
+): Promise<Infer<typeof vScreenshotUrlTransport>> {
+	if (!job || job.kind !== 'screenshot_url') {
+		throw new NonRetryableError(RUN_NO_LONGER_ACTIVE);
+	}
+	return await fetchScreenshot(ctx, urlFromPayload(job.payload));
+}
+
+async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPage> {
+	const url = requireHttpUrl(urlValue);
+	const document = await requestFirecrawlScrape(ctx, url, {
+		formats: [...SCRAPE_FORMATS],
+		onlyMainContent: true
+	});
 	const page: ScrapedPage = {
-		url: parsed.data.metadata?.sourceURL ?? parsed.data.metadata?.url ?? url.toString(),
-		markdown: parsed.data.markdown ?? '',
-		summary: scrapeSummary(parsed.data.summary),
-		images: parsed.data.images ?? []
+		url: document.metadata?.sourceURL ?? document.metadata?.url ?? url.toString(),
+		markdown: document.markdown ?? '',
+		summary: scrapeSummary(document.summary),
+		images: document.images ?? []
 	};
-	if (parsed.data.audio) page.audio = parsed.data.audio;
-	if (parsed.data.video) page.video = parsed.data.video;
+	if (document.audio) page.audio = document.audio;
+	if (document.video) page.video = document.video;
 	return page;
+}
+
+async function fetchScreenshot(
+	ctx: ActionCtx,
+	urlValue: string
+): Promise<Infer<typeof vScreenshotUrlTransport>> {
+	const url = requireHttpUrl(urlValue);
+	const document = await requestFirecrawlScrape(ctx, url, {
+		formats: [...SCREENSHOT_FORMATS]
+	});
+	const screenshot = document.screenshot?.trim() ?? '';
+	if (!screenshot) {
+		throw new NonRetryableError('Firecrawl screenshot is unavailable.');
+	}
+	try {
+		requireHttpUrl(screenshot);
+	} catch {
+		throw new NonRetryableError('Firecrawl screenshot returned an invalid URL.');
+	}
+	return {
+		url: url.toString(),
+		screenshotUrl: screenshot
+	};
 }
 
 async function localScrapeTransport(
@@ -386,8 +440,29 @@ export const scrapeForTool = action({
 	returns: vScrapeUrlTransport,
 	handler: async (ctx, args): Promise<Infer<typeof vScrapeUrlTransport>> => {
 		try {
-			const job: PoolScrapeJob = await ctx.runQuery(internal.webToolPool.getLocalScrapeJob, args);
+			const job: LocalScrapeJob = await ctx.runQuery(internal.webToolPool.getLocalScrapeJob, args);
 			return await localScrapeTransport(ctx, await scrapeClaimedUrl(ctx, job));
+		} catch (error) {
+			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+});
+
+export const screenshotForTool = action({
+	args: {
+		runId: v.id('runs'),
+		claimId: v.string(),
+		jobId: v.id('executorJobs'),
+		executionSecret: v.string()
+	},
+	returns: vScreenshotUrlTransport,
+	handler: async (ctx, args): Promise<Infer<typeof vScreenshotUrlTransport>> => {
+		try {
+			const job: LocalScreenshotJob = await ctx.runQuery(
+				internal.webToolPool.getLocalScreenshotJob,
+				args
+			);
+			return await screenshotClaimedUrl(ctx, job);
 		} catch (error) {
 			throw toAgentToolConvexError(error instanceof Error ? error : new Error(String(error)));
 		}

--- a/apps/web/src/lib/chat/tool-icons.ts
+++ b/apps/web/src/lib/chat/tool-icons.ts
@@ -1,5 +1,6 @@
 import {
 	BookOpen,
+	Camera,
 	CircleDollarSign,
 	CircleQuestionMark,
 	CreditCard,
@@ -54,6 +55,8 @@ export function toolKindIcon(kind: string): LucideIcon {
 			return NotebookPen;
 		case 'scrape_url':
 			return Globe;
+		case 'screenshot_url':
+			return Camera;
 		case 'edit_artifact':
 		case 'list_artifacts':
 		case 'update_artifact':

--- a/apps/web/src/lib/chat/tool-summaries.ts
+++ b/apps/web/src/lib/chat/tool-summaries.ts
@@ -54,6 +54,8 @@ export function toolGroupLabel(toolKey: string) {
 			return 'Parsed Files';
 		case 'scrape_url':
 			return 'Read URLs';
+		case 'screenshot_url':
+			return 'Captured Screenshots';
 		case 'web_search':
 			return 'Searched Web';
 		case 'write_stdin':
@@ -118,6 +120,7 @@ function summarizeTool(name: string, input: JsonValue | undefined) {
 			return name ? `$${name}` : 'Skill';
 		}
 		case 'scrape_url':
+		case 'screenshot_url':
 			return jsonString(fields?.url) ?? 'URL';
 		case 'parse_file':
 			return jsonString(fields?.path) ?? jsonString(fields?.url) ?? 'File';

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -51,20 +51,25 @@ URLs; `parse_file` rejects a `url` argument and URL-shaped paths.
 Hosted parsing still calls Firecrawl's Parse API directly because the official
 Convex component does not expose parsing.
 
-`scrape_url` fetches supported raster images in memory and returns their pixels
-to image-capable models. Images and short scrapes are not saved locally.
+`scrape_url` downloads supported raster images and returns their pixels
+to image-capable models. Short text scrapes are not saved locally.
 Page scraping uses the official `@firecrawl/firecrawl-convex` component with
 `markdown`, `summary`, `images`, `audio`, and `video` formats. The backend needs
 `FIRECRAWL_API_KEY`; `CONTEXT_DEV_API_KEY` is no longer used. Audio and video are
 returned as provider URLs, not downloaded media files.
 
 `screenshot_url` captures a public page's viewport through Firecrawl's
-`screenshot` format with `maxAge: 0` for a fresh capture and returns its pixels
-in memory. It shares `scrape_url`'s
-image size limits and never writes the screenshot to disk. The tool is not
-registered for models without image support. History stores the page URL
-and image metadata, not the signed screenshot URL or image bytes. Captures do
+`screenshot` format with `maxAge: 0` for a fresh capture. It shares `scrape_url`'s
+image size limits. The tool is not registered for models without image support.
+History stores the page URL, not the signed screenshot URL. Captures do
 not share the user's browser session; use browser tools for signed-in pages.
+
+Image results from `parse_file`, `scrape_url`, and `screenshot_url` keep their
+original bytes in the thread's local `parse_file/` directory. Convex stores only
+the local path and image metadata. Both the initial tool response and later runs
+read that saved copy and return native image content to the model. History does
+not fetch the source again. Missing or invalid local copies produce a text notice;
+models without image support receive a text notice instead of image content.
 
 Scrape outputs above 40,000 serialized characters are saved as JSON in the host's temporary
 directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
@@ -72,8 +77,7 @@ directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
 temporary-file lifetime. Convex transfer copies expire after one hour. The
 `summary` field remains inline in both short and saved results. Summaries that
 alone exceed the inline budget fail explicitly rather than being truncated.
-Rebuilt history keeps image metadata and asks the model to call
-the tool again if it needs the pixels. HTML uses the cloud scraper through an
+HTML uses the cloud scraper through an
 authenticated action. A HEAD request identifies image content types without
 consuming page bodies. Image filename extensions cover servers without useful
 HEAD responses. Downloaded image bytes are validated by signature; a mislabeled

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -58,6 +58,14 @@ Page scraping uses the official `@firecrawl/firecrawl-convex` component with
 `FIRECRAWL_API_KEY`; `CONTEXT_DEV_API_KEY` is no longer used. Audio and video are
 returned as provider URLs, not downloaded media files.
 
+`screenshot_url` captures a public page's viewport through Firecrawl's
+`screenshot` format with `maxAge: 0` for a fresh capture and returns its pixels
+in memory. It shares `scrape_url`'s
+image size limits and never writes the screenshot to disk. The tool is not
+registered for models without image support. History stores the page URL
+and image metadata, not the signed screenshot URL or image bytes. Captures do
+not share the user's browser session; use browser tools for signed-in pages.
+
 Scrape outputs above 40,000 serialized characters are saved as JSON in the host's temporary
 directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
 `The scrape was saved to <file-path>.` These files have the operating system's

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -26,6 +26,7 @@ pub(crate) const AGENT_TOOL_NAMES: &[&str] = &[
     "read_skill",
     "save_artifact",
     "scrape_url",
+    "screenshot_url",
     "web_search",
     "write_stdin",
 ];

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -194,8 +194,13 @@ where
         .tool(tools.mandate_charge)
         .tool(tools.mandate_report)
         .tool(tools.parse_file)
-        .tool(context_handoff_hook.tool())
-        .build();
+        .tool(context_handoff_hook.tool());
+    let agent = if request.supports_images {
+        agent.tool(tools.screenshot_url)
+    } else {
+        agent
+    }
+    .build();
 
     eprintln!("sprocket-agent: built agent {}", request.run_id);
     eprintln!("sprocket-agent: prompting model {}", request.run_id);

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -799,7 +799,7 @@ async fn load_prior_history(
     };
     cache_prompt_attachments(store, user_id, thread_id, &mut parts).await?;
     let mut history = agent_history_from_parts(&state, &parts, Some(run_id));
-    crate::tools::hydrate_parse_file_history(&mut history, &parts, supports_images).await;
+    crate::tools::hydrate_tool_history(&mut history, &parts, supports_images).await;
     Ok(PriorHistory {
         current_prompt: parts
             .iter()

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -28,7 +28,7 @@ use self::parse_file::ParseFileTool;
 use self::patch::ApplyPatchTool;
 use self::questions::{AskQuestionTool, AwaitQuestionTool};
 use self::skills::ReadSkillTool;
-use self::web::{ScrapeUrlTool, WebSearchTool};
+use self::web::{ScrapeUrlTool, ScreenshotUrlTool, WebSearchTool};
 use crate::convex::RuntimeClient;
 use crate::hooks::ToolCallTracker;
 
@@ -61,6 +61,7 @@ pub(crate) struct AgentToolSet {
     pub(crate) parse_file: ParseFileTool,
     pub(crate) read_skill: ReadSkillTool,
     pub(crate) scrape_url: ScrapeUrlTool,
+    pub(crate) screenshot_url: ScreenshotUrlTool,
     pub(crate) web_search: WebSearchTool,
     pub(crate) write_stdin: WriteStdinTool,
     pub(crate) add_artifact: AddArtifactTool,
@@ -77,7 +78,7 @@ pub(crate) struct AgentToolSet {
     pub(crate) mandate_report: MandateReportTool,
 }
 
-pub(crate) async fn hydrate_parse_file_history(
+pub(crate) async fn hydrate_tool_history(
     history: &mut [crate::types::AgentHistoryMessage],
     parts: &[crate::transcript::TranscriptPart],
     supports_images: bool,
@@ -85,7 +86,8 @@ pub(crate) async fn hydrate_parse_file_history(
     use crate::types::{AgentHistoryContent, AgentHistoryToolResultItem};
     let mut results = std::collections::HashMap::new();
     for tool in parts.iter().filter_map(|part| part.tool.as_ref()) {
-        if (parse_file::is_parse_file_tool(&tool.name) || tool.name == "scrape_url")
+        if (parse_file::is_parse_file_tool(&tool.name)
+            || matches!(tool.name.as_str(), "scrape_url" | "screenshot_url"))
             && tool.status != "started"
         {
             results.entry(tool.call_id.as_str()).or_insert(tool);
@@ -103,12 +105,12 @@ pub(crate) async fn hydrate_parse_file_history(
                 continue;
             }
             let Some(output) = &tool.output else { continue };
-            if tool.name == "scrape_url" {
+            if matches!(tool.name.as_str(), "scrape_url" | "screenshot_url") {
                 if output.get("outputType").and_then(serde_json::Value::as_str) == Some("image") {
                     let guidance = if supports_images {
-                        "Use scrape_url again to view it."
+                        format!("Use {} again to view it.", tool.name)
                     } else {
-                        "The selected model cannot view images."
+                        "The selected model cannot view images.".to_string()
                     };
                     *items = vec![AgentHistoryToolResultItem::Text {
                         text: format!(
@@ -190,6 +192,7 @@ pub(crate) fn agent_tools(
             skills,
         },
         scrape_url: ScrapeUrlTool(context.clone()),
+        screenshot_url: ScreenshotUrlTool(context.clone()),
         web_search: WebSearchTool(context.clone()),
         write_stdin: WriteStdinTool(context.clone()),
         add_artifact: AddArtifactTool(context.clone()),
@@ -241,7 +244,7 @@ mod tests {
                 }],
             }],
         }];
-        hydrate_parse_file_history(&mut history, &[part], false).await;
+        hydrate_tool_history(&mut history, &[part], false).await;
         let serialized = serde_json::to_string(&history).unwrap();
         assert!(serialized.contains("Image omitted"));
         assert!(!serialized.contains("not available"));
@@ -253,29 +256,38 @@ mod tests {
         use crate::types::{
             AgentHistoryContent, AgentHistoryMessage, AgentHistoryRole, AgentHistoryToolResultItem,
         };
-        let part = serde_json::from_value(serde_json::json!({
-            "number": 1, "sourceKey": "tool:1", "kind": "tool", "runId": "run",
-            "tool": {"callId": "call", "name": "scrape_url", "status": "completed", "output": {
-                "outputType": "image", "url": "http://127.0.0.1:1/image", "mediaType": "image/png",
-                "byteSize": 1, "width": 1, "height": 1
-            }}
-        }))
-        .unwrap();
-        let mut history = vec![AgentHistoryMessage {
-            role: AgentHistoryRole::User,
-            assistant_id: None,
-            contents: vec![AgentHistoryContent::ToolResult {
-                id: "call".into(),
-                call_id: Some("call".into()),
-                items: vec![AgentHistoryToolResultItem::Text {
-                    text: "old output".into(),
-                }],
-            }],
-        }];
-        hydrate_parse_file_history(&mut history, &[part], true).await;
-        let serialized = serde_json::to_string(&history).unwrap();
-        assert!(serialized.contains("not saved locally"));
-        assert!(!serialized.contains("imageJson"));
+        for name in ["scrape_url", "screenshot_url"] {
+            for supports_images in [true, false] {
+                let part = serde_json::from_value(serde_json::json!({
+                "number": 1, "sourceKey": "tool:1", "kind": "tool", "runId": "run",
+                "tool": {"callId": "call", "name": name, "status": "completed", "output": {
+                    "outputType": "image", "url": "http://127.0.0.1:1/image", "mediaType": "image/png",
+                    "byteSize": 1, "width": 1, "height": 1
+                }}
+            }))
+            .unwrap();
+                let mut history = vec![AgentHistoryMessage {
+                    role: AgentHistoryRole::User,
+                    assistant_id: None,
+                    contents: vec![AgentHistoryContent::ToolResult {
+                        id: "call".into(),
+                        call_id: Some("call".into()),
+                        items: vec![AgentHistoryToolResultItem::Text {
+                            text: "old output".into(),
+                        }],
+                    }],
+                }];
+                hydrate_tool_history(&mut history, &[part], supports_images).await;
+                let serialized = serde_json::to_string(&history).unwrap();
+                assert!(serialized.contains("not saved locally"));
+                if supports_images {
+                    assert!(serialized.contains(&format!("Use {name} again")));
+                } else {
+                    assert!(serialized.contains("cannot view images"));
+                }
+                assert!(!serialized.contains("imageJson"));
+            }
+        }
     }
 
     #[test]

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -105,50 +105,27 @@ pub(crate) async fn hydrate_tool_history(
                 continue;
             }
             let Some(output) = &tool.output else { continue };
-            if matches!(tool.name.as_str(), "scrape_url" | "screenshot_url") {
-                if output.get("outputType").and_then(serde_json::Value::as_str) == Some("image") {
-                    let guidance = if supports_images {
-                        format!("Use {} again to view it.", tool.name)
-                    } else {
-                        "The selected model cannot view images.".to_string()
-                    };
-                    *items = vec![AgentHistoryToolResultItem::Text {
-                        text: format!(
-                            "This image was viewed but not saved locally. {guidance} Original result: {output}"
-                        ),
-                    }];
-                }
+            let is_image =
+                output.get("outputType").and_then(serde_json::Value::as_str) == Some("image");
+            if !is_image && !parse_file::is_parse_file_tool(&tool.name) {
                 continue;
             }
-            if !supports_images
-                && output.get("outputType").and_then(serde_json::Value::as_str) == Some("image")
-            {
+            if !supports_images && is_image {
                 *items = vec![AgentHistoryToolResultItem::Text {
                     text: format!(
-                        "Image omitted because the selected model does not support images. Original parse_file result: {output}"
+                        "Image omitted because the selected model does not support images. Original result: {output}"
                     ),
                 }];
                 continue;
             }
-            *items = match parse_file::replay_parse_file_history_items(output).await {
+            *items = match parse_file::replay_local_tool_history_items(output).await {
                 Ok(items) => items,
                 Err(error) => vec![AgentHistoryToolResultItem::Text {
                     text: format!(
-                        "Previously parsed file is not available in the local cache: {error}. Use parse_file again if needed. Original result: {output}"
+                        "Previous tool output is not available in the local cache: {error}. Original result: {output}"
                     ),
                 }],
             };
-            if !supports_images {
-                for item in items {
-                    if matches!(item, AgentHistoryToolResultItem::Image { .. }) {
-                        *item = AgentHistoryToolResultItem::Text {
-                            text: format!(
-                                "Image omitted because the selected model does not support images. Original parse_file result: {output}"
-                            ),
-                        };
-                    }
-                }
-            }
         }
     }
 }
@@ -252,7 +229,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn web_image_history_never_fetches_or_reads_a_cache() {
+    async fn unavailable_web_images_fall_back_to_text_without_refetching() {
         use crate::types::{
             AgentHistoryContent, AgentHistoryMessage, AgentHistoryRole, AgentHistoryToolResultItem,
         };
@@ -279,12 +256,12 @@ mod tests {
                 }];
                 hydrate_tool_history(&mut history, &[part], supports_images).await;
                 let serialized = serde_json::to_string(&history).unwrap();
-                assert!(serialized.contains("not saved locally"));
                 if supports_images {
-                    assert!(serialized.contains(&format!("Use {name} again")));
+                    assert!(serialized.contains("not available in the local cache"));
                 } else {
-                    assert!(serialized.contains("cannot view images"));
+                    assert!(serialized.contains("Image omitted"));
                 }
+                assert!(!serialized.contains(&format!("Use {name} again")));
                 assert!(!serialized.contains("imageJson"));
             }
         }

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -228,45 +228,6 @@ mod tests {
         assert!(!serialized.contains("imageJson"));
     }
 
-    #[tokio::test]
-    async fn unavailable_web_images_fall_back_to_text_without_refetching() {
-        use crate::types::{
-            AgentHistoryContent, AgentHistoryMessage, AgentHistoryRole, AgentHistoryToolResultItem,
-        };
-        for name in ["scrape_url", "screenshot_url"] {
-            for supports_images in [true, false] {
-                let part = serde_json::from_value(serde_json::json!({
-                "number": 1, "sourceKey": "tool:1", "kind": "tool", "runId": "run",
-                "tool": {"callId": "call", "name": name, "status": "completed", "output": {
-                    "outputType": "image", "url": "http://127.0.0.1:1/image", "mediaType": "image/png",
-                    "byteSize": 1, "width": 1, "height": 1
-                }}
-            }))
-            .unwrap();
-                let mut history = vec![AgentHistoryMessage {
-                    role: AgentHistoryRole::User,
-                    assistant_id: None,
-                    contents: vec![AgentHistoryContent::ToolResult {
-                        id: "call".into(),
-                        call_id: Some("call".into()),
-                        items: vec![AgentHistoryToolResultItem::Text {
-                            text: "old output".into(),
-                        }],
-                    }],
-                }];
-                hydrate_tool_history(&mut history, &[part], supports_images).await;
-                let serialized = serde_json::to_string(&history).unwrap();
-                if supports_images {
-                    assert!(serialized.contains("not available in the local cache"));
-                } else {
-                    assert!(serialized.contains("Image omitted"));
-                }
-                assert!(!serialized.contains(&format!("Use {name} again")));
-                assert!(!serialized.contains("imageJson"));
-            }
-        }
-    }
-
     #[test]
     fn tool_error_includes_anyhow_context_chain() {
         let error =

--- a/crates/sprocket-agent/src/tools/parse_file.rs
+++ b/crates/sprocket-agent/src/tools/parse_file.rs
@@ -427,14 +427,14 @@ fn convert_non_image_blocking(
     persist_parsed_text(&cache_dir, &text, "text", &cancellation)
 }
 
-async fn persist_image_bytes(
+pub(super) async fn persist_image_bytes(
     cache_dir: &Path,
     bytes: &[u8],
     media_type: &ImageMediaType,
 ) -> anyhow::Result<PathBuf> {
     anyhow::ensure!(
         !cache_dir.as_os_str().is_empty(),
-        "parse_file cache directory is not configured"
+        "image cache directory is not configured"
     );
     tokio::fs::create_dir_all(cache_dir)
         .await
@@ -642,13 +642,13 @@ async fn replay_image_output(
 ) -> anyhow::Result<ToolOutput> {
     anyhow::ensure!(
         !path.is_empty(),
-        "parse_file tool output is missing a cached path"
+        "image tool output is missing a cached path"
     );
     let bytes = read_image_bytes_bounded(Path::new(path), &WorkspaceCancellation::new())
         .await
         .with_context(|| format!("failed to read cached image {path}"))?;
     let media_type = ImageMediaType::from_mime_type(media_type)
-        .ok_or_else(|| anyhow!("parse_file tool output has unsupported media type {media_type}"))?;
+        .ok_or_else(|| anyhow!("image tool output has unsupported media type {media_type}"))?;
     let (decoded_type, decoded_width, decoded_height) = decode_image_info(&bytes)?;
     anyhow::ensure!(
         decoded_type == media_type
@@ -704,10 +704,43 @@ pub(crate) async fn replay_parse_file_tool_output(
     }
 }
 
-pub(crate) async fn replay_parse_file_history_items(
+pub(super) async fn replay_image_tool_output(
+    output: &serde_json::Value,
+) -> anyhow::Result<ToolOutput> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ImageReference {
+        media_type: String,
+        path: String,
+        #[serde(deserialize_with = "sprocket_convex::deserialize_convex_u64")]
+        byte_size: u64,
+        #[serde(deserialize_with = "sprocket_convex::deserialize_convex_u32")]
+        width: u32,
+        #[serde(deserialize_with = "sprocket_convex::deserialize_convex_u32")]
+        height: u32,
+    }
+
+    let image: ImageReference = serde_json::from_value(output.clone())
+        .context("image tool output is not replay metadata")?;
+    replay_image_output(
+        &image.media_type,
+        &image.path,
+        image.byte_size,
+        image.width,
+        image.height,
+    )
+    .await
+}
+
+pub(crate) async fn replay_local_tool_history_items(
     output: &serde_json::Value,
 ) -> anyhow::Result<Vec<AgentHistoryToolResultItem>> {
-    let tool_output = replay_parse_file_tool_output(output).await?;
+    let tool_output =
+        if output.get("outputType").and_then(serde_json::Value::as_str) == Some("image") {
+            replay_image_tool_output(output).await?
+        } else {
+            replay_parse_file_tool_output(output).await?
+        };
     tool_output
         .into_content()
         .into_iter()
@@ -1071,7 +1104,7 @@ mod tests {
         let output = replay_parse_file_tool_output(&value).await.expect("replay");
         assert_png_image_output(&output, &png);
 
-        let history = replay_parse_file_history_items(&value)
+        let history = replay_local_tool_history_items(&value)
             .await
             .expect("history");
         assert_eq!(history.len(), 1);
@@ -1118,7 +1151,7 @@ mod tests {
         let output = replay_parse_file_tool_output(&value).await.expect("replay");
         assert_text_contains(&output, "Hello from RTF");
 
-        let history = replay_parse_file_history_items(&value)
+        let history = replay_local_tool_history_items(&value)
             .await
             .expect("history");
         match &history[0] {

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use super::context::{AgentToolContext, tool_error};
+use super::context::{AgentToolContext, tool_error, tool_failure};
 use super::job::{execute_cloud_tool_job, execute_tool_job_with_id, run_convex_tool_action};
 use super::parse_file::{
     MAX_PARSE_FILE_IMAGE_BYTES, decode_image_info, tool_output_from_image_bytes,
@@ -18,6 +18,9 @@ pub(super) const DEFAULT_WEB_SEARCH_RESULTS: u32 = 5;
 
 #[derive(Clone)]
 pub(crate) struct ScrapeUrlTool(pub(super) AgentToolContext);
+
+#[derive(Clone)]
+pub(crate) struct ScreenshotUrlTool(pub(super) AgentToolContext);
 
 #[derive(Clone)]
 pub(crate) struct WebSearchTool(pub(super) AgentToolContext);
@@ -54,6 +57,18 @@ pub(crate) struct WebSearchArgs {
 #[serde(deny_unknown_fields)]
 pub(crate) struct ScrapeUrlArgs {
     pub(crate) url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub(crate) struct ScreenshotUrlArgs {
+    pub(crate) url: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScreenshotTransport {
+    url: String,
+    screenshot_url: String,
 }
 
 impl rig::tool::Tool for WebSearchTool {
@@ -146,6 +161,79 @@ impl rig::tool::Tool for ScrapeUrlTool {
         }
         Ok(image_output.unwrap_or_else(|| ToolOutput::json(result)))
     }
+}
+
+impl rig::tool::Tool for ScreenshotUrlTool {
+    const NAME: &'static str = "screenshot_url";
+    type Error = ToolExecutionError;
+    type Args = ScreenshotUrlArgs;
+    type Output = ToolOutput;
+
+    fn description(&self) -> String {
+        "Use to take a viewport screenshot of ANY public HTTP(S) URL".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schemars::schema_for!(ScreenshotUrlArgs))
+    }
+
+    async fn call(
+        &self,
+        _context: &mut rig::tool::ToolContext,
+        args: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        if !self.0.supports_images {
+            return Err(tool_failure("The selected model cannot view images."));
+        }
+        validate_web_url(&args.url).map_err(tool_error)?;
+        let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
+        let mut image_output = None;
+        let image_result = &mut image_output;
+        execute_tool_job_with_id(
+            &self.0.runtime,
+            &self.0.run_id,
+            &self.0.claim_id,
+            Self::NAME,
+            &self.0.tool_call_tracker,
+            payload,
+            |cancellation, job_id| async move {
+                let action_args = BTreeMap::from([
+                    ("runId".to_string(), self.0.run_id.clone().into()),
+                    ("claimId".to_string(), self.0.claim_id.clone().into()),
+                    ("jobId".to_string(), job_id.into()),
+                ]);
+                let result = run_convex_tool_action(
+                    &self.0.runtime,
+                    cancellation.clone(),
+                    "webTools:screenshotForTool",
+                    action_args,
+                )
+                .await?;
+                let (metadata, output) = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
+                    result = fetch_screenshot(result) => result.map_err(tool_error)?,
+                };
+                *image_result = Some(output);
+                Ok(metadata)
+            },
+        )
+        .await?;
+        image_output.ok_or_else(|| tool_failure("Screenshot image is unavailable."))
+    }
+}
+
+async fn fetch_screenshot(
+    result: serde_json::Value,
+) -> anyhow::Result<(serde_json::Value, ToolOutput)> {
+    let transport: ScreenshotTransport =
+        serde_json::from_value(result).context("invalid screenshot response")?;
+    let page_url = validate_web_url(&transport.url)?;
+    let screenshot_url = validate_web_url(&transport.screenshot_url)?;
+    let (mut metadata, output) = download_image(&image_client()?, screenshot_url).await?;
+    // Signed provider URLs expire; history keeps the page URL for an explicit re-capture.
+    metadata["url"] = json!(page_url.as_str());
+    Ok((metadata, output))
 }
 
 fn validate_web_url(value: &str) -> anyhow::Result<reqwest::Url> {
@@ -280,6 +368,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn screenshot_returns_pixels_but_persists_only_page_metadata() {
+        let mut download = serve("application/octet-stream", png()).await;
+        download.set_query(Some("signature=temporary-secret"));
+        let (metadata, output) = fetch_screenshot(json!({
+            "url": "https://example.com/page", "screenshotUrl": download.as_str(),
+        }))
+        .await
+        .unwrap();
+        assert_eq!(metadata["url"], "https://example.com/page");
+        assert_eq!(metadata["mediaType"], "image/png");
+        assert_eq!(metadata["width"], 1);
+        assert!(metadata.get("path").is_none());
+        assert!(!metadata.to_string().contains("temporary-secret"));
+        assert!(matches!(
+            output.into_content().first(),
+            Some(rig::message::ToolResultContent::Image(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn screenshot_rejects_missing_fields_and_non_http_downloads() {
+        for result in [
+            json!({"url": "https://example.com"}),
+            json!({"url": "https://example.com", "screenshotUrl": "file:///tmp/image.png"}),
+            json!({"url": "file:///tmp/page.html", "screenshotUrl": "https://example.com/image.png"}),
+        ] {
+            assert!(fetch_screenshot(result).await.is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn screenshot_rejects_non_images_and_oversized_dimensions() {
+        let mut oversized = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(8193, 1)
+            .write_to(&mut oversized, image::ImageFormat::Png)
+            .unwrap();
+        for bytes in [
+            b"<html>not a screenshot</html>".to_vec(),
+            oversized.into_inner(),
+        ] {
+            let download = serve("image/png", bytes).await;
+            assert!(
+                fetch_screenshot(json!({
+                    "url": "https://example.com", "screenshotUrl": download.as_str(),
+                }))
+                .await
+                .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn image_without_extension_is_returned_in_memory_and_validated_by_signature() {
         let url = serve("image/jpeg", png()).await;
         let (metadata, output) = fetch_web_image(url, true).await.unwrap().unwrap();
@@ -347,10 +487,41 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn screenshot_download_reads_extensionless_images_without_head() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = reqwest::Url::parse(&format!("http://{}/opaque", listener.local_addr().unwrap()))
+            .unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).await.unwrap();
+            assert!(request.starts_with(b"GET "));
+            let bytes = png();
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                bytes.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(&bytes).await.unwrap();
+        });
+        let (metadata, _) = fetch_screenshot(json!({
+            "url": "https://example.com/page", "screenshotUrl": url.as_str(),
+        }))
+        .await
+        .unwrap();
+        server.await.unwrap();
+        assert_eq!(metadata["mediaType"], "image/png");
+    }
+
     #[test]
-    fn scrape_schema_only_advertises_a_required_url() {
-        let schema = json!(schemars::schema_for!(ScrapeUrlArgs));
-        assert_eq!(schema["properties"], json!({"url": {"type": "string"}}));
-        assert_eq!(schema["required"], json!(["url"]));
+    fn url_tool_schemas_only_advertise_a_required_url() {
+        for schema in [
+            json!(schemars::schema_for!(ScrapeUrlArgs)),
+            json!(schemars::schema_for!(ScreenshotUrlArgs)),
+        ] {
+            assert_eq!(schema["properties"], json!({"url": {"type": "string"}}));
+            assert_eq!(schema["required"], json!(["url"]));
+        }
     }
 }

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -11,7 +12,7 @@ use serde_json::json;
 use super::context::{AgentToolContext, tool_error, tool_failure};
 use super::job::{execute_cloud_tool_job, execute_tool_job_with_id, run_convex_tool_action};
 use super::parse_file::{
-    MAX_PARSE_FILE_IMAGE_BYTES, decode_image_info, tool_output_from_image_bytes,
+    MAX_PARSE_FILE_IMAGE_BYTES, decode_image_info, persist_image_bytes, replay_image_tool_output,
 };
 
 pub(super) const DEFAULT_WEB_SEARCH_RESULTS: u32 = 5;
@@ -125,8 +126,6 @@ impl rig::tool::Tool for ScrapeUrlTool {
     ) -> Result<Self::Output, Self::Error> {
         let url = validate_web_url(&args.url).map_err(tool_error)?;
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
-        let mut image_output = None;
-        let image_result = &mut image_output;
         let mut scrape_file = None;
         let saved_file = &mut scrape_file;
         let result = execute_tool_job_with_id(
@@ -140,10 +139,9 @@ impl rig::tool::Tool for ScrapeUrlTool {
                 let image = tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
-                    result = fetch_web_image(url, self.0.supports_images) => result.map_err(tool_error)?,
+                    result = fetch_web_image(url, self.0.supports_images, &self.0.parse_file_cache_dir) => result.map_err(tool_error)?,
                 };
-                if let Some((metadata, output)) = image {
-                    *image_result = Some(output);
+                if let Some(metadata) = image {
                     return Ok(metadata);
                 }
                 let action_args = BTreeMap::from([
@@ -159,7 +157,11 @@ impl rig::tool::Tool for ScrapeUrlTool {
         if let Some(file) = scrape_file.as_mut() {
             file.disable_cleanup(true);
         }
-        Ok(image_output.unwrap_or_else(|| ToolOutput::json(result)))
+        if result.get("outputType").and_then(serde_json::Value::as_str) == Some("image") {
+            replay_image_tool_output(&result).await.map_err(tool_error)
+        } else {
+            Ok(ToolOutput::json(result))
+        }
     }
 }
 
@@ -187,9 +189,7 @@ impl rig::tool::Tool for ScreenshotUrlTool {
         }
         validate_web_url(&args.url).map_err(tool_error)?;
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
-        let mut image_output = None;
-        let image_result = &mut image_output;
-        execute_tool_job_with_id(
+        let result = execute_tool_job_with_id(
             &self.0.runtime,
             &self.0.run_id,
             &self.0.claim_id,
@@ -209,31 +209,29 @@ impl rig::tool::Tool for ScreenshotUrlTool {
                     action_args,
                 )
                 .await?;
-                let (metadata, output) = tokio::select! {
+                tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
-                    result = fetch_screenshot(result) => result.map_err(tool_error)?,
-                };
-                *image_result = Some(output);
-                Ok(metadata)
+                    result = fetch_screenshot(result, &self.0.parse_file_cache_dir) => result.map_err(tool_error),
+                }
             },
         )
         .await?;
-        image_output.ok_or_else(|| tool_failure("Screenshot image is unavailable."))
+        replay_image_tool_output(&result).await.map_err(tool_error)
     }
 }
 
 async fn fetch_screenshot(
     result: serde_json::Value,
-) -> anyhow::Result<(serde_json::Value, ToolOutput)> {
+    cache_dir: &Path,
+) -> anyhow::Result<serde_json::Value> {
     let transport: ScreenshotTransport =
         serde_json::from_value(result).context("invalid screenshot response")?;
     let page_url = validate_web_url(&transport.url)?;
     let screenshot_url = validate_web_url(&transport.screenshot_url)?;
-    let (mut metadata, output) = download_image(&image_client()?, screenshot_url).await?;
-    // Signed provider URLs expire; history keeps the page URL for an explicit re-capture.
+    let mut metadata = download_image(&image_client()?, screenshot_url, cache_dir).await?;
     metadata["url"] = json!(page_url.as_str());
-    Ok((metadata, output))
+    Ok(metadata)
 }
 
 fn validate_web_url(value: &str) -> anyhow::Result<reqwest::Url> {
@@ -248,13 +246,16 @@ fn validate_web_url(value: &str) -> anyhow::Result<reqwest::Url> {
 async fn fetch_web_image(
     url: reqwest::Url,
     supports_images: bool,
-) -> anyhow::Result<Option<(serde_json::Value, ToolOutput)>> {
+    cache_dir: &Path,
+) -> anyhow::Result<Option<serde_json::Value>> {
     let client = image_client()?;
     let Some(image_url) = discover_image_url(&client, url).await else {
         return Ok(None);
     };
     anyhow::ensure!(supports_images, "The selected model cannot view images.");
-    download_image(&client, image_url).await.map(Some)
+    download_image(&client, image_url, cache_dir)
+        .await
+        .map(Some)
 }
 
 fn image_client() -> reqwest::Result<reqwest::Client> {
@@ -268,7 +269,8 @@ fn image_client() -> reqwest::Result<reqwest::Client> {
 async fn download_image(
     client: &reqwest::Client,
     image_url: reqwest::Url,
-) -> anyhow::Result<(serde_json::Value, ToolOutput)> {
+    cache_dir: &Path,
+) -> anyhow::Result<serde_json::Value> {
     let mut response = client.get(image_url).send().await?.error_for_status()?;
     anyhow::ensure!(
         response
@@ -285,11 +287,12 @@ async fn download_image(
         bytes.extend_from_slice(&chunk);
     }
     let (media_type, width, height) = decode_image_info(&bytes)?;
-    let metadata = json!({
+    let path = persist_image_bytes(cache_dir, &bytes, &media_type).await?;
+    Ok(json!({
         "outputType": "image", "url": response.url().as_str(),
+        "path": path,
         "mediaType": media_type.to_mime_type(), "byteSize": bytes.len(), "width": width, "height": height,
-    });
-    Ok((metadata, tool_output_from_image_bytes(&bytes, media_type)))
+    }))
 }
 
 async fn discover_image_url(client: &reqwest::Client, url: reqwest::Url) -> Option<reqwest::Url> {
@@ -368,38 +371,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn screenshot_returns_pixels_but_persists_only_page_metadata() {
+    async fn screenshot_saves_pixels_locally_for_history() {
+        let cache = tempfile::tempdir().unwrap();
         let mut download = serve("application/octet-stream", png()).await;
         download.set_query(Some("signature=temporary-secret"));
-        let (metadata, output) = fetch_screenshot(json!({
-            "url": "https://example.com/page", "screenshotUrl": download.as_str(),
-        }))
+        let metadata = fetch_screenshot(
+            json!({
+                "url": "https://example.com/page", "screenshotUrl": download.as_str(),
+            }),
+            cache.path(),
+        )
         .await
         .unwrap();
         assert_eq!(metadata["url"], "https://example.com/page");
         assert_eq!(metadata["mediaType"], "image/png");
         assert_eq!(metadata["width"], 1);
-        assert!(metadata.get("path").is_none());
         assert!(!metadata.to_string().contains("temporary-secret"));
-        assert!(matches!(
-            output.into_content().first(),
-            Some(rig::message::ToolResultContent::Image(_))
-        ));
+        assert_image_history("screenshot_url", metadata, cache.path()).await;
     }
 
     #[tokio::test]
     async fn screenshot_rejects_missing_fields_and_non_http_downloads() {
+        let cache = tempfile::tempdir().unwrap();
         for result in [
             json!({"url": "https://example.com"}),
             json!({"url": "https://example.com", "screenshotUrl": "file:///tmp/image.png"}),
             json!({"url": "file:///tmp/page.html", "screenshotUrl": "https://example.com/image.png"}),
         ] {
-            assert!(fetch_screenshot(result).await.is_err());
+            assert!(fetch_screenshot(result, cache.path()).await.is_err());
         }
     }
 
     #[tokio::test]
     async fn screenshot_rejects_non_images_and_oversized_dimensions() {
+        let cache = tempfile::tempdir().unwrap();
         let mut oversized = std::io::Cursor::new(Vec::new());
         image::DynamicImage::new_rgb8(8193, 1)
             .write_to(&mut oversized, image::ImageFormat::Png)
@@ -410,9 +415,12 @@ mod tests {
         ] {
             let download = serve("image/png", bytes).await;
             assert!(
-                fetch_screenshot(json!({
-                    "url": "https://example.com", "screenshotUrl": download.as_str(),
-                }))
+                fetch_screenshot(
+                    json!({
+                        "url": "https://example.com", "screenshotUrl": download.as_str(),
+                    }),
+                    cache.path()
+                )
                 .await
                 .is_err()
             );
@@ -420,19 +428,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn image_without_extension_is_returned_in_memory_and_validated_by_signature() {
+    async fn image_without_extension_is_saved_locally_and_validated_by_signature() {
+        let cache = tempfile::tempdir().unwrap();
         let url = serve("image/jpeg", png()).await;
-        let (metadata, output) = fetch_web_image(url, true).await.unwrap().unwrap();
+        let metadata = fetch_web_image(url, true, cache.path())
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(metadata["mediaType"], "image/png");
-        assert!(metadata.get("path").is_none());
-        assert!(matches!(
-            output.into_content().first(),
-            Some(rig::message::ToolResultContent::Image(_))
-        ));
+        assert_image_history("scrape_url", metadata, cache.path()).await;
+    }
+
+    async fn assert_image_history(name: &str, mut metadata: serde_json::Value, cache: &Path) {
+        use crate::types::{
+            AgentHistoryContent, AgentHistoryMessage, AgentHistoryRole, AgentHistoryToolResultItem,
+        };
+        use base64::Engine;
+
+        let path = Path::new(metadata["path"].as_str().unwrap());
+        assert_eq!(path.parent().unwrap(), cache.canonicalize().unwrap());
+        assert_eq!(tokio::fs::read(path).await.unwrap(), png());
+        assert!(!metadata.to_string().contains("iVBORw0KGgo"));
+        let output = replay_image_tool_output(&metadata).await.unwrap();
+        let expected = rig::message::ToolResultContent::image_base64(
+            base64::engine::general_purpose::STANDARD.encode(png()),
+            Some(rig::message::ImageMediaType::PNG),
+            None,
+        );
+        assert_eq!(
+            serde_json::to_value(output.into_content()).unwrap(),
+            json!([expected])
+        );
+
+        metadata["url"] = json!("http://127.0.0.1:1/unavailable");
+        let part = serde_json::from_value(json!({
+            "number": 1, "sourceKey": "tool:1", "kind": "tool", "runId": "run",
+            "tool": {"callId": "call", "name": name, "status": "completed", "output": metadata}
+        }))
+        .unwrap();
+        let mut history = vec![AgentHistoryMessage {
+            role: AgentHistoryRole::User,
+            assistant_id: None,
+            contents: vec![AgentHistoryContent::ToolResult {
+                id: "call".into(),
+                call_id: Some("call".into()),
+                items: vec![AgentHistoryToolResultItem::Text {
+                    text: metadata.to_string(),
+                }],
+            }],
+        }];
+        super::super::hydrate_tool_history(&mut history, std::slice::from_ref(&part), true).await;
+        let AgentHistoryContent::ToolResult { items, .. } = &history[0].contents[0] else {
+            panic!("missing result")
+        };
+        let [AgentHistoryToolResultItem::Image { image_json }] = items.as_slice() else {
+            panic!("missing image")
+        };
+        let rig::message::ToolResultContent::Image(expected) = expected else {
+            unreachable!()
+        };
+        assert_eq!(image_json, &serde_json::to_string(&expected).unwrap());
+
+        super::super::hydrate_tool_history(&mut history, std::slice::from_ref(&part), false).await;
+        let serialized = serde_json::to_string(&history).unwrap();
+        assert!(serialized.contains("Image omitted"));
+        assert!(!serialized.contains("imageJson"));
+
+        tokio::fs::remove_file(metadata["path"].as_str().unwrap())
+            .await
+            .unwrap();
+        super::super::hydrate_tool_history(&mut history, &[part], true).await;
+        let serialized = serde_json::to_string(&history).unwrap();
+        assert!(serialized.contains("not available in the local cache"));
+        assert!(!serialized.contains("imageJson"));
+    }
+
+    #[tokio::test]
+    async fn image_download_fails_when_local_persistence_fails() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let url = serve("image/png", png()).await;
+        assert!(fetch_web_image(url, true, file.path()).await.is_err());
     }
 
     #[tokio::test]
     async fn html_is_left_to_the_scraper() {
+        let cache = tempfile::tempdir().unwrap();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = reqwest::Url::parse(&format!("http://{}/page", listener.local_addr().unwrap()))
             .unwrap();
@@ -444,7 +524,12 @@ mod tests {
             stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 50\r\nConnection: close\r\n\r\n").await.unwrap();
             listener
         });
-        assert!(fetch_web_image(url, true).await.unwrap().is_none());
+        assert!(
+            fetch_web_image(url, true, cache.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
         let listener = server.await.unwrap();
         assert!(
             tokio::time::timeout(Duration::from_millis(50), listener.accept())
@@ -455,20 +540,32 @@ mod tests {
 
     #[tokio::test]
     async fn image_extension_handles_generic_content_types() {
+        let cache = tempfile::tempdir().unwrap();
         let mut url = serve("application/octet-stream", png()).await;
         url.set_path("/image.PNG");
-        assert!(fetch_web_image(url, true).await.unwrap().is_some());
+        assert!(
+            fetch_web_image(url, true, cache.path())
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
     async fn unrecognized_content_is_scraped_but_text_only_models_reject_images() {
+        let cache = tempfile::tempdir().unwrap();
         let url = serve("image/svg+xml", b"<svg></svg>".to_vec()).await;
-        assert!(fetch_web_image(url, true).await.unwrap().is_none());
+        assert!(
+            fetch_web_image(url, true, cache.path())
+                .await
+                .unwrap()
+                .is_none()
+        );
         let url = serve("image/jpeg", b"<html>mislabelled</html>".to_vec()).await;
-        assert!(fetch_web_image(url, true).await.is_err());
+        assert!(fetch_web_image(url, true, cache.path()).await.is_err());
         let url = serve("image/png", png()).await;
         assert!(
-            fetch_web_image(url, false)
+            fetch_web_image(url, false, cache.path())
                 .await
                 .unwrap_err()
                 .to_string()
@@ -489,6 +586,7 @@ mod tests {
 
     #[tokio::test]
     async fn screenshot_download_reads_extensionless_images_without_head() {
+        let cache = tempfile::tempdir().unwrap();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = reqwest::Url::parse(&format!("http://{}/opaque", listener.local_addr().unwrap()))
             .unwrap();
@@ -505,9 +603,12 @@ mod tests {
             stream.write_all(headers.as_bytes()).await.unwrap();
             stream.write_all(&bytes).await.unwrap();
         });
-        let (metadata, _) = fetch_screenshot(json!({
-            "url": "https://example.com/page", "screenshotUrl": url.as_str(),
-        }))
+        let metadata = fetch_screenshot(
+            json!({
+                "url": "https://example.com/page", "screenshotUrl": url.as_str(),
+            }),
+            cache.path(),
+        )
         .await
         .unwrap();
         server.await.unwrap();


### PR DESCRIPTION
Builds on merged #325. Step 4 of the URL-tool stack.

## Changes
- Disable Firecrawl cache reads and writes with maxAge: 0 and storeInCache: false. Temporary transfer-blob expiry is unchanged; it is not a reusable scrape cache.
- Add screenshot_url through the Firecrawl component using fresh viewport captures.
- Save original scrape_url and screenshot_url image bytes in the thread-local parse_file directory. Reuse parse_file storage and native image replay on the initial call and later runs. Convex stores only the local path, page URL, and image metadata, never image bytes or signed screenshot URLs.
- Remove the in-memory-only image handling and metadata-only history notices. Missing local files and text-only models get a text notice without re-fetching.
- Authenticate requests against the active run, claim, and local executor job. Keep screenshot and scrape dispatch separate.
- Register the tool only for image-capable models and use the requested URL-only schema and description.
- Integrate tracking, transcript history, and UI labels/icons.

## Compatibility decision
The user confirmed scrape_url and screenshot_url have never been used. No metadata-only image results exist. Local image paths are required; the optional-path shim and its compatibility entry/test are removed. No migration is needed. Missing local files still produce a text notice.

The user also explicitly requested removing both localExecution and the asImage stored-payload field. Neither field exists on main; both were introduced in this unmerged stack. Do not restore either compatibility path.

Inherits the user's current-clients-only policy from #322 and #325. Historical transcripts and stored results remain readable. No older-client scrape execution or archive negotiation remains.

## Checks
Passed 68 targeted Convex tests and all 176 sprocket-agent library tests on this PR. Full prek formatting/lint hooks passed. The #330 rebase has an identical patch according to git range-diff. Convex codegen and Svelte/TypeScript checks passed. Regressions cover exact native-image replay, missing local files, text-only models, local write failures, and reference-only Convex persistence. Provider calls are mocked.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.



















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an image-capable `screenshot_url` tool backed by fresh Firecrawl viewport captures.
- Authenticates screenshot dispatch against the active run, claim, execution secret, and local job.
- Downloads and validates screenshot bytes before saving them in thread-local `parse_file` storage.
- Replays locally stored images on initial and subsequent runs without persisting image bytes or signed provider URLs in Convex.
- Extends validators, transcript handling, tests, documentation, and UI labels for the new tool.
- Disables reusable Firecrawl cache reads and writes for scrape and screenshot requests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

Current producers persist validated image bytes and a required local path before completing web-image jobs, authenticated dispatch remains restricted to the matching active local job, and the explicit unused-tool compatibility decision supports removing the optional-path shim.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/tools/web.rs | Implements screenshot execution, validates downloaded images, persists them locally, and replays native image content. |
| apps/web/src/convex/webTools.ts | Adds fresh Firecrawl screenshot requests and authenticated screenshot transport without exposing provider URLs in persisted results. |
| apps/web/src/convex/webToolPool.ts | Separates authenticated local screenshot and scrape job dispatch. |
| crates/sprocket-agent/src/tools/mod.rs | Generalizes transcript hydration to replay locally stored parse, scrape, and screenshot images. |
| apps/web/src/convex/lib/validators.ts | Registers screenshot payloads, transport, job kinds, and required local paths for web-image results. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as Image-capable model
    participant A as Sprocket agent
    participant C as Convex
    participant F as Firecrawl
    participant L as Thread-local storage

    M->>A: screenshot_url(page URL)
    A->>C: Begin claimed local tool job
    A->>C: screenshotForTool(run, claim, job)
    C->>C: Validate active run, claim, secret, and job kind
    C->>F: Fresh viewport screenshot
    F-->>C: Signed screenshot URL
    C-->>A: Page URL and temporary screenshot URL
    A->>A: Download and validate image
    A->>L: Persist original bytes
    A->>C: Complete job with path and metadata
    A->>L: Replay native image
    A-->>M: Image content
```
</details>

<sub>Reviews (15): Last reviewed commit: ["fix(agent-tools): Require local paths fo..."](https://github.com/spikonado/sprocket/commit/8e82b6dfd0f4633405d0133f2f0e34cba397fd89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61439811)</sub>

<!-- /greptile_comment -->