### PR TITLE
fix(agent): Prevent transcript cache write races

### DIFF
--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -818,7 +818,11 @@ async fn load_prior_history(
     })
 }
 
-pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::Result<()> {
+pub async fn run_agent(
+    run: AgentRun,
+    live: Arc<LiveCompletionHub>,
+    store: Arc<TranscriptStore>,
+) -> anyhow::Result<()> {
     let AgentRun {
         request,
         runtime,
@@ -843,7 +847,6 @@ pub async fn run_agent(run: AgentRun, live: Arc<LiveCompletionHub>) -> anyhow::R
             Err(error) => return abort_before_start(&runtime, &run_id, error).await,
         };
 
-    let store = TranscriptStore::new(request.transcript_root.clone());
     let prepare_history = load_prior_history(
         &runtime,
         &store,

--- a/crates/sprocket-agent/src/transcript/store.rs
+++ b/crates/sprocket-agent/src/transcript/store.rs
@@ -298,16 +298,20 @@ impl TranscriptStore {
         thread_id: &str,
     ) -> anyhow::Result<TranscriptState> {
         let path = self.thread_dir(user_id, thread_id).join("state.json");
-        if !tokio::fs::try_exists(&path).await? {
-            return Ok(TranscriptState::new(
-                user_id.to_string(),
-                thread_id.to_string(),
-            ));
-        }
-        let contents = tokio::fs::read_to_string(&path)
-            .await
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        serde_json::from_str(&contents).with_context(|| "failed to parse transcript state")
+        let contents = match tokio::fs::read_to_string(&path).await {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(TranscriptState::new(
+                    user_id.to_string(),
+                    thread_id.to_string(),
+                ));
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to read {}", path.display()));
+            }
+        };
+        serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse transcript state {}", path.display()))
     }
 
     async fn write_state(
@@ -317,12 +321,35 @@ impl TranscriptStore {
         state: &TranscriptState,
     ) -> anyhow::Result<()> {
         let dir = self.thread_dir(user_id, thread_id);
-        tokio::fs::create_dir_all(dir.join("parts")).await?;
+        let parts_dir = dir.join("parts");
+        tokio::fs::create_dir_all(&parts_dir)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create transcript directory {}",
+                    parts_dir.display()
+                )
+            })?;
         let path = dir.join("state.json");
-        let tmp = dir.join("state.json.tmp");
         let payload = serde_json::to_vec_pretty(state)?;
-        tokio::fs::write(&tmp, payload).await?;
-        tokio::fs::rename(&tmp, &path).await?;
+        let temporary = tempfile::NamedTempFile::new_in(&dir).with_context(|| {
+            format!(
+                "failed to create temporary transcript state in {}",
+                dir.display()
+            )
+        })?;
+        let (file, temporary_path) = temporary.into_parts();
+        let mut file = tokio::fs::File::from_std(file);
+        file.write_all(&payload)
+            .await
+            .with_context(|| format!("failed to write transcript state {}", path.display()))?;
+        file.flush()
+            .await
+            .with_context(|| format!("failed to flush transcript state {}", path.display()))?;
+        drop(file);
+        temporary_path
+            .persist(&path)
+            .with_context(|| format!("failed to publish transcript state {}", path.display()))?;
         Ok(())
     }
 
@@ -1397,6 +1424,70 @@ mod tests {
             part.completion.as_ref().unwrap().items[0]["providerMetadata"]["openai"]["reasoningEncryptedContent"],
             ENVELOPE
         );
+    }
+
+    #[tokio::test]
+    async fn only_missing_state_is_treated_as_an_empty_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TranscriptStore::new(dir.path().to_path_buf());
+        assert_eq!(
+            store.load_state("user", "thread").await.unwrap(),
+            TranscriptState::new("user".into(), "thread".into())
+        );
+        let path = store.thread_dir("user", "thread").join("state.json");
+        std::fs::create_dir_all(&path).unwrap();
+        let error = store.load_state("user", "thread").await.unwrap_err();
+        assert!(error.to_string().contains(path.to_str().unwrap()));
+        std::fs::remove_dir(&path).unwrap();
+        std::fs::write(&path, "invalid JSON").unwrap();
+        let error = store.load_state("user", "thread").await.unwrap_err();
+        assert!(error.to_string().contains(path.to_str().unwrap()));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "invalid JSON");
+    }
+
+    #[tokio::test]
+    async fn independent_state_writers_do_not_share_temporary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let writes = (0..32).map(|number| {
+            let store = TranscriptStore::new(dir.path().to_path_buf());
+            async move {
+                let mut state = TranscriptState::new("user".into(), "thread".into());
+                state.remote_total_parts = number;
+                store.save_state("user", "thread", &state).await
+            }
+        });
+        for result in futures::future::join_all(writes).await {
+            result.expect("concurrent state publication should succeed");
+        }
+        let store = TranscriptStore::new(dir.path().to_path_buf());
+        let state = store.load_state("user", "thread").await.unwrap();
+        assert!(state.remote_total_parts < 32);
+        let files = std::fs::read_dir(store.thread_dir("user", "thread"))
+            .unwrap()
+            .count();
+        assert_eq!(files, 2, "only state.json and parts should remain");
+    }
+
+    #[tokio::test]
+    async fn shared_store_preserves_concurrent_part_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = TranscriptStore::new(dir.path().to_path_buf());
+        let writes = (0..32).map(|number| {
+            let store = Arc::clone(&store);
+            async move {
+                store
+                    .append_parts("user", "thread", &[prompt(number, "hello")])
+                    .await
+            }
+        });
+        for result in futures::future::join_all(writes).await {
+            result.unwrap();
+        }
+        let numbers = (0..32).collect::<Vec<_>>();
+        let parts = store.read_parts("user", "thread", &numbers).await.unwrap();
+        assert_eq!(parts.len(), numbers.len());
+        let state = store.load_state("user", "thread").await.unwrap();
+        assert!(numbers.iter().all(|number| state.covers(*number)));
     }
 
     #[tokio::test]

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -25,7 +25,6 @@ pub struct RunAgentRequest {
     pub reasoning_effort: String,
     pub service_tier: String,
     pub workspace_path: String,
-    pub transcript_root: std::path::PathBuf,
     pub installation_id: String,
     pub continuation_of_run_id: Option<String>,
 }

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -112,7 +112,6 @@ async fn run_agent_handler(
         reasoning_effort: payload.reasoning_effort,
         service_tier: payload.service_tier,
         workspace_path,
-        transcript_root: state.transcript.root(),
         installation_id: state.machine_identity.installation_id.clone(),
         continuation_of_run_id: payload.continuation_of_run_id,
     };
