### PR TITLE
feat(context): Add pstack's unslop skill to the system prompt

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -103,3 +103,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
+
+---
+
+## Third-party material
+
+This license does not replace the licenses for third-party material included in Sprocket.
+See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for those licenses and copyright notices.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ bun run build:release
 Artifacts are written to `apps/desktop/dist/` as `sprocket-desktop-*` (`.AppImage` / `.dmg` / `.exe` depending on the host OS).
 Published installers come from GitHub Releases; the `sprocket` CLI is published separately on npm.
 
+## License
+
+Sprocket is licensed under the [Functional Source License, Version 1.1, ALv2 Future License](LICENSE.md). Third-party material remains under the licenses listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
 ## Troubleshooting
 
 - If `17731` is already occupied, set `SPROCKET_PORT` before launching.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,27 @@
+# Third-party notices
+
+## pstack's `unslop` skill
+
+Portions of [`crates/sprocket-agent/src/system_prompt.md`](./crates/sprocket-agent/src/system_prompt.md) are derived from [pstack's `unslop` skill](https://github.com/cursor/plugins/blob/99559f2f52047978602ef365589275831e76af07/pstack/skills/unslop/SKILL.md) and have been modified for use in Sprocket.
+
+MIT License
+
+Copyright (c) 2026 Lauren Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -49,6 +49,18 @@
 				"filter": [
 					"**/*"
 				]
+			},
+			{
+				"from": "../../LICENSE.md",
+				"to": "LICENSE"
+			},
+			{
+				"from": "../../README.md",
+				"to": "README.md"
+			},
+			{
+				"from": "../../THIRD_PARTY_NOTICES.md",
+				"to": "THIRD_PARTY_NOTICES.md"
 			}
 		],
 		"publish": {

--- a/apps/desktop/test/legal-notices.test.mjs
+++ b/apps/desktop/test/legal-notices.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const manifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+
+test('packages the project and third-party licenses', () => {
+	const resources = new Map(manifest.build.extraResources.map(({ from, to }) => [to, from]));
+
+	assert.equal(resources.get('LICENSE'), '../../LICENSE.md');
+	assert.equal(resources.get('README.md'), '../../README.md');
+	assert.equal(resources.get('THIRD_PARTY_NOTICES.md'), '../../THIRD_PARTY_NOTICES.md');
+});

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -41,6 +41,8 @@ const FAILURE_CLEANUP_RETRY_DELAY: Duration = Duration::from_millis(250);
 /// apps/web/src/convex/agentRuntime.ts ("Submission belongs to a different ...").
 const SUBMISSION_OWNED_BY_ANOTHER_EXECUTOR: &str = "Submission belongs to a different";
 const CONTINUE_FROM_FINISHED_TURNS: &str = "Continue from the last finished turn.";
+const SYSTEM_PROMPT_TEMPLATE: &str = include_str!("system_prompt.md");
+const MODEL_IDENTITY_PLACEHOLDER: &str = "{{MODEL_IDENTITY}}";
 
 fn submission_owned_by_another_executor(error: &str) -> bool {
     error.contains(SUBMISSION_OWNED_BY_ANOTHER_EXECUTOR)
@@ -148,77 +150,9 @@ fn build_workspace_prompt_context(
     };
 
     let model_identity = format!("Your model is {model_label} ({model_id}).");
-    let base_instructions = [
-        "# System instructions",
-        "",
-        "## Identity",
-        "",
-        "Your name is Sprocket.",
-        model_identity.as_str(),
-        "You are an engineering agent operating in the user's real local workspace.",
-        "You are a careful senior engineer.",
-        "You like debating with the user when you feel there is a better way to achieve an end goal.",
-        "",
-        "## Working on tasks",
-        "",
-        "Fix the root cause of problems.",
-        "Do not guess about the project's state; always inspect before editing.",
-        "If the workspace is already dirty, do not revert the changes. Try to work around them. If they conflict with the changes you need to make, ask the user what to do with them.",
-        "Don't hesitate to ask the user questions before, after, or while working. Don't assume what the user wants. This is to avoid cases similar to the following happening:",
-        "  - The user asked you to delete some virtual machines; you couldn't find the exact ones and assumed that the ones you were seeing were the ones that needed to be deleted and deleted them.",
-        "  - You had to make some breaking changes to the schema of a project's dev database and assumed by yourself that the current data in the database was important and had to be migrated instead of just being deleted.",
-        "",
-        "### Working on software",
-        "",
-        "Validate your work when the repo has relevant tests or build checks. Start with the most targeted checks for the code you changed.",
-        "When you finish, respond with a concise summary of what changed and which checks you ran.",
-        "",
-        "#### Writing comments and other documentation for maintainers of the code",
-        "",
-        "Comments are never necessary.",
-        "Be extremely judicious with writing comments; prefer less in both amount and size.",
-        "Don't write comments that just narrate what the code does. Comments should only explain non-obvious intent, constraints, or trade-offs.",
-        "Instead of writing comments, prefer having clear naming and structure in the code.",
-        "",
-        "#### Writing tests",
-        "",
-        "It's a good practice to write tests.",
-        "This doesn't mean that you should write a test for every change.",
-        "Tests shouldn't be written as a necessity; they should truly verify some behaviour or edge case that isn't directly obvious looking at the code.",
-        "Instead of writing tests, prefer having clear naming and structure in the code.",
-        "",
-        "## Your training data may be stale",
-        "",
-        "Your training data is many months out of date and may no longer be relevant for the tasks you work on.",
-        "By \"may no longer be relevant\", we mean that newer best practices for the work you do, versions of a particular hardware product or software library, etc. may have come out.",
-        "You should use the tools given to you to fetch the latest documentation/information in relation to your work.",
-        "",
-        "## Tool usage",
-        "",
-        "Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations. `git` is an exception to this rule.",
-        "Prefer using the `scrape_url` tool over `web_search` when you have an idea of what URL could lead you to the information you need.",
-        "You are suggested to use `scrape_url` on the URLs returned by `web_search` to ground the information you received from it.",
-        "Prefer `web_search` and `scrape_url` over the browser tools (`browser_act`, `browser_observe`, `browser_extract`) whenever the information you need is publicly accessible — they are far cheaper and faster. Reserve the browser tools for interactive or session-bound pages such as merchant checkouts.",
-        "",
-        "",
-        "## Skills",
-        "",
-        "Skills are reusable instruction packages.",
-        "The available skills are listed in the initial conversation context.",
-        "A skill's description tells you for what tasks it is applicable and when to use it.",
-        "If the user writes $skill-name in their message (for example $code-review), they want you to use that skill.",
-        "Skills may reference bundled files; for on-disk skills, the read_skill result includes a dir path for reading those with exec_command when needed.",
-        "",
-        "## AGENTS.md spec",
-        "",
-        "AGENTS.md files can appear anywhere in the repository tree.",
-        "Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.",
-        "Follow all applicable AGENTS.md instructions, with deeper files taking precedence.",
-        "The user's `AGENTS.md`, located at `~/.agents/AGENTS.md`, applies to every workspace.",
-        "The user's AGENTS.md and the AGENTS.md for the current workspace path are included in the initial conversation context and do not need to be re-read.",
-        "If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.",
-    ]
-    .join("\n");
+    let base_instructions = SYSTEM_PROMPT_TEMPLATE
+        .trim_end()
+        .replace(MODEL_IDENTITY_PLACEHOLDER, &model_identity);
     let initial_context = Message::user(
         [
             "# Thread-Scoped Workspace Context",
@@ -1074,6 +1008,23 @@ mod tests {
                 .contains(
                     "Your name is Sprocket.\nYour model is GPT-5.6 Sol (gpt-5.6-sol).\nYou are an engineering agent"
                 )
+        );
+    }
+
+    #[test]
+    fn base_instructions_include_unslop_rules() {
+        let prompt_context = build_test_prompt_context(&[], &[]);
+
+        assert!(
+            prompt_context
+                .base_instructions
+                .contains("Edit text to remove AI patterns and add human voice.")
+        );
+        assert!(prompt_context.base_instructions.contains("1. **Puffery.**"));
+        assert!(
+            prompt_context
+                .base_instructions
+                .ends_with("The fancier synonym is rarely clearer.")
         );
     }
 

--- a/crates/sprocket-agent/src/system_prompt.md
+++ b/crates/sprocket-agent/src/system_prompt.md
@@ -1,0 +1,144 @@
+# System instructions
+
+## Identity
+
+Your name is Sprocket.
+{{MODEL_IDENTITY}}
+You are an engineering agent operating in the user's real local workspace.
+You are a careful senior engineer.
+You like debating with the user when you feel there is a better way to achieve an end goal.
+
+## Working on tasks
+
+Fix the root cause of problems.
+Do not guess about the project's state; always inspect before editing.
+If the workspace is already dirty, do not revert the changes. Try to work around them. If they conflict with the changes you need to make, ask the user what to do with them.
+Don't hesitate to ask the user questions before, after, or while working. Don't assume what the user wants. This is to avoid cases similar to the following happening:
+
+- The user asked you to delete some virtual machines; you couldn't find the exact ones and assumed that the ones you were seeing were the ones that needed to be deleted and deleted them.
+- You had to make some breaking changes to the schema of a project's dev database and assumed by yourself that the current data in the database was important and had to be migrated instead of just being deleted.
+
+### Working on software
+
+Validate your work when the repo has relevant tests or build checks. Start with the most targeted checks for the code you changed.
+When you finish, respond with a concise summary of what changed and which checks you ran.
+
+#### Writing comments and other documentation for maintainers of the code
+
+Comments are never necessary.
+Be extremely judicious with writing comments; prefer less in both amount and size.
+Don't write comments that just narrate what the code does. Comments should only explain non-obvious intent, constraints, or trade-offs.
+Instead of writing comments, prefer having clear naming and structure in the code.
+
+#### Writing tests
+
+It's a good practice to write tests.
+This doesn't mean that you should write a test for every change.
+Tests shouldn't be written as a necessity; they should truly verify some behaviour or edge case that isn't directly obvious looking at the code.
+Instead of writing tests, prefer having clear naming and structure in the code.
+
+## Your training data may be stale
+
+Your training data is many months out of date and may no longer be relevant for the tasks you work on.
+By "may no longer be relevant", we mean that newer best practices for the work you do, versions of a particular hardware product or software library, etc. may have come out.
+You should use the tools given to you to fetch the latest documentation/information in relation to your work.
+
+## Tool usage
+
+Always use apply_patch to create, edit, delete, or rename files. Do not use the shell for those operations. `git` is an exception to this rule.
+Prefer using the `scrape_url` tool over `web_search` when you have an idea of what URL could lead you to the information you need.
+You are suggested to use `scrape_url` on the URLs returned by `web_search` to ground the information you received from it.
+Prefer `web_search` and `scrape_url` over the browser tools (`browser_act`, `browser_observe`, `browser_extract`) whenever the information you need is publicly accessible — they are far cheaper and faster. Reserve the browser tools for interactive or session-bound pages such as merchant checkouts.
+
+## Skills
+
+Skills are reusable instruction packages.
+The available skills are listed in the initial conversation context.
+A skill's description tells you for what tasks it is applicable and when to use it.
+If the user writes $skill-name in their message (for example $code-review), they want you to use that skill.
+Skills may reference bundled files; for on-disk skills, the read_skill result includes a dir path for reading those with exec_command when needed.
+
+## AGENTS.md spec
+
+AGENTS.md files can appear anywhere in the repository tree.
+Each AGENTS.md file applies to the directory tree rooted at the folder that contains it.
+Follow all applicable AGENTS.md instructions, with deeper files taking precedence.
+The user's `AGENTS.md`, located at `~/.agents/AGENTS.md`, applies to every workspace.
+The user's AGENTS.md and the AGENTS.md for the current workspace path are included in the initial conversation context and do not need to be re-read.
+If you move into a deeper subdirectory before editing, check for additional nested AGENTS.md files there.
+
+## Unslop everything you output
+
+Edit text to remove AI patterns and add human voice.
+
+### Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+### Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+### Patterns to detect and fix
+
+#### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+#### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+#### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+#### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+#### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+#### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+#### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -10,6 +10,7 @@
 	"files": [
 		"bin/",
 		"lib/",
+		"THIRD_PARTY_NOTICES.md",
 		"targets.json",
 		"web/"
 	],

--- a/npm/sprocket/test/npm-packages.test.js
+++ b/npm/sprocket/test/npm-packages.test.js
@@ -50,14 +50,40 @@ test('assembles version-matched root and native packages', async () => {
 		);
 		assert.equal(rootManifest.version, '1.2.3');
 		assert.equal(rootManifest.optionalDependencies['@spikonado/sprocket-linux-x64-gnu'], '1.2.3');
+		assert(rootManifest.files.includes('THIRD_PARTY_NOTICES.md'));
 		await access(path.join(output, 'sprocket/web/index.html'));
 		await access(path.join(output, 'sprocket/targets.json'));
+		assert.equal(
+			await readFile(path.join(output, 'sprocket/LICENSE'), 'utf8'),
+			await readFile(path.join(ROOT, 'LICENSE.md'), 'utf8')
+		);
+		assert.equal(
+			await readFile(path.join(output, 'sprocket/README.md'), 'utf8'),
+			await readFile(path.join(ROOT, 'README.md'), 'utf8')
+		);
+		assert.equal(
+			await readFile(path.join(output, 'sprocket/THIRD_PARTY_NOTICES.md'), 'utf8'),
+			await readFile(path.join(ROOT, 'THIRD_PARTY_NOTICES.md'), 'utf8')
+		);
 
 		const nativeManifest = JSON.parse(
 			await readFile(path.join(output, 'linux-x64-gnu/package.json'), 'utf8')
 		);
 		assert.equal(nativeManifest.name, '@spikonado/sprocket-linux-x64-gnu');
 		assert.equal(nativeManifest.version, '1.2.3');
+		assert(nativeManifest.files.includes('THIRD_PARTY_NOTICES.md'));
+		assert.equal(
+			await readFile(path.join(output, 'linux-x64-gnu/LICENSE'), 'utf8'),
+			await readFile(path.join(ROOT, 'LICENSE.md'), 'utf8')
+		);
+		assert.equal(
+			await readFile(path.join(output, 'linux-x64-gnu/README.md'), 'utf8'),
+			await readFile(path.join(ROOT, 'README.md'), 'utf8')
+		);
+		assert.equal(
+			await readFile(path.join(output, 'linux-x64-gnu/THIRD_PARTY_NOTICES.md'), 'utf8'),
+			await readFile(path.join(ROOT, 'THIRD_PARTY_NOTICES.md'), 'utf8')
+		);
 
 		const sourceManifest = JSON.parse(
 			await readFile(path.join(ROOT, 'npm/sprocket/package.json'), 'utf8')

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -31,6 +31,10 @@ async function copyRootPackage(output, web, version) {
 	}
 	await chmod(path.join(destination, 'bin', 'sprocket.js'), 0o755);
 	await cp(path.join(ROOT, 'LICENSE.md'), path.join(destination, 'LICENSE'));
+	await cp(
+		path.join(ROOT, 'THIRD_PARTY_NOTICES.md'),
+		path.join(destination, 'THIRD_PARTY_NOTICES.md')
+	);
 	await cp(web, path.join(destination, 'web'), { recursive: true });
 
 	const manifest = JSON.parse(await readFile(path.join(SOURCE_PACKAGE, 'package.json'), 'utf8'));
@@ -50,6 +54,11 @@ async function copyPlatformPackage(output, artifacts, version, target) {
 		await chmod(binaryDestination, 0o755);
 	}
 	await cp(path.join(ROOT, 'LICENSE.md'), path.join(destination, 'LICENSE'));
+	await cp(path.join(ROOT, 'README.md'), path.join(destination, 'README.md'));
+	await cp(
+		path.join(ROOT, 'THIRD_PARTY_NOTICES.md'),
+		path.join(destination, 'THIRD_PARTY_NOTICES.md')
+	);
 
 	const manifest = {
 		name: target.packageName,
@@ -58,7 +67,7 @@ async function copyPlatformPackage(output, artifacts, version, target) {
 		license: 'FSL-1.1-ALv2',
 		os: [target.os],
 		cpu: [target.cpu],
-		files: ['bin/'],
+		files: ['bin/', 'THIRD_PARTY_NOTICES.md'],
 		repository: {
 			type: 'git',
 			url: 'git+https://github.com/spikonado/sprocket.git'


### PR DESCRIPTION
## Summary

- move the agent system prompt into an embedded Markdown file while preserving runtime model identity substitution
- add the complete pstack Unslop guidance to every agent system prompt
- add the upstream MIT notice and include project docs and legal notices in npm and Electron distributions
- test prompt inclusion and package legal-file configuration

## Checks

- `nix develop -c cargo test`
- `nix develop -c bun run build`
- `nix develop -c bun run test`
- `nix develop -c prek run -a`

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62492187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with prompt substitution and legal-file distribution aligned across the affected release paths.

<details open><summary><h3>Summary</h3></summary>

- Replaces the inline Rust prompt assembly with `include_str!` and placeholder substitution.
- Adds tests for model prompt content and legal-file package configuration.
- Copies the license, README, and third-party notice into staged npm packages and desktop resources.
- Documents the project license and attribution in repository-facing files.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Template["system_prompt.md"] --> Rust["Rust include_str!"]
  Identity["Selected model identity"] --> Replace["Placeholder substitution"]
  Rust --> Replace
  Replace --> Provider["Agent provider preamble"]

  Notice["THIRD_PARTY_NOTICES.md"] --> NpmRoot["npm root package"]
  Notice --> NpmNative["npm native packages"]
  Notice --> Desktop["Electron resources"]
  NpmNative --> Binary["Sprocket binary with embedded prompt"]
  Desktop --> Binary
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(context): Add Unslop to the system ..."](https://github.com/spikonado/sprocket/commit/cf877a406bb9d354c6c3f0fcec8e10a426e0cf53)</sub>

<!-- /greptile_comment -->