### PR TITLE
fix(ui): Restore responsive part-based transcript scrolling

### DIFF
--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -48,7 +48,7 @@
 		emptyStateMessage?: string;
 		stale?: boolean;
 		loadingOlder?: boolean;
-		hasOlder?: boolean;
+		nextBefore?: number;
 		onLoadOlder?: () => void;
 		loadAttachment?: (storageId: MessageAttachment['storageId']) => Promise<string | null>;
 		onLoadDetails?: (message: ThreadMessage) => Promise<void>;
@@ -68,7 +68,7 @@
 			: 'Add a project to begin.',
 		stale = false,
 		loadingOlder = false,
-		hasOlder = false,
+		nextBefore,
 		onLoadOlder,
 		loadAttachment,
 		onLoadDetails
@@ -77,46 +77,63 @@
 	let scrollViewport = $state<HTMLDivElement | null>(null);
 	let scrollContent = $state<HTMLDivElement | null>(null);
 	let stickToBottom = $state(true);
-	let adjustingScroll = false;
+	let lastScrollTop = 0;
 	let touchY: number | undefined;
+	let automaticPagesRemaining = 2;
+	let lastAutomaticBefore: number | undefined;
 
 	const SCROLL_EPSILON_PX = 28;
-	const LOAD_OLDER_THRESHOLD_PX = 200;
 
 	function updateStickToBottom() {
 		const viewport = scrollViewport;
-		if (!viewport) {
-			return;
-		}
-		if (adjustingScroll) {
-			return;
-		}
+		if (!viewport || viewport.scrollTop === lastScrollTop) return;
+		const movingUp = viewport.scrollTop < lastScrollTop;
+		lastScrollTop = viewport.scrollTop;
 		const distanceToBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
 		stickToBottom = distanceToBottom <= SCROLL_EPSILON_PX;
-		if (
-			!stickToBottom &&
-			hasOlder &&
-			!loadingOlder &&
-			onLoadOlder &&
-			viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX
-		) {
-			onLoadOlder();
-		}
+		if (movingUp) loadOlderOnUpwardIntent();
 	}
 
 	function loadOlderOnUpwardIntent() {
 		const viewport = scrollViewport;
 		if (
 			viewport &&
-			hasOlder &&
+			nextBefore !== undefined &&
 			!loadingOlder &&
 			viewport.clientHeight > 0 &&
-			viewport.scrollTop <= LOAD_OLDER_THRESHOLD_PX
+			viewport.scrollTop <= viewport.clientHeight
 		) {
 			stickToBottom = false;
 			onLoadOlder?.();
 		}
 	}
+
+	function fillViewport() {
+		const viewport = scrollViewport;
+		if (
+			viewport &&
+			nextBefore !== undefined &&
+			nextBefore !== lastAutomaticBefore &&
+			!loadingOlder &&
+			onLoadOlder &&
+			automaticPagesRemaining > 0 &&
+			viewport.clientHeight > 0 &&
+			viewport.scrollHeight <= viewport.clientHeight + SCROLL_EPSILON_PX
+		) {
+			// Collapsed work can consume many pages without making the viewport taller.
+			automaticPagesRemaining -= 1;
+			lastAutomaticBefore = nextBefore;
+			onLoadOlder();
+		}
+	}
+
+	$effect(() => {
+		void messages;
+		void nextBefore;
+		void loadingOlder;
+		void scrollViewport;
+		untrack(fillViewport);
+	});
 
 	function handleHistoryKey(event: KeyboardEvent) {
 		if (
@@ -189,7 +206,12 @@
 		if (!viewport || !stickToBottom) {
 			return;
 		}
-		viewport.scrollTop = viewport.scrollHeight;
+		setScrollTop(viewport, viewport.scrollHeight);
+	}
+
+	function setScrollTop(viewport: HTMLDivElement, top: number) {
+		viewport.scrollTop = top;
+		lastScrollTop = viewport.scrollTop;
 	}
 
 	function firstVisibleAnchor(viewport: HTMLDivElement) {
@@ -208,6 +230,7 @@
 	$effect.pre(() => {
 		void messages;
 		void actions;
+		void scrollViewport;
 		untrack(() => {
 			const viewport = scrollViewport;
 			if (!viewport) return;
@@ -217,7 +240,6 @@
 			const scrollHeight = viewport.scrollHeight;
 			void tick().then(() => {
 				if (viewport !== scrollViewport) return;
-				adjustingScroll = true;
 				if (stickToBottom) {
 					scrollToBottom();
 				} else if (
@@ -225,13 +247,10 @@
 					offset !== undefined &&
 					viewport.scrollTop === scrollTop
 				) {
-					viewport.scrollTop += anchor.getBoundingClientRect().top - offset;
+					setScrollTop(viewport, scrollTop + anchor.getBoundingClientRect().top - offset);
 				} else if (anchor && !anchor.isConnected && viewport.scrollTop === scrollTop) {
-					viewport.scrollTop += viewport.scrollHeight - scrollHeight;
+					setScrollTop(viewport, scrollTop + viewport.scrollHeight - scrollHeight);
 				}
-				requestAnimationFrame(() => {
-					adjustingScroll = false;
-				});
 			});
 		});
 	});
@@ -244,11 +263,8 @@
 		}
 
 		const observer = new ResizeObserver(() => {
-			adjustingScroll = true;
 			scrollToBottom();
-			requestAnimationFrame(() => {
-				adjustingScroll = false;
-			});
+			fillViewport();
 		});
 		observer.observe(viewport);
 		observer.observe(content);

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -5,6 +5,7 @@ import type { ThreadMessage } from '$lib/types/sprocket';
 import ThreadTranscript from './thread-transcript.svelte';
 
 let cleanup: (() => Promise<void>) | undefined;
+let resize: () => void;
 
 function message(number: number): ThreadMessage {
 	return {
@@ -38,7 +39,7 @@ async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600)
 		actions: [],
 		activeRunId: null,
 		project: null,
-		hasOlder: true,
+		nextBefore: messages.length ? 3 : undefined,
 		onLoadOlder: vi.fn()
 	});
 	const component = mount(ThreadTranscript, { target: document.body, props });
