### PR TITLE
fix(agent-tools): Clarify oversized scrape_url output

### DIFF
--- a/apps/web/src/convex/webTools.test.ts
+++ b/apps/web/src/convex/webTools.test.ts
@@ -311,13 +311,15 @@ describe('stored scrape_url results', () => {
 			jobId,
 			result: {
 				url: PAGE_URL,
-				markdown: 'The scrape was saved to /tmp/scrape.md.'
+				markdown:
+					'The scrape was too large to directly output. Instead, it has been saved to /tmp/scrape.md for you to view.'
 			}
 		});
 		const job = await t.run(async (ctx) => ctx.db.get('executorJobs', jobId));
 		expect(job?.result).toEqual({
 			url: PAGE_URL,
-			markdown: 'The scrape was saved to /tmp/scrape.md.'
+			markdown:
+				'The scrape was too large to directly output. Instead, it has been saved to /tmp/scrape.md for you to view.'
 		});
 		expect(job?.result).not.toHaveProperty('truncated');
 		expect(job?.result).not.toHaveProperty('summary');

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -88,7 +88,7 @@ models without image support receive a text notice instead of image content.
 
 Scrape outputs above 40,000 serialized characters are saved as JSON in the host's temporary
 directory, such as `/tmp` or Windows `%TEMP%`. The `markdown` output reports
-`The scrape was saved to <file-path>.` These files have the operating system's
+`The scrape was too large to directly output. Instead, it has been saved to <file-path> for you to view.` These files have the operating system's
 temporary-file lifetime. Convex transfer copies expire after one hour. The
 `summary` field remains inline in both short and saved results. Summaries that
 alone exceed the inline budget fail explicitly rather than being truncated.

--- a/crates/sprocket-agent/src/tools/scrape_files.rs
+++ b/crates/sprocket-agent/src/tools/scrape_files.rs
@@ -62,7 +62,7 @@ fn record_saved_scrape(
     fields.insert(
         "markdown".into(),
         Value::String(format!(
-            "The scrape was saved to {}.",
+            "The scrape was too large to directly output. Instead, it has been saved to {} for you to view.",
             temp.path().display()
         )),
     );
@@ -174,7 +174,10 @@ mod tests {
         assert_eq!(result["summary"], full["summary"]);
         assert_eq!(
             result["markdown"],
-            format!("The scrape was saved to {}.", path.display())
+            format!(
+                "The scrape was too large to directly output. Instead, it has been saved to {} for you to view.",
+                path.display()
+            )
         );
         drop(file);
         assert!(!path.exists());
@@ -212,9 +215,11 @@ mod tests {
         let path = result["markdown"]
             .as_str()
             .unwrap()
-            .strip_prefix("The scrape was saved to ")
+            .strip_prefix(
+                "The scrape was too large to directly output. Instead, it has been saved to ",
+            )
             .unwrap()
-            .strip_suffix('.')
+            .strip_suffix(" for you to view.")
             .unwrap();
         assert_eq!(tokio::fs::read_to_string(path).await.unwrap(), text);
         assert_eq!(result["summary"], "Full summary");


### PR DESCRIPTION
## Summary
- explain that oversized scrapes cannot be returned inline
- direct the model to open the saved temporary file
- update related tests and documentation

## Validation
- `nix develop -c cargo test -p sprocket-agent scrape_files`
- `nix develop -c bun run --cwd apps/web test src/convex/webTools.test.ts`
- `nix develop -c prek run -a`

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61672182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/spikonado/-/pull-requests/spikonado/sprocket/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the notice remains accessible to consumers and accurately directs the model to a readable agent-local temporary file.

<details><summary><h3>Summary</h3></summary>

- Explains why the scrape is not included directly.
- Directs the model to view the saved temporary file.
- Updates the Rust and web tests to expect the revised message.
- Aligns the agent README with the implemented behavior.
</details>

<!-- /greptile_comment -->