### PR TITLE
fix(machines): Retry registration after a crashed process lease expires

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -292,6 +292,19 @@ Use `--prod` for the production deployment.
 
 ## Client APIs
 
+### Machine registration retries
+
+New local servers call `machines:tryRegister`, which returns a typed busy result
+and a retry delay while another process's heartbeat lease is valid. They retry
+within a bounded wait instead of leaving startup stuck after a crash. Deploy the
+Convex endpoint before releasing the updated local server.
+
+`machines:register` retains its original arguments, success result, and conflict
+error for released clients. Both endpoints use the same registration transaction
+and existing machine rows. No stored-data migration or table deletion is needed.
+Remove the legacy endpoint only after all supported local servers use
+`machines:tryRegister`.
+
 ### Local sessions created before account binding
 
 Persisted local sessions created before native WorkOS account binding have no

--- a/apps/web/src/convex/machines.test.ts
+++ b/apps/web/src/convex/machines.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api } from '@convex/_generated/api';
 import { executionSecretHash } from '@convex/lib/auth';
+import { MACHINE_ONLINE_THRESHOLD_MS } from '@convex/lib/machineRuns';
 import { initConvexTest, insertQueuedRun, seedOwnedThread } from './test.setup';
 
 const machine = {
@@ -14,6 +15,109 @@ const machine = {
 afterEach(() => vi.useRealTimers());
 
 describe('machines', () => {
+	it('returns a retry delay without changing the live process or its runs', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		await asUser.mutation(api.machines.register, {
+			...machine,
+			credentialHash: await executionSecretHash('credential-a')
+		});
+		const run = await insertQueuedRun(t, asUser, {
+			threadId,
+			submissionId: 'busy-run',
+			executionSecret: 'run-secret',
+			prompt: 'Run locally',
+			machineId: machine.machineId
+		});
+		const original = await t.run((ctx) => ctx.db.query('machines').unique());
+		const args = { ...machine, credentialHash: await executionSecretHash('credential-b') };
+
+		vi.advanceTimersByTime(30_000);
+		expect(await asUser.mutation(api.machines.tryRegister, args)).toEqual({
+			status: 'busy',
+			retryAfterMs: MACHINE_ONLINE_THRESHOLD_MS - 30_000 + 1
+		});
+		expect(await t.run((ctx) => ctx.db.query('machines').unique())).toEqual(original);
+		expect(await t.run((ctx) => ctx.db.get('runs', run.runId))).toMatchObject({ status: 'queued' });
+
+		await t.mutation(api.machines.heartbeat, {
+			userId: 'user_alice',
+			machineId: machine.machineId,
+			credential: 'credential-a'
+		});
+		vi.advanceTimersByTime(MACHINE_ONLINE_THRESHOLD_MS);
+		expect(await asUser.mutation(api.machines.tryRegister, args)).toEqual({
+			status: 'busy',
+			retryAfterMs: 1
+		});
+		vi.advanceTimersByTime(1);
+		expect(await asUser.mutation(api.machines.tryRegister, args)).toEqual({
+			status: 'registered',
+			machineId: machine.machineId,
+			userId: 'user_alice'
+		});
+		expect(await t.run((ctx) => ctx.db.get('runs', run.runId))).toMatchObject({ status: 'failed' });
+		expect(await t.run((ctx) => ctx.db.query('machines').unique())).toMatchObject({
+			_id: original?._id,
+			credentialHash: args.credentialHash,
+			runIds: []
+		});
+
+		for (const mutation of [api.machines.heartbeat, api.machines.end]) {
+			await expect(
+				t.mutation(mutation, {
+					userId: 'user_alice',
+					machineId: machine.machineId,
+					credential: 'credential-a'
+				})
+			).rejects.toThrow('Machine is not active.');
+		}
+		await expect(
+			t.mutation(api.machines.heartbeat, {
+				userId: 'user_alice',
+				machineId: machine.machineId,
+				credential: 'credential-b'
+			})
+		).resolves.toBeNull();
+	});
+
+	it('keeps registration retries from the same process idempotent', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const args = { ...machine, credentialHash: await executionSecretHash('credential-a') };
+		const registered = await asUser.mutation(api.machines.tryRegister, args);
+		const run = await insertQueuedRun(t, asUser, {
+			threadId,
+			submissionId: 'retry-run',
+			executionSecret: 'run-secret',
+			prompt: 'Run locally',
+			machineId: machine.machineId
+		});
+
+		expect(await asUser.mutation(api.machines.tryRegister, args)).toEqual(registered);
+		expect(await t.run((ctx) => ctx.db.get('runs', run.runId))).toMatchObject({ status: 'queued' });
+		expect(await t.run((ctx) => ctx.db.query('machines').unique())).toMatchObject({
+			runIds: [run.runId]
+		});
+	});
+
+	it('requires authentication before reporting a registration conflict', async () => {
+		const t = initConvexTest();
+		const { asUser } = await seedOwnedThread(t);
+		await asUser.mutation(api.machines.tryRegister, {
+			...machine,
+			credentialHash: await executionSecretHash('credential-a')
+		});
+		await expect(
+			t.mutation(api.machines.tryRegister, {
+				...machine,
+				credentialHash: await executionSecretHash('credential-b')
+			})
+		).rejects.toThrow('Authentication required.');
+	});
+
 	it('rejects a second process while the machine is still online', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);

--- a/apps/web/src/convex/machines.ts
+++ b/apps/web/src/convex/machines.ts
@@ -1,8 +1,13 @@
 import { mutation, query, type MutationCtx } from '@convex/_generated/server';
 import type { Doc } from '@convex/_generated/dataModel';
-import { v } from 'convex/values';
+import { v, type Infer } from 'convex/values';
 import { constantTimeEqual, executionSecretHash, getUserId } from '@convex/lib/auth';
-import { getOwnedMachine, isMachineActive, MAX_ACTIVE_MACHINE_RUNS } from '@convex/lib/machineRuns';
+import {
+	getOwnedMachine,
+	isMachineActive,
+	MACHINE_ONLINE_THRESHOLD_MS,
+	MAX_ACTIVE_MACHINE_RUNS
+} from '@convex/lib/machineRuns';
 import { finalizeRunRecord } from '@convex/lib/runFinalize';
 
 const MACHINE_ENDED = 'The machine stopped before this run finished.';
@@ -78,64 +83,91 @@ async function requireMachine(
 	return machine;
 }
 
+const vRegistration = v.object({
+	machineId: v.string(),
+	credentialHash: v.string(),
+	friendlyName: v.string(),
+	platform: v.string(),
+	platformVersion: v.optional(v.string()),
+	architecture: v.string(),
+	hostname: v.optional(v.string()),
+	appVersion: v.string()
+});
+
+const vRegistrationResult = v.union(
+	v.object({ status: v.literal('registered'), machineId: v.string(), userId: v.string() }),
+	v.object({ status: v.literal('busy'), retryAfterMs: v.number() })
+);
+
+async function registerMachine(
+	ctx: MutationCtx,
+	args: Infer<typeof vRegistration>
+): Promise<Infer<typeof vRegistrationResult>> {
+	const userId = await getUserId(ctx);
+	const now = Date.now();
+	for (const value of [
+		args.machineId,
+		args.friendlyName,
+		args.platform,
+		args.architecture,
+		args.appVersion
+	]) {
+		if (!value.trim()) throw new Error('Machine registration fields cannot be empty.');
+	}
+	if (!/^[0-9a-f]{64}$/.test(args.credentialHash)) {
+		throw new Error('Machine credential digest is invalid.');
+	}
+	const existing = await getOwnedMachine(ctx, userId, args.machineId);
+	const metadata = {
+		friendlyName: args.friendlyName,
+		platform: args.platform,
+		platformVersion: args.platformVersion,
+		architecture: args.architecture,
+		hostname: args.hostname,
+		appVersion: args.appVersion,
+		credentialHash: args.credentialHash,
+		lastSeenAt: now,
+		updatedAt: now
+	};
+	if (existing) {
+		const sameProcess = constantTimeEqual(existing.credentialHash, args.credentialHash);
+		if (!sameProcess && existing.lastSeenAt !== undefined && isMachineActive(existing, now)) {
+			return {
+				status: 'busy',
+				retryAfterMs: existing.lastSeenAt + MACHINE_ONLINE_THRESHOLD_MS + 1 - now
+			};
+		}
+		if (!sameProcess) {
+			await failMachineRuns(ctx, existing);
+		}
+		await ctx.db.patch('machines', existing._id, metadata);
+	} else {
+		await ctx.db.insert('machines', {
+			userId,
+			machineId: args.machineId,
+			runIds: [],
+			createdAt: now,
+			...metadata
+		});
+	}
+	return { status: 'registered', machineId: args.machineId, userId };
+}
+
+export const tryRegister = mutation({
+	args: vRegistration.fields,
+	returns: vRegistrationResult,
+	handler: registerMachine
+});
+
 export const register = mutation({
-	args: {
-		machineId: v.string(),
-		credentialHash: v.string(),
-		friendlyName: v.string(),
-		platform: v.string(),
-		platformVersion: v.optional(v.string()),
-		architecture: v.string(),
-		hostname: v.optional(v.string()),
-		appVersion: v.string()
-	},
+	args: vRegistration.fields,
 	returns: v.object({ machineId: v.string(), userId: v.string() }),
 	handler: async (ctx, args) => {
-		const userId = await getUserId(ctx);
-		const now = Date.now();
-		for (const value of [
-			args.machineId,
-			args.friendlyName,
-			args.platform,
-			args.architecture,
-			args.appVersion
-		]) {
-			if (!value.trim()) throw new Error('Machine registration fields cannot be empty.');
+		const result = await registerMachine(ctx, args);
+		if (result.status === 'busy') {
+			throw new Error('Machine is already active on another process.');
 		}
-		if (!/^[0-9a-f]{64}$/.test(args.credentialHash)) {
-			throw new Error('Machine credential digest is invalid.');
-		}
-		const existing = await getOwnedMachine(ctx, userId, args.machineId);
-		const metadata = {
-			friendlyName: args.friendlyName,
-			platform: args.platform,
-			platformVersion: args.platformVersion,
-			architecture: args.architecture,
-			hostname: args.hostname,
-			appVersion: args.appVersion,
-			credentialHash: args.credentialHash,
-			lastSeenAt: now,
-			updatedAt: now
-		};
-		if (existing) {
-			const sameProcess = constantTimeEqual(existing.credentialHash, args.credentialHash);
-			if (!sameProcess && isMachineActive(existing, now)) {
-				throw new Error('Machine is already active on another process.');
-			}
-			if (!sameProcess) {
-				await failMachineRuns(ctx, existing);
-			}
-			await ctx.db.patch('machines', existing._id, metadata);
-		} else {
-			await ctx.db.insert('machines', {
-				userId,
-				machineId: args.machineId,
-				runIds: [],
-				createdAt: now,
-				...metadata
-			});
-		}
-		return { machineId: args.machineId, userId };
+		return { machineId: result.machineId, userId: result.userId };
 	}
 });
 

--- a/crates/sprocket-server/Cargo.toml
+++ b/crates/sprocket-server/Cargo.toml
@@ -42,4 +42,5 @@ workos = "3.4.0"
 dotenvy = "0.15.7"
 
 [dev-dependencies]
+tokio = { version = "1.52.1", features = ["test-util"] }
 gix = { version = "0.87", default-features = false, features = ["sha1", "max-performance-safe"] }

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -232,12 +232,16 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         }
     });
     let router = build_router(state, static_dir);