@@ -82,23 +83,89 @@ async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600)
 	};
 }
 
-beforeEach(() => vi.useFakeTimers());
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.stubGlobal(
+		'ResizeObserver',
+		class {
+			constructor(callback: () => void) {
+				resize = callback;
+			}
+			observe = vi.fn();
+			disconnect = vi.fn();
+		}
+	);
+});
 afterEach(async () => {
 	await cleanup?.();
 	cleanup = undefined;
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	vi.useRealTimers();
 });
 
 describe('transcript viewport paging', () => {
-	it('loads only near the top, not at the bottom or while an older page is loading', async () => {
-		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3].map(message));
+	it('fills an initially empty thread after its first page arrives, and stops once it scrolls', async () => {
+		const { props, viewport } = await renderTranscript([]);
 		expect(props.onLoadOlder).not.toHaveBeenCalled();
-		scrollTo(300);
+		props.messages = [message(3)];
+		props.nextBefore = 3;
+		await settle();
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.messages = [1, 2, 3].map(message);
+		props.nextBefore = 1;
+		await settle();
+		resize();
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		expect(viewport.scrollTop).toBe(300);
-		scrollTo(201);
+	});
+
+	it('does not drop an upward scroll just after a resize notification', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+		resize();
+		scrollTo(500);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		props.messages = [...props.messages, message(6)];
+		await settle();
+		resize();
+		expect(viewport.scrollTop).toBe(500);
+	});
+
+	it('follows new output only at the bottom, and resumes after scrolling back down', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4].map(message));
+		props.messages = [...props.messages, message(5)];
+		await settle();
+		expect(viewport.scrollTop).toBe(900);
+		scrollTo(500);
+		props.messages = [...props.messages, message(6)];
+		await settle();
+		expect(viewport.scrollTop).toBe(500);
+		scrollTo(1200);
+		props.messages = [...props.messages, message(7)];
+		await settle();
+		expect(viewport.scrollTop).toBe(1500);
+	});
+
+	it('opens a newly mounted thread at the bottom rather than reusing the previous reading position', async () => {
+		const first = await renderTranscript([1, 2, 3, 4].map(message));
+		first.scrollTo(100);
+		await cleanup?.();
+		const second = await renderTranscript([]);
+		second.props.messages = [11, 12, 13, 14, 15].map(message);
+		await settle();
+		expect(second.viewport.scrollTop).toBe(900);
+		expect(second.viewport.textContent).not.toContain('Message 4');
+	});
+
+	it('starts loading a viewport ahead of the top, only while scrolling upward', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4, 5].map(message));
 		expect(props.onLoadOlder).not.toHaveBeenCalled();
