### PR TITLE
chore(release): Bump version to v0.3.5

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             source_sha="$TESTED_SHA"
-            version="0.3.4-dev.$source_sha"
+            version="0.3.5-dev.$source_sha"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             source_sha="$GITHUB_SHA"
             version="${GITHUB_REF_NAME#v}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-agent"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anydoc",
  "anyhow",
@@ -7772,7 +7772,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -7787,7 +7787,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-convex"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-server"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -7837,7 +7837,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-workspace"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -55,7 +55,7 @@ Before tagging, a manual workflow run with publishing disabled can be used to bu
 
 ## Development releases
 
-After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.3.4-dev.<full-commit-sha>` with the npm `dev` dist-tag.
+After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.3.5-dev.<full-commit-sha>` with the npm `dev` dist-tag.
 
 Install the newest development build with:
 

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spikonado/sprocket",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "Agentic platform for streamlining hardware and software development",
 	"license": "FSL-1.1-ALv2",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the Rust workspace and npm package to 0.3.5
- update the npm development release version and release documentation

## Checks

- `git diff --check`
- `nix develop -c cargo metadata --locked --no-deps --format-version 1`

Written by GPT-5.6 Luna (gpt-5.6-luna) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62587441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The version bump appears internally consistent and safe to merge.

<details open><summary><h3>Summary</h3></summary>

- Updates the Rust workspace version and corresponding lockfile entries.
- Updates the npm package manifest and development-release workflow version.
- Aligns npm release documentation with the new development version.
</details>

<sub>Reviews (1) · Last reviewed commit: ["build(release): Bump version to v0.3.5"](https://github.com/spikonado/sprocket/commit/da4896d66ca95fd17ebed441eb1db0cb210b3feb)</sub>

<!-- /greptile_comment -->