### PR TITLE
fix(cli): Refresh CLI help

### DIFF
--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::Context;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use sprocket_server::{
     INSTALLED_WEB_DIR, PairingProofRequest, PairingProofResponse, RunOptions, ServerConfig,
     browser_launch_url, load_repo_env, pairing_proof_message, read_pairing_credential, run,
@@ -24,7 +24,7 @@ const VERSION: &str = match option_env!("SPROCKET_VERSION") {
 #[derive(Debug, Parser)]
 #[command(
     name = "sprocket",
-    about = "Agentic platform for streamlining hardware and software development",
+    about = "The best and only AI agent for developing both hardware and software",
     version = VERSION,
     arg_required_else_help = false
 )]
@@ -45,9 +45,13 @@ struct Cli {
 enum Commands {
     /// Start only the local Sprocket server
     Serve(ServeArgs),
+
+    /// Update a global npm, bun, pnpm, or yarn installation on its current channel
+    #[command(visible_alias = "upgrade")]
+    Update(UpdateArgs),
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Args)]
 struct ServeArgs {
     #[command(flatten)]
     server: ServerConfig,
@@ -55,6 +59,13 @@ struct ServeArgs {
     /// Only print machine-readable startup output
     #[arg(long, env = "SPROCKET_QUIET")]
     quiet: bool,
+}
+
+#[derive(Debug, Args)]
+struct UpdateArgs {
+    /// Report whether an update is available without installing it
+    #[arg(long)]
+    check: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -84,6 +95,9 @@ fn main() -> anyhow::Result<()> {
                 anyhow::bail!("a workspace directory cannot be combined with `serve`");
             }
             serve_local(serve.server, serve.quiet, false, None)
+        }
+        Some(Commands::Update(_)) => {
+            anyhow::bail!("`sprocket update` requires the @spikonado/sprocket package launcher")
         }
         None if cli.web => {
             let server = ServerConfig::try_parse_from(["sprocket"])?;
@@ -293,9 +307,40 @@ fn find_dev_desktop_launcher() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::error::ErrorKind;
+
+    fn help_for(args: &[&str]) -> String {
+        let error = Cli::try_parse_from(std::iter::once("sprocket").chain(args.iter().copied()))
+            .expect_err("help should exit before parsing a command");
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+        error.to_string()
+    }
 
     #[test]
-    fn parses_desktop_web_and_server_modes() {
+    fn root_help_covers_current_commands() {
+        let help = help_for(&["--help"]);
+        assert_eq!(help, help_for(&["help"]));
+
+        for expected in [
+            "developing both hardware and software",
+            "Start only the local Sprocket server",
+            "Update a global npm, bun, pnpm, or yarn installation on its current channel",
+            "alias: upgrade",
+        ] {
+            assert!(help.contains(expected), "help is missing {expected:?}");
+        }
+    }
+
+    #[test]
+    fn update_help_describes_check_option() {
+        let help = help_for(&["help", "update"]);
+
+        assert!(help.contains("--check"));
+        assert!(help.contains("without installing it"));
+    }
+
+    #[test]
+    fn parses_launch_server_and_update_modes() {
         let desktop = Cli::try_parse_from(["sprocket"]).unwrap();
         assert!(!desktop.web);
         assert!(desktop.directory.is_none());
@@ -314,5 +359,11 @@ mod tests {
         assert!(!server.web);
         assert!(server.directory.is_none());
         assert!(matches!(server.command, Some(Commands::Serve(_))));
+
+        let update = Cli::try_parse_from(["sprocket", "upgrade", "--check"]).unwrap();
+        assert!(matches!(
+            update.command,
+            Some(Commands::Update(UpdateArgs { check: true }))
+        ));
     }
 }

--- a/npm/sprocket/lib/launcher.js
+++ b/npm/sprocket/lib/launcher.js
@@ -90,7 +90,7 @@ export async function launch(args, options = {}) {
 	const env = { ...(options.env ?? process.env) };
 	delete env.SPROCKET_UPDATE_MANAGED;
 	const parsed = parseUpdateArgs(args);
-	if (parsed.kind !== 'none') {
+	if (parsed.kind !== 'none' && parsed.kind !== 'native') {
 		const code = await runUpdateCli(parsed, options.host ?? createHost({ env }));
 		process.exitCode = code;
 		return code;

--- a/npm/sprocket/lib/update.js
+++ b/npm/sprocket/lib/update.js
@@ -24,18 +24,6 @@ const OUTPUT_LIMIT = 1_000_000;
 
 export const PACKAGE_ROOT = path.resolve(import.meta.dirname, '..');
 
-const HELP = `Usage: sprocket update [--check]
-
-Update a global ${PACKAGE_NAME} install.
-
-  --check   Report whether an update is available, without installing
-
-\`sprocket upgrade\` is the same command.
-
-Updates stay on the current channel: latest, canary, or dev.
-Only global installs from npm, bun, pnpm, or yarn can be updated this way.
-`;
-
 const MANAGERS = [
 	{
 		name: 'bun',
@@ -170,7 +158,7 @@ export function parseUpdateArgs(args) {
 	let check = false;
 	for (const arg of args.slice(1)) {
 		if (arg === '--help' || arg === '-h') {
-			return { kind: 'help' };
+			return { kind: 'native' };
 		}
 		if (arg === '--check') {
 			check = true;
@@ -618,10 +606,6 @@ export async function runUpdateApi(command, host = createHost()) {
 }
 
 export async function runUpdateCli(parsed, host = createHost()) {
-	if (parsed.kind === 'help') {
-		host.writeStdout(HELP);
-		return 0;
-	}
 	if (parsed.kind === 'invalid') {
 		host.writeStderr(`sprocket: ${parsed.error}\nTry \`sprocket update --help\`.\n`);
 		return 1;

--- a/npm/sprocket/test/launcher.test.js
+++ b/npm/sprocket/test/launcher.test.js
@@ -11,7 +11,6 @@ import {
 	nativePackage,
 	run
 } from '../lib/launcher.js';
-import { createHost } from '../lib/update.js';
 
 test('selects the native package for supported platforms', () => {
 	assert.deepEqual(nativePackage('linux', 'x64'), [
@@ -88,21 +87,23 @@ test('overrides inherited update helper environment for the native child', async
 	assert.equal(Object.hasOwn(invocation.options.env, 'SPROCKET_UPDATE_MANAGED'), false);
 });
 
-test('update and upgrade do not spawn the native binary', async () => {
-	let stdout = '';
-	const code = await launch(['upgrade', '--help'], {
-		host: createHost({
-			writeStdout(text) {
-				stdout += text;
-			},
-			writeStderr() {}
-		}),
-		spawn() {
-			throw new Error('native binary should not run');
-		}
-	});
-	assert.equal(code, 0);
-	assert.match(stdout, /sprocket update/);
+test('update and upgrade help is delegated to the native CLI', async () => {
+	for (const args of [
+		['update', '--help'],
+		['upgrade', '-h']
+	]) {
+		let invocation;
+		const code = await launch(args, {
+			resolveBinary: () => '/tmp/sprocket',
+			ensureExecutable: () => {},
+			spawn(binary, childArgs) {
+				invocation = { binary, args: childArgs };
+				return { status: 0 };
+			}
+		});
+		assert.equal(code, 0);
+		assert.deepEqual(invocation, { binary: '/tmp/sprocket', args });
+	}
 });
 
 test('native child environment always overwrites helper paths', () => {

--- a/npm/sprocket/test/update.test.js
+++ b/npm/sprocket/test/update.test.js
@@ -249,7 +249,7 @@ test('parses update, upgrade, --check, and help', () => {
 	assert.deepEqual(parseUpdateArgs(['serve']), { kind: 'none' });
 	assert.deepEqual(parseUpdateArgs(['update']), { kind: 'run', check: false });
 	assert.deepEqual(parseUpdateArgs(['upgrade', '--check']), { kind: 'run', check: true });
-	assert.equal(parseUpdateArgs(['update', '--help']).kind, 'help');
+	assert.equal(parseUpdateArgs(['update', '--help']).kind, 'native');
 	assert.equal(parseUpdateArgs(['update', '--force']).kind, 'invalid');
 });
 
@@ -603,23 +603,6 @@ test('upgrade --check is the same as update --check', async () => {
 	const code = await runUpdateCli(parseUpdateArgs(['upgrade', '--check']), host);
 	assert.equal(code, 0);
 	assert.match(stdout, /0\.3\.5 is available/);
-});
-
-test('CLI help does not query the registry', async () => {
-	let stdout = '';
-	let fetched = false;
-	const host = testHost({
-		fetch: async () => {
-			fetched = true;
-			return jsonResponse(versionDoc('0.3.5'));
-		},
-		writeStdout(text) {
-			stdout += text;
-		}
-	}).host;
-	assert.equal(await runUpdateCli(parseUpdateArgs(['update', '--help']), host), 0);
-	assert.match(stdout, /sprocket update/);
-	assert.equal(fetched, false);
 });
 
 test('refuses to install when the lock cannot be created', async () => {


### PR DESCRIPTION
## Summary

- update the root Clap description
- define `update`, its `upgrade` alias, and `--check` in the Clap command model with inline help
- remove the handwritten root and update help blocks
- delegate package update help to the native CLI so Clap renders every help form
- verify `sprocket help` and `sprocket --help` produce identical output

## Validation

- `nix develop -c cargo test -p sprocket-cli`
- `nix develop -c node --test npm/sprocket/test/launcher.test.js npm/sprocket/test/update.test.js`
- `nix develop -c cargo build -p sprocket-cli`
- compared `target/debug/sprocket help` with `target/debug/sprocket --help`
- `nix develop -c prek run -a`

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62024092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/spikonado/-/pull-requests/spikonado/sprocket/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no blocking or independently actionable regression remains.

<details><summary><h3>Summary</h3></summary>

- Adds native `update` metadata, the visible `upgrade` alias, and the `--check` option.
- Keeps actual package updates in the JavaScript launcher while forwarding help requests unchanged.
- Updates Rust and Node.js tests for the revised help ownership and command parsing.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    User["sprocket invocation"] --> Launcher["Node.js package launcher"]
    Launcher --> Parse{"Update invocation?"}
    Parse -->|"update / upgrade"| Updater["JavaScript package updater"]
    Parse -->|"update --help / upgrade -h"| Native["Native Clap CLI"]
    Parse -->|"other command"| Native
    Native --> Help["Clap-rendered command help"]
```
</details>

<!-- /greptile_comment -->