+    let shutdown_machines = Arc::clone(&machines);
 
     let result = axum::serve(
         listener,
         router.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .with_graceful_shutdown(shutdown_signal())
+    .with_graceful_shutdown(async move {
+        shutdown_signal().await;
+        shutdown_machines.stop_registration();
+    })
     .await;
     cleanup.abort();
     let _ = cleanup.await;

--- a/crates/sprocket-server/src/machines.rs
+++ b/crates/sprocket-server/src/machines.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,6 +7,7 @@ use convex::Value;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
+use tokio_util::sync::CancellationToken;
 
 use crate::machine_identity::MachineIdentity;
 use crate::native_auth::NativeAuthManager;
@@ -13,12 +15,54 @@ use crate::transcript_client::UserConvexClient;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+// Covers a 90-second lease plus two RPCs.
+const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RegisteredMachine {
     machine_id: String,
     user_id: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+enum RegistrationResult {
+    Registered(RegisteredMachine),
+    Busy {
+        #[serde(
+            rename = "retryAfterMs",
+            deserialize_with = "sprocket_convex::deserialize_convex_u64"
+        )]
+        retry_after_ms: u64,
+    },
+}
+
+async fn register_when_available<F, Fut>(
+    shutdown: &CancellationToken,
+    mut attempt: F,
+) -> anyhow::Result<RegisteredMachine>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<RegistrationResult>>,
+{
+    let registration = timeout(REGISTRATION_TIMEOUT, async {
+        loop {
+            match attempt().await? {
+                RegistrationResult::Registered(machine) => return Ok(machine),
+                RegistrationResult::Busy { retry_after_ms } => {
+                    sleep(Duration::from_millis(retry_after_ms.max(1))).await;
+                }
+            }
+        }
+    });
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => anyhow::bail!("machine manager is shutting down"),
+        result = registration => result.map_err(|_| anyhow::anyhow!(
+            "Machine is still active in another Sprocket process. Close that process and try again."
+        ))?,
+    }
 }
 
 struct AccountPresence {
@@ -31,13 +75,8 @@ pub struct MachineManager {
     identity: Arc<MachineIdentity>,
     accounts: Mutex<HashMap<String, AccountPresence>>,
     registration: Mutex<()>,
-    lifecycle: Mutex<LifecycleState>,
-}
-
-#[derive(Default)]
-struct LifecycleState {
-    shutting_down: bool,
-    locks: HashMap<String, Arc<Mutex<()>>>,
+    account_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    shutdown: CancellationToken,
 }
 
 impl MachineManager {
@@ -52,13 +91,16 @@ impl MachineManager {
             identity,
             accounts: Mutex::new(HashMap::new()),
             registration: Mutex::new(()),
-            lifecycle: Mutex::new(LifecycleState::default()),
+            account_locks: Mutex::new(HashMap::new()),
+            shutdown: CancellationToken::new(),
         })
     }
 
     pub async fn register(self: &Arc<Self>, expected_user_id: &str) -> anyhow::Result<()> {
         let _registration = self.registration.lock().await;
-        self.ensure_running().await?;
+        let account = self.account_lock(expected_user_id, false).await?;
+        let _account = account.lock().await;
+        self.ensure_running()?;
         let registered = self.register_remote(expected_user_id).await?;
         if registered.machine_id != self.identity.installation_id {
             anyhow::bail!("machine registration returned a different installation");
@@ -102,20 +144,22 @@ impl MachineManager {
         self.end_remote(user_id).await
     }
 
+    pub(crate) fn stop_registration(&self) {
+        self.shutdown.cancel();
+    }
+
     pub async fn shutdown(&self) {
-        let locks = {
-            let mut lifecycle = self.lifecycle.lock().await;
-            lifecycle.shutting_down = true;
-            lifecycle.locks.values().cloned().collect::<Vec<_>>()
-        };
-        for lock in locks {
-            let _lock = lock.lock().await;
-            let accounts = self.accounts.lock().await.drain().collect::<Vec<_>>();
-            for (user_id, presence) in accounts {
-                presence.heartbeat.abort();
-                if let Err(error) = self.end_remote(&user_id).await {
-                    tracing::warn!("failed to end machine presence during shutdown: {error:#}");
-                }
+        self.stop_registration();
+        let users = self
+            .account_locks
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for user_id in users {
+            if let Err(error) = self.end(&user_id).await {
+                tracing::warn!("failed to end machine presence during shutdown: {error:#}");
             }
         }
     }
@@ -125,19 +169,18 @@ impl MachineManager {
         user_id: &str,
         allow_shutdown: bool,
     ) -> anyhow::Result<Arc<Mutex<()>>> {
-        let mut lifecycle = self.lifecycle.lock().await;
-        if lifecycle.shutting_down && !allow_shutdown {
-            anyhow::bail!("machine manager is shutting down");
+        let mut locks = self.account_locks.lock().await;
+        if !allow_shutdown {
+            self.ensure_running()?;
         }
-        Ok(lifecycle
-            .locks
+        Ok(locks
             .entry(user_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone())
     }
 
-    async fn ensure_running(&self) -> anyhow::Result<()> {
-        if self.lifecycle.lock().await.shutting_down {
+    fn ensure_running(&self) -> anyhow::Result<()> {
+        if self.shutdown.is_cancelled() {
             anyhow::bail!("machine manager is shutting down");
         }
         Ok(())
@@ -173,19 +216,23 @@ impl MachineManager {
     }
 
     async fn register_remote(&self, expected_user_id: &str) -> anyhow::Result<RegisteredMachine> {
-        timeout(RPC_TIMEOUT, async {
-            let client = UserConvexClient::connect_with_fetcher(
-                &self.deployment_url,
-                self.native_auth
-                    .auth_token_fetcher_for_user(expected_user_id.to_string()),
-            )
-            .await?;
-            client
-                .mutate("machines:register", self.registration_args())
-                .await
+        register_when_available(&self.shutdown, || async {
+            self.ensure_running()?;
+            timeout(RPC_TIMEOUT, async {
+                let client = UserConvexClient::connect_with_fetcher(
+                    &self.deployment_url,
+                    self.native_auth
+                        .auth_token_fetcher_for_user(expected_user_id.to_string()),
+                )
+                .await?;
+                client
+                    .mutate("machines:tryRegister", self.registration_args())
+                    .await
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("machine registration timed out"))?
         })
         .await
-        .map_err(|_| anyhow::anyhow!("machine registration timed out"))?
     }
 
     async fn end_remote(&self, user_id: &str) -> anyhow::Result<()> {
@@ -247,6 +294,99 @@ impl MachineManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn registration_recovers_after_a_crashed_process_lease_expires() {
+        let started = tokio::time::Instant::now();
+        let mut attempts = 0;
+        let registered = register_when_available(&CancellationToken::new(), || {
+            attempts += 1;
+            let result = if attempts == 1 {
+                serde_json::from_value::<RegistrationResult>(serde_json::json!({
+                    "status": "busy",
+                    "retryAfterMs": 90001.0,
+                }))
+                .unwrap()
+            } else {
+                serde_json::from_value(serde_json::json!({
+                    "status": "registered",
+                    "machineId": "machine-a",
+                    "userId": "user-a",
+                }))
+                .unwrap()
+            };
+            std::future::ready(Ok(result))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(attempts, 2);
+        assert_eq!(started.elapsed(), Duration::from_millis(90_001));
+        assert_eq!(registered.machine_id, "machine-a");
+        assert_eq!(registered.user_id, "user-a");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registration_does_not_wait_forever_for_a_live_process() {
+        let started = tokio::time::Instant::now();
+        let mut attempts = 0;
+        let result = register_when_available(&CancellationToken::new(), || {
+            attempts += 1;
+            std::future::ready(Ok(RegistrationResult::Busy {
+                retry_after_ms: 90_001,
+            }))
+        })
+        .await;
+
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("Close that process")
+        );
+        assert_eq!(attempts, 2);
+        assert_eq!(started.elapsed(), REGISTRATION_TIMEOUT);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registration_does_not_retry_other_errors() {
+        let started = tokio::time::Instant::now();
+        let mut attempts = 0;
+        let result = register_when_available(&CancellationToken::new(), || {
+            attempts += 1;
+            std::future::ready(Err(anyhow::anyhow!("authentication failed")))
+        })
+        .await;
+
+        assert_eq!(result.err().unwrap().to_string(), "authentication failed");
+        assert_eq!(attempts, 1);
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_interrupts_registration_waiting_for_a_stale_lease() {
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let started = tokio::time::Instant::now();
+        let (attempted, attempt_received) = tokio::sync::oneshot::channel();
+        let registration = tokio::spawn(async move {
+            let mut attempted = Some(attempted);
+            register_when_available(&task_shutdown, || {
+                attempted.take().unwrap().send(()).unwrap();
+                std::future::ready(Ok(RegistrationResult::Busy {
+                    retry_after_ms: 90_001,
+                }))
+            })
+            .await
+        });
+
+        attempt_received.await.unwrap();
+        shutdown.cancel();
+        let error = registration.await.unwrap().err().unwrap();
+        assert!(error.to_string().contains("shutting down"));
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
 
     fn manager_for_test() -> (std::path::PathBuf, Arc<MachineManager>) {
         let dir = std::env::temp_dir().join(format!("sprocket-machine-{}", uuid::Uuid::new_v4()));

--- a/crates/sprocket-server/src/machines.rs
+++ b/crates/sprocket-server/src/machines.rs
@@ -74,7 +74,6 @@ pub struct MachineManager {
     native_auth: Arc<NativeAuthManager>,
     identity: Arc<MachineIdentity>,
     accounts: Mutex<HashMap<String, AccountPresence>>,
-    registration: Mutex<()>,
     account_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     shutdown: CancellationToken,
 }
@@ -90,14 +89,12 @@ impl MachineManager {
             native_auth,
             identity,
             accounts: Mutex::new(HashMap::new()),
-            registration: Mutex::new(()),
             account_locks: Mutex::new(HashMap::new()),
             shutdown: CancellationToken::new(),
         })
     }
 
     pub async fn register(self: &Arc<Self>, expected_user_id: &str) -> anyhow::Result<()> {
-        let _registration = self.registration.lock().await;
         let account = self.account_lock(expected_user_id, false).await?;
         let _account = account.lock().await;
         self.ensure_running()?;
@@ -414,6 +411,24 @@ mod tests {
             .expect_err("registration after shutdown must fail");
         assert!(error.to_string().contains("shutting down"));
 
+        let _ = tokio::fs::remove_dir_all(dir).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registration_for_one_account_does_not_block_other_accounts() {
+        let (dir, manager) = manager_for_test();
+        let account = manager.account_lock("user-a", false).await.unwrap();
+        let guard = account.lock().await;
+        let mut waiting = Box::pin(manager.register("user-a"));
+        assert!(futures::poll!(&mut waiting).is_pending());
+
+        let result = timeout(Duration::from_secs(1), manager.register("user-b"))
+            .await
+            .expect("another account must not wait for user-a's registration");
+        assert!(result.is_err(), "invalid deployment must fail registration");
+
+        drop(waiting);
+        drop(guard);
         let _ = tokio::fs::remove_dir_all(dir).await;
     }
 


### PR DESCRIPTION
## Problem

A crash leaves the old process heartbeat valid for up to 90 seconds. Reopening Sprocket generates a new process credential, which registration rejects during that window. Startup falls back to the thread cache without retrying, leaving the machine disconnected after the lease expires.

## Changes

- Add `machines:tryRegister` with a typed busy result and a server-calculated retry delay. Busy attempts leave the existing machine and its runs untouched.
- Retry registration automatically after the old lease expires, with a two-minute overall limit. Keep rejecting takeover while another process is still heartbeating.
- Serialize registration with account shutdown and cancel pending registration waits before HTTP graceful shutdown drains requests.
- Keep the released `machines:register` contract and document the removal gate. Existing rows need no migration or deletion. Deploy the Convex endpoint before releasing the updated local server.

Recovery can wait for the remainder of the 90-second lease. It does not force another live process off the machine.

## Validation

- Passed the targeted Convex and Rust machine regression tests.
- Passed the full web test suite with one worker and a 30-second test timeout, plus npm wrapper tests. The initial parallel suite hit resource-related timeouts on this machine.
- Ran Convex codegen and typechecking successfully.
- Passed all 92 Rust server tests, including the cross-account regression, and the final `prek run -a`.
- Grok cleanup/review subagents were attempted but blocked by the account usage limit.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds lease-aware machine registration so a restarted local server waits for a crashed process’s heartbeat lease to expire and then reconnects automatically.
- Introduces the authenticated `machines:tryRegister` endpoint with typed registered/busy results while preserving the legacy endpoint.
- Retries registration for up to two minutes and allows cancellation during graceful shutdown.
- Serializes registration and shutdown per account without blocking unrelated accounts.
- Adds Convex and Rust regression coverage and documents deployment compatibility.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the previous cross-account blocking problem resolved and no new actionable failures identified.

The manager-wide registration lock was removed, so one account’s lease wait no longer stalls another account; immutable registration data, user-bound authentication, per-user presence state, and returned-identity checks preserve account isolation. The previous thread was manually resolved after Amronos reported the fix, and the current code and regression test support that resolution.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/machines.ts | Adds an authenticated, transactional registration result that preserves live leases and safely replaces stale process credentials. |
| apps/web/src/convex/machines.test.ts | Covers busy retry timing, unchanged live-process state, stale takeover, credential fencing, idempotency, and authentication. |
| crates/sprocket-server/src/machines.rs | Implements bounded cancellable retries and per-account lifecycle serialization, including cross-account concurrency coverage. |
| crates/sprocket-server/src/lib.rs | Cancels pending registration waits before graceful HTTP shutdown begins draining requests. |
| BACKWARDS_COMPATIBILITY.md | Documents endpoint deployment order, legacy contract retention, and the absence of a data migration. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Local as Local server
    participant Convex
    participant Old as Previous process lease
    Local->>Convex: machines:tryRegister(new credential)
    Convex->>Convex: Authenticate user and inspect machine lease
    alt Previous lease remains active
        Convex-->>Local: busy(retryAfterMs)
        Local->>Local: Wait, bounded by timeout and shutdown cancellation
        Old-->>Convex: Lease expires
        Local->>Convex: machines:tryRegister(new credential)
        Convex->>Convex: Fail runs owned by stale process and replace credential
        Convex-->>Local: registered(machineId, userId)
    else Same process or no active lease
        Convex-->>Local: registered(machineId, userId)
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(machines): Scope registration waits ..."](https://github.com/spikonado/sprocket/commit/283d4931682bb204e5cd7c478d249ac3e44775cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61447752)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Machine session coordination](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/machine-session-coordination.md)
- Knowledge Base — [Local server API](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/server-api.md)
- Knowledge Base — [Convex application data model](https://app.greptile.com/spikonado/-/custom-context/knowledge-base/spikonado/sprocket/-/docs/web-convex-data-model.md)
</details>


<!-- /greptile_comment -->