### PR TITLE
fix(auth): Retry token fetches before sending Convex requests

### DIFF
--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -37,7 +37,7 @@ impl RuntimeClient {
         let client = ConvexRpcClient::new(&request.deployment_url).await?;
         client
             .set_auth_token_fetcher(request.auth_token_fetcher.clone())
-            .await;
+            .await?;
         eprintln!(
             "sprocket-agent: Convex client ready for thread {}",
             request.thread_id

--- a/crates/sprocket-convex/src/auth.rs
+++ b/crates/sprocket-convex/src/auth.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::Deserialize;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, watch};
 use tokio::task::JoinHandle;
 
 use crate::{AuthSignedOut, AuthTokenFetcher};
@@ -19,6 +19,8 @@ const REFRESH_LEEWAY_SECS: u64 = 10;
 const MIN_TOKEN_LIFETIME_SECS: u64 = 2;
 /// Matches Convex JS `MAXIMUM_REFRESH_DELAY` (setTimeout's 32-bit cap).
 const MAXIMUM_REFRESH_DELAY: Duration = Duration::from_secs(20 * 24 * 60 * 60);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 
 pub(crate) type ApplyRefresh =
     Arc<dyn Fn(u64) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
@@ -29,7 +31,7 @@ struct AuthSlots {
 }
 
 pub(crate) struct AuthState {
-    generation: AtomicU64,
+    generation: watch::Sender<u64>,
     fetch_epoch: AtomicU64,
     slots: Mutex<AuthSlots>,
     refresh: std::sync::Mutex<Option<JoinHandle<()>>>,
@@ -39,7 +41,7 @@ pub(crate) struct AuthState {
 impl AuthState {
     pub(crate) fn new() -> Arc<Self> {
         Arc::new(Self {
-            generation: AtomicU64::new(0),
+            generation: watch::channel(0).0,
             fetch_epoch: AtomicU64::new(0),
             slots: Mutex::new(AuthSlots {
                 fetcher: None,
@@ -55,19 +57,18 @@ impl AuthState {
     }
 
     pub(crate) fn shutdown(&self) {
-        self.generation.fetch_add(1, Ordering::SeqCst);
+        self.generation.send_modify(|generation| *generation += 1);
         self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
         self.abort_refresh();
     }
 
     pub(crate) fn generation(&self) -> u64 {
-        self.generation.load(Ordering::SeqCst)
+        *self.generation.borrow()
     }
 
     pub(crate) async fn install(self: &Arc<Self>, fetcher: AuthTokenFetcher) -> u64 {
-        self.abort_refresh();
-        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
+        self.shutdown();
+        let generation = self.generation();
         let mut slots = self.slots.lock().await;
         slots.fetcher = Some(fetcher);
         slots.pending_user_token = None;
@@ -86,12 +87,43 @@ impl AuthState {
         generation: u64,
         force_refresh: bool,
     ) -> anyhow::Result<String> {
-        if self.generation.load(Ordering::SeqCst) != generation {
+        let mut generations = self.generation.subscribe();
+        let retry = async {
+            let mut delay = INITIAL_RETRY_DELAY;
+            loop {
+                match self.resolve_once(generation, force_refresh).await {
+                    Ok(token) => return Ok(token),
+                    Err(error) if error.is::<AuthSignedOut>() => return Err(error),
+                    Err(_) => {}
+                }
+                // Convex 0.10.4 sends queued requests anonymously if its fetcher returns an error.
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_RETRY_DELAY);
+            }
+        };
+        tokio::select! {
+            biased;
+            _ = generations.wait_for(|current| *current != generation) => {
+                anyhow::bail!("stale auth callback");
+            }
+            result = retry => result,
+        }
+    }
+
+    async fn resolve_once(
+        self: &Arc<Self>,
+        generation: u64,
+        force_refresh: bool,
+    ) -> anyhow::Result<String> {
+        if self.generation() != generation {
             anyhow::bail!("stale auth callback");
         }
 
         let (fetcher, pending, epoch) = {
             let mut slots = self.slots.lock().await;
+            if self.generation() != generation {
+                anyhow::bail!("stale auth callback");
+            }
             if force_refresh {
                 slots.pending_user_token = None;
             }
@@ -108,24 +140,20 @@ impl AuthState {
             (slots.fetcher.clone(), pending, epoch)
         };
 
-        let token = if let Some(token) = pending {
-            token?
+        let result = if let Some(token) = pending {
+            token.map_err(Into::into)
         } else {
             let fetcher = fetcher.context("auth fetcher missing")?;
-            let token = fetcher(force_refresh).await?;
-            if self.generation.load(Ordering::SeqCst) != generation
-                || self.fetch_epoch.load(Ordering::SeqCst) != epoch
-            {
-                anyhow::bail!("stale auth callback");
-            }
-            token
+            fetcher(force_refresh).await
         };
-
-        Ok(token)
+        if self.generation() != generation || self.fetch_epoch.load(Ordering::SeqCst) != epoch {
+            anyhow::bail!("stale auth callback");
+        }
+        result
     }
 
     pub(crate) async fn arm(self: &Arc<Self>, generation: u64, token: &str) {
-        if self.generation.load(Ordering::SeqCst) != generation {
+        if self.generation() != generation {
             return;
         }
         self.abort_refresh();
@@ -151,16 +179,7 @@ impl AuthState {
 
 impl Drop for AuthState {
     fn drop(&mut self) {
-        self.generation.fetch_add(1, Ordering::SeqCst);
-        self.fetch_epoch.fetch_add(1, Ordering::SeqCst);
-        if let Some(handle) = self
-            .refresh
-            .get_mut()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take()
-        {
-            handle.abort();
-        }
+        self.shutdown();
     }
 }
 
@@ -178,7 +197,7 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
         let Some(auth) = weak.upgrade() else {
             return;
         };
-        if auth.generation.load(Ordering::SeqCst) != generation {
+        if auth.generation() != generation {
             return;
         }
         // Capture, don't bump: bumping here would make a concurrent SDK
@@ -190,7 +209,7 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
     let Some(fetcher) = fetcher else {
         return;
     };
-    let mut retry_delay = Duration::from_secs(1);
+    let mut retry_delay = INITIAL_RETRY_DELAY;
     let token = loop {
         match fetcher(true).await {
             Ok(token) => break Ok(token),
@@ -198,7 +217,7 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
             Err(_) => {}
         }
         tokio::time::sleep(retry_delay).await;
-        retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
+        retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
         let Some(auth) = weak.upgrade() else {
             return;
         };
@@ -209,9 +228,7 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
     let Some(auth) = weak.upgrade() else {
         return;
     };
-    if auth.generation.load(Ordering::SeqCst) != generation
-        || auth.fetch_epoch.load(Ordering::SeqCst) != epoch
-    {
+    if auth.generation() != generation || auth.fetch_epoch.load(Ordering::SeqCst) != epoch {
         return;
     }
     auth.slots.lock().await.pending_user_token = Some(token);

--- a/crates/sprocket-convex/src/auth.rs
+++ b/crates/sprocket-convex/src/auth.rs
@@ -21,9 +21,12 @@ const MIN_TOKEN_LIFETIME_SECS: u64 = 2;
 const MAXIMUM_REFRESH_DELAY: Duration = Duration::from_secs(20 * 24 * 60 * 60);
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+const AUTH_RECOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub(crate) type ApplyRefresh =
     Arc<dyn Fn(u64) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+pub(crate) type AuthFailureHandler =
+    Arc<dyn Fn(u64, String) -> Pin<Box<dyn Future<Output = bool> + Send>> + Send + Sync>;
 
 struct AuthSlots {
     fetcher: Option<AuthTokenFetcher>,
@@ -36,6 +39,8 @@ pub(crate) struct AuthState {
     slots: Mutex<AuthSlots>,
     refresh: std::sync::Mutex<Option<JoinHandle<()>>>,
     on_apply: std::sync::OnceLock<ApplyRefresh>,
+    on_failure: std::sync::OnceLock<AuthFailureHandler>,
+    failure: watch::Sender<Option<String>>,
 }
 
 impl AuthState {
@@ -49,11 +54,33 @@ impl AuthState {
             }),
             refresh: std::sync::Mutex::new(None),
             on_apply: std::sync::OnceLock::new(),
+            on_failure: std::sync::OnceLock::new(),
+            failure: watch::channel(None).0,
         })
     }
 
     pub(crate) fn set_on_apply(&self, on_apply: ApplyRefresh) {
         let _ = self.on_apply.set(on_apply);
+    }
+
+    pub(crate) fn set_on_failure(&self, on_failure: AuthFailureHandler) {
+        let _ = self.on_failure.set(on_failure);
+    }
+
+    pub(crate) fn report_failure(&self, error: String) {
+        self.failure.send_replace(Some(error));
+        self.abort_refresh();
+    }
+
+    pub(crate) async fn wait_for_failure(&self) -> String {
+        self.failure
+            .subscribe()
+            .wait_for(Option::is_some)
+            .await
+            .expect("auth state owns the failure sender")
+            .as_ref()
+            .expect("failure is present")
+            .clone()
     }
 
     pub(crate) fn shutdown(&self) {
@@ -68,6 +95,7 @@ impl AuthState {
 
     pub(crate) async fn install(self: &Arc<Self>, fetcher: AuthTokenFetcher) -> u64 {
         self.shutdown();
+        self.failure.send_replace(None);
         let generation = self.generation();
         let mut slots = self.slots.lock().await;
         slots.fetcher = Some(fetcher);
@@ -88,25 +116,40 @@ impl AuthState {
         force_refresh: bool,
     ) -> anyhow::Result<String> {
         let mut generations = self.generation.subscribe();
+        let mut last_error = None;
         let retry = async {
             let mut delay = INITIAL_RETRY_DELAY;
             loop {
                 match self.resolve_once(generation, force_refresh).await {
                     Ok(token) => return Ok(token),
                     Err(error) if error.is::<AuthSignedOut>() => return Err(error),
-                    Err(_) => {}
+                    Err(error) => last_error = Some(format!("{error:#}")),
                 }
                 // Convex 0.10.4 sends queued requests anonymously if its fetcher returns an error.
                 tokio::time::sleep(delay).await;
                 delay = (delay * 2).min(MAX_RETRY_DELAY);
             }
         };
-        tokio::select! {
+        let result = tokio::select! {
             biased;
             _ = generations.wait_for(|current| *current != generation) => {
                 anyhow::bail!("stale auth callback");
             }
-            result = retry => result,
+            result = tokio::time::timeout(AUTH_RECOVERY_TIMEOUT, retry) => result,
+        };
+        match result {
+            Ok(result) => result,
+            Err(_) => {
+                let error = recovery_timeout_error(last_error.as_deref());
+                if let Some(on_failure) = self.on_failure.get()
+                    && on_failure(generation, error).await
+                {
+                    // Only aborting the closed SDK worker may release this callback, even after clear_auth.
+                    std::future::pending().await
+                } else {
+                    anyhow::bail!("stale auth callback");
+                }
+            }
         }
     }
 
@@ -209,19 +252,34 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
     let Some(fetcher) = fetcher else {
         return;
     };
-    let mut retry_delay = INITIAL_RETRY_DELAY;
-    let token = loop {
-        match fetcher(true).await {
-            Ok(token) => break Ok(token),
-            Err(error) if error.is::<AuthSignedOut>() => break Err(AuthSignedOut),
-            Err(_) => {}
+    let mut last_error = None;
+    let refresh = async {
+        let mut retry_delay = INITIAL_RETRY_DELAY;
+        loop {
+            match fetcher(true).await {
+                Ok(token) => return Some(Ok(token)),
+                Err(error) if error.is::<AuthSignedOut>() => return Some(Err(AuthSignedOut)),
+                Err(error) => last_error = Some(format!("{error:#}")),
+            }
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
+            let auth = weak.upgrade()?;
+            if auth.generation() != generation || auth.fetch_epoch.load(Ordering::SeqCst) != epoch {
+                return None;
+            }
         }
-        tokio::time::sleep(retry_delay).await;
-        retry_delay = (retry_delay * 2).min(MAX_RETRY_DELAY);
-        let Some(auth) = weak.upgrade() else {
-            return;
-        };
-        if auth.generation() != generation || auth.fetch_epoch.load(Ordering::SeqCst) != epoch {
+    };
+    let token = match tokio::time::timeout(AUTH_RECOVERY_TIMEOUT, refresh).await {
+        Ok(Some(token)) => token,
+        Ok(None) => return,
+        Err(_) => {
+            if let Some(auth) = weak.upgrade()
+                && auth.generation() == generation
+                && auth.fetch_epoch.load(Ordering::SeqCst) == epoch
+                && let Some(on_failure) = auth.on_failure.get()
+            {
+                on_failure(generation, recovery_timeout_error(last_error.as_deref())).await;
+            }
             return;
         }
     };
@@ -237,6 +295,14 @@ async fn scheduled_refresh(weak: Weak<AuthState>, generation: u64, delay: Durati
     if let Some(on_apply) = on_apply {
         on_apply(generation).await;
     }
+}
+
+fn recovery_timeout_error(last_error: Option<&str>) -> String {
+    format!(
+        "Convex authentication did not recover within {} seconds: {}",
+        AUTH_RECOVERY_TIMEOUT.as_secs(),
+        last_error.unwrap_or("token fetch did not complete")
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sprocket-convex/src/lib.rs
+++ b/crates/sprocket-convex/src/lib.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for AuthSignedOut {
 impl std::error::Error for AuthSignedOut {}
 
 struct Inner {
-    convex: Mutex<ConvexClient>,
+    convex: Mutex<Option<ConvexClient>>,
     auth: Arc<AuthState>,
 }
 
@@ -61,7 +61,7 @@ impl Client {
             .await
             .context("failed to initialize Convex client")?;
         let inner = Arc::new(Inner {
-            convex: Mutex::new(client),
+            convex: Mutex::new(Some(client)),
             auth: AuthState::new(),
         });
         let inner_weak = Arc::downgrade(&inner);
@@ -71,11 +71,22 @@ impl Client {
                 apply_pending_token(inner_weak, generation).await;
             })
         }));
+        let inner_weak = Arc::downgrade(&inner);
+        inner
+            .auth
+            .set_on_failure(Arc::new(move |generation, error| {
+                Box::pin(close_failed_connection(
+                    inner_weak.clone(),
+                    generation,
+                    error,
+                ))
+            }));
         Ok(Self { inner })
     }
 
-    pub async fn set_auth_token_fetcher(&self, fetcher: AuthTokenFetcher) {
+    pub async fn set_auth_token_fetcher(&self, fetcher: AuthTokenFetcher) -> anyhow::Result<()> {
         let mut convex = self.inner.convex.lock().await;
+        let convex = convex.as_mut().context("Convex connection is closed")?;
         let generation = self.inner.auth.install(fetcher).await;
         convex
             .set_auth_callback(Some(sdk_fetcher(
@@ -83,12 +94,15 @@ impl Client {
                 generation,
             )))
             .await;
+        Ok(())
     }
 
     pub async fn clear_auth(&self) {
         let mut convex = self.inner.convex.lock().await;
         self.inner.auth.clear().await;
-        convex.set_auth_callback(None).await;
+        if let Some(convex) = convex.as_mut() {
+            convex.set_auth_callback(None).await;
+        }
     }
 
     pub async fn query(
@@ -96,11 +110,14 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner.convex).await;
-        timeout(CONVEX_RPC_TIMEOUT, convex.query(function, args))
-            .await
-            .with_context(|| format!("query timed out for {function}"))?
-            .map_err(Into::into)
+        self.with_auth_failure(async {
+            let mut convex = self.connected_client().await?;
+            timeout(CONVEX_RPC_TIMEOUT, convex.query(function, args))
+                .await
+                .with_context(|| format!("query timed out for {function}"))?
+                .map_err(Into::into)
+        })
+        .await
     }
 
     pub async fn subscribe(
@@ -108,11 +125,14 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<QuerySubscription> {
-        let mut convex = clone_locked(&self.inner.convex).await;
-        timeout(CONVEX_RPC_TIMEOUT, convex.subscribe(function, args))
-            .await
-            .with_context(|| format!("subscription timed out for {function}"))?
-            .map_err(Into::into)
+        self.with_auth_failure(async {
+            let mut convex = self.connected_client().await?;
+            timeout(CONVEX_RPC_TIMEOUT, convex.subscribe(function, args))
+                .await
+                .with_context(|| format!("subscription timed out for {function}"))?
+                .map_err(Into::into)
+        })
+        .await
     }
 
     pub async fn mutation(
@@ -120,11 +140,14 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner.convex).await;
-        timeout(CONVEX_RPC_TIMEOUT, convex.mutation(function, args))
-            .await
-            .with_context(|| format!("mutation timed out for {function}"))?
-            .map_err(Into::into)
+        self.with_auth_failure(async {
+            let mut convex = self.connected_client().await?;
+            timeout(CONVEX_RPC_TIMEOUT, convex.mutation(function, args))
+                .await
+                .with_context(|| format!("mutation timed out for {function}"))?
+                .map_err(Into::into)
+        })
+        .await
     }
 
     pub async fn action(
@@ -132,16 +155,35 @@ impl Client {
         function: &str,
         args: BTreeMap<String, Value>,
     ) -> anyhow::Result<FunctionResult> {
-        let mut convex = clone_locked(&self.inner.convex).await;
-        timeout(CONVEX_RPC_TIMEOUT, convex.action(function, args))
-            .await
-            .with_context(|| format!("action timed out for {function}"))?
-            .map_err(Into::into)
+        self.with_auth_failure(async {
+            let mut convex = self.connected_client().await?;
+            timeout(CONVEX_RPC_TIMEOUT, convex.action(function, args))
+                .await
+                .with_context(|| format!("action timed out for {function}"))?
+                .map_err(Into::into)
+        })
+        .await
     }
-}
 
-async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
-    inner.lock().await.clone()
+    async fn connected_client(&self) -> anyhow::Result<ConvexClient> {
+        self.inner
+            .convex
+            .lock()
+            .await
+            .clone()
+            .context("Convex connection is closed")
+    }
+
+    async fn with_auth_failure<T>(
+        &self,
+        operation: impl Future<Output = anyhow::Result<T>>,
+    ) -> anyhow::Result<T> {
+        tokio::select! {
+            biased;
+            error = self.inner.auth.wait_for_failure() => Err(anyhow::anyhow!(error)),
+            result = operation => result,
+        }
+    }
 }
 
 fn sdk_fetcher(auth: Weak<AuthState>, generation: u64) -> convex::AuthTokenFetcher {
@@ -168,7 +210,23 @@ async fn apply_pending_token(inner: Weak<Inner>, generation: u64) {
     if inner.auth.generation() != generation {
         return;
     }
+    let Some(convex) = convex.as_mut() else {
+        return;
+    };
     convex
         .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&inner.auth), generation)))
         .await;
+}
+
+async fn close_failed_connection(inner: Weak<Inner>, generation: u64, error: String) -> bool {
+    let Some(inner) = inner.upgrade() else {
+        return false;
+    };
+    let mut convex = inner.convex.lock().await;
+    if inner.auth.generation() == generation {
+        inner.auth.report_failure(error);
+        convex.take();
+        return true;
+    }
+    false
 }

--- a/crates/sprocket-convex/src/lib.rs
+++ b/crates/sprocket-convex/src/lib.rs
@@ -12,6 +12,8 @@ use tokio::time::timeout;
 
 mod auth;
 mod decode;
+#[cfg(test)]
+mod tests;
 
 use auth::AuthState;
 pub use decode::{
@@ -76,7 +78,10 @@ impl Client {
         let mut convex = self.inner.convex.lock().await;
         let generation = self.inner.auth.install(fetcher).await;
         convex
-            .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&self.inner), generation)))
+            .set_auth_callback(Some(sdk_fetcher(
+                Arc::downgrade(&self.inner.auth),
+                generation,
+            )))
             .await;
     }
 
@@ -139,14 +144,11 @@ async fn clone_locked<T: Clone>(inner: &Mutex<T>) -> T {
     inner.lock().await.clone()
 }
 
-fn sdk_fetcher(inner: Weak<Inner>, generation: u64) -> convex::AuthTokenFetcher {
+fn sdk_fetcher(auth: Weak<AuthState>, generation: u64) -> convex::AuthTokenFetcher {
     Box::new(move |force_refresh| {
-        let inner = inner.clone();
+        let auth = auth.clone();
         Box::pin(async move {
-            let auth = {
-                let inner = inner.upgrade().context("convex client dropped")?;
-                Arc::clone(&inner.auth)
-            };
+            let auth = auth.upgrade().context("convex client dropped")?;
             let token = match auth.resolve(generation, force_refresh).await {
                 Ok(token) => token,
                 Err(error) if error.is::<AuthSignedOut>() => return Ok(AuthenticationToken::None),
@@ -167,6 +169,6 @@ async fn apply_pending_token(inner: Weak<Inner>, generation: u64) {
         return;
     }
     convex
-        .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&inner), generation)))
+        .set_auth_callback(Some(sdk_fetcher(Arc::downgrade(&inner.auth), generation)))
         .await;
 }

--- a/crates/sprocket-convex/src/tests.rs
+++ b/crates/sprocket-convex/src/tests.rs
@@ -1,0 +1,219 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use convex::base_client::BaseConvexClient;
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tokio::time;
+
+use crate::{AuthSignedOut, AuthTokenFetcher, Client, auth::AuthState, sdk_fetcher};
+
+fn scripted_fetcher(
+    outcomes: Vec<anyhow::Result<String>>,
+) -> (AuthTokenFetcher, Arc<Mutex<Vec<bool>>>) {
+    let outcomes = Arc::new(Mutex::new(VecDeque::from(outcomes)));
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let fetcher: AuthTokenFetcher = {
+        let calls = Arc::clone(&calls);
+        Arc::new(move |force_refresh| {
+            let outcomes = Arc::clone(&outcomes);
+            let calls = Arc::clone(&calls);
+            Box::pin(async move {
+                calls.lock().await.push(force_refresh);
+                outcomes.lock().await.pop_front().expect("script exhausted")
+            })
+        })
+    };
+    (fetcher, calls)
+}
+
+fn next_message(client: &mut BaseConvexClient) -> Value {
+    client
+        .pop_next_message()
+        .expect("outgoing message")
+        .try_into()
+        .expect("message JSON")
+}
+
+fn assert_authenticate(client: &mut BaseConvexClient, token: &str) {
+    assert_eq!(
+        next_message(client),
+        json!({
+            "type": "Authenticate",
+            "baseVersion": 0,
+            "tokenType": "User",
+            "value": token,
+        })
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn initial_token_failure_does_not_send_an_anonymous_transcript_mutation() {
+    let auth = AuthState::new();
+    let (fetcher, calls) = scripted_fetcher(vec![
+        Err(anyhow::anyhow!("provider unavailable")),
+        Ok("user-token".into()),
+    ]);
+    let generation = auth.install(fetcher).await;
+    let mut client = BaseConvexClient::new();
+    client
+        .set_auth_fetcher(Some(sdk_fetcher(Arc::downgrade(&auth), generation)))
+        .await;
+    let _result = client.mutation(
+        "transcript:ensureMigrated".parse().expect("function path"),
+        BTreeMap::new(),
+    );
+
+    assert_authenticate(&mut client, "user-token");
+    assert_eq!(next_message(&mut client)["type"], "Mutation");
+    assert_eq!(*calls.lock().await, vec![false, false]);
+    auth.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn reconnect_token_failures_do_not_replay_requests_without_authentication() {
+    let auth = AuthState::new();
+    let (fetcher, calls) = scripted_fetcher(vec![
+        Ok("old-token".into()),
+        Err(anyhow::anyhow!("provider unavailable")),
+        Err(anyhow::anyhow!("provider still unavailable")),
+        Ok("refreshed-token".into()),
+    ]);
+    let generation = auth.install(fetcher).await;
+    let mut client = BaseConvexClient::new();
+    client
+        .set_auth_fetcher(Some(sdk_fetcher(Arc::downgrade(&auth), generation)))
+        .await;
+    client.subscribe(
+        "transcript:getState".parse().expect("function path"),
+        BTreeMap::new(),
+    );
+    let _result = client.mutation(
+        "transcript:ensureMigrated".parse().expect("function path"),
+        BTreeMap::new(),
+    );
+    while client.pop_next_message().is_some() {}
+
+    client.resend_ongoing_queries_mutations().await;
+
+    assert_authenticate(&mut client, "refreshed-token");
+    assert_eq!(next_message(&mut client)["type"], "ModifyQuerySet");
+    assert_eq!(next_message(&mut client)["type"], "Mutation");
+    assert_eq!(*calls.lock().await, vec![false, true, true, true]);
+    auth.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_sign_out_does_not_retry() {
+    let auth = AuthState::new();
+    let (fetcher, calls) = scripted_fetcher(vec![Err(AuthSignedOut.into())]);
+    let generation = auth.install(fetcher).await;
+    let callback = sdk_fetcher(Arc::downgrade(&auth), generation);
+
+    assert_eq!(
+        callback(false).await.expect("signed out"),
+        convex::AuthenticationToken::None
+    );
+    assert_eq!(*calls.lock().await, vec![false]);
+    auth.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn clear_cancels_a_hung_sdk_token_fetch() {
+    let auth = AuthState::new();
+    let generation = auth
+        .install(Arc::new(|_| Box::pin(std::future::pending())))
+        .await;
+    let callback = sdk_fetcher(Arc::downgrade(&auth), generation);
+    let pending = tokio::spawn(callback(false));
+    tokio::task::yield_now().await;
+
+    auth.clear().await;
+
+    let error = time::timeout(Duration::from_secs(1), pending)
+        .await
+        .expect("clear must unblock the SDK worker")
+        .expect("join")
+        .expect_err("stale callback");
+    assert!(!error.is::<AuthSignedOut>());
+}
+
+#[tokio::test(start_paused = true)]
+async fn retries_back_off_and_cap_the_delay() {
+    let auth = AuthState::new();
+    let mut outcomes: Vec<_> = (0..8)
+        .map(|_| Err(anyhow::anyhow!("provider unavailable")))
+        .collect();
+    outcomes.push(Ok("user-token".into()));
+    let (fetcher, calls) = scripted_fetcher(outcomes);
+    let generation = auth.install(fetcher).await;
+    let callback = sdk_fetcher(Arc::downgrade(&auth), generation);
+    let start = time::Instant::now();
+
+    assert_eq!(
+        callback(true).await.expect("recovered"),
+        convex::AuthenticationToken::User("user-token".into())
+    );
+    assert_eq!(
+        start.elapsed(),
+        Duration::from_secs(1 + 2 + 4 + 8 + 16 + 30 + 30 + 30)
+    );
+    assert_eq!(*calls.lock().await, vec![true; 9]);
+    auth.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn replacement_cancels_retry_backoff_without_using_the_new_fetcher() {
+    let auth = AuthState::new();
+    let (fetcher, calls) = scripted_fetcher(vec![Err(anyhow::anyhow!("provider unavailable"))]);
+    let generation = auth.install(fetcher).await;
+    let callback = sdk_fetcher(Arc::downgrade(&auth), generation);
+    let pending = tokio::spawn(callback(false));
+    tokio::task::yield_now().await;
+    assert_eq!(*calls.lock().await, vec![false]);
+    assert!(!pending.is_finished());
+
+    let (replacement, replacement_calls) = scripted_fetcher(vec![Ok("new-user-token".into())]);
+    let new_generation = auth.install(replacement).await;
+    let error = time::timeout(Duration::from_millis(100), pending)
+        .await
+        .expect("replacement must not wait for retry backoff")
+        .expect("join")
+        .expect_err("stale callback");
+    assert!(!error.is::<AuthSignedOut>());
+    assert!(replacement_calls.lock().await.is_empty());
+
+    let callback = sdk_fetcher(Arc::downgrade(&auth), new_generation);
+    assert_eq!(
+        callback(false).await.expect("replacement token"),
+        convex::AuthenticationToken::User("new-user-token".into())
+    );
+    auth.shutdown();
+}
+
+#[tokio::test(start_paused = true)]
+async fn last_client_drop_cancels_a_hung_sdk_token_fetch() {
+    let client = Client::new("http://127.0.0.1:1").await.expect("client");
+    let clone = client.clone();
+    let auth = Arc::downgrade(&client.inner.auth);
+    let generation = client
+        .inner
+        .auth
+        .install(Arc::new(|_| Box::pin(std::future::pending())))
+        .await;
+    let callback = sdk_fetcher(auth.clone(), generation);
+    let pending = tokio::spawn(callback(false));
+    tokio::task::yield_now().await;
+    drop(client);
+    assert!(!pending.is_finished());
+
+    drop(clone);
+
+    time::timeout(Duration::from_secs(1), pending)
+        .await
+        .expect("client drop must unblock the SDK worker")
+        .expect("join")
+        .expect_err("client dropped");
+    assert!(auth.upgrade().is_none());
+}

--- a/crates/sprocket-convex/src/tests.rs
+++ b/crates/sprocket-convex/src/tests.rs
@@ -142,7 +142,7 @@ async fn clear_cancels_a_hung_sdk_token_fetch() {
 #[tokio::test(start_paused = true)]
 async fn retries_back_off_and_cap_the_delay() {
     let auth = AuthState::new();
-    let mut outcomes: Vec<_> = (0..8)
+    let mut outcomes: Vec<_> = (0..7)
         .map(|_| Err(anyhow::anyhow!("provider unavailable")))
         .collect();
     outcomes.push(Ok("user-token".into()));
@@ -157,9 +157,9 @@ async fn retries_back_off_and_cap_the_delay() {
     );
     assert_eq!(
         start.elapsed(),
-        Duration::from_secs(1 + 2 + 4 + 8 + 16 + 30 + 30 + 30)
+        Duration::from_secs(1 + 2 + 4 + 8 + 16 + 30 + 30)
     );
-    assert_eq!(*calls.lock().await, vec![true; 9]);
+    assert_eq!(*calls.lock().await, vec![true; 8]);
     auth.shutdown();
 }
 
@@ -216,4 +216,139 @@ async fn last_client_drop_cancels_a_hung_sdk_token_fetch() {
         .expect("join")
         .expect_err("client dropped");
     assert!(auth.upgrade().is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn persistent_auth_failure_closes_the_connection_and_fails_all_pending_operations() {
+    let client = Client::new("http://127.0.0.1:1").await.expect("client");
+    client
+        .set_auth_token_fetcher(Arc::new(|_| {
+            Box::pin(async { anyhow::bail!("credential store unavailable") })
+        }))
+        .await
+        .expect("install fetcher");
+    let start = time::Instant::now();
+
+    let (query, mutation, action, subscription) = tokio::join!(
+        client.query("transcript:getState", BTreeMap::new()),
+        client.mutation("transcript:ensureMigrated", BTreeMap::new()),
+        client.action("example:action", BTreeMap::new()),
+        client.subscribe("transcript:getState", BTreeMap::new()),
+    );
+
+    for error in [
+        query.expect_err("query must fail locally"),
+        mutation.expect_err("mutation must fail locally"),
+        action.expect_err("action must fail locally"),
+        subscription.expect_err("subscription must fail locally"),
+    ] {
+        assert!(error.to_string().contains("credential store unavailable"));
+        assert!(error.to_string().contains("120 seconds"));
+    }
+    assert_eq!(start.elapsed(), Duration::from_secs(120));
+    assert!(client.inner.convex.lock().await.is_none());
+    let start = time::Instant::now();
+    client
+        .query("transcript:getState", BTreeMap::new())
+        .await
+        .expect_err("closed connection must reject new work");
+    assert_eq!(start.elapsed(), Duration::ZERO);
+    client.clear_auth().await;
+    assert!(client.inner.convex.lock().await.is_none());
+    client
+        .set_auth_token_fetcher(Arc::new(|_| Box::pin(async { Ok("new-token".into()) })))
+        .await
+        .expect_err("recovery requires a new connection");
+}
+
+#[tokio::test(start_paused = true)]
+async fn auth_deadline_never_releases_the_sdk_to_send_anonymous_requests() {
+    let client = Client::new("http://127.0.0.1:1").await.expect("client");
+    let generation = client
+        .inner
+        .auth
+        .install(Arc::new(|_| Box::pin(std::future::pending())))
+        .await;
+    let mut sdk = BaseConvexClient::new();
+    let error = {
+        let mut authenticate = Box::pin(sdk.set_auth_fetcher(Some(sdk_fetcher(
+            Arc::downgrade(&client.inner.auth),
+            generation,
+        ))));
+        let error = time::timeout(Duration::from_secs(121), async {
+            tokio::select! {
+                error = client.inner.auth.wait_for_failure() => error,
+                _ = &mut authenticate => panic!("failed auth resumed the SDK worker"),
+            }
+        })
+        .await
+        .expect("auth failure deadline");
+        client.clear_auth().await;
+        assert!(
+            time::timeout(Duration::from_secs(1), authenticate)
+                .await
+                .is_err(),
+            "clearing failed auth must not release queued requests"
+        );
+        error
+    };
+    assert!(sdk.pop_next_message().is_none());
+    assert!(client.inner.convex.lock().await.is_none());
+    assert!(error.contains("token fetch did not complete"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn scheduled_auth_failure_closes_the_idle_connection() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let client = Client::new("http://127.0.0.1:1").await.expect("client");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let fetcher: AuthTokenFetcher = {
+        let calls = Arc::clone(&calls);
+        Arc::new(move |_| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { anyhow::bail!("provider misconfigured") })
+        })
+    };
+    let generation = client.inner.auth.install(fetcher).await;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("unix time")
+        .as_secs();
+    use base64::Engine as _;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(json!({ "iat": now, "exp": now + 11 }).to_string());
+    client
+        .inner
+        .auth
+        .arm(generation, &format!("header.{payload}.sig"))
+        .await;
+    let error = client.inner.auth.wait_for_failure().await;
+
+    assert!(error.contains("provider misconfigured"));
+    assert!(client.inner.convex.lock().await.is_none());
+    let attempts = calls.load(Ordering::SeqCst);
+    time::advance(Duration::from_secs(300)).await;
+    assert_eq!(calls.load(Ordering::SeqCst), attempts);
+}
+
+#[tokio::test(start_paused = true)]
+async fn stale_auth_failure_cannot_close_a_replacement_session() {
+    let client = Client::new("http://127.0.0.1:1").await.expect("client");
+    let fetcher: AuthTokenFetcher = Arc::new(|_| Box::pin(async { Ok("user-token".into()) }));
+    let previous = client.inner.auth.install(Arc::clone(&fetcher)).await;
+    client.inner.auth.install(fetcher).await;
+
+    crate::close_failed_connection(
+        Arc::downgrade(&client.inner),
+        previous,
+        "old failure".into(),
+    )
+    .await;
+
+    assert!(client.inner.convex.lock().await.is_some());
+    client
+        .with_auth_failure(async { Ok(()) })
+        .await
+        .expect("current session is healthy");
 }

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -20,7 +20,7 @@ impl UserConvexClient {
         fetcher: AuthTokenFetcher,
     ) -> anyhow::Result<Self> {
         let client = ConvexClient::new(deployment_url).await?;
-        client.set_auth_token_fetcher(fetcher).await;
+        client.set_auth_token_fetcher(fetcher).await?;
         Ok(Self { client })
     }
 


### PR DESCRIPTION
## Summary

Convex Rust SDK 0.10.4 continues without an Authenticate message when a token fetch fails during setup or reconnect. This can send transcript:ensureMigrated and replay subscriptions anonymously, producing Authentication required despite a valid local session.

- Retry transient token-fetch failures before returning control to the SDK, with exponential backoff capped at 30 seconds. Preserve forced refresh on reconnect.
- Bound token recovery and scheduled refresh to 120 seconds. Close the connection and fail pending calls locally on persistent errors, without allowing anonymous requests.
- Cancel stalled fetches and retry waits on clear-auth, account replacement, or final client drop. Only AuthSignedOut returns an anonymous token.
- Add request-ordering regression tests against the SDK BaseConvexClient, plus retry and cancellation coverage. Backend auth and ownership checks are unchanged. No API or stored-data changes.

## Validation

- Reproduced missing authentication messages on initial mutation and reconnect before the fix.
- cargo test -p sprocket-convex --locked: 35 tests passed.
- Full Rust workspace tests: passed locally before the review follow-up and in CI on final commit 9403dc1. Stopped the redundant final local rerun to avoid memory pressure.
- Final-commit CI: all checks passed, including web build/tests, cross-platform native checks, Prek, and CodeQL.
- Greptile approved final commit 9403dc1 with 5/5 confidence.
- cargo fmt --all -- --check: passed.
- Commit hooks passed, including cargo check, ESLint, Oxlint, Svelte checks, Prettier, and Mermaid lint.
- Requested Cursor subagent reviews were blocked by the account usage limit.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62523139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previously unbounded permanent-failure retry now terminates through a bounded connection-failure path.

<details open><summary><h3>Summary</h3></summary>

- Retries token acquisition with capped exponential backoff and a bounded recovery deadline.
- Cancels stale authentication work when auth is cleared, replaced, or dropped.
- Closes failed connections and propagates terminal authentication errors to pending operations.
- Updates client constructors to propagate authentication setup failures.
- Adds regression coverage for request ordering, retry timing, cancellation, and terminal recovery behavior.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Client
    participant AuthState
    participant TokenProvider
    participant Convex

    Caller->>Client: query / mutation / subscribe
    Client->>Convex: authenticated operation
    Convex->>AuthState: fetch token
    loop Until success, sign-out, cancellation, or 120s deadline
        AuthState->>TokenProvider: fetch(force_refresh)
        alt Token returned
            TokenProvider-->>AuthState: token
            AuthState-->>Convex: Authenticate(token)
            Convex-->>Caller: operation result
        else Transient failure
            TokenProvider-->>AuthState: error
            AuthState->>AuthState: exponential backoff
        else Signed out
            TokenProvider-->>AuthState: AuthSignedOut
            AuthState-->>Convex: anonymous token
        end
    end
    alt Recovery deadline expires
        AuthState->>Client: report terminal failure
        Client->>Convex: close connection
        Client-->>Caller: authentication recovery error
    end
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(auth): Bound recovery and close fail..."](https://github.com/spikonado/sprocket/commit/9403dc13941244b5389ec93c6b298d1003fc7467)</sub>

<!-- /greptile_comment -->