@@ -182,7 +181,7 @@ async fn run_agent_handler(
                     )
                 };
                 let _ = start_result_sender.send(Ok((run_id.clone(), thread_id.clone())));
-                let result = run_agent(run, live).await;
+                let result = run_agent(run, live, transcript).await;
                 if let Some(watch) = &artifact_watch {
                     if let Err(error) = watch.flush().await {
                         tracing::warn!("artifact sync after run {run_id} failed: {error:#}");

--- a/crates/sprocket-workspace/src/commands.rs
+++ b/crates/sprocket-workspace/src/commands.rs
@@ -97,7 +97,7 @@ impl CommandSessionManager {
         cancellation.ensure_active()?;
         let mut child = process
             .spawn()
-            .with_context(|| format!("failed to start command in {}", cwd.display()))?;
+            .with_context(|| format!("failed to start shell \"{shell}\" in {}", cwd.display()))?;
         let process_id = child.id();
         let (stdin, stdin_requests) = mpsc::channel(STDIN_QUEUE_CAPACITY);
         let stdin_task = tokio::spawn(write_command_input(child.stdin.take(), stdin_requests));
@@ -663,6 +663,33 @@ mod tests {
 
     use super::{CommandSessionManager, WorkspaceCancellation, default_command_shell};
     use crate::test_support::temp_workspace;
+
+    #[tokio::test]
+    async fn exec_command_reports_the_shell_and_workdir_when_spawn_fails() {
+        let root = temp_workspace();
+        let shell = root.join("missing-shell");
+        let sessions = CommandSessionManager::new(root.clone());
+        let error = sessions
+            .exec_command(
+                WorkspaceCancellation::new(),
+                "echo hello",
+                ".",
+                shell.to_str().unwrap(),
+                5_000,
+                5_000,
+                20_000,
+            )
+            .await
+            .expect_err("a missing shell must not fall back to another executable");
+
+        assert!(error.to_string().contains(shell.to_str().unwrap()));
+        assert!(error.to_string().contains(root.to_str().unwrap()));
+        assert_eq!(
+            error.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::NotFound
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
 
     #[tokio::test]
     async fn exec_command_defaults_to_workspace_root() {


### PR DESCRIPTION
## Summary

Agent startup constructed its own TranscriptStore for the same directory already used by server transcript watchers. Each store had separate locks, so read-modify-write operations could overlap. Both writers also used state.json.tmp, letting one rename remove the other writer's source file.

- Pass the server's existing transcript store into run_agent to share thread and attachment locks.
- Publish transcript state through a unique same-directory temporary file, flushing pending writes before the atomic replacement.
- Read missing state directly instead of checking existence first. Preserve other failures and include the affected path in errors.
- Include the selected shell and working directory in command-spawn errors. Do not silently fall back to a different shell or directory.

No network protocol or stored-data format changes.

## Validation

- The new 32-writer regression test failed against the original state-publication code with exactly `No such file or directory (os error 2)`.
- Transcript-store tests: 26 passed after the fix, including concurrent publication and preservation of shared-store updates.
- Command-session tests: 11 passed, including missing-shell diagnostics.
- Changed-file pre-commit checks passed, including formatting and spelling. JavaScript hooks were skipped because no JavaScript changed; redundant cargo-check was skipped in favor of tests.
- `bun run build`, `bun run test`, and `cargo test` passed in CI. Full pre-commit CI and native server checks on Linux, macOS, and Windows passed. The redundant fresh local workspace build was stopped after the equivalent CI tests passed.
- Requested Grok cleanup and review attempts were blocked by the Cursor account usage limit.

This fixes a reproduced cause of the reported error, not a claim that every ENOENT has the same cause.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62485770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the shared-store wiring and unique temporary-file publication directly address the reported race without leaving a concrete correctness issue.

<details open><summary><h3>Summary</h3></summary>

- Injects the canonical `Arc<TranscriptStore>` into `run_agent`, sharing per-thread locks with transcript watchers.
- Publishes state through uniquely named temporary files and atomically replaces `state.json`.
- Distinguishes missing state from other read failures and adds path-aware diagnostics.
- Improves command-spawn errors with the selected shell and working directory.
- Adds regression coverage for concurrent publication, shared-store updates, state-read failures, and missing shells.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Server[Server AppState] --> Store[Shared Arc TranscriptStore]
    Watcher[Transcript watcher] --> Store
    Agent[Agent run] --> Store
    Store --> Lock[Per-user/thread lock]
    Lock --> Read[Read state.json]
    Read --> Update[Apply state update]
    Update --> Temp[Write and flush unique temp file]
    Temp --> Persist[Atomically replace state.json]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(agent): Prevent transcript cache wri..."](https://github.com/spikonado/sprocket/commit/32a052f22edcfd79c13b2a891d3cf8186b9e4c43)</sub>

<!-- /greptile_comment -->