### PR TITLE
fix(agent-tools): Remove audio and video formats from scrape_url

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -342,12 +342,10 @@ including for historical results.
 
 Firecrawl adds `summary` and `images` fields to new scrape results. Their stored
 validators remain optional so pre-Firecrawl transcript and executor rows still
-load. Stored results also accept the `audio` and `video` fields produced by
-earlier Firecrawl-backed agents, although new scrapes no longer request or
-return those formats. Remove the optional content fields only after those rows
-and local JSONL replicas have aged out or been rewritten. Current agents archive
-large scrapes as JSON and always keep the summary inline. Raw-markdown archive
-negotiation is not supported; deploy the updated client and backend together.
+load. Remove that optionality only after those rows and local JSONL replicas
+have aged out or been rewritten. Current agents archive large scrapes as
+JSON and always keep the summary inline. Raw-markdown archive negotiation
+is not supported; deploy the updated client and backend together.
 
 Web image results store URL and image metadata, not bytes or local paths.
 History displays a notice rather than fetching the URL again. Local-path

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -340,12 +340,14 @@ jobs and transcripts; remove it only after stored results and JSONL replicas
 have aged out or been migrated. The UI no longer displays a truncation badge,
 including for historical results.
 
-Firecrawl adds `summary` and media fields to new scrape results. Their stored
+Firecrawl adds `summary` and `images` fields to new scrape results. Their stored
 validators remain optional so pre-Firecrawl transcript and executor rows still
-load. Remove that optionality only after those rows and local JSONL replicas
-have aged out or been rewritten. Current agents archive large scrapes as
-JSON and always keep the summary inline. Raw-markdown archive negotiation
-is not supported; deploy the updated client and backend together.
+load. Stored results also accept the `audio` and `video` fields produced by
+earlier Firecrawl-backed agents, although new scrapes no longer request or
+return those formats. Remove the optional content fields only after those rows
+and local JSONL replicas have aged out or been rewritten. Current agents archive
+large scrapes as JSON and always keep the summary inline. Raw-markdown archive
+negotiation is not supported; deploy the updated client and backend together.
 
 Web image results store URL and image metadata, not bytes or local paths.
 History displays a notice rather than fetching the URL again. Local-path

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -240,19 +240,13 @@ export const vCommandExecResult = v.object({
 	error: v.optional(v.string())
 });
 
-const vLegacyScrapeMediaFields = {
-	audio: v.optional(v.string()),
-	video: v.optional(v.string())
-};
-
-/** Stored scrape_url job result. Historical rows may include `truncated`, audio, or video. */
+/** Stored scrape_url job result. Historical rows may include `truncated`. */
 export const vScrapeUrlResult = v.object({
 	url: v.string(),
 	markdown: v.string(),
 	truncated: v.optional(v.boolean()),
 	summary: v.optional(v.string()),
 	images: v.optional(v.array(v.string())),
-	...vLegacyScrapeMediaFields
 });
 
 /** Local scrapeForTool transport. Oversized pages return a temporary JSON download URL. */

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -246,7 +246,7 @@ export const vScrapeUrlResult = v.object({
 	markdown: v.string(),
 	truncated: v.optional(v.boolean()),
 	summary: v.optional(v.string()),
-	images: v.optional(v.array(v.string())),
+	images: v.optional(v.array(v.string()))
 });
 
 /** Local scrapeForTool transport. Oversized pages return a temporary JSON download URL. */

--- a/apps/web/src/convex/lib/validators.ts
+++ b/apps/web/src/convex/lib/validators.ts
@@ -240,19 +240,19 @@ export const vCommandExecResult = v.object({
 	error: v.optional(v.string())
 });
 
-const vScrapeMediaFields = {
-	summary: v.optional(v.string()),
-	images: v.optional(v.array(v.string())),
+const vLegacyScrapeMediaFields = {
 	audio: v.optional(v.string()),
 	video: v.optional(v.string())
 };
 
-/** Stored scrape_url job result. Historical rows omit summary/media; cloud rows may include `truncated`. */
+/** Stored scrape_url job result. Historical rows may include `truncated`, audio, or video. */
 export const vScrapeUrlResult = v.object({
 	url: v.string(),
 	markdown: v.string(),
 	truncated: v.optional(v.boolean()),
-	...vScrapeMediaFields
+	summary: v.optional(v.string()),
+	images: v.optional(v.array(v.string())),
+	...vLegacyScrapeMediaFields
 });
 
 /** Local scrapeForTool transport. Oversized pages return a temporary JSON download URL. */
@@ -261,9 +261,7 @@ export const vScrapeUrlTransport = v.union(
 		url: v.string(),
 		markdown: v.string(),
 		summary: v.string(),
-		images: v.array(v.string()),
-		audio: v.optional(v.string()),
-		video: v.optional(v.string())
+		images: v.array(v.string())
 	}),
 	v.object({
 		url: v.string(),

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -18,8 +18,6 @@ import {
 import { initConvexTest, seedStartedWebJob, type ConvexTestInstance } from './test.setup';
 
 const PAGE_URL = 'https://example.com/page';
-const AUDIO_URL = 'https://storage.googleapis.com/scrape/audio.mp3?X-Goog-Signature=sig';
-const VIDEO_URL = 'https://storage.googleapis.com/scrape/video.mp4?X-Goog-Signature=sig';
 const SCREENSHOT_URL = 'https://storage.googleapis.com/firecrawl/shot.png?X-Goog-Signature=sig';
 
 function firecrawlApiError(status: number) {
@@ -349,32 +347,6 @@ describe('stored scrape_url results', () => {
 			markdown: 'partial',
 			truncated: true
 		});
-	});
-
-	it('accepts stored scrape results with additive summary and media', async () => {
-		const t = initConvexTest();
-		const { asUser, runId, claimId, jobId, executionSecret } = await seedStartedWebJob(t, {
-			executionSecret: 'saved-media-secret',
-			kind: 'scrape_url',
-			payload: { url: PAGE_URL }
-		});
-		const result = {
-			url: PAGE_URL,
-			markdown: '# Page',
-			summary: 'A page.',
-			images: ['https://example.com/a.png'],
-			audio: AUDIO_URL,
-			video: VIDEO_URL
-		};
-		await asUser.mutation(api.executor.complete, {
-			runId,
-			claimId,
-			executionSecret,
-			jobId,
-			result
-		});
-		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
-		expect(job?.result).toEqual(result);
 	});
 });
 

