### PR TITLE
perf(agent-tools): Try markdown endpoints for scrape_url before Firecrawl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7755,6 +7755,7 @@ dependencies = [
  "convex",
  "futures",
  "image",
+ "percent-encoding",
  "reqwest 0.13.4",
  "rig",
  "schemars 1.2.2",

--- a/crates/sprocket-agent/Cargo.toml
+++ b/crates/sprocket-agent/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.22.1"
 convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-native-roots"] }
 futures = "0.3.32"
 image = { version = "0.25.8", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
+percent-encoding = "2.3.2"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 rig = { version = "0.42.0", default-features = false, features = ["agent", "reqwest", "rustls"] }
 schemars = "1"

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -53,7 +53,22 @@ Convex component does not expose parsing.
 
 `scrape_url` downloads supported raster images and returns their pixels
 to image-capable models. Short text scrapes are not saved locally.
-Page scraping uses the official `@firecrawl/firecrawl-convex` component with
+For extensionless paths, the agent first requests the URL path with `.md`
+appended, preserving query parameters and dropping the fragment. It removes
+trailing slashes before checking the last path segment. Paths with any file
+extension, including `.html`, skip the probe. Existing `.md` URLs are read
+directly without appending again. Extension detection decodes percent escapes;
+dots in parent directories, query parameters, and fragments do not count.
+A successful UTF-8 markdown or plain-text response bypasses Firecrawl. Failed
+requests, non-200 responses, HTML, binary content, and empty responses fall back
+to Firecrawl using the original URL supplied by the model. The probe has a
+10-second timeout, five-redirect limit, and 64 MiB download limit. Image requests
+retain their existing handling before this probe.
+Direct markdown returns an explicit "summary not generated" value and an empty
+image list; it does not extract media. Long direct results use the same JSON
+temporary-file behavior as Firecrawl results, without a Convex transfer blob.
+
+Fallback page scraping uses the official `@firecrawl/firecrawl-convex` component with
 `markdown`, `summary`, `images`, `audio`, and `video` formats. The backend needs
 `FIRECRAWL_API_KEY`; `CONTEXT_DEV_API_KEY` is no longer used. Audio and video are
 returned as provider URLs, not downloaded media files.
@@ -84,7 +99,7 @@ HEAD responses. Downloaded image bytes are validated by signature; a mislabeled
 image fails rather than issuing another GET through the scraper.
 Image URLs that cannot be identified from HEAD or their filename follow the
 normal scraping path. There is no explicit image mode.
-Like shell commands and the former `parse_file` URL handling, the image probe
+Like shell commands and the former `parse_file` URL handling, the image and markdown probes
 can reach local devices and private networks. It is not a network isolation
 boundary. It does not attach browser cookies or provider credentials.
 

--- a/crates/sprocket-agent/src/tools/markdown_url.rs
+++ b/crates/sprocket-agent/src/tools/markdown_url.rs
@@ -1,0 +1,366 @@
+use std::time::Duration;
+
+use reqwest::Url;
+use serde_json::{Value, json};
+use sprocket_workspace::{WorkspaceCancellation, WorkspaceOperationCancelled};
+
+use super::scrape_files::MAX_SCRAPE_BYTES;
+
+const MARKDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(super) async fn try_markdown_url(
+    url: Url,
+    cancellation: &WorkspaceCancellation,
+) -> anyhow::Result<Option<Value>> {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(WorkspaceOperationCancelled.into()),
+        result = async {
+            match markdown_url(url) {
+                Some(url) => fetch_markdown(url, MAX_SCRAPE_BYTES).await.ok(),
+                None => None,
+            }
+        } => Ok(result),
+    }
+}
+
+fn markdown_url(mut url: Url) -> Option<Url> {
+    let path = url.path().trim_end_matches('/');
+    let filename = percent_encoding::percent_decode_str(path.rsplit('/').next().unwrap_or(""))
+        .decode_utf8_lossy();
+    let extension = filename
+        .rsplit_once('.')
+        .filter(|(stem, extension)| !stem.is_empty() && !extension.is_empty())
+        .map(|(_, extension)| extension);
+    match extension {
+        Some(extension) if extension.eq_ignore_ascii_case("md") => {}
+        Some(_) => return None,
+        None if filename.eq_ignore_ascii_case(".md") => {}
+        None => url.set_path(&format!("{path}.md")),
+    }
+    url.set_fragment(None);
+    Some(url)
+}
+
+async fn fetch_markdown(url: Url, max_bytes: u64) -> anyhow::Result<Value> {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(MARKDOWN_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()?;
+    let mut response = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "text/markdown, text/plain;q=0.9")
+        .send()
+        .await?;
+    anyhow::ensure!(
+        response.status() == reqwest::StatusCode::OK,
+        "no markdown endpoint"
+    );
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    anyhow::ensure!(
+        matches!(
+            content_type.as_str(),
+            "text/markdown" | "text/x-markdown" | "text/plain"
+        ),
+        "not a markdown response"
+    );
+    anyhow::ensure!(
+        response
+            .content_length()
+            .is_none_or(|size| size <= max_bytes),
+        "markdown exceeds the download limit"
+    );
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        anyhow::ensure!(
+            bytes.len().saturating_add(chunk.len()) as u64 <= max_bytes,
+            "markdown exceeds the download limit"
+        );
+        bytes.extend_from_slice(&chunk);
+    }
+    let markdown = String::from_utf8(bytes)?;
+    let start = markdown.trim_start_matches('\u{feff}').trim_start();
+    anyhow::ensure!(
+        !start.is_empty() && !markdown.contains('\0'),
+        "empty or binary markdown response"
+    );
+    anyhow::ensure!(!looks_like_html(start), "HTML fallback instead of markdown");
+    Ok(json!({
+        "url": response.url().as_str(),
+        "markdown": markdown,
+        "summary": "Summary not generated; markdown was read directly from the site.",
+        "images": [],
+    }))
+}
+
+fn looks_like_html(mut text: &str) -> bool {
+    while let Some(comment) = text.strip_prefix("<!--") {
+        let Some((_, rest)) = comment.split_once("-->") else {
+            break;
+        };
+        text = rest.trim_start();
+    }
+    let Some(tag) = text.strip_prefix('<') else {
+        return false;
+    };
+    if tag.starts_with(['!', '?']) {
+        return true;
+    }
+    let tag = tag.strip_prefix('/').unwrap_or(tag);
+    if !tag.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        return false;
+    }
+    let after_name = tag.trim_start_matches(|c: char| c.is_ascii_alphanumeric() || c == '-');
+    after_name.starts_with(|c: char| c.is_ascii_whitespace() || c == '>' || c == '/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    async fn serve(responses: Vec<Vec<u8>>) -> (Url, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!(
+            "http://{}/docs/start?lang=en#intro",
+            listener.local_addr().unwrap()
+        ))
+        .unwrap();
+        let task = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut bytes = [0; 4096];
+                let count = stream.read(&mut bytes).await.unwrap();
+                requests.push(String::from_utf8_lossy(&bytes[..count]).into_owned());
+                let _ = stream.write_all(&response).await;
+            }
+            requests
+        });
+        (url, task)
+    }
+
+    fn response(status: u16, mime: &str, body: &[u8]) -> Vec<u8> {
+        let mut bytes = format!("HTTP/1.1 {status} Test\r\nContent-Type: {mime}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", body.len()).into_bytes();
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    #[test]
+    fn html_detection_preserves_markdown_containing_code_examples() {
+        assert!(!looks_like_html("<https://example.com>"));
+        assert!(!looks_like_html("<user@example.com>"));
+        assert!(!looks_like_html(
+            "# HTML example\n```html\n<html><body>Hello</body></html>\n```"
+        ));
+        assert!(!looks_like_html(
+            "<!-- docs -->\n# Title\nAn example of <html>."
+        ));
+        assert!(looks_like_html(
+            "<!-- fallback -->\n<!DOCTYPE HTML><html>Not found</html>"
+        ));
+    }
+
+    #[test]
+    fn candidate_changes_only_the_path_and_fragment() {
+        for (source, expected) in [
+            (
+                "https://eve.dev/docs/getting-started",
+                "https://eve.dev/docs/getting-started.md",
+            ),
+            (
+                "https://example.com/docs/?q=a%26b#heading",
+                "https://example.com/docs.md?q=a%26b",
+            ),
+            (
+                "https://example.com/a%2Fb%20c",
+                "https://example.com/a%2Fb%20c.md",
+            ),
+            (
+                "https://example.com/README.MD?raw=true",
+                "https://example.com/README.MD?raw=true",
+            ),
+            (
+                "https://example.com/docs.v2/start?file=guide.pdf#intro",
+                "https://example.com/docs.v2/start.md?file=guide.pdf",
+            ),
+            (
+                "https://example.com/guide%2Emd",
+                "https://example.com/guide%2Emd",
+            ),
+            ("https://example.com/.md", "https://example.com/.md"),
+            (
+                "https://example.com/.well-known/guide",
+                "https://example.com/.well-known/guide.md",
+            ),
+            ("https://example.com/", "https://example.com/.md"),
+        ] {
+            assert_eq!(
+                markdown_url(Url::parse(source).unwrap()).unwrap().as_str(),
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn file_extensions_skip_the_probe_without_a_request() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        for path in [
+            "/guide.html",
+            "/guide.PDF?download=1#page=2",
+            "/archive.tar.gz",
+            "/photo.png",
+            "/download.custom",
+            "/guide%2Ehtml",
+            "/guide.html/",
+            "/.config.json",
+        ] {
+            let url =
+                Url::parse(&format!("http://{}{path}", listener.local_addr().unwrap())).unwrap();
+            assert!(markdown_url(url.clone()).is_none(), "{path}");
+            assert!(
+                try_markdown_url(url, &WorkspaceCancellation::new())
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "{path}"
+            );
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_markdown_url_is_read_without_appending() {
+        let (mut url, server) = serve(vec![response(200, "text/markdown", b"# Direct")]).await;
+        url.set_path("/guide.md");
+        let result = try_markdown_url(url, &WorkspaceCancellation::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result["markdown"], "# Direct");
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("GET /guide.md?lang=en HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn direct_markdown_is_read_with_a_single_get() {
+        for mime in [
+            "text/markdown; charset=utf-8",
+            "text/plain",
+            "text/x-markdown",
+        ] {
+            let (url, server) = serve(vec![response(200, mime, "# Héllo\n".as_bytes())]).await;
+            let result = try_markdown_url(url, &WorkspaceCancellation::new())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(result["markdown"], "# Héllo\n");
+            assert!(
+                result["url"]
+                    .as_str()
+                    .unwrap()
+                    .ends_with("/docs/start.md?lang=en")
+            );
+            assert_eq!(result["images"], json!([]));
+            assert!(
+                result["summary"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not generated")
+            );
+            let requests = server.await.unwrap();
+            assert_eq!(requests.len(), 1);
+            assert!(requests[0].starts_with("GET /docs/start.md?lang=en HTTP/1.1"));
+            assert!(!requests[0].to_lowercase().contains("authorization:"));
+            assert!(!requests[0].to_lowercase().contains("cookie:"));
+        }
+    }
+
+    #[tokio::test]
+    async fn unusable_responses_allow_firecrawl_fallback() {
+        for bytes in [
+            response(404, "text/plain", b"Not found"),
+            response(403, "text/plain", b"Forbidden"),
+            response(500, "text/plain", b"Unavailable"),
+            response(206, "text/markdown", b"# Partial"),
+            response(200, "text/html", b"<p>Login</p>"),
+            response(200, "text/plain", b"<title>Not found</title>"),
+            response(200, "text/plain", b"<meta charset=utf-8>"),
+            response(200, "text/markdown", b"<script>location.href='/login'</script>"),
+            response(200, "text/markdown", b"<div class=error>Not found</div>"),
+            response(200, "text/markdown", b"<p>Not found</p>"),
+            response(200, "text/plain", b" \n<!-- fallback -->\n<!DOCTYPE HTML><html>Not found</html>"),
+            response(200, "application/json", b"{}"),
+            response(200, "text/markdown", &[0xff, 0xfe]),
+            response(200, "text/markdown", b"# Title\0binary"),
+            response(200, "text/markdown", b" \n"),
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/markdown\r\nContent-Length: 100\r\nConnection: close\r\n\r\npartial".to_vec(),
+        ] {
+            let (url, server) = serve(vec![bytes]).await;
+            assert!(try_markdown_url(url, &WorkspaceCancellation::new()).await.unwrap().is_none());
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn redirects_are_followed_without_appending_again() {
+        let (url, server) = serve(vec![
+            b"HTTP/1.1 302 Found\r\nLocation: /canonical.md\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec(),
+            response(200, "text/markdown", b"# Canonical"),
+        ]).await;
+        let result = try_markdown_url(url, &WorkspaceCancellation::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result["url"].as_str().unwrap().ends_with("/canonical.md"));
+        let requests = server.await.unwrap();
+        assert!(requests[1].starts_with("GET /canonical.md HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn byte_limit_applies_with_or_without_content_length() {
+        for bytes in [
+            response(200, "text/markdown", b"123456789"),
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/markdown\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n9\r\n123456789\r\n0\r\n\r\n".to_vec(),
+        ] {
+            let (url, server) = serve(vec![bytes]).await;
+            let error = fetch_markdown(url, 8).await.unwrap_err();
+            assert!(error.to_string().contains("download limit"));
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_does_not_trigger_fallback() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!("http://{}/slow", listener.local_addr().unwrap())).unwrap();
+        let cancellation = WorkspaceCancellation::new();
+        let cancel = cancellation.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).await.unwrap();
+            cancel.cancel();
+            let mut eof = [0];
+            assert_eq!(stream.read(&mut eof).await.unwrap(), 0);
+        });
+        let error = try_markdown_url(url, &cancellation).await.unwrap_err();
+        assert!(error.is::<WorkspaceOperationCancelled>());
+        server.await.unwrap();
+    }
+}

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -5,6 +5,7 @@ mod context;
 mod hosted_parse;
 mod job;
 mod mandates;
+mod markdown_url;
 mod parse_file;
 mod patch;
 mod questions;

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -5,7 +5,8 @@ use serde_json::Value;
 use sprocket_workspace::{WorkspaceCancellation, WorkspaceOperationCancelled};
 use tokio::io::AsyncWriteExt;
 
-const MAX_SCRAPE_BYTES: u64 = 64 * 1024 * 1024;
+pub(super) const MAX_SCRAPE_BYTES: u64 = 64 * 1024 * 1024;
+const SCRAPE_INLINE_MAX_CHARS: usize = 40_000;
 
 pub(super) async fn localize_scrape(
     mut result: Value,
@@ -24,22 +25,48 @@ pub(super) async fn localize_scrape(
             .suffix(".json")
             .tempfile()?;
         let temp = download_scrape(url, temp, cancellation).await?;
-        fields.insert(
-            "markdown".into(),
-            Value::String(format!(
-                "The scrape was saved to {}.",
-                temp.path().display()
-            )),
-        );
-        *saved_file = Some(temp);
+        record_saved_scrape(fields, temp, saved_file);
     } else {
         anyhow::ensure!(
             fields.get("markdown").is_some_and(Value::is_string),
             "scrape response is missing markdown"
         );
+        let archive = serde_json::to_string(fields)?;
+        // Match JSON.stringify(...).length in the backend, including surrogate pairs.
+        if archive.encode_utf16().count() > SCRAPE_INLINE_MAX_CHARS {
+            let temp = tempfile::Builder::new()
+                .prefix("sprocket-scrape-")
+                .suffix(".json")
+                .tempfile()?;
+            let mut file = tokio::fs::File::from_std(temp.reopen()?);
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => return Err(WorkspaceOperationCancelled.into()),
+                result = async {
+                    file.write_all(archive.as_bytes()).await?;
+                    file.flush().await
+                } => result?,
+            }
+            record_saved_scrape(fields, temp, saved_file);
+        }
     }
     fields.remove("truncated");
     Ok(result)
+}
+
+fn record_saved_scrape(
+    fields: &mut serde_json::Map<String, Value>,
+    temp: tempfile::NamedTempFile,
+    saved_file: &mut Option<tempfile::NamedTempFile>,
+) {
+    fields.insert(
+        "markdown".into(),
+        Value::String(format!(
+            "The scrape was saved to {}.",
+            temp.path().display()
+        )),
+    );
+    *saved_file = Some(temp);
 }
 
 async fn download_scrape(
@@ -116,6 +143,57 @@ mod tests {
             result,
             json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3"})
         );
+    }
+
+    #[tokio::test]
+    async fn direct_scrapes_use_utf16_budget_and_keep_full_json_until_completion() {
+        let short = json!({"url": "https://example.com/page.md", "markdown": "# Short", "summary": "Not generated", "images": []});
+        let mut saved = None;
+        assert_eq!(
+            localize_scrape(short.clone(), &WorkspaceCancellation::new(), &mut saved)
+                .await
+                .unwrap(),
+            short
+        );
+        assert!(saved.is_none());
+
+        let mut full = short;
+        full["markdown"] = json!("😀".repeat(20_000));
+        assert!(full.to_string().chars().count() < SCRAPE_INLINE_MAX_CHARS);
+        let result = localize_scrape(full.clone(), &WorkspaceCancellation::new(), &mut saved)
+            .await
+            .unwrap();
+        let file = saved.unwrap();
+        let path = file.path().to_owned();
+        assert_eq!(path.extension().unwrap(), "json");
+        assert_eq!(
+            serde_json::from_str::<Value>(&tokio::fs::read_to_string(&path).await.unwrap())
+                .unwrap(),
+            full
+        );
+        assert_eq!(result["summary"], full["summary"]);
+        assert_eq!(
+            result["markdown"],
+            format!("The scrape was saved to {}.", path.display())
+        );
+        drop(file);
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn cancelled_direct_saves_do_not_return_a_file() {
+        let cancellation = WorkspaceCancellation::new();
+        cancellation.cancel();
+        let mut saved = None;
+        let error = localize_scrape(
+            json!({"markdown": "x".repeat(40_001)}),
+            &cancellation,
+            &mut saved,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.is::<WorkspaceOperationCancelled>());
+        assert!(saved.is_none());
     }
 
     #[tokio::test]

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -139,10 +139,13 @@ impl rig::tool::Tool for ScrapeUrlTool {
                 let image = tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
-                    result = fetch_web_image(url, self.0.supports_images, &self.0.parse_file_cache_dir) => result.map_err(tool_error)?,
+                    result = fetch_web_image(url.clone(), self.0.supports_images, &self.0.parse_file_cache_dir) => result.map_err(tool_error)?,
                 };
                 if let Some(metadata) = image {
                     return Ok(metadata);
+                }
+                if let Some(result) = super::markdown_url::try_markdown_url(url, &cancellation).await.map_err(tool_error)? {
+                    return super::scrape_files::localize_scrape(result, &cancellation, saved_file).await.map_err(tool_error);
                 }
                 let action_args = BTreeMap::from([
                     ("runId".to_string(), self.0.run_id.clone().into()),


### PR DESCRIPTION
Depends on #326. Fifth PR in the URL-tool stack.

## Changes
- Disable Firecrawl cache reads and writes with maxAge: 0 and storeInCache: false. Temporary transfer-blob expiry is unchanged; it is not a reusable scrape cache.
- Probe extensionless paths with .md appended before invoking Firecrawl. Read existing .md URLs directly, preserve query parameters, and remove fragments.
- Accept bounded UTF-8 markdown/plain-text responses. Fall back to Firecrawl on failed, invalid, HTML, or oversized responses; cancellation stops the tool.
- Keep the user-requested direct-markdown behavior: no generated summary or extracted media.
- Save oversized direct results as complete local JSON files with completion-gated cleanup.

This PR contains only markdown probing and direct-result handling. File/scrape API changes belong to #322, temporary-file handling to #324, Firecrawl and JSON-only archives to #325, and screenshot registration to #326.

## Compatibility decision
The user confirmed scrape_url and screenshot_url have never been used. No metadata-only image results exist. Local image paths are required; the optional-path shim and its compatibility entry/test are removed. No migration is needed. Missing local files still produce a text notice.

The user also explicitly requested removing both localExecution and the asImage stored-payload field. Neither field exists on main; both were introduced in this unmerged stack. Do not restore either compatibility path.

The stack now intentionally supports current clients only, as requested. Historical transcripts, executor results, and local-path caches remain readable. No old-client cloud scrape fallback or raw-markdown archive negotiation remains.

## Checks
- The previous stack passed 188 Rust library tests. This update removes one obsolete compatibility test; all 176 tests on #326 passed, and the #330 rebase has an identical patch according to git range-diff.
- 68 targeted Convex tests passed.
- Convex codegen, Svelte/TypeScript checks, and full prek formatting/lint hooks passed.
- No paid Firecrawl calls were made.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.























<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds direct markdown endpoint probing before Firecrawl and localizes oversized direct results as temporary JSON files.
- Appends `.md` to extensionless URL paths while preserving queries and removing fragments.
- Accepts bounded UTF-8 markdown/plain-text responses and falls back to Firecrawl for unusable responses.
- Preserves cancellation behavior and existing image handling.
- Disables reusable Firecrawl caching.
- No code changed since the previous review.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding findings or newly introduced issues since the previous review.

The earlier HTML-detection concern was fixed and its thread resolved; the explicit image-mode concern was withdrawn after the intended API decision was clarified. The head contains no changes since the previous review, and no repository-rule violations remain.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/sprocket-agent/src/tools/markdown_url.rs | Implements bounded direct-markdown URL construction, fetching, validation, cancellation, and fallback behavior. |
| crates/sprocket-agent/src/tools/scrape_files.rs | Saves oversized inline scrape results as completion-gated temporary JSON files. |
| crates/sprocket-agent/src/tools/web.rs | Integrates markdown probing between existing image detection and Firecrawl fallback. |
| crates/sprocket-agent/README.md | Documents markdown probing, direct-result semantics, limits, and network behavior. |
| crates/sprocket-agent/Cargo.toml | Adds percent-encoding support used to classify decoded URL path extensions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scrape_url request] --> B{Image detected?}
    B -->|Yes| C[Return validated local image]
    B -->|No| D{Markdown candidate?}
    D -->|No| H[Invoke Firecrawl]
    D -->|Yes| E[Fetch bounded markdown response]
    E --> F{Valid UTF-8 markdown or plain text?}
    F -->|No| H
    F -->|Yes| G{Inline result within limit?}
    G -->|Yes| I[Return direct markdown]
    G -->|No| J[Save complete temporary JSON]
    J --> K[Return temporary file notice]
```
</details>

<sub>Reviews (18): Last reviewed commit: ["feat(agent-tools): Prefer markdown endpo..."](https://github.com/spikonado/sprocket/commit/2deb5358bab9f5c070a5176952206c659f472cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61462479)</sub>

<!-- /greptile_comment -->