### PR TITLE
perf(dev): Use kache to share build cache across worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,18 @@ Common Sprocket server overrides are available as environment variables:
 
 ### Requirements
 
-- Bun 1.x, version 1.3.9 or newer
-- Node.js 24.x, version 24.14 or newer
-- A current stable Rust toolchain
+- Nix with flakes enabled
+
+Enter the default development shell and keep it open for the commands below:
+
+```sh
+nix develop
+```
+
+The shell runs Rust builds through [Kache](https://kunobi.ninja/docs/kache),
+whose local cache is shared by all worktrees. Do not run Rust commands outside
+the shell against this repository's `target` directory. Use `kache stats` to
+inspect cache usage.
 
 Install dependencies:
 
@@ -131,11 +140,6 @@ bun run test
 bun run build
 prek run -a
 ```
-
-The default Nix development shell runs Rust builds through
-[Kache](https://kunobi.ninja/docs/kache). Its local cache is shared by all
-worktrees. Run Rust commands that use this repository's `target` directory from
-the Nix shell, and use `kache stats` to inspect cache usage.
 
 Create a local Electron installer package with:
 

--- a/README.md
+++ b/README.md
@@ -87,18 +87,9 @@ Common Sprocket server overrides are available as environment variables:
 
 ### Requirements
 
-- Nix with flakes enabled
-
-Enter the default development shell and keep it open for the commands below:
-
-```sh
-nix develop
-```
-
-The shell runs Rust builds through [Kache](https://kunobi.ninja/docs/kache),
-whose local cache is shared by all worktrees. Do not run Rust commands outside
-the shell against this repository's `target` directory. Use `kache stats` to
-inspect cache usage.
+- Bun 1.x, version 1.3.9 or newer
+- Node.js 24.x, version 24.14 or newer
+- A current stable Rust toolchain
 
 Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ bun run build
 prek run -a
 ```
 
+The default Nix development shell runs Rust builds through
+[Kache](https://kunobi.ninja/docs/kache). Its local cache is shared by all
+worktrees. Run Rust commands that use this repository's `target` directory from
+the Nix shell, and use `kache stats` to inspect cache usage.
+
 Create a local Electron installer package with:
 
 ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,46 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+        kacheVersion = "0.19.0";
+        kacheArtifact =
+          {
+            x86_64-linux = {
+              target = "x86_64-unknown-linux-musl";
+              hash = "sha256-ZNjhCrwekWhZzlvyk3iH3xWTPhtl5moe/n3Habyqd5g=";
+            };
+            aarch64-linux = {
+              target = "aarch64-unknown-linux-musl";
+              hash = "sha256-z5iAIA0oyosswztSJ7nMJglMR8CSf3eRc0wCuhpc1qw=";
+            };
+            x86_64-darwin = {
+              target = "x86_64-apple-darwin";
+              hash = "sha256-FiZG+UQDwqLjDcM1e5upesvHiKKXY0zXVZvrM9g8DUw=";
+            };
+            aarch64-darwin = {
+              target = "aarch64-apple-darwin";
+              hash = "sha256-jc2qlfNniwBpbKR0LYrWfB8A2bqn0ULL+TN7Pz7LA7c=";
+            };
+          }
+          .${system};
+        kache = pkgs.stdenvNoCC.mkDerivation {
+          pname = "kache";
+          version = kacheVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/kunobi-ninja/kache/releases/download/v${kacheVersion}/kache-${kacheArtifact.target}.tar.gz";
+            inherit (kacheArtifact) hash;
+          };
+          sourceRoot = ".";
+          installPhase = ''
+            install -Dm755 kache "$out/bin/kache"
+          '';
+          meta = {
+            description = "Content-addressed compiler cache";
+            homepage = "https://kunobi.ninja/product/kache";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "kache";
+            sourceProvenance = [ pkgs.lib.sourceTypes.binaryNativeCode ];
+          };
+        };
         electronRuntimeLibs = with pkgs; [
           alsa-lib
           atk
@@ -59,6 +99,7 @@
               cargo
               cargo-edit
               gcc
+              kache
               nodejs_24
               prek
               rustc
@@ -68,6 +109,11 @@
             ++ electronRuntimeLibs;
 
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath electronRuntimeLibs;
+          shellHook = ''
+            if [[ -z "''${CI:-}" ]]; then
+              export RUSTC_WRAPPER="${pkgs.lib.getExe kache}"
+            fi
+          '';
         };
       }
     );

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
 	"$schema": "https://turborepo.dev/schema.json",
 	"ui": "tui",
 	"globalDependencies": [".env", "turbo-cache-key.json"],
+	"globalPassThroughEnv": ["RUSTC_WRAPPER"],
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- pin Kache 0.19.0 release binaries and hashes for the systems supported by the flake
- enable Kache as `RUSTC_WRAPPER` only in the default local Nix development shell, leaving CI on its existing Rust cache
- pass `RUSTC_WRAPPER` through Turbo so desktop Cargo tasks use the same wrapper

## Validation

- `nix flake check --no-build`
- `nix run nixpkgs#nixfmt -- --check flake.nix`
- `nix develop -c prek run -a`
- `nix develop -c cargo test`
- `nix develop -c bun run build`
- `nix develop -c bun run test`
- clean-target `cargo test --locked -p sprocket-workspace` and `cargo build --locked -p sprocket-cli`
- Turbo dry run confirmed that `RUSTC_WRAPPER` reaches tasks

A repeat of the representative test and build sequence against a second empty target finished in 206.653 seconds using the populated local Kache cache.

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62648879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The code changes appear safe to merge, with no outstanding reportable findings.

<details open><summary><h3>Summary</h3></summary>

- Pins Kache 0.19.0 binaries and hashes for all flake-supported systems.
- Enables Kache as `RUSTC_WRAPPER` in non-CI Nix development shells.
- Passes `RUSTC_WRAPPER` through Turborepo to workspace tasks.
</details>

<sub>Reviews (3) · Last reviewed commit: ["docs: Restore existing development requi..."](https://github.com/spikonado/sprocket/commit/7e5de92dc3aff91fda045e4ef1b60ad4fc36d535)</sub>

<!-- /greptile_comment -->