### PR TITLE
fix(agent-tools): Require/support complete commands

### DIFF
--- a/apps/web/src/convex/firecrawlBrowser.test.ts
+++ b/apps/web/src/convex/firecrawlBrowser.test.ts
@@ -478,7 +478,7 @@ describe('Firecrawl browser lifecycle', () => {
 
 	it.each([
 		'agent-browser help',
-		'agent-browser --json screenshot',
+		'agent-browser --json get url',
 		'agent-browser fill @e1 "$(touch /tmp/owned); echo secret"'
 	])('forwards %s to Firecrawl unchanged', async (command) => {
 		const fetch = remote();

--- a/apps/web/src/convex/firecrawlBrowser.test.ts
+++ b/apps/web/src/convex/firecrawlBrowser.test.ts
@@ -91,9 +91,9 @@ describe('Firecrawl browser lifecycle', () => {
 		const first = await fixture(t, 'first');
 		const second = await fixture(t, 'second');
 		const third = await fixture(t, 'third');
-		await interact(t, { ...first, command: 'get url' });
-		await interact(t, { ...second, command: 'get url' });
-		await expect(interact(t, { ...third, command: 'get url' })).rejects.toThrow(
+		await interact(t, { ...first, command: 'agent-browser get url' });
+		await interact(t, { ...second, command: 'agent-browser get url' });
+		await expect(interact(t, { ...third, command: 'agent-browser get url' })).rejects.toThrow(
 			'Both browser session slots are in use'
 		);
 		expect(fetch).toHaveBeenCalledTimes(4);
@@ -112,13 +112,13 @@ describe('Firecrawl browser lifecycle', () => {
 		await vi.advanceTimersByTimeAsync(0);
 		await t.finishInProgressScheduledFunctions();
 		expect(await t.run((ctx) => ctx.db.query('browserCapacity').collect())).toHaveLength(2);
-		await expect(interact(t, { ...third, command: 'get url' })).rejects.toThrow(
+		await expect(interact(t, { ...third, command: 'agent-browser get url' })).rejects.toThrow(
 			'Both browser session slots are in use'
 		);
 		await vi.advanceTimersByTimeAsync(60_000);
 		await t.finishInProgressScheduledFunctions();
 		expect(await t.run((ctx) => ctx.db.query('browserCapacity').collect())).toHaveLength(1);
-		await interact(t, { ...third, command: 'get url' });
+		await interact(t, { ...third, command: 'agent-browser get url' });
 		expect(await t.run((ctx) => ctx.db.query('browserCapacity').collect())).toHaveLength(2);
 	});
 
@@ -128,8 +128,8 @@ describe('Firecrawl browser lifecycle', () => {
 		const t = initConvexTest();
 		const auth = await fixture(t);
 		for (let i = 0; i < 2; i++)
-			await expect(interact(t, { ...auth, command: 'click @e1' })).rejects.toThrow();
-		await expect(interact(t, { ...auth, command: 'click @e1' })).rejects.toThrow(
+			await expect(interact(t, { ...auth, command: 'agent-browser click @e1' })).rejects.toThrow();
+		await expect(interact(t, { ...auth, command: 'agent-browser click @e1' })).rejects.toThrow(
 			'Both browser session slots are in use'
 		);
 		expect(fetch).toHaveBeenCalledTimes(2);
@@ -153,10 +153,10 @@ describe('Firecrawl browser lifecycle', () => {
 		const t = initConvexTest();
 		const first = await fixture(t, 'reader');
 		const second = await fixture(t, 'other');
-		await interact(t, { ...first, command: 'get url' });
-		await interact(t, { ...second, command: 'get url' });
+		await interact(t, { ...first, command: 'agent-browser get url' });
+		await interact(t, { ...second, command: 'agent-browser get url' });
 		await expect(
-			interact(t, { ...first, command: 'click @e1', enforce_saving: true })
+			interact(t, { ...first, command: 'agent-browser click @e1', enforce_saving: true })
 		).rejects.toThrow('Both browser session slots are in use');
 		expect(fetch).toHaveBeenCalledTimes(5);
 		expect(fetch.mock.calls.some(([, options]) => options.method === 'DELETE')).toBe(false);
@@ -178,7 +178,7 @@ describe('Firecrawl browser lifecycle', () => {
 			runId,
 			claimId,
 			executionSecret,
-			command: 'get url'
+			command: 'agent-browser get url'
 		});
 		const requests = fetch.mock.calls.map(([, options]) => JSON.parse(String(options.body)));
 		expect(requests.map((body) => body.profile?.saveChanges)).toEqual([true, false, undefined]);
@@ -200,7 +200,7 @@ describe('Firecrawl browser lifecycle', () => {
 					runId,
 					claimId,
 					executionSecret,
-					command: 'click @e1'
+					command: 'agent-browser click @e1'
 				})
 			).rejects.toThrow();
 			expect(fetch).toHaveBeenCalledTimes(1);
@@ -217,7 +217,7 @@ describe('Firecrawl browser lifecycle', () => {
 				runId,
 				claimId,
 				executionSecret,
-				command: 'open https://example.com',
+				command: 'agent-browser open https://example.com',
 				enforce_saving: true
 			})
 		).rejects.toThrow('browser saving is disabled in Settings');
@@ -229,7 +229,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote().mockResolvedValueOnce(new Response('{}', { status: 409 }));
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		const reader = await t.run((ctx) => ctx.db.query('browserSessions').unique());
 		vi.setSystemTime(Date.now() + 1_000);
@@ -257,7 +257,7 @@ describe('Firecrawl browser lifecycle', () => {
 			const fetch = remote().mockResolvedValueOnce(new Response('{}', { status: 409 }));
 			const t = initConvexTest();
 			const { runId, claimId, executionSecret } = await fixture(t);
-			const args = { runId, claimId, executionSecret, command: 'get url' };
+			const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 			await interact(t, args);
 			fetch.mockResolvedValueOnce(new Response('{}', { status }));
 			await expect(interact(t, { ...args, enforce_saving: true })).rejects.toThrow(
@@ -285,7 +285,7 @@ describe('Firecrawl browser lifecycle', () => {
 			const fetch = remote().mockResolvedValueOnce(new Response('{}', { status: 409 }));
 			const t = initConvexTest();
 			const { asUser, runId, claimId, executionSecret } = await fixture(t);
-			const args = { runId, claimId, executionSecret, command: 'get url' };
+			const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 			await interact(t, args);
 			fetch.mockImplementationOnce(async () => {
 				if (change === 'saving disabled')
@@ -318,7 +318,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote().mockResolvedValueOnce(new Response('{}', { status: 409 }));
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		fetch.mockResolvedValueOnce(new Response(JSON.stringify({ success: true, id: 'writer' })));
 		await interact(t, { ...args, enforce_saving: true });
@@ -346,7 +346,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { asUser, runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'click @e1' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser click @e1' };
 		if (replacing) {
 			fetch.mockResolvedValueOnce(new Response('{}', { status: 409 }));
 			await interact(t, args);
@@ -381,7 +381,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { asUser, runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		const session = await t.run((ctx) => ctx.db.query('browserSessions').unique());
 		fetch.mockImplementationOnce(async () => {
@@ -415,7 +415,7 @@ describe('Firecrawl browser lifecycle', () => {
 			const fetch = remote();
 			const t = initConvexTest();
 			const { asUser, userId, threadId, runId, claimId, executionSecret } = await fixture(t);
-			const args = { runId, claimId, executionSecret, command: 'get url' };
+			const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 			const replacing = transition === 'saving upgrade';
 			if (replacing) {
 				fetch.mockResolvedValueOnce(new Response('{}', { status: 409 }));
@@ -476,12 +476,19 @@ describe('Firecrawl browser lifecycle', () => {
 		}
 	);
 
-	it('maps the advertised help command to CLI help', async () => {
+	it.each([
+		'agent-browser help',
+		'agent-browser --json screenshot',
+		'agent-browser fill @e1 "$(touch /tmp/owned); echo secret"'
+	])('forwards %s to Firecrawl unchanged', async (command) => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
-		await interact(t, { runId, claimId, executionSecret, command: 'help' });
-		expect(JSON.parse(String(fetch.mock.calls[1][1].body)).code).toBe("'agent-browser' '--help'");
+		await interact(t, { runId, claimId, executionSecret, command });
+		expect(JSON.parse(String(fetch.mock.calls[1][1].body))).toMatchObject({
+			code: command,
+			language: 'bash'
+		});
 	});
 
 	it('does not discard an attached session when its attachment acknowledgement is lost', async () => {
@@ -493,7 +500,7 @@ describe('Firecrawl browser lifecycle', () => {
 			runId,
 			claimId,
 			executionSecret,
-			command: 'get url'
+			command: 'agent-browser get url'
 		});
 		const session = await t.run((ctx) => ctx.db.query('browserSessions').unique());
 		await t.mutation(internal.browserSessions.discardUnattached, {
@@ -564,7 +571,7 @@ describe('Firecrawl browser lifecycle', () => {
 					runId,
 					claimId,
 					executionSecret,
-					command: 'get url'
+					command: 'agent-browser get url'
 				})
 			).toEqual({ text: 'Done', truncated: false });
 		}
@@ -593,7 +600,7 @@ describe('Firecrawl browser lifecycle', () => {
 			runId,
 			claimId,
 			executionSecret,
-			command: 'get url'
+			command: 'agent-browser get url'
 		});
 		const session = await t.run((ctx) => ctx.db.query('browserSessions').unique());
 		expect(session?.expiresAt).toBe((session?.startedAt ?? 0) + 3_600_000);
@@ -608,7 +615,7 @@ describe('Firecrawl browser lifecycle', () => {
 				runId,
 				claimId,
 				executionSecret,
-				command: 'click @e1',
+				command: 'agent-browser click @e1',
 				enforce_saving: true
 			})
 		).rejects.toThrow(
@@ -622,7 +629,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { asUser, runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		await asUser.mutation(api.browserProfiles.setSaving, { enabled: false });
 		await interact(t, args);
@@ -639,7 +646,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { asUser, threadId, runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		await asUser.mutation(api.browserProfiles.setHumanControl, { threadId, enabled: true });
 		await expect(interact(t, args)).rejects.toThrow(
@@ -655,7 +662,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		fetch.mockResolvedValue(
 			new Response(JSON.stringify({ success: true, exitCode: 1, stderr: 'Command failed' }))
@@ -749,21 +756,6 @@ describe('Firecrawl browser lifecycle', () => {
 		).rejects.toThrow();
 	});
 
-	it('keeps commands shell-quoted and does not execute shell substitutions', async () => {
-		const fetch = remote();
-		const t = initConvexTest();
-		const { runId, claimId, executionSecret } = await fixture(t);
-		await interact(t, {
-			runId,
-			claimId,
-			executionSecret,
-			command: 'fill @e1 "$(touch /tmp/owned); echo secret"'
-		});
-		expect(JSON.parse(String(fetch.mock.calls[1][1].body)).code).toBe(
-			"'agent-browser' 'fill' '@e1' '$(touch /tmp/owned); echo secret'"
-		);
-	});
-
 	it('starts non-saving when the preference is disabled, without discarding the saved profile', async () => {
 		const fetch = remote();
 		const t = initConvexTest();
@@ -774,24 +766,12 @@ describe('Firecrawl browser lifecycle', () => {
 			runId,
 			claimId,
 			executionSecret,
-			command: 'get url'
+			command: 'agent-browser get url'
 		});
 		expect(JSON.parse(String(fetch.mock.calls[0][1].body)).profile).toEqual({
 			name: profile!.name,
 			saveChanges: false
 		});
-	});
-
-	it('rejects global options with or without the CLI prefix before creating a session', async () => {
-		const fetch = remote();
-		const t = initConvexTest();
-		const { runId, claimId, executionSecret } = await fixture(t);
-		for (const command of ['--help', 'agent-browser --help', 'agent-browser --json screenshot']) {
-			await expect(interact(t, { runId, claimId, executionSecret, command })).rejects.toThrow(
-				'without global options'
-			);
-		}
-		expect(fetch).not.toHaveBeenCalled();
 	});
 
 	it.each([68, 600_000, 600_001])(
@@ -801,7 +781,7 @@ describe('Firecrawl browser lifecycle', () => {
 			const t = initConvexTest();
 			const { runId, claimId, executionSecret } = await fixture(t);
 			const args = { runId, claimId, executionSecret };
-			await interact(t, { ...args, command: 'get url' });
+			await interact(t, { ...args, command: 'agent-browser get url' });
 			const image = Buffer.alloc(byteLength);
 			image.set(Buffer.from('89504e470d0a1a0a', 'hex'));
 			fetch.mockImplementation(async (_url, options) => {
@@ -843,7 +823,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
 		const args = { runId, claimId, executionSecret };
-		await interact(t, { ...args, command: 'get url' });
+		await interact(t, { ...args, command: 'agent-browser get url' });
 		const dataBase64 =
 			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jBf8AAAAASUVORK5CYII=';
 		const output = JSON.stringify({ dataBase64, byteLength: 68, url: 'https://example.com' });
@@ -876,7 +856,7 @@ describe('Firecrawl browser lifecycle', () => {
 			const t = initConvexTest();
 			const { runId, claimId, executionSecret } = await fixture(t);
 			const args = { runId, claimId, executionSecret };
-			await interact(t, { ...args, command: 'get url' });
+			await interact(t, { ...args, command: 'agent-browser get url' });
 			fetch.mockImplementation(async () => new Response(JSON.stringify({ success: true, stdout })));
 			await expect(screenshot(t, args)).rejects.toThrow(error);
 			expect(fetch).toHaveBeenCalledTimes(3);
@@ -891,7 +871,7 @@ describe('Firecrawl browser lifecycle', () => {
 			runId,
 			claimId,
 			executionSecret,
-			command: 'get url'
+			command: 'agent-browser get url'
 		});
 		fetch.mockImplementation(
 			async () => new Response(JSON.stringify({ success: true, sessions: [] }))
@@ -921,7 +901,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
 		await expect(
-			interact(t, { runId, claimId, executionSecret, command: 'get url' })
+			interact(t, { runId, claimId, executionSecret, command: 'agent-browser get url' })
 		).rejects.toThrow(`Firecrawl request failed (HTTP 429). ${detail}`);
 		expect(fetch).toHaveBeenCalledTimes(1);
 		expect(await t.run((ctx) => ctx.db.query('browserSessions').unique())).toBeNull();
@@ -935,7 +915,12 @@ describe('Firecrawl browser lifecycle', () => {
 			const fetch = remote();
 			const t = initConvexTest();
 			const { runId, claimId, executionSecret } = await fixture(t);
-			const args = { runId, claimId, executionSecret, command: 'click @e1' };
+			const args = {
+				runId,
+				claimId,
+				executionSecret,
+				command: 'agent-browser click @e1'
+			};
 			await interact(t, args);
 			const session = await t.run((ctx) => ctx.db.query('browserSessions').unique());
 			fetch.mockResolvedValueOnce(
@@ -968,7 +953,7 @@ describe('Firecrawl browser lifecycle', () => {
 		const fetch = remote();
 		const t = initConvexTest();
 		const { runId, claimId, executionSecret } = await fixture(t);
-		const args = { runId, claimId, executionSecret, command: 'get url' };
+		const args = { runId, claimId, executionSecret, command: 'agent-browser get url' };
 		await interact(t, args);
 		fetch.mockResolvedValueOnce(
 			new Response(body, { status: 429, headers: { 'Retry-After': retryAfter } })
@@ -989,7 +974,12 @@ describe('Firecrawl browser lifecycle', () => {
 			const fetch = remote();
 			const t = initConvexTest();
 			const { runId, claimId, executionSecret } = await fixture(t);
-			const args = { runId, claimId, executionSecret, command: 'click @e1' };
+			const args = {
+				runId,
+				claimId,
+				executionSecret,
+				command: 'agent-browser click @e1'
+			};
 			await interact(t, args);
 			if (failure === 'connection reset') fetch.mockRejectedValue(new Error('Connection reset'));
 			else

--- a/apps/web/src/convex/firecrawlBrowser.ts
+++ b/apps/web/src/convex/firecrawlBrowser.ts
@@ -14,13 +14,10 @@ const EXECUTE_TIMEOUT_SECONDS = 120;
 const FETCH_TIMEOUT_MS = 140_000;
 const MAX_RESPONSE_BYTES = 2_000_000;
 const MAX_RESULT_CHARS = 8_000;
-const MAX_COMMAND_CHARS = 100_000;
 const MAX_SCREENSHOT_BYTES = 600_000;
 const SAVING_IN_USE_ERROR =
 	"Saving can't be enforced currently as the main browser session is in use by another agent. Ask the user whether they want the cookies and login state saved for future use. If yes, they have to stop the other agent and its browser session.";
 const GONE_STATUSES = new Set([404, 410]);
-const MANAGED_SUBCOMMANDS = new Set(['close', 'connect', 'state', 'cookies', 'session']);
-const MANAGED_FLAG = /^(--(?:cdp|session|profile|state|session-name))(=|$)/;
 
 const envelopeSchema = z.object({
 	success: z.boolean(),
@@ -190,71 +187,6 @@ async function destroy(ctx: ActionCtx, sessionId: string): Promise<void> {
 		if (!isGone(error)) throw error;
 	}
 	await ctx.runMutation(internal.browserCapacity.releaseSession, { sessionId });
-}
-
-function tokenizeCommand(command: string): string[] {
-	if (command.length > MAX_COMMAND_CHARS || /[\0\r\n]/.test(command)) {
-		throw new Error('Browser commands must be a single line, at most 100,000 characters.');
-	}
-	const words: string[] = [];
-	let word = '';
-	let quote = '';
-	let escaped = false;
-	let started = false;
-	for (const char of command) {
-		if (escaped) {
-			word += char;
-			escaped = false;
-			continue;
-		}
-		if (char === '\\' && quote !== "'") {
-			escaped = true;
-			started = true;
-			continue;
-		}
-		if (quote) {
-			if (char === quote) quote = '';
-			else word += char;
-			continue;
-		}
-		if (char === '"' || char === "'") {
-			quote = char;
-			started = true;
-			continue;
-		}
-		if (/\s/.test(char)) {
-			if (started) words.push(word);
-			word = '';
-			started = false;
-			continue;
-		}
-		word += char;
-		started = true;
-	}
-	if (quote || escaped) throw new Error('Browser command has an incomplete quote or escape.');
-	if (started) words.push(word);
-	return words;
-}
-
-function commandCode(command: string): string {
-	const words = tokenizeCommand(command);
-	if (words[0] === 'agent-browser') words.shift();
-	const help = words[0] === 'help';
-	if (!words.length || words[0].startsWith('-')) {
-		throw new Error('Provide an agent-browser command without global options.');
-	}
-	if (MANAGED_SUBCOMMANDS.has(words[0]) || words.some((word) => MANAGED_FLAG.test(word))) {
-		throw new Error('Browser session and profile management are handled by Sprocket.');
-	}
-	if (words[0] === 'screenshot') throw new Error('Use browser_screenshot to receive an image.');
-	if (help) words[0] = '--help';
-	const code = ['agent-browser', ...words]
-		.map((word) => `'${word.replaceAll("'", "'\\''")}'`)
-		.join(' ');
-	if (code.length > MAX_COMMAND_CHARS) {
-		throw new Error('Browser commands must be a single line, at most 100,000 characters.');
-	}
-	return code;
 }
 
 function commandFailure(result: z.infer<typeof executionSchema>): string | undefined {
@@ -439,7 +371,7 @@ export async function interact(
 	args: BrowserArgs & { command: string; enforce_saving?: boolean }
 ) {
 	try {
-		const result = await execute(ctx, args, commandCode(args.command), 'bash', args.enforce_saving);
+		const result = await execute(ctx, args, args.command, 'bash', args.enforce_saving);
 		return clip([outputText(result), result.stderr].filter(Boolean).join('\n'));
 	} catch (error) {
 		toolError(error);

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -46,38 +46,6 @@ struct BrowserScreenshotResult {
     truncated: bool,
 }
 
-/// Screenshots must go through browser_screenshot; capture them from here and
-/// the transcript loses the image block and the size cap that comes with it.
-fn screenshot_subcommand(command: &str) -> bool {
-    let mut tokens = command.split_whitespace();
-    tokens.next() == Some("agent-browser") && tokens.next() == Some("screenshot")
-}
-
-fn is_json_command(command: &str) -> bool {
-    command.trim_start().starts_with('{')
-}
-
-fn has_agent_browser_prefix(command: &str) -> bool {
-    command.split_whitespace().next() == Some("agent-browser")
-}
-
-fn validate_browser_command(command: &str) -> Result<(), &'static str> {
-    if is_json_command(command) {
-        return Err(
-            "command must be a plain agent-browser command string like 'agent-browser open https://example.com' or 'agent-browser snapshot -i', not JSON.",
-        );
-    }
-    if !has_agent_browser_prefix(command) {
-        return Err(
-            "command must start with `agent-browser`, for example `agent-browser open https://example.com`.",
-        );
-    }
-    if screenshot_subcommand(command) {
-        return Err("Use the browser_screenshot tool instead of `agent-browser screenshot`.");
-    }
-    Ok(())
-}
-
 impl rig::tool::Tool for BrowserInteractTool {
     const NAME: &'static str = "browser_interact";
     type Error = ToolExecutionError;
@@ -97,7 +65,6 @@ impl rig::tool::Tool for BrowserInteractTool {
         _context: &mut rig::tool::ToolContext,
         args: Self::Args,
     ) -> Result<Self::Output, Self::Error> {
-        validate_browser_command(&args.command).map_err(tool_failure)?;
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         let action_args = action_args_from_payload(&self.0.run_id, &self.0.claim_id, &payload)?;
         execute_tool_job(
@@ -228,62 +195,6 @@ mod tests {
     use rig::message::ToolResultContent;
 
     use super::*;
-
-    #[test]
-    fn json_object_commands_are_detected_for_guidance_errors() {
-        for command in [
-            r#"{"instruction": "go to robu.in"}"#,
-            "  {\"startUrl\": \"https://x\"}",
-        ] {
-            assert_eq!(
-                validate_browser_command(command),
-                Err(
-                    "command must be a plain agent-browser command string like 'agent-browser open https://example.com' or 'agent-browser snapshot -i', not JSON."
-                )
-            );
-        }
-    }
-
-    #[test]
-    fn agent_browser_prefix_is_required() {
-        assert_eq!(validate_browser_command("agent-browser help"), Ok(()));
-        assert_eq!(
-            validate_browser_command("  agent-browser snapshot -i"),
-            Ok(())
-        );
-        for command in [
-            "help",
-            "browser open https://example.com",
-            "agent-browserish help",
-        ] {
-            assert_eq!(
-                validate_browser_command(command),
-                Err(
-                    "command must start with `agent-browser`, for example `agent-browser open https://example.com`."
-                )
-            );
-        }
-    }
-
-    #[test]
-    fn screenshot_subcommand_is_detected_after_cli_prefix() {
-        for command in [
-            "agent-browser screenshot",
-            "agent-browser screenshot --full-page",
-        ] {
-            assert_eq!(
-                validate_browser_command(command),
-                Err("Use the browser_screenshot tool instead of `agent-browser screenshot`.")
-            );
-        }
-        for command in [
-            "agent-browser snapshot",
-            "agent-browser open https://example.com",
-            "agent-browser find text \"screenshot\" click",
-        ] {
-            assert_eq!(validate_browser_command(command), Ok(()));
-        }
-    }
 
     fn png() -> Vec<u8> {
         let mut bytes = std::io::Cursor::new(Vec::new());

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -472,10 +472,7 @@ mod tests {
         assert_eq!(args.get("enforce_saving"), Some(&Value::Boolean(true)));
         let schema = json!(schemars::schema_for!(BrowserInteractArgs));
         assert!(schema["properties"].get("disable_saving").is_none());
-        assert_eq!(
-            schema["properties"]["command"]["description"],
-            "Full agent-browser command, including the `agent-browser` prefix."
-        );
+        assert!(schema["properties"]["command"].get("description").is_none());
         assert_eq!(schema["required"], json!(["command"]));
         let screenshot_schema = json!(schemars::schema_for!(BrowserScreenshotArgs));
         assert!(

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -24,6 +24,7 @@ fn is_false(value: &bool) -> bool {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BrowserInteractArgs {
+    /// Full agent-browser command, including the `agent-browser` prefix.
     command: String,
     /// Set to true to ensure that cookies and login state that you change are preserved across the user's conversations with other agents in Sprocket. Recommended when you know for sure you are going to be changing login state on websites.
     #[serde(default, skip_serializing_if = "is_false")]
@@ -50,14 +51,32 @@ struct BrowserScreenshotResult {
 /// the transcript loses the image block and the size cap that comes with it.
 fn screenshot_subcommand(command: &str) -> bool {
     let mut tokens = command.split_whitespace();
-    if tokens.next() == Some("agent-browser") {
-        return tokens.next() == Some("screenshot");
-    }
-    command.split_whitespace().next() == Some("screenshot")
+    tokens.next() == Some("agent-browser") && tokens.next() == Some("screenshot")
 }
 
 fn is_json_command(command: &str) -> bool {
     command.trim_start().starts_with('{')
+}
+
+fn has_agent_browser_prefix(command: &str) -> bool {
+    command.split_whitespace().next() == Some("agent-browser")
+}
+
+fn validate_browser_command(command: &str) -> Result<(), &'static str> {
+    if is_json_command(command) {
+        return Err(
+            "command must be a plain agent-browser command string like 'agent-browser open https://example.com' or 'agent-browser snapshot -i', not JSON.",
+        );
+    }
+    if !has_agent_browser_prefix(command) {
+        return Err(
+            "command must start with `agent-browser`, for example `agent-browser open https://example.com`.",
+        );
+    }
+    if screenshot_subcommand(command) {
+        return Err("Use the browser_screenshot tool instead of `agent-browser screenshot`.");
+    }
+    Ok(())
 }
 
 impl rig::tool::Tool for BrowserInteractTool {
@@ -67,7 +86,7 @@ impl rig::tool::Tool for BrowserInteractTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Run an agent-browser (a CLI tool) command in a persistent browser session in the cloud. Omit the `agent-browser` prefix. Run `help` to learn more about the CLI. This session may retain cookies and login state on websites used by the user with other agents in Sprocket.".to_string()
+        "Run an agent-browser CLI command in a persistent browser session in the cloud. Every command must start with the `agent-browser` prefix. Run `agent-browser help` to learn more about the CLI. This session may retain cookies and login state on websites used by the user with other agents in Sprocket.".to_string()
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -79,19 +98,8 @@ impl rig::tool::Tool for BrowserInteractTool {
         _context: &mut rig::tool::ToolContext,
         args: Self::Args,
     ) -> Result<Self::Output, Self::Error> {
+        validate_browser_command(&args.command).map_err(tool_failure)?;
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
-        if is_json_command(&args.command) {
-            return Err(tool_failure(
-                "command must be a plain agent-browser command string like 'open https://example.com' or 'snapshot -i', not JSON."
-                    .to_string(),
-            ));
-        }
-        if screenshot_subcommand(&args.command) {
-            return Err(tool_failure(
-                "Use the browser_screenshot tool instead of `agent-browser screenshot`."
-                    .to_string(),
-            ));
-        }
         let action_args = action_args_from_payload(&self.0.run_id, &self.0.claim_id, &payload)?;
         execute_tool_job(
             &self.0.runtime,
@@ -224,23 +232,58 @@ mod tests {
 
     #[test]
     fn json_object_commands_are_detected_for_guidance_errors() {
-        assert!(is_json_command(r#"{"instruction": "go to robu.in"}"#));
-        assert!(is_json_command("  {\"startUrl\": \"https://x\"}"));
-        assert!(!is_json_command("open https://example.com"));
-        assert!(!is_json_command("snapshot -i"));
+        for command in [
+            r#"{"instruction": "go to robu.in"}"#,
+            "  {\"startUrl\": \"https://x\"}",
+        ] {
+            assert_eq!(
+                validate_browser_command(command),
+                Err(
+                    "command must be a plain agent-browser command string like 'agent-browser open https://example.com' or 'agent-browser snapshot -i', not JSON."
+                )
+            );
+        }
     }
 
     #[test]
-    fn screenshot_subcommand_is_detected_with_or_without_cli_prefix() {
-        assert!(screenshot_subcommand("screenshot"));
-        assert!(screenshot_subcommand("screenshot --full-page"));
-        assert!(screenshot_subcommand("agent-browser screenshot"));
-        assert!(!screenshot_subcommand("snapshot -i"));
-        assert!(!screenshot_subcommand("agent-browser snapshot"));
-        assert!(!screenshot_subcommand("open https://example.com"));
-        // Only the dedicated subcommand is routed away; other commands may
-        // legitimately mention the word in an argument.
-        assert!(!screenshot_subcommand("find text \"screenshot\" click"));
+    fn agent_browser_prefix_is_required() {
+        assert_eq!(validate_browser_command("agent-browser help"), Ok(()));
+        assert_eq!(
+            validate_browser_command("  agent-browser snapshot -i"),
+            Ok(())
+        );
+        for command in [
+            "help",
+            "browser open https://example.com",
+            "agent-browserish help",
+        ] {
+            assert_eq!(
+                validate_browser_command(command),
+                Err(
+                    "command must start with `agent-browser`, for example `agent-browser open https://example.com`."
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn screenshot_subcommand_is_detected_after_cli_prefix() {
+        for command in [
+            "agent-browser screenshot",
+            "agent-browser screenshot --full-page",
+        ] {
+            assert_eq!(
+                validate_browser_command(command),
+                Err("Use the browser_screenshot tool instead of `agent-browser screenshot`.")
+            );
+        }
+        for command in [
+            "agent-browser snapshot",
+            "agent-browser open https://example.com",
+            "agent-browser find text \"screenshot\" click",
+        ] {
+            assert_eq!(validate_browser_command(command), Ok(()));
+        }
     }
 
     fn png() -> Vec<u8> {
@@ -402,12 +445,12 @@ mod tests {
     #[test]
     fn saving_enforcement_is_opt_in_and_only_on_interact() {
         let interact: BrowserInteractArgs =
-            serde_json::from_value(serde_json::json!({ "command": "snapshot -i" }))
+            serde_json::from_value(serde_json::json!({ "command": "agent-browser snapshot -i" }))
                 .expect("minimal interact args");
         assert!(!interact.enforce_saving);
         assert_eq!(
             serde_json::to_value(&interact).unwrap(),
-            serde_json::json!({ "command": "snapshot -i" })
+            serde_json::json!({ "command": "agent-browser snapshot -i" })
         );
 
         let screenshot: BrowserScreenshotArgs =
@@ -418,16 +461,22 @@ mod tests {
         );
 
         let interact = BrowserInteractArgs {
-            command: "help".to_string(),
+            command: "agent-browser help".to_string(),
             enforce_saving: true,
         };
         let payload = serde_json::to_value(interact).unwrap();
-        assert_eq!(payload, json!({"command": "help", "enforce_saving": true}));
+        assert_eq!(
+            payload,
+            json!({"command": "agent-browser help", "enforce_saving": true})
+        );
         let args = action_args_from_payload("run-1", "claim-1", &payload).unwrap();
         assert_eq!(args.get("enforce_saving"), Some(&Value::Boolean(true)));
         let schema = json!(schemars::schema_for!(BrowserInteractArgs));
         assert!(schema["properties"].get("disable_saving").is_none());
-        assert!(schema["properties"]["command"].get("description").is_none());
+        assert_eq!(
+            schema["properties"]["command"]["description"],
+            "Full agent-browser command, including the `agent-browser` prefix."
+        );
         assert_eq!(schema["required"], json!(["command"]));
         let screenshot_schema = json!(schemars::schema_for!(BrowserScreenshotArgs));
         assert!(
@@ -437,7 +486,7 @@ mod tests {
         );
         assert!(
             serde_json::from_value::<BrowserInteractArgs>(
-                json!({"command": "help", "disable_saving": true})
+                json!({"command": "agent-browser help", "disable_saving": true})
             )
             .is_err()
         );

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -86,7 +86,7 @@ impl rig::tool::Tool for BrowserInteractTool {
     type Output = serde_json::Value;
 
     fn description(&self) -> String {
-        "Run an agent-browser CLI command in a persistent browser session in the cloud. Every command must start with the `agent-browser` prefix. Run `agent-browser help` to learn more about the CLI. This session may retain cookies and login state on websites used by the user with other agents in Sprocket.".to_string()
+        "Run an agent-browser CLI command in a persistent browser session in the cloud. Run `agent-browser help` to learn more about the CLI. This session may retain cookies and login state on websites used by the user with other agents in Sprocket.".to_string()
     }
 
     fn parameters(&self) -> serde_json::Value {

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -24,7 +24,6 @@ fn is_false(value: &bool) -> bool {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct BrowserInteractArgs {
-    /// Full agent-browser command, including the `agent-browser` prefix.
     command: String,
     /// Set to true to ensure that cookies and login state that you change are preserved across the user's conversations with other agents in Sprocket. Recommended when you know for sure you are going to be changing login state on websites.
     #[serde(default, skip_serializing_if = "is_false")]

--- a/crates/sprocket-agent/src/tools/browser.rs
+++ b/crates/sprocket-agent/src/tools/browser.rs
@@ -46,6 +46,11 @@ struct BrowserScreenshotResult {
     truncated: bool,
 }
 
+fn is_screenshot_command(command: &str) -> bool {
+    let mut tokens = command.split_whitespace();
+    tokens.next() == Some("agent-browser") && tokens.next() == Some("screenshot")
+}
+
 impl rig::tool::Tool for BrowserInteractTool {
     const NAME: &'static str = "browser_interact";
     type Error = ToolExecutionError;
@@ -65,6 +70,11 @@ impl rig::tool::Tool for BrowserInteractTool {
         _context: &mut rig::tool::ToolContext,
         args: Self::Args,
     ) -> Result<Self::Output, Self::Error> {
+        if is_screenshot_command(&args.command) {
+            return Err(tool_failure(
+                "Use the browser_screenshot tool instead of `agent-browser screenshot`.",
+            ));
+        }
         let payload = serde_json::to_value(&args).map_err(|e| tool_error(e.into()))?;
         let action_args = action_args_from_payload(&self.0.run_id, &self.0.claim_id, &payload)?;
         execute_tool_job(
@@ -195,6 +205,23 @@ mod tests {
     use rig::message::ToolResultContent;
 
     use super::*;
+
+    #[test]
+    fn screenshot_commands_use_the_dedicated_tool() {
+        for command in [
+            "agent-browser screenshot",
+            "agent-browser screenshot --full-page",
+        ] {
+            assert!(is_screenshot_command(command));
+        }
+        for command in [
+            "agent-browser snapshot",
+            "agent-browser open https://example.com",
+            "agent-browser find text \"screenshot\" click",
+        ] {
+            assert!(!is_screenshot_command(command));
+        }
+    }
 
     fn png() -> Vec<u8> {
         let mut bytes = std::io::Cursor::new(Vec::new());


### PR DESCRIPTION
## Summary

- have the agent send the complete `agent-browser` command
- keep the guard that directs `agent-browser screenshot` calls to the dedicated screenshot tool
- forward every other command string to Firecrawl without parsing or rewriting
- update browser lifecycle tests to use full commands and verify exact pass-through

## Checks

- `nix develop -c cargo test -p sprocket-agent tools::browser::tests`
- `nix develop -c bun run test src/convex/firecrawlBrowser.test.ts`
- `nix develop -c prek run -a`

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62565374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge under the explicitly accepted raw-command contract, with no new non-duplicate actionable findings.

<details open><summary><h3>Summary</h3></summary>

- Removes TypeScript command tokenization, rewriting, and managed-command validation.
- Updates the Rust tool description and request payloads to use complete CLI commands.
- Adds a Rust guard directing direct `agent-browser screenshot` commands to the dedicated screenshot tool.
- Updates lifecycle tests to verify exact Bash pass-through.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Agent supplies complete command] --> B[BrowserInteractTool]
    B -->|Direct screenshot command| C[Reject and direct to browser_screenshot]
    B -->|Other command| D[Convex interact action]
    D --> E[Forward unchanged as Bash code]
    E --> F[Firecrawl remote browser session]
    F --> G[Clip stdout and stderr]
```
</details>

<sub>Reviews (8) · Last reviewed commit: ["fix(browser): Keep screenshot tool guard"](https://github.com/spikonado/sprocket/commit/53c67d7c2316dacd8d12104542b7e6366574eb2c)</sub>

<!-- /greptile_comment -->