--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -36,8 +36,6 @@ function mockScrape(
 		markdown?: string;
 		summary?: string;
 		images?: string[];
-		audio?: string;
-		video?: string;
 		screenshot?: string;
 		metadata?: { sourceURL?: string; url?: string; statusCode?: number };
 	},
@@ -47,8 +45,6 @@ function mockScrape(
 		markdown: document.markdown,
 		summary: document.summary,
 		images: document.images,
-		audio: document.audio,
-		video: document.video,
 		screenshot: document.screenshot,
 		metadata: document.metadata ?? { sourceURL: url, statusCode: 200 }
 	});
@@ -59,7 +55,7 @@ function expectedScrapeArgs(url = PAGE_URL) {
 		expect.anything(),
 		url,
 		{
-			formats: ['markdown', 'summary', 'images', 'audio', 'video'],
+			formats: ['markdown', 'summary', 'images'],
 			onlyMainContent: true,
 			maxAge: 0,
 			storeInCache: false,
@@ -387,8 +383,6 @@ async function scrapeLocalPage(
 		markdown?: string;
 		summary?: string;
 		images?: string[];
-		audio?: string;
-		video?: string;
 	},
 	url = PAGE_URL
 ) {
@@ -413,15 +407,13 @@ async function scrapeLocalPage(
 }
 
 describe('scrape size budget', () => {
-	it('keeps short markdown plus media inline', () => {
+	it('keeps short markdown plus images inline', () => {
 		expect(
 			localInlineFits({
 				url: PAGE_URL,
 				markdown: 'x'.repeat(SCRAPE_INLINE_MAX_CHARS - 1_000),
 				summary: 'Short page.',
-				images: ['https://example.com/a.png'],
-				audio: AUDIO_URL,
-				video: VIDEO_URL
+				images: ['https://example.com/a.png']
 			})
 		).toBe(true);
 	});
@@ -508,22 +500,18 @@ describe('scrapeForTool markdown transport', () => {
 		expect(blobs[0]?.size).toBe(64 * 1024 * 1024);
 	});
 
-	it('returns short markdown, summary, and media inline without truncated or storage', async () => {
+	it('returns short markdown, summary, and images inline without truncated or storage', async () => {
 		const markdown = 'x'.repeat(SCRAPE_INLINE_MAX_CHARS - 1_000);
 		const { t, result, scrapeCalls } = await scrapeLocalPage({
 			markdown,
 			summary: 'A long but inline page.',
-			images: ['https://example.com/a.png'],
-			audio: AUDIO_URL,
-			video: VIDEO_URL
+			images: ['https://example.com/a.png']
 		});
 		expect(result).toEqual({
 			url: PAGE_URL,
 			markdown,
 			summary: 'A long but inline page.',
-			images: ['https://example.com/a.png'],
-			audio: AUDIO_URL,
-			video: VIDEO_URL
+			images: ['https://example.com/a.png']
 		});
 		expect(result).not.toHaveProperty('truncated');
 		expect(result).not.toHaveProperty('scrapeUrl');
@@ -541,24 +529,20 @@ describe('scrapeForTool markdown transport', () => {
 		});
 	});
 
-	it('stores the full scrape JSON including all media and returns scrapeUrl', async () => {
+	it('stores the full scrape JSON including images and returns scrapeUrl', async () => {
 		const markdown = `${'x'.repeat(SCRAPE_INLINE_MAX_CHARS)}é`;
 		const images = ['https://example.com/a.png', 'https://example.com/b.png'];
 		const archive = {
 			url: PAGE_URL,
 			markdown,
 			summary: 'Huge page.',
-			images,
-			audio: AUDIO_URL,
-			video: VIDEO_URL
+			images
 		};
 		const expectedBytes = new TextEncoder().encode(JSON.stringify(archive));
 		const { t, result, scrapeCalls } = await scrapeLocalPage({
 			markdown,
 			summary: 'Huge page.',
-			images,
-			audio: AUDIO_URL,
-			video: VIDEO_URL
+			images
 		});
 		expect(result).toEqual({
 			url: PAGE_URL,

--- a/apps/web/src/convex/webTools.ts
+++ b/apps/web/src/convex/webTools.ts
@@ -25,7 +25,7 @@ const SCRAPE_MAX_BYTES = 64 * 1024 * 1024;
 export const SCRAPE_INLINE_MAX_CHARS = 40_000;
 export const SCRAPE_STORAGE_TTL_MS = 60 * 60 * 1_000;
 export const SCRAPE_TIMEOUT_MS = 60_000;
-export const SCRAPE_FORMATS = ['markdown', 'summary', 'images', 'audio', 'video'] as const;
+export const SCRAPE_FORMATS = ['markdown', 'summary', 'images'] as const;
 export const SCREENSHOT_FORMATS = ['screenshot'] as const;
 export const DEFAULT_SCRAPE_SUMMARY = 'No summary was returned for this page.';
 const SCRAPE_JSON_BLOB_TYPE = 'application/json; charset=utf-8';
@@ -55,8 +55,6 @@ const firecrawlDocumentSchema = z.object({
 	markdown: z.string().nullish(),
 	summary: z.string().nullish(),
 	images: z.array(z.string()).nullish(),
-	audio: z.string().nullish(),
-	video: z.string().nullish(),
 	screenshot: z.string().nullish(),
 	metadata: z
 		.object({
@@ -75,8 +73,6 @@ export type ScrapedPage = {
 	markdown: string;
 	summary: string;
 	images: string[];
-	audio?: string;
-	video?: string;
 };
 
 function convexErrorData(error: Error): ProviderError | undefined {
@@ -274,8 +270,6 @@ async function fetchScrape(ctx: ActionCtx, urlValue: string): Promise<ScrapedPag
 		summary: scrapeSummary(document.summary),
 		images: document.images ?? []
 	};
-	if (document.audio) page.audio = document.audio;
-	if (document.video) page.video = document.video;
 	return page;
 }
 

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -131,9 +131,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn short_scrapes_preserve_summary_and_media_without_a_truncation_flag() {
+    async fn short_scrapes_preserve_summary_and_images_without_a_truncation_flag() {
         let result = localize_scrape(
-            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3", "truncated": false}),
+            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "truncated": false}),
             &WorkspaceCancellation::new(),
             &mut None,
         )
@@ -141,7 +141,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             result,
-            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3"})
+            json!({"url": "https://example.com", "markdown": "# Hello", "summary": "A greeting", "images": ["https://example.com/image.png"]})
         );
     }
 
@@ -198,7 +198,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_scrape_is_saved_while_summary_stays_in_the_output() {
-        let scrape = json!({"markdown": "é\n".repeat(40_001), "summary": "Full summary", "images": ["https://example.com/image.png"], "audio": "https://example.com/audio.mp3", "video": "https://example.com/video.mp4"});
+        let scrape = json!({"markdown": "é\n".repeat(40_001), "summary": "Full summary", "images": ["https://example.com/image.png"]});
         let text = scrape.to_string();
         let url = serve(&text, text.len()).await;
         let mut saved_file = None;


### PR DESCRIPTION
## Summary
- stop requesting Firecrawl audio and video formats for `scrape_url`
- remove audio and video from active and stored scrape result contracts
- update scrape tests and compatibility documentation

## Validation
- `bun convex codegen`
- `bun run build`
- `bun run test`
- `cargo test`
- `prek run -a`
- `bunx vitest --run src/convex/webTools.test.ts`

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stops requesting and transporting Firecrawl-generated audio and video while retaining markdown, summaries, and images.
- Narrows `SCRAPE_FORMATS` and the corresponding Firecrawl response schema.
- Aligns Convex validators and web-tool tests with the reduced result shape.
- Updates Rust localization tests and compatibility documentation.
- The previous legacy-result concern is no longer outstanding because the thread was resolved after Amronos confirmed that affected historical data had been cleared.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding correctness or repository-rule violations identified.

The audio/video removal is applied consistently across request formats, parsed responses, validators, transport types, documentation, and tests. The prior compatibility finding was manually resolved after Amronos confirmed that affected historical rows had been cleared.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/convex/webTools.ts | Removes audio and video from requested Firecrawl formats and the active scrape response model. |
| apps/web/src/convex/lib/validators.ts | Aligns stored and transport validators with markdown, summary, and image scrape results. |
| apps/web/src/convex/webTools.test.ts | Updates scrape expectations and fixtures to exclude audio and video. |
| crates/sprocket-agent/src/tools/scrape_files.rs | Updates localization tests to cover the narrowed image-only media payload. |
| BACKWARDS_COMPATIBILITY.md | Documents the currently retained optional Firecrawl fields. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(agent-tools): remove legacy scrape ..."](https://github.com/spikonado/sprocket/commit/326d9565ee1469a7a4687df6a6db8c6e7c020991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61626361)</sub>

<!-- /greptile_comment -->