### PR TITLE
feat(context): Include model identity in system prompt

### DIFF
--- a/crates/sprocket-agent/src/catalog.rs
+++ b/crates/sprocket-agent/src/catalog.rs
@@ -47,6 +47,7 @@ struct GatewaySprocketCatalog {
 #[serde(rename_all = "camelCase")]
 struct GatewayCatalogModel {
     id: String,
+    label: String,
     supports_images: bool,
     context_window_tokens: u64,
     #[serde(rename = "autoCompactTokenLimit")]
@@ -70,6 +71,7 @@ fn select_catalog_model(
         .find(|model| model.id == model_id)
         .ok_or_else(|| anyhow!("model {model_id} is not in the AI gateway catalog"))?;
     Ok(CatalogModelCapabilities {
+        label: model.label.clone(),
         context_budget: ContextBudget {
             context_window_tokens: model.context_window_tokens,
             auto_handoff_token_limit: model.auto_handoff_token_limit,
@@ -111,12 +113,14 @@ mod tests {
                 "models": [
                     {
                         "id": "gpt-5.6-sol",
+                        "label": "GPT-5.6 Sol",
                         "supportsImages": supports_images,
                         "contextWindowTokens": 272000,
                         "autoCompactTokenLimit": 258000
                     },
                     {
                         "id": "deepseek-v4-pro-0813",
+                        "label": "DeepSeek V4 Pro",
                         "supportsImages": false,
                         "contextWindowTokens": 1000000,
                         "autoCompactTokenLimit": 967000
@@ -128,10 +132,11 @@ mod tests {
     }
 
     #[test]
-    fn fixture_reports_image_capability_with_budget_from_one_payload() {
+    fn fixture_reports_selected_model_metadata_from_one_payload() {
         let vision =
             select_catalog_model(catalog_payload(true), "gpt-5.6-sol").expect("vision model");
         assert!(vision.supports_images);
+        assert_eq!(vision.label, "GPT-5.6 Sol");
         assert_eq!(vision.context_budget.context_window_tokens, 272000);
         assert_eq!(vision.context_budget.auto_handoff_token_limit, 258000);
 
@@ -153,6 +158,7 @@ mod tests {
     fn catalog_model_requires_supports_images() {
         let error = serde_json::from_value::<GatewayCatalogModel>(serde_json::json!({
             "id": "gpt-5.6-sol",
+            "label": "GPT-5.6 Sol",
             "contextWindowTokens": 272000,
             "autoCompactTokenLimit": 258000
         }))

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -101,6 +101,8 @@ fn build_workspace_prompt_context(
     workspace_path: &str,
     workspace_instructions: &[WorkspaceInstruction],
     skills: &[WorkspaceSkill],
+    model_label: &str,
+    model_id: &str,
 ) -> WorkspacePromptContext {
     let user_instructions = workspace_instructions
         .iter()
@@ -145,12 +147,14 @@ fn build_workspace_prompt_context(
         format!("<SKILLS>\n{entries}\n</SKILLS>")
     };
 
+    let model_identity = format!("Your model is {model_label} ({model_id}).");
     let base_instructions = [
         "# System Instructions",
         "",
         "## Identity",
         "",
         "Your name is Sprocket.",
+        model_identity.as_str(),
         "You are an engineering agent operating in the user's real local workspace.",
         "You are a careful senior engineer.",
         "You like debating with the user when you feel there is a better way to achieve an end goal.",
@@ -903,6 +907,8 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
             &request.workspace_path,
             &workspace_instructions,
             &skills,
+            &capabilities.label,
+            &context.run.selected_model,
         );
         Ok((prompt, provider, prompt_context, skills))
     })();
@@ -1016,6 +1022,9 @@ mod tests {
 
     use super::{build_workspace_prompt_context, submission_owned_by_another_executor};
 
+    const MODEL_LABEL: &str = "GPT-5.6 Sol";
+    const MODEL_ID: &str = "gpt-5.6-sol";
+
     fn initial_context_text(message: &Message) -> &str {
         match message {
             Message::User { content } => match content.first() {
@@ -1024,6 +1033,19 @@ mod tests {
             },
             other => panic!("expected initial context user message, got {other:?}"),
         }
+    }
+
+    fn build_test_prompt_context(
+        workspace_instructions: &[WorkspaceInstruction],
+        skills: &[WorkspaceSkill],
+    ) -> super::WorkspacePromptContext {
+        build_workspace_prompt_context(
+            "/tmp/project",
+            workspace_instructions,
+            skills,
+            MODEL_LABEL,
+            MODEL_ID,
+        )
     }
 
     #[test]
@@ -1043,6 +1065,20 @@ mod tests {
     }
 
     #[test]
+    fn base_instructions_include_the_selected_model_identity() {
+        let prompt_context =
+            build_workspace_prompt_context("/tmp/project", &[], &[], MODEL_LABEL, MODEL_ID);
+
+        assert!(
+            prompt_context
+                .base_instructions
+                .contains(
+                    "Your name is Sprocket.\nYour model is GPT-5.6 Sol (gpt-5.6-sol).\nYou are an engineering agent"
+                )
+        );
+    }
+
+    #[test]
     fn initial_context_renders_skills_block() {
         let skills = [WorkspaceSkill {
             name: "pdf-processing".to_string(),
@@ -1051,7 +1087,7 @@ mod tests {
                 contents: "---\nname: pdf-processing\ndescription: Handle PDFs\n---\n",
             },
         }];
-        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &skills);
+        let prompt_context = build_test_prompt_context(&[], &skills);
         let initial_context = initial_context_text(&prompt_context.initial_context);
         assert!(initial_context.starts_with("# Thread-Scoped Workspace Context\n"));
         assert!(initial_context.contains("## Available Skills"));
@@ -1064,7 +1100,7 @@ mod tests {
 
     #[test]
     fn initial_context_renders_empty_skills_line() {
-        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &[]);
+        let prompt_context = build_test_prompt_context(&[], &[]);
         let initial_context = initial_context_text(&prompt_context.initial_context);
         assert!(initial_context.contains("## Available Skills"));
         assert!(initial_context.contains("No skills are installed."));
@@ -1080,7 +1116,7 @@ mod tests {
                 contents: "---\nname: demo\ndescription: Line one\n---\n",
             },
         }];
-        let prompt_context = build_workspace_prompt_context("/tmp/project", &[], &skills);
+        let prompt_context = build_test_prompt_context(&[], &skills);
         let initial_context = initial_context_text(&prompt_context.initial_context);
         assert!(initial_context.contains("description: Line one line two"));
         assert!(!initial_context.contains("description: Line one\n"));
@@ -1105,7 +1141,7 @@ mod tests {
             },
         ];
 
-        let prompt_context = build_workspace_prompt_context("/tmp/project", &instructions, &[]);
+        let prompt_context = build_test_prompt_context(&instructions, &[]);
         let initial_context = initial_context_text(&prompt_context.initial_context);
 
         let user_heading = "### The user's AGENTS.md";

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -93,6 +93,7 @@ pub struct ContextBudget {
 /// Live catalog fields for the selected model. Fetched once with the budget.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CatalogModelCapabilities {
+    pub label: String,
     pub context_budget: ContextBudget,
     pub supports_images: bool,
 }


### PR DESCRIPTION
## Summary
- read the selected model label from the live gateway catalog
- add the model label and ID to the agent identity section of the system prompt
- cover catalog propagation and prompt rendering with unit tests

## Testing
- `nix develop -c cargo test -p sprocket-agent`
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c prek run -a` (Rust and repository checks passed; frontend ESLint/Svelte checks could not start because this clean worktree has no local JS dependencies)

Written by GPT 6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62037310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/spikonado/-/pull-requests/spikonado/sprocket/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

<details><summary><h3>Summary</h3></summary>

- Adds the catalog label to selected-model capabilities.
- Renders both the model label and ID in the system prompt.
- Adds unit coverage for catalog propagation and prompt rendering.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Live gateway catalog] --> B[Select model by ID]
    B --> C[CatalogModelCapabilities]
    C --> D[Workspace prompt context]
    D --> E[System prompt identity]
```
</details>

<!-- /greptile_comment -->