### PR TITLE
ci(desktop-release): Ignore empty signing secrets

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -143,7 +143,22 @@ jobs:
           CSC_LINK: ${{ runner.os == 'macOS' && secrets.CSC_LINK || '' }}
           WIN_CSC_KEY_PASSWORD: ${{ runner.os == 'Windows' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
           WIN_CSC_LINK: ${{ runner.os == 'Windows' && secrets.WIN_CSC_LINK || '' }}
-        run: bunx electron-builder ${{ matrix.electron_args }} --publish never
+        run: |
+          for name in \
+            APPLE_API_ISSUER \
+            APPLE_API_KEY_ID \
+            APPLE_APP_SPECIFIC_PASSWORD \
+            APPLE_ID \
+            APPLE_TEAM_ID \
+            CSC_KEY_PASSWORD \
+            CSC_LINK \
+            WIN_CSC_KEY_PASSWORD \
+            WIN_CSC_LINK; do
+            if [[ -z "${!name}" ]]; then
+              unset "$name"
+            fi
+          done
+          bunx electron-builder ${{ matrix.electron_args }} --publish never
       - name: Drop builder debug files
         working-directory: apps/desktop/dist
         shell: bash


### PR DESCRIPTION
## Summary

- unset optional signing and notarization variables when their repository secrets are empty
- prevent electron-builder from treating an empty `CSC_LINK` as the desktop directory

## Failure

Desktop Release run 34506299674 failed in both macOS packaging jobs. GitHub Actions exported the unset `CSC_LINK` secret as an empty environment variable. electron-builder 26.15.3 resolved that empty value against `apps/desktop`, then rejected the resulting directory with `apps/desktop not a file`. Windows and both Linux jobs completed, and their artifacts were added manually to the v0.3.5 release before this PR.

## Checks

- `bun prettier --check .github/workflows/desktop-release.yml`
- `prek run check-yaml --files .github/workflows/desktop-release.yml`
- `prek run check-github-workflows --files .github/workflows/desktop-release.yml`
- shell assertion that empty credential variables are absent after filtering

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62708358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The workflow change appears safe to merge and directly addresses the reported empty-secret packaging failure.

<details open><summary><h3>Summary</h3></summary>

- Prevents an empty `CSC_LINK` from resolving to the desktop working directory.
- Applies the filtering consistently across macOS, Windows, and Linux packaging jobs.
- Preserves configured, non-empty credentials unchanged.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(desktop): Ignore empty signing secre..."](https://github.com/spikonado/sprocket/commit/a1df6833ed2ce9704ead177a892538348532c0f6)</sub>

<!-- /greptile_comment -->