-		scrollTo(200);
+		expect(viewport.scrollTop).toBe(900);
+		scrollTo(601);
+		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		scrollTo(600);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		scrollTo(650);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
@@ -106,27 +173,24 @@ describe('transcript viewport paging', () => {
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 	});
 
-	it('loads short history only on upward gestures, never to fill the viewport automatically', async () => {
+	it('fills short history with at most two older pages, even when collapsed work adds no height', async () => {
 		const { props, viewport } = await renderTranscript([message(3)]);
 		expect(viewport.textContent).not.toContain('Load earlier messages');
 		expect(viewport.scrollHeight).toBe(viewport.clientHeight);
-		await vi.advanceTimersByTimeAsync(10_000);
-		expect(props.onLoadOlder).not.toHaveBeenCalled();
-		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
-		expect(props.onLoadOlder).not.toHaveBeenCalled();
-		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
 		expect(viewport.textContent).not.toContain('Loading earlier messages');
-		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
-		props.messages = [message(2), ...props.messages];
+		props.nextBefore = 2;
 		props.loadingOlder = false;
 		await settle();
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
-		viewport.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+		props.nextBefore = 1;
+		await settle();
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
+		viewport.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(3);
 	});
 
 	it('allows retry by touch after a failed short-page load without a background retry loop', async () => {
@@ -136,8 +200,6 @@ describe('transcript viewport paging', () => {
 			Object.defineProperty(event, 'touches', { value: [{ clientY }] });
 			viewport.dispatchEvent(event);
 		};
-		touch('touchstart', 100);
-		touch('touchmove', 150);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
 		props.loadingOlder = true;
 		await settle();
@@ -153,10 +215,13 @@ describe('transcript viewport paging', () => {
 
 	it('accepts upward gestures within the bottom-stick tolerance', async () => {
 		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3].map(message), 880);
-		expect(props.onLoadOlder).not.toHaveBeenCalled();
+		props.loadingOlder = true;
+		await settle();
 		scrollTo(0);
+		props.loadingOlder = false;
+		await settle();
 		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
-		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);
+		expect(props.onLoadOlder).toHaveBeenCalledTimes(2);
 	});
 
 	it('retries from the top of overflowing history without requiring another scroll event', async () => {
@@ -210,6 +275,7 @@ describe('transcript viewport paging', () => {
 		const offset = anchor.getBoundingClientRect().top;
 		props.messages = [message(1), message(2), ...props.messages];
 		await settle();
+		viewport.dispatchEvent(new Event('scroll'));
 		expect(viewport.scrollTop).toBe(750);
 		expect(anchor.getBoundingClientRect().top).toBe(offset);
 		expect(props.onLoadOlder).toHaveBeenCalledTimes(1);

--- a/apps/web/src/lib/project/transcript-history.test.ts
+++ b/apps/web/src/lib/project/transcript-history.test.ts
@@ -244,20 +244,68 @@ describe('TranscriptHistory', () => {
 		expect(texts(history)).toEqual([]);
 	});
 
-	it('fills every gap after reconnecting beyond the newest page', async () => {
+	it('shows the newest window without downloading an offline gap', async () => {
 		const fetchPage = vi
 			.fn()
 			.mockResolvedValueOnce(page([0, 1]))
-			.mockResolvedValueOnce(page([6, 7], 6))
-			.mockResolvedValueOnce(page([4, 5], 4))
-			.mockResolvedValueOnce(page([1, 2, 3], 1));
+			.mockResolvedValueOnce(page([998, 999], 998))
+			.mockResolvedValueOnce(page([996, 997], 996));
 		const history = new TranscriptHistory(fetchPage, () => {});
 		await history.refresh();
 		await history.refresh();
-		expect(texts(history)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7']);
-		expect(history.nextBefore).toBeUndefined();
+		expect(texts(history)).toEqual(['998', '999']);
+		expect(history.nextBefore).toBe(998);
+		expect(history.windowVersion).toBe(1);
+		expect(fetchPage).toHaveBeenCalledTimes(2);
+		await history.loadOlder();
+		expect(texts(history)).toEqual(['996', '997', '998', '999']);
 		history.stop();
 	});
+
+	it('retains loaded history when the recent window is adjacent', async () => {
+		const fetchPage = vi
+			.fn()
+			.mockResolvedValueOnce(page([0, 1]))
+			.mockResolvedValueOnce(page([2, 3], 2));
+		const history = new TranscriptHistory(fetchPage, () => {});
+		await history.refresh();
+		await history.refresh();
+		expect(texts(history)).toEqual(['0', '1', '2', '3']);
+		expect(history.nextBefore).toBeUndefined();
+		expect(history.windowVersion).toBe(0);
+		history.stop();
+	});
+
+	it.each([false, true])(
+		'ignores an older-page result from a replaced window: failure=%s',
+		async (fail) => {
+			let resolveOlder: (value: LocalTranscriptPage) => void = () => {};
+			let rejectOlder: (reason: Error) => void = () => {};
+			const fetchPage = vi
+				.fn()
+				.mockResolvedValueOnce(page([10, 11], 10))
+				.mockImplementationOnce(
+					() =>
+						new Promise<LocalTranscriptPage>((resolve, reject) => {
+							resolveOlder = resolve;
+							rejectOlder = reject;
+						})
+				)
+				.mockResolvedValueOnce(page([98, 99], 98));
+			const history = new TranscriptHistory(fetchPage, () => {});
+			await history.refresh();
+			const older = history.loadOlder();
+			await history.refresh();
+			if (fail) rejectOlder(new Error('offline'));
+			else resolveOlder(page([8, 9], 8));
+			await older;
+			expect(texts(history)).toEqual(['98', '99']);
+			expect(history.nextBefore).toBe(98);
+			expect(history.stale).toBe(false);
+			expect(history.loadingOlder).toBe(false);
+			history.stop();
+		}
+	);
 
 	it('coalesces concurrent refreshes and ignores requests completed after a thread switch', async () => {
 		let resolve: (value: LocalTranscriptPage) => void = () => {};
@@ -278,22 +326,22 @@ describe('TranscriptHistory', () => {
 		expect(changed).not.toHaveBeenCalled();
 	});
 
-	it('retries a failed catch-up without committing a gap in history', async () => {
+	it('keeps cached output on refresh failure, then retries the latest window', async () => {
 		vi.useFakeTimers();
 		const fetchPage = vi
 			.fn()
 			.mockResolvedValueOnce(page([0, 1]))
-			.mockResolvedValueOnce(page([4, 5], 4))
 			.mockRejectedValueOnce(new Error('offline'))
-			.mockResolvedValueOnce(page([4, 5], 4))
-			.mockResolvedValueOnce(page([1, 2, 3], 1));
+			.mockResolvedValueOnce(page([4, 5], 4));
 		const history = new TranscriptHistory(fetchPage, () => {});
 		await history.refresh();
 		await history.refresh();
 		expect(texts(history)).toEqual(['0', '1']);
 		expect(history.stale).toBe(true);
 		await vi.runAllTimersAsync();
-		expect(texts(history)).toEqual(['0', '1', '2', '3', '4', '5']);
+		expect(texts(history)).toEqual(['4', '5']);
+		expect(history.nextBefore).toBe(4);
+		expect(fetchPage).toHaveBeenCalledTimes(3);
 		history.stop();
 	});
 
@@ -330,22 +378,6 @@ describe('TranscriptHistory', () => {
 		expect(
 			history.messages[0]?.parts.map((part) => (part.type === 'text' ? part.text : ''))
 		).toEqual(parts.map((part) => part.message?.text));
-		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
-			{ limit: 12 },
-			{ before: 40, limit: 40 },
-			{ limit: 12 }
-		]);
-		history.stop();
-	});
-
-	it('uses the newest raw part as the catch-up cursor so a loaded response is not rescanned', async () => {
-		const runId = 'run-long';
-		const parts = Array.from({ length: 52 }, (_, number) => completionPart(number, runId));
-		const fetchPage = vi.fn(windowedFetch(parts));
-		const history = new TranscriptHistory(fetchPage, () => {});
-		await history.refresh();
-		await history.loadOlder();
-		await history.refresh();
 		expect(fetchPage.mock.calls.map(([request]) => request)).toEqual([
 			{ limit: 12 },
 			{ before: 40, limit: 40 },

--- a/apps/web/src/lib/project/transcript-history.ts
+++ b/apps/web/src/lib/project/transcript-history.ts
@@ -31,6 +31,7 @@ export class TranscriptHistory {
 	nextBefore: number | undefined;
 	loading = true;
 	loadingOlder = false;
+	windowVersion = 0;
 	stale = false;
 	error: string | null = null;
 	private parts = new Map<number, LocalTranscriptPart>();
@@ -70,24 +71,16 @@ export class TranscriptHistory {
 			do {
 				this.refreshPending = false;
 				const newestLoaded = this.newestLoadedNumber();
-				const incoming: LocalTranscriptPart[] = [];
-				let newestPage: LocalTranscriptPage | undefined;
-				let before: number | undefined;
-				do {
-					const page = await this.fetchPage({ before, limit: RECENT_PAGE_LIMIT });
-					if (this.stopped) return;
-					newestPage ??= page;
-					incoming.push(...page.parts);
-					if (page.nextBefore === undefined) break;
-					if (before !== undefined && page.nextBefore >= before) {
-						throw new Error('Transcript history cursor did not advance');
-					}
-					before = page.nextBefore;
-				} while (newestLoaded !== undefined && before !== undefined && before > newestLoaded);
-				if (!newestPage) return;
-				if (this.parts.size === 0) this.nextBefore = newestPage.nextBefore;
-				this.commit(incoming);
-				this.stale = newestPage.stale;
+				const page = await this.fetchPage({ limit: RECENT_PAGE_LIMIT });
+				if (this.stopped) return;
+				// Do not download an entire offline gap just to display the latest output.
+				if (newestLoaded !== undefined && (page.nextBefore ?? 0) > newestLoaded + 1) {
+					this.parts.clear();
+					this.windowVersion += 1;
+				}
+				if (this.parts.size === 0) this.nextBefore = page.nextBefore;
+				this.commit(page.parts);
+				this.stale = page.stale;
 				this.error = null;
 				this.loading = false;
 				this.changed();
@@ -117,11 +110,12 @@ export class TranscriptHistory {
 		}
 		if (this.nextBefore === undefined) return;
 		const before = this.nextBefore;
+		const version = this.windowVersion;
 		this.loadingOlder = true;
 		this.changed();
 		try {
 			const page = await this.fetchPage({ before, limit: OLDER_PAGE_LIMIT });
-			if (this.stopped) return;
+			if (this.stopped || version !== this.windowVersion) return;
 			if (page.nextBefore !== undefined && page.nextBefore >= before) {
 				throw new Error('Transcript history cursor did not advance');
 			}
@@ -129,7 +123,7 @@ export class TranscriptHistory {
 			this.nextBefore = page.nextBefore;
 			this.stale = page.stale;
 		} catch {
-			if (!this.stopped) this.stale = true;
+			if (!this.stopped && version === this.windowVersion) this.stale = true;
 		} finally {
 			this.loadingOlder = false;
 			if (!this.stopped) this.changed();

--- a/apps/web/src/lib/project/transcript.test.ts
+++ b/apps/web/src/lib/project/transcript.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Id } from '$convex/_generated/dataModel';
 import type { LiveCompletionOverlay, ThreadMessage } from '$lib/types/sprocket';
-import { mergePagedTranscriptWithLive, mergeTranscriptMessages } from '$lib/project/transcript';
+import { mergePagedTranscriptWithLive } from '$lib/project/transcript';
 import { buildAssistantTimeline } from '$lib/chat/assistant-timeline';
 
 // SAFETY: Tests use stable opaque strings where only ID equality matters.
@@ -153,46 +153,5 @@ describe('mergePagedTranscriptWithLive', () => {
 			threadId
 		});
 		expect(messages.map((entry) => entry.text)).toEqual(['working']);
-	});
-});
-
-describe('mergeTranscriptMessages', () => {
-	it('does not re-render immutable messages when the same source snapshot is refreshed', () => {
-		const current = message();
-		expect(mergeTranscriptMessages([current], [message()])[0]).toBe(current);
-	});
-
-	it('hydrates an older snapshot without erasing new output, and retains it on later refreshes', () => {
-		const reasoning = { type: 'reasoning' as const, id: 'reasoning', text: '' };
-		const latest = message({ sourceNumbers: [1, 2], parts: [reasoning, ...message().parts] });
-		const details = message({
-			sourceNumbers: [1],
-			detailsLoaded: true,
-			parts: [{ ...reasoning, text: 'details' }]
-		});
-		const merged = mergeTranscriptMessages([latest], [details]);
-		expect(merged[0].parts).toEqual([{ ...reasoning, text: 'details' }, ...message().parts]);
-		expect(merged[0].sourceNumbers).toEqual([1, 2]);
-		expect(merged[0].detailsLoaded).toBe(false);
-		expect(mergeTranscriptMessages(merged, [latest])[0].parts).toEqual(merged[0].parts);
-	});
-	it('merges pages by message id and source order', () => {
-		const newer = message({ _id: 'prompt:run-2', type: 'prompt', sourceNumbers: [4] });
-		const older = message({ _id: 'prompt:run-1', type: 'prompt', sourceNumbers: [0] });
-		expect(mergeTranscriptMessages([newer], [older]).map((entry) => entry._id)).toEqual([
-			'prompt:run-1',
-			'prompt:run-2'
-		]);
-	});
-
-	it('replaces a lightweight message with its detailed version', () => {
-		const lightweight = message({ parts: [], detailsLoaded: false, sourceNumbers: [1, 2] });
-		const detailed = message({
-			parts: [{ type: 'reasoning', id: 'reasoning-1', text: 'details' }],
-			detailsLoaded: true,
-			sourceNumbers: [1, 2]
-		});
-
-		expect(mergeTranscriptMessages([lightweight], [detailed])).toEqual([detailed]);
 	});
 });

--- a/apps/web/src/lib/project/transcript.ts
+++ b/apps/web/src/lib/project/transcript.ts
@@ -1,6 +1,5 @@
 import type { Id } from '$convex/_generated/dataModel';
 import { joinAssistantTextParts, type AssistantPart } from '$convex/lib/assistantParts';
-import { isJsonObject } from '$convex/lib/json';
 import type { LiveCompletionOverlay, ThreadMessage } from '$lib/types/sprocket';
 
 function responseMessageId(runId: ThreadMessage['runId']): string {
@@ -97,55 +96,4 @@ export function mergePagedTranscriptWithLive(args: {
 	}
 
 	return messages;
-}
-
-function retainDetails(message: ThreadMessage, detailed: ThreadMessage): ThreadMessage {
-	if (message.detailsLoaded) return message;
-	const details = new Map(detailed.parts.map((part) => [partKey(part), part]));
-	const parts = message.parts.map((part) => {
-		const full = details.get(partKey(part));
-		if (!full) return part;
-		if (part.type === 'reasoning' && full.type === 'reasoning' && !part.text) return full;
-		if (part.type === 'tool-call' && full.type === 'tool-call' && part.input == null) return full;
-		if (part.type === 'tool-result' && full.type === 'tool-result' && full.output != null) {
-			return isJsonObject(part.output) && isJsonObject(full.output)
-				? { ...part, output: { ...full.output, ...part.output } }
-				: full;
-		}
-		return part;
-	});
-	return { ...message, parts };
-}
-
-export function mergeTranscriptMessages(existing: ThreadMessage[], incoming: ThreadMessage[]) {
-	const byId = new Map(existing.map((message) => [message._id, message]));
-	for (const message of incoming) {
-		const current = byId.get(message._id);
-		if (!current) {
-			byId.set(message._id, message);
-			continue;
-		}
-		const currentNumbers = new Set(current.sourceNumbers ?? []);
-		const incomingNumbers = new Set(message.sourceNumbers ?? []);
-		const currentContainsIncoming = [...incomingNumbers].every((number) =>
-			currentNumbers.has(number)
-		);
-		const incomingContainsCurrent = [...currentNumbers].every((number) =>
-			incomingNumbers.has(number)
-		);
-		if (currentContainsIncoming && incomingContainsCurrent) {
-			if (message.detailsLoaded && !current.detailsLoaded) byId.set(message._id, message);
-			continue;
-		}
-		if (currentContainsIncoming) {
-			if (message.detailsLoaded) byId.set(message._id, retainDetails(current, message));
-			continue;
-		}
-		if (incomingContainsCurrent) {
-			byId.set(message._id, retainDetails(message, current));
-		}
-	}
-	return [...byId.values()].sort(
-		(left, right) => (left.sourceNumbers?.[0] ?? 0) - (right.sourceNumbers?.[0] ?? 0)
-	);
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -564,6 +564,7 @@
 	);
 	let replicaMessages = $state<ThreadMessage[]>([]);
 	let replicaNextBefore = $state<number | null>(null);
+	let replicaWindowVersion = $state(0);
 	let replicaStale = $state(false);
 	let replicaThreadId = $state<Id<'threadRecords'> | null>(null);
 	let replicaLoading = $state(false);
@@ -590,6 +591,7 @@
 		replicaError = null;
 		replicaMessages = [];
 		replicaNextBefore = null;
+		replicaWindowVersion = 0;
 		replicaStale = false;
 		replicaLoading = threadId !== null;
 	}
@@ -621,8 +623,10 @@
 				api.fetchTranscriptPage({ userId, threadId: watchedThreadId, ...request }, ac.signal),
 			() => {
 				if (ac.signal.aborted || replicaGeneration !== generation) return;
+				if (replicaWindowVersion !== history.windowVersion) pendingCompletions = [];
 				replicaMessages = history.messages;
 				replicaNextBefore = history.nextBefore ?? null;
+				replicaWindowVersion = history.windowVersion;
 				replicaStale = history.stale;
 				replicaLoading = history.loading;
 				loadingOlderTranscript = history.loadingOlder;
@@ -2417,7 +2421,7 @@
 						<SettingsAccount user={$authState.user} onSignOut={() => void signOut()} />
 					{/if}
 				{:else}
-					{#key currentThreadId}
+					{#key `${currentThreadId}:${replicaWindowVersion}`}
 						<ThreadTranscript
 							currentError={replicaError ??
 								currentError ??
@@ -2441,7 +2445,7 @@
 							}}
 							stale={replicaStale}
 							loadingOlder={loadingOlderTranscript}
-							hasOlder={replicaNextBefore != null}
+							nextBefore={replicaNextBefore ?? undefined}
 							emptyStateMessage={currentThreadId &&
 							(replicaLoading || replicaThreadId !== currentThreadId)
 								? ''


### PR DESCRIPTION
## Summary

Fix slow older-history loading and partial transcript views after switching threads, while keeping the numbered-part paging introduced in #313.

The original request was to avoid downloading hundreds of parts just to open a thread. It also removed the paging button and loading text. Those constraints remain. Threads open at the latest output, as requested.

- Replace the unbounded refresh catch-up loop with a single recent-page fetch. If that page is separated from the loaded history by a gap, display the new window immediately instead of downloading the entire gap first. The discarded window remains accessible through older-page loading.
- Reset the viewport when the displayed window changes, discard obsolete pending overlays, and ignore late older-page responses from the previous window.
- Start older-page loading one viewport before the top, only when moving upward. Silently fill a short viewport with at most two additional 40-part pages. Stop automatic retries at a failed cursor and retain gesture-based retry. Collapsed work cannot trigger an unbounded fill loop.
- Replace frame-wide scroll-event suppression with tracking of the actual scroll position. A resize no longer causes the next user scroll to be ignored. Keep intra-response anchors and work-disclosure identity.
- Remove the unused complete-message merge implementation and its tests. Part assembly and lazy-detail merging remain covered through the code the UI actually uses.

No server endpoints, stored formats, or compatibility shims change. Metadata-only watches, 12-part recent pages, and 40-part older pages remain.

## Validation

- Targeted transcript history, part assembly, and viewport tests: 36 passed.
- All frontend and component suites: 223 tests passed across 23 files.
- Svelte check: 0 errors and 0 warnings.
- Web production build passed.
- Changed-file ESLint and Prettier checks passed. Repository Oxlint passed.
- Applicable commit hooks and `git diff --check` passed.
- Grok cleanup and both pre-PR review attempts were blocked by the account usage limit. Greptile will review this PR.

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62034951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/spikonado/-/pull-requests/spikonado/sprocket/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations were identified.

<details><summary><h3>Summary</h3></summary>

- Replaces multi-page refresh catch-up with a single recent-page fetch and explicit window replacement across history gaps.
- Discards obsolete older-page responses and pending overlays when the displayed window changes.
- Adds direction-aware near-top paging, bounded short-viewport filling, and position-based scroll tracking.
- Removes an unused transcript-message merge implementation and its tests.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    W[Transcript watch event] --> R[Fetch one 12-part recent page]
    R --> G{Gap from loaded history?}
    G -- No --> M[Merge page into current window]
    G -- Yes --> C[Clear parts and increment window version]
    C --> N[Commit newest window]
    N --> K[Remount transcript viewport]
    K --> F{Viewport still short?}
    M --> F
    F -- Yes, budget remains --> O[Fetch one 40-part older page]
    F -- No --> D[Display transcript]
    O --> V{Window version unchanged?}
    V -- Yes --> P[Prepend page and preserve anchor]
    V -- No --> X[Ignore obsolete response]
    P --> F
    X --> D
```
</details>

<!-- /greptile_comment -->