### PR TITLE
perf(convex): Change artifact revision polling to subscriptions

### DIFF
--- a/apps/web/src/lib/chat/cloud-artifacts.test.ts
+++ b/apps/web/src/lib/chat/cloud-artifacts.test.ts
@@ -8,17 +8,21 @@ function clientFixture() {
 	let fail: (error: Error) => void = () => {};
 	const unsubscribe = vi.fn();
 	const query = vi.fn<Parameters<typeof watchCloudArtifacts>[0]['query']>();
-	const client: Parameters<typeof watchCloudArtifacts>[0] = {
-		query,
-		onUpdate: (_query, _scope, onUpdate, onError) => {
+	const onUpdate = vi.fn<Parameters<typeof watchCloudArtifacts>[0]['onUpdate']>(
+		(_query, _scope, onUpdate, onError) => {
 			update = onUpdate;
 			fail = onError;
 			return unsubscribe;
 		}
+	);
+	const client: Parameters<typeof watchCloudArtifacts>[0] = {
+		query,
+		onUpdate
 	};
 	return {
 		client,
 		query,
+		onUpdate,
 		unsubscribe,
 		update: () => update(1),
 		fail: () => fail(new Error('Denied'))
@@ -30,6 +34,27 @@ afterEach(() => {
 });
 
 describe('cloud artifact subscriptions', () => {
+	it('subscribes by repository but reads artifacts in the selected thread', async () => {
+		const fixture = clientFixture();
+		fixture.query.mockResolvedValue({ page: [], isDone: true, continueCursor: '', revision: 1 });
+		// SAFETY: the mock records this ID without sending a Convex request.
+		const threadId = 'thread' as Id<'threadRecords'>;
+		const stop = watchCloudArtifacts(
+			fixture.client,
+			{ userId: 'alice', repositoryKey: 'repo', threadId },
+			vi.fn()
+		);
+		expect(fixture.onUpdate.mock.calls[0]?.[1]).toEqual({ repositoryKey: 'repo' });
+		fixture.update();
+		await Promise.resolve();
+		expect(fixture.query.mock.calls[0]?.[1]).toEqual({
+			repositoryKey: 'repo',
+			threadId,
+			cursor: null
+		});
+		stop();
+	});
+
 	it('filters a cached response from the previous account during auth handoff', async () => {
 		const fixture = clientFixture();
 		// SAFETY: this mocked response uses the ID only as an opaque string, never in a Convex request.

--- a/apps/web/src/lib/chat/cloud-artifacts.ts
+++ b/apps/web/src/lib/chat/cloud-artifacts.ts
@@ -4,7 +4,10 @@ import type { LocalArtifact } from '$lib/types/sprocket';
 import type { ArtifactWatchState } from './artifacts';
 
 type ArtifactPage = FunctionReturnType<typeof api.artifacts.listArtifacts>;
-export type CloudArtifactScope = FunctionArgs<typeof api.artifacts.getArtifactState> & {
+export type CloudArtifactScope = Pick<
+	FunctionArgs<typeof api.artifacts.listArtifacts>,
+	'repositoryKey' | 'threadId'
+> & {
 	userId: string;
 };
 type CloudArtifactClient = {
@@ -14,7 +17,7 @@ type CloudArtifactClient = {
 	) => Promise<ArtifactPage>;
 	onUpdate: (
 		query: typeof api.artifacts.getArtifactState,
-		args: FunctionArgs<typeof api.artifacts.getArtifactState>,
+		args: Pick<FunctionArgs<typeof api.artifacts.getArtifactState>, 'repositoryKey'>,
 		onUpdate: (revision: number) => void,
 		onError: (error: Error) => void
 	) => () => void;
@@ -66,7 +69,7 @@ export function watchCloudArtifacts(
 	}
 	const unsubscribe = client.onUpdate(
 		api.artifacts.getArtifactState,
-		queryScope,
+		{ repositoryKey: scope.repositoryKey },
 		() => {
 			clearTimeout(retry);
 			void refresh(++generation);

--- a/crates/sprocket-server/src/artifact_watch.rs
+++ b/crates/sprocket-server/src/artifact_watch.rs
@@ -3,17 +3,17 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use futures::{StreamExt, stream};
+use futures::{Stream, StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use sprocket_agent::artifact_bindings::{ArtifactBindings, content_hash};
-use sprocket_convex::deserialize_convex_u64;
+use sprocket_convex::{decode_labeled_function_result, deserialize_convex_u64};
 use sprocket_workspace::{ArtifactContentType, read_artifact_file};
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval, timeout};
 
 use crate::native_auth::NativeAuthManager;
-use crate::transcript_client::UserConvexClient;
+use crate::transcript_client::{ArtifactSnapshot, UserConvexClient};
 
 const NETWORK_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -192,7 +192,12 @@ impl ArtifactWatchSession {
             let mut feed = ArtifactFeed::new(self.key.clone(), bindings.clone());
             flush_feed(
                 &mut feed,
-                || client.list_artifacts(&self.key.repository_key, self.key.thread_id.as_deref()),
+                || async {
+                    Ok(client
+                        .list_artifacts(&self.key.repository_key, self.key.thread_id.as_deref())
+                        .await?
+                        .artifacts)
+                },
                 |request| {
                     let client = &client;
                     let bindings = &bindings;
@@ -273,43 +278,6 @@ async fn connect(
     .await
 }
 
-struct CloudSnapshot {
-    artifacts: Vec<RemoteArtifact>,
-    revision: u64,
-}
-
-async fn cloud_snapshot(
-    client: &UserConvexClient,
-    key: &WatchKey,
-    known_revision: Option<u64>,
-    bindings: &ArtifactBindings,
-    pending: Vec<SyncRequest>,
-) -> anyhow::Result<Option<CloudSnapshot>> {
-    for request in pending {
-        timeout(NETWORK_TIMEOUT, sync(client, bindings, &request)).await??;
-    }
-    let revision = client
-        .artifact_revision(&key.repository_key, key.thread_id.as_deref())
-        .await?;
-    if known_revision == Some(revision) {
-        return Ok(None);
-    }
-    let artifacts = client
-        .list_artifacts(&key.repository_key, key.thread_id.as_deref())
-        .await?;
-    // A later revision requires another read rather than labeling an older body as current.
-    let after = client
-        .artifact_revision(&key.repository_key, key.thread_id.as_deref())
-        .await?;
-    if revision != after {
-        anyhow::bail!("Artifact registry changed during refresh; retrying");
-    }
-    Ok(Some(CloudSnapshot {
-        artifacts,
-        revision,
-    }))
-}
-
 async fn watch(
     url: String,
     auth: Arc<NativeAuthManager>,
@@ -337,7 +305,7 @@ async fn watch(
             result = cloud_rx.recv() => {
                 match result {
                     Some(Ok(snapshot)) => {
-                        if let Some(snapshot) = snapshot { feed.apply_registry(snapshot.artifacts); }
+                        feed.apply_registry(snapshot.artifacts);
                         stale = false;
                         error = None;
                     }
@@ -366,32 +334,96 @@ async fn cloud_worker(
     key: WatchKey,
     bindings: ArtifactBindings,
     pending: tokio::sync::watch::Receiver<Vec<SyncRequest>>,
-    output: tokio::sync::mpsc::Sender<anyhow::Result<Option<CloudSnapshot>>>,
+    output: tokio::sync::mpsc::Sender<anyhow::Result<ArtifactSnapshot>>,
 ) {
-    let mut client = None;
-    let mut revision = None;
+    loop {
+        let outcome = async {
+            let client = timeout(NETWORK_TIMEOUT, connect(&url, &auth, &key)).await??;
+            let updates = timeout(
+                NETWORK_TIMEOUT,
+                client.subscribe_artifact_state(&key.repository_key),
+            )
+            .await??;
+            cloud_session(
+                updates.map(|result| {
+                    let revision: f64 =
+                        decode_labeled_function_result(result, "artifacts:getArtifactState")?;
+                    Ok(revision as u64)
+                }),
+                &pending,
+                &output,
+                || client.list_artifacts(&key.repository_key, key.thread_id.as_deref()),
+                |request| {
+                    let client = &client;
+                    let bindings = &bindings;
+                    async move { sync(client, bindings, &request).await }
+                },
+            )
+            .await
+        }
+        .await;
+        match outcome {
+            Ok(()) => return,
+            Err(error) => {
+                if output.send(Err(error)).await.is_err() {
+                    return;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn cloud_session<U, L, LF, S, SF>(
+    mut updates: U,
+    pending: &tokio::sync::watch::Receiver<Vec<SyncRequest>>,
+    output: &tokio::sync::mpsc::Sender<anyhow::Result<ArtifactSnapshot>>,
+    mut load: L,
+    mut synchronize: S,
+) -> anyhow::Result<()>
+where
+    U: Stream<Item = anyhow::Result<u64>> + Unpin,
+    L: FnMut() -> LF,
+    LF: std::future::Future<Output = anyhow::Result<ArtifactSnapshot>>,
+    S: FnMut(SyncRequest) -> SF,
+    SF: std::future::Future<Output = anyhow::Result<()>>,
+{
+    let first = timeout(NETWORK_TIMEOUT, updates.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Artifact subscription ended"))??;
+    let mut observed_revision = Some(first);
+    let mut loaded_revision = None;
+    let mut requests = Vec::new();
     let mut poll = interval(Duration::from_secs(1));
     poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
-        poll.tick().await;
-        let requests = pending.borrow().clone();
-        let outcome = async {
-            timeout(NETWORK_TIMEOUT, auth.require_user(&key.user_id)).await??;
-            let connection = match &client {
-                Some(client) => client,
-                None => client.insert(timeout(NETWORK_TIMEOUT, connect(&url, &auth, &key)).await??),
-            };
-            cloud_snapshot(connection, &key, revision, &bindings, requests).await
+        let had_pending = !requests.is_empty();
+        for request in requests.drain(..) {
+            timeout(NETWORK_TIMEOUT, synchronize(request)).await??;
         }
-        .await;
-        if let Ok(Some(snapshot)) = &outcome {
-            revision = Some(snapshot.revision);
+        // A page load can read ahead of buffered subscription updates.
+        if had_pending
+            || observed_revision
+                .is_some_and(|next| loaded_revision.is_none_or(|loaded| next > loaded))
+        {
+            let snapshot = load().await?;
+            if observed_revision.is_some_and(|revision| snapshot.revision < revision) {
+                anyhow::bail!("Artifact registry changed during refresh; retrying");
+            }
+            loaded_revision = Some(snapshot.revision);
+            if output.send(Ok(snapshot)).await.is_err() {
+                return Ok(());
+            }
         }
-        if outcome.is_err() {
-            client = None;
-        }
-        if output.send(outcome).await.is_err() {
-            return;
+        tokio::select! {
+            update = updates.next() => {
+                observed_revision = Some(update.ok_or_else(|| anyhow::anyhow!("Artifact subscription ended"))??);
+            }
+            _ = poll.tick() => {
+                requests = pending.borrow().clone();
+                observed_revision = None;
+            }
+            _ = output.closed() => return Ok(()),
         }
     }
 }
@@ -399,7 +431,7 @@ async fn cloud_worker(
 async fn check_auth(
     auth: Arc<NativeAuthManager>,
     user_id: String,
-    output: tokio::sync::mpsc::Sender<anyhow::Result<Option<CloudSnapshot>>>,
+    output: tokio::sync::mpsc::Sender<anyhow::Result<ArtifactSnapshot>>,
 ) {
     loop {
         tokio::time::sleep(Duration::from_secs(15)).await;
@@ -628,6 +660,124 @@ impl ArtifactFeed {
 mod tests {
     use super::*;
     use sprocket_agent::artifact_bindings::ArtifactBinding;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test(start_paused = true)]
+    async fn cloud_subscription_does_not_poll_or_reload_already_loaded_revisions() {
+        let (updates, subscription) = futures::channel::mpsc::unbounded();
+        let (_pending, pending) = tokio::sync::watch::channel(Vec::new());
+        let (output, mut snapshots) = tokio::sync::mpsc::channel(1);
+        let loads = Arc::new(AtomicUsize::new(0));
+        let task_loads = Arc::clone(&loads);
+        let task = tokio::spawn(async move {
+            cloud_session(
+                subscription,
+                &pending,
+                &output,
+                || {
+                    let revision = task_loads.fetch_add(1, Ordering::SeqCst) as u64 + 2;
+                    std::future::ready(Ok(ArtifactSnapshot {
+                        artifacts: vec![],
+                        revision,
+                    }))
+                },
+                |_| async { panic!("idle watcher must not sync") },
+            )
+            .await
+        });
+        updates.unbounded_send(Ok(1)).unwrap();
+        assert_eq!(snapshots.recv().await.unwrap().unwrap().revision, 2);
+        updates.unbounded_send(Ok(1)).unwrap();
+        updates.unbounded_send(Ok(2)).unwrap();
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert!(snapshots.try_recv().is_err());
+
+        updates.unbounded_send(Ok(3)).unwrap();
+        assert_eq!(snapshots.recv().await.unwrap().unwrap().revision, 3);
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+        drop(snapshots);
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn local_changes_sync_without_a_cloud_revision_event() {
+        let (updates, subscription) = futures::channel::mpsc::unbounded();
+        let (pending_tx, pending) = tokio::sync::watch::channel(Vec::new());
+        let (output, mut snapshots) = tokio::sync::mpsc::channel(1);
+        let syncs = Arc::new(AtomicUsize::new(0));
+        let task_syncs = Arc::clone(&syncs);
+        let task = tokio::spawn(async move {
+            cloud_session(
+                subscription,
+                &pending,
+                &output,
+                || async {
+                    Ok(ArtifactSnapshot {
+                        artifacts: vec![],
+                        revision: 1,
+                    })
+                },
+                |request| {
+                    assert_eq!(request.content, "local edit");
+                    task_syncs.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Ok(()))
+                },
+            )
+            .await
+        });
+        updates.unbounded_send(Ok(1)).unwrap();
+        snapshots.recv().await.unwrap().unwrap();
+        pending_tx.send_replace(vec![SyncRequest {
+            artifact: remote(),
+            path: "notes.md".into(),
+            baseline: content_hash("initial"),
+            content: "local edit".into(),
+        }]);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        snapshots.recv().await.unwrap().unwrap();
+        assert_eq!(syncs.load(Ordering::SeqCst), 1);
+        drop(snapshots);
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cloud_subscription_failures_exit_for_reconnect() {
+        for updates in [
+            vec![],
+            vec![Err(anyhow::anyhow!("Denied"))],
+            vec![Ok(1), Err(anyhow::anyhow!("Disconnected"))],
+        ] {
+            let (_pending_tx, pending) = tokio::sync::watch::channel(Vec::new());
+            let (output, _snapshots) = tokio::sync::mpsc::channel(1);
+            let result = cloud_session(
+                stream::iter(updates),
+                &pending,
+                &output,
+                || async {
+                    Ok(ArtifactSnapshot {
+                        artifacts: vec![],
+                        revision: 1,
+                    })
+                },
+                |_| async { Ok(()) },
+            )
+            .await;
+            assert!(result.is_err());
+        }
+        let (_pending_tx, pending) = tokio::sync::watch::channel(Vec::new());
+        let (output, _snapshots) = tokio::sync::mpsc::channel(1);
+        let result = cloud_session(
+            stream::pending(),
+            &pending,
+            &output,
+            || async { panic!("must receive the first revision before loading") },
+            |_| async { Ok(()) },
+        )
+        .await;
+        assert!(result.unwrap_err().is::<tokio::time::error::Elapsed>());
+    }
 
     #[tokio::test]
     async fn last_consumer_releases_shared_watch() {

--- a/crates/sprocket-server/src/transcript_client.rs
+++ b/crates/sprocket-server/src/transcript_client.rs
@@ -71,27 +71,23 @@ impl UserConvexClient {
         self.client.subscribe("threads:listRecent", args).await
     }
 
-    pub async fn artifact_revision(
+    pub async fn subscribe_artifact_state(
         &self,
         repository_key: &str,
-        thread_id: Option<&str>,
-    ) -> anyhow::Result<u64> {
-        let revision: f64 = tokio::time::timeout(
-            Duration::from_secs(10),
-            self.query_json(
+    ) -> anyhow::Result<QuerySubscription> {
+        self.client
+            .subscribe(
                 "artifacts:getArtifactState",
-                artifacts_list_args(repository_key, thread_id),
-            ),
-        )
-        .await??;
-        Ok(revision as u64)
+                artifacts_list_args(repository_key, None),
+            )
+            .await
     }
 
     pub(crate) async fn list_artifacts(
         &self,
         repository_key: &str,
         thread_id: Option<&str>,
-    ) -> anyhow::Result<Vec<crate::artifact_watch::RemoteArtifact>> {
+    ) -> anyhow::Result<ArtifactSnapshot> {
         let mut args = artifacts_list_args(repository_key, thread_id);
         let mut artifacts = Vec::new();
         let mut revision = None;
@@ -108,7 +104,10 @@ impl UserConvexClient {
             revision = Some(page.revision);
             artifacts.extend(page.page);
             if page.is_done {
-                return Ok(artifacts);
+                return Ok(ArtifactSnapshot {
+                    artifacts,
+                    revision: page.revision,
+                });
             }
             let cursor = Value::String(page.continue_cursor);
             if args.get("cursor") == Some(&cursor) {
@@ -194,6 +193,11 @@ fn thread_id_args(thread_id: &str) -> BTreeMap<String, Value> {
     let mut args = BTreeMap::new();
     args.insert("threadId".to_string(), thread_id.to_string().into());
     args
+}
+
+pub(crate) struct ArtifactSnapshot {
+    pub artifacts: Vec<crate::artifact_watch::RemoteArtifact>,
+    pub revision: u64,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Cause

The native artifact watcher called `artifacts:getArtifactState` every second, even while idle, and queried it again after loading artifacts. Each one-shot Rust SDK query creates and drops a subscription. Both web and native watchers also supplied `threadId` to this repository-wide revision query, adding a thread-record dependency and separate cache entries per thread. Thread updates therefore invalidated artifact revision queries even when no artifacts changed.

## Changes

- Keep a persistent native revision subscription instead of making roughly 3,600 idle revision requests per watcher per hour.
- Subscribe with only `repositoryKey` in both clients. Keep thread authorization on artifact reads, writes, and native watch setup.
- Return the validated page revision alongside the native artifact snapshot. Remove the before/after revision queries and ignore subscription updates already covered by a snapshot.
- Preserve local-file synchronization, retry failed subscriptions, and reload on reconnect.

The backend API and stored data are unchanged. Older native clients remain compatible, but need an update to stop polling.

## Validation

- `bun run test` passed.
- `cargo test -p sprocket-server` passed, including 129 tests.
- New regressions cover idle subscriptions, buffered revisions, local sync without remote events, subscription failures, and repository-scoped subscriptions with thread-scoped reads.
- `prek run -a` passed.

Cursor subagent cleanup and review attempts were blocked by the account usage limit.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62713444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

<details open><summary><h3>Summary</h3></summary>

- Returns artifact snapshots with their validated pagination revision.
- Reloads only for newer subscription revisions, local synchronization, or reconnection.
- Retries subscription failures and preserves local-file synchronization.
- Updates the web watcher to use repository-scoped revision notifications.
- Adds regression coverage for subscription scope, idle behavior, buffered revisions, synchronization, and reconnect failures.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Watcher as Artifact watcher
    participant State as Repository revision subscription
    participant API as Artifact API
    participant Disk as Local files

    Watcher->>State: Subscribe(repositoryKey)
    State-->>Watcher: Current revision
    Watcher->>API: listArtifacts(repositoryKey, threadId)
    API-->>Watcher: ArtifactSnapshot(artifacts, revision)
    Watcher->>Disk: Apply thread-visible snapshot

    State-->>Watcher: Newer repository revision
    Watcher->>API: listArtifacts(repositoryKey, threadId)
    API-->>Watcher: Updated snapshot

    Disk-->>Watcher: Local edit
    Watcher->>API: Synchronize artifact
    Watcher->>API: Reload thread-visible snapshot

    State--xWatcher: Subscription error
    Watcher->>State: Retry subscription
    State-->>Watcher: Current revision
    Watcher->>API: Reload snapshot after reconnect
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(artifacts): Replace revision polling..."](https://github.com/spikonado/sprocket/commit/16391af9307dc06681cb124bddc4266ea1ac6476)</sub>

<!-- /greptile_comment -->