### PR TITLE
fix(convex): Restore production rollout compatibility

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -2,22 +2,74 @@
 
 We ship breaking changes ahead of our users' installed clients and keep the old behavior working until those clients age out. That debt is easy to accumulate and easier to forget. This file lists every backwards-compatibility layer we currently ship, what it protects, how to remove it, and the signal that says removal is safe. When a removal PR merges, remove its entry from this document.
 
-Current as of 2026-09-10.
+Current as of 2026-09-11.
 
-## Production rollout fields
+## Production rollout cleanup
 
-The deployment before v0.3.5 writes `runs.completionTransport`,
-`threadUsage.totalTokensProcessed`, and `executorJobs.cloudWorkPool`. Those
-fields remain optional in the stored schema so traffic during a deployment
-cannot recreate data that blocks the next schema push. The usage table also
-accepts the old `usageLedgerMigratedAt` marker.
+PR #345 removed several stored fields before its code had deployed and before
+production data had been rewritten. The production deployment that remained
+active after that failed rollout could still write those fields, so merely
+cleaning existing rows would race with active mutations. This release restores
+the old schema shapes and ships the cleanup migrations in
+`convex/migrations.ts`. Do not run the cleanup runner until this release is live
+and work started by the preceding deployment has settled.
 
-Some historical `threadRecords` rows have no `status`. Readers treat a missing
-status as completed, and all current run lifecycle writes set it.
+### Thread status
 
-Remove these fields only after the code that stopped writing them is live, all
-in-flight work from the previous deployment has settled, and a production scan
-finds no rows carrying the retired fields or missing `threadRecords.status`.
+Production has historical `threadRecords` without `status`. Current run
+lifecycle code writes the field, but the thread cache must still ingest old
+rows. The schema and local cache parser therefore accept a missing value, and
+`threadRecordToSummary` treats it as `completed`.
+
+`backfillMissingThreadStatus` copies the latest run status onto each affected thread.
+It marks a runless thread as `completed` rather than deleting user data. Remove
+the optional schema and parser handling, and the summary default, after the
+migration completes and a production scan finds no thread without `status`.
+
+### Run completion transport
+
+The preceding schema accepted `runs.completionTransport` with either
+`convex-action` or `gateway`, and the preceding production writer still stores
+`gateway`. Current code neither reads nor writes this field. Both values remain
+accepted so stored rows and writes made during the rollout validate.
+
+`removeRunCompletionTransport` unsets the field. Remove it from the schema after
+the migration completes and a production scan finds no run carrying it.
+
+### Usage ledger fields
+
+The preceding production writer still dual-writes
+`threadUsage.totalTokensProcessed`. Current code calculates processed tokens
+from `threadUsageEvents` and the Aggregate component instead. The
+`usageLedgerMigratedAt` field is a marker left by the completed ledger backfill;
+current code does not read it. Both fields remain optional only to validate old
+rows and writes made during the rollout.
+
+`removeThreadUsageLegacyFields` unsets both fields. Remove them from the schema
+after the migration completes and a production scan finds neither field.
+
+### Executor work pool
+
+The preceding production code writes `executorJobs.cloudWorkPool` for hosted
+parse work and reads it to choose the cancellation pool. Current code no longer
+reads or writes it, but an in-flight job from the preceding deployment can still
+store `firecrawlScrape` while this release rolls out.
+
+`removeExecutorJobCloudWorkPool` unsets the field. Remove it from the schema
+after the migration completes, all jobs started by the preceding deployment
+have settled, and a production scan finds no executor job carrying it.
+
+Once this release is live and the old work has settled, run the resumable
+cleanup from `apps/web`:
+
+```sh
+bunx convex run migrations:runProductionRolloutCleanup '{"dryRun":true}' --prod
+bunx convex run migrations:runProductionRolloutCleanup --prod
+```
+
+Keep the migration definitions until the runner reports completion. A later PR
+may tighten the schema and remove the read fallbacks only after the production
+scans described above pass.
 
 ## Stored executor jobs
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -11,8 +11,14 @@ production data had been rewritten. The production deployment that remained
 active after that failed rollout could still write those fields, so merely
 cleaning existing rows would race with active mutations. This release restores
 the old schema shapes and ships the cleanup migrations in
-`convex/migrations.ts`. Do not run the cleanup runner until this release is live
-and work started by the preceding deployment has settled.
+`convex/migrations.ts`.
+
+The hourly cron calls `runProductionRolloutCleanupAutomatically`. Its first call
+records a cleanup time 48 hours later. That delay exceeds the preceding
+deployment's 36-hour gateway token lifetime and one-hour hosted parse lifetime,
+so its writers have expired before cleanup starts. Once the delay passes, the
+cron starts or resumes the migrations in order. It records completion after the
+migrations component reports that every migration finished.
 
 ### Thread status
 
@@ -59,8 +65,9 @@ store `firecrawlScrape` while this release rolls out.
 after the migration completes, all jobs started by the preceding deployment
 have settled, and a production scan finds no executor job carrying it.
 
-Once this release is live and the old work has settled, run the resumable
-cleanup from `apps/web`:
+The cleanup runs automatically. `runProductionRolloutCleanup` remains available
+for operator recovery, but it must not be called before the scheduled
+`notBefore` time in `migrationSchedules`:
 
 ```sh
 bunx convex run migrations:runProductionRolloutCleanup '{"dryRun":true}' --prod
@@ -69,7 +76,8 @@ bunx convex run migrations:runProductionRolloutCleanup --prod
 
 Keep the migration definitions until the runner reports completion. A later PR
 may tighten the schema and remove the read fallbacks only after the production
-scans described above pass.
+scans described above pass. That PR may also remove the cleanup cron and its
+`migrationSchedules` row and table.
 
 ## Stored executor jobs
 

--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,6 +4,21 @@ We ship breaking changes ahead of our users' installed clients and keep the old 
 
 Current as of 2026-09-10.
 
+## Production rollout fields
+
+The deployment before v0.3.5 writes `runs.completionTransport`,
+`threadUsage.totalTokensProcessed`, and `executorJobs.cloudWorkPool`. Those
+fields remain optional in the stored schema so traffic during a deployment
+cannot recreate data that blocks the next schema push. The usage table also
+accepts the old `usageLedgerMigratedAt` marker.
+
+Some historical `threadRecords` rows have no `status`. Readers treat a missing
+status as completed, and all current run lifecycle writes set it.
+
+Remove these fields only after the code that stopped writing them is live, all
+in-flight work from the previous deployment has settled, and a production scan
+finds no rows carrying the retired fields or missing `threadRecords.status`.
+
 ## Stored executor jobs
 
 ### Historical artifact tools

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -74,6 +74,7 @@ import type * as lib_validators from "../lib/validators.js";
 import type * as machineSessions from "../machineSessions.js";
 import type * as machines from "../machines.js";
 import type * as messages from "../messages.js";
+import type * as migrations from "../migrations.js";
 import type * as modelCatalog from "../modelCatalog.js";
 import type * as payments from "../payments.js";
 import type * as projects from "../projects.js";
@@ -159,6 +160,7 @@ declare const fullApi: ApiFromModules<{
   machineSessions: typeof machineSessions;
   machines: typeof machines;
   messages: typeof messages;
+  migrations: typeof migrations;
   modelCatalog: typeof modelCatalog;
   payments: typeof payments;
   projects: typeof projects;

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -30,6 +30,13 @@ crons.interval(
 );
 
 crons.interval(
+	'run production rollout cleanup migrations',
+	{ hours: 1 },
+	internal.migrations.runProductionRolloutCleanupAutomatically,
+	{}
+);
+
+crons.interval(
 	'reconcile Firecrawl browser sessions',
 	{ minutes: 1 },
 	internal.firecrawlBrowser.reconcile

--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { internal } from '@convex/_generated/api';
 import { initConvexTest, seedOwnedThread } from './test.setup';
+import { AUTOMATIC_CLEANUP_DELAY_MS } from './migrations';
 
 const oneBatch = {
 	cursor: null,
@@ -87,5 +88,60 @@ describe('production rollout cleanup migrations', () => {
 		expect(migrated.usage?.totalTokensProcessed).toBeUndefined();
 		expect(migrated.usage?.usageLedgerMigratedAt).toBeUndefined();
 		expect(migrated.job?.cloudWorkPool).toBeUndefined();
+	});
+
+	it('waits for prior writers and then runs the cleanup automatically', async () => {
+		vi.useFakeTimers();
+		const deployedAt = Date.UTC(2026, 8, 11);
+		vi.setSystemTime(deployedAt);
+		try {
+			const t = initConvexTest();
+			const { threadId } = await seedOwnedThread(t);
+			const runId = await t.run(async (ctx) => {
+				const run = await ctx.db
+					.query('runs')
+					.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
+					.unique();
+				if (!run) throw new Error('Missing test fixture.');
+				await ctx.db.patch('threadRecords', threadId, { status: undefined });
+				await ctx.db.patch('runs', run._id, {
+					status: 'failed',
+					completionTransport: 'gateway'
+				});
+				return run._id;
+			});
+
+			await t.mutation(internal.migrations.runProductionRolloutCleanupAutomatically, {});
+			const schedule = await t.run((ctx) =>
+				ctx.db.query('migrationSchedules').withIndex('by_name').unique()
+			);
+			expect(schedule).toMatchObject({
+				notBefore: deployedAt + AUTOMATIC_CLEANUP_DELAY_MS
+			});
+			expect(schedule?.startedAt).toBeUndefined();
+
+			vi.setSystemTime(deployedAt + AUTOMATIC_CLEANUP_DELAY_MS - 1);
+			await t.mutation(internal.migrations.runProductionRolloutCleanupAutomatically, {});
+			expect((await t.run((ctx) => ctx.db.get('runs', runId)))?.completionTransport).toBe(
+				'gateway'
+			);
+
+			vi.setSystemTime(deployedAt + AUTOMATIC_CLEANUP_DELAY_MS);
+			await t.mutation(internal.migrations.runProductionRolloutCleanupAutomatically, {});
+			await t.finishAllScheduledFunctions(vi.runAllTimers);
+			await t.mutation(internal.migrations.runProductionRolloutCleanupAutomatically, {});
+
+			const migrated = await t.run(async (ctx) => ({
+				schedule: await ctx.db.query('migrationSchedules').withIndex('by_name').unique(),
+				thread: await ctx.db.get('threadRecords', threadId),
+				run: await ctx.db.get('runs', runId)
+			}));
+			expect(migrated.schedule?.startedAt).toBeDefined();
+			expect(migrated.schedule?.completedAt).toBeDefined();
+			expect(migrated.thread?.status).toBe('failed');
+			expect(migrated.run?.completionTransport).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { internal } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+const oneBatch = {
+	cursor: null,
+	dryRun: false,
+	oneBatchOnly: true
+} as const;
+
+describe('production rollout cleanup migrations', () => {
+	it('backfills thread status from the latest run and preserves runless threads', async () => {
+		const t = initConvexTest();
+		const { threadId } = await seedOwnedThread(t);
+		const runlessThreadId = await t.run(async (ctx) => {
+			const latestRun = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
+				.order('desc')
+				.first();
+			if (!latestRun) throw new Error('Missing test fixture.');
+			await ctx.db.patch('runs', latestRun._id, { status: 'failed' });
+			await ctx.db.patch('threadRecords', threadId, { status: undefined });
+			return await ctx.db.insert('threadRecords', {
+				userId: 'user_alice',
+				submissionId: 'runless-thread',
+				repositoryKey: 'alpha',
+				selectedModel: 'gpt-5.6-sol',
+				reasoningEffort: 'medium',
+				serviceTier: 'standard',
+				lastMessageAt: 1
+			});
+		});
+
+		await t.mutation(internal.migrations.backfillMissingThreadStatus, oneBatch);
+
+		const records = await t.run(async (ctx) => ({
+			withRun: await ctx.db.get('threadRecords', threadId),
+			runless: await ctx.db.get('threadRecords', runlessThreadId)
+		}));
+		expect(records.withRun?.status).toBe('failed');
+		expect(records.runless?.status).toBe('completed');
+	});
+
+	it('unsets fields retained for the rolling deployment', async () => {
+		const t = initConvexTest();
+		const { threadId } = await seedOwnedThread(t);
+		const ids = await t.run(async (ctx) => {
+			const run = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
+				.unique();
+			const usage = await ctx.db
+				.query('threadUsage')
+				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+				.unique();
+			if (!run || !usage) throw new Error('Missing test fixture.');
+			await ctx.db.patch('runs', run._id, { completionTransport: 'convex-action' });
+			await ctx.db.patch('threadUsage', usage._id, {
+				totalTokensProcessed: 42,
+				usageLedgerMigratedAt: 1
+			});
+			const jobId = await ctx.db.insert('executorJobs', {
+				threadId,
+				runId: run._id,
+				kind: 'web_search',
+				payload: { query: 'compatibility' },
+				hidden: false,
+				status: 'pending',
+				enqueuedAt: 1,
+				sequence: 0,
+				cloudWorkPool: 'firecrawlScrape'
+			});
+			return { runId: run._id, usageId: usage._id, jobId };
+		});
+
+		await t.mutation(internal.migrations.removeRunCompletionTransport, oneBatch);
+		await t.mutation(internal.migrations.removeThreadUsageLegacyFields, oneBatch);
+		await t.mutation(internal.migrations.removeExecutorJobCloudWorkPool, oneBatch);
+
+		const migrated = await t.run(async (ctx) => ({
+			run: await ctx.db.get('runs', ids.runId),
+			usage: await ctx.db.get('threadUsage', ids.usageId),
+			job: await ctx.db.get('executorJobs', ids.jobId)
+		}));
+		expect(migrated.run?.completionTransport).toBeUndefined();
+		expect(migrated.usage?.totalTokensProcessed).toBeUndefined();
+		expect(migrated.usage?.usageLedgerMigratedAt).toBeUndefined();
+		expect(migrated.job?.cloudWorkPool).toBeUndefined();
+	});
+});

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -1,0 +1,55 @@
+import { Migrations } from '@convex-dev/migrations';
+import { components, internal } from '@convex/_generated/api';
+import { internalMutation } from '@convex/_generated/server';
+import schema from '@convex/schema';
+
+export const migrations = new Migrations(components.migrations, {
+	schema,
+	internalMutation
+});
+
+export const runProductionRolloutCleanup = migrations.runner([
+	internal.migrations.backfillMissingThreadStatus,
+	internal.migrations.removeRunCompletionTransport,
+	internal.migrations.removeThreadUsageLegacyFields,
+	internal.migrations.removeExecutorJobCloudWorkPool
+]);
+
+export const backfillMissingThreadStatus = migrations.define({
+	table: 'threadRecords',
+	migrateOne: async (ctx, thread) => {
+		if (thread.status !== undefined) return;
+		const latestRun = await ctx.db
+			.query('runs')
+			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', thread._id))
+			.order('desc')
+			.first();
+		return { status: latestRun?.status ?? 'completed' };
+	}
+});
+
+export const removeRunCompletionTransport = migrations.define({
+	table: 'runs',
+	migrateOne: (_ctx, run) => {
+		if (run.completionTransport === undefined) return;
+		return { completionTransport: undefined };
+	}
+});
+
+export const removeThreadUsageLegacyFields = migrations.define({
+	table: 'threadUsage',
+	migrateOne: (_ctx, usage) => {
+		if (usage.totalTokensProcessed === undefined && usage.usageLedgerMigratedAt === undefined) {
+			return;
+		}
+		return { totalTokensProcessed: undefined, usageLedgerMigratedAt: undefined };
+	}
+});
+
+export const removeExecutorJobCloudWorkPool = migrations.define({
+	table: 'executorJobs',
+	migrateOne: (_ctx, job) => {
+		if (job.cloudWorkPool === undefined) return;
+		return { cloudWorkPool: undefined };
+	}
+});

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -2,18 +2,58 @@ import { Migrations } from '@convex-dev/migrations';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation } from '@convex/_generated/server';
 import schema from '@convex/schema';
+import { v } from 'convex/values';
+
+export const AUTOMATIC_CLEANUP_DELAY_MS = 48 * 60 * 60 * 1_000;
+const PRODUCTION_ROLLOUT_CLEANUP = 'production-rollout-cleanup-2026-09';
 
 export const migrations = new Migrations(components.migrations, {
 	schema,
 	internalMutation
 });
 
-export const runProductionRolloutCleanup = migrations.runner([
+const productionRolloutCleanupMigrations = [
 	internal.migrations.backfillMissingThreadStatus,
 	internal.migrations.removeRunCompletionTransport,
 	internal.migrations.removeThreadUsageLegacyFields,
 	internal.migrations.removeExecutorJobCloudWorkPool
-]);
+];
+
+export const runProductionRolloutCleanup = migrations.runner(productionRolloutCleanupMigrations);
+
+export const runProductionRolloutCleanupAutomatically = internalMutation({
+	args: {},
+	returns: v.null(),
+	handler: async (ctx) => {
+		const now = Date.now();
+		const schedule = await ctx.db
+			.query('migrationSchedules')
+			.withIndex('by_name', (query) => query.eq('name', PRODUCTION_ROLLOUT_CLEANUP))
+			.unique();
+		if (!schedule) {
+			await ctx.db.insert('migrationSchedules', {
+				name: PRODUCTION_ROLLOUT_CLEANUP,
+				notBefore: now + AUTOMATIC_CLEANUP_DELAY_MS
+			});
+			return null;
+		}
+		if (schedule.completedAt !== undefined || now < schedule.notBefore) return null;
+
+		const statuses = await migrations.getStatus(ctx, {
+			migrations: productionRolloutCleanupMigrations
+		});
+		if (statuses.every((status) => status.isDone)) {
+			await ctx.db.patch('migrationSchedules', schedule._id, { completedAt: now });
+			return null;
+		}
+
+		if (schedule.startedAt === undefined) {
+			await ctx.db.patch('migrationSchedules', schedule._id, { startedAt: now });
+		}
+		await migrations.runSerially(ctx, productionRolloutCleanupMigrations);
+		return null;
+	}
+});
 
 export const backfillMissingThreadStatus = migrations.define({
 	table: 'threadRecords',

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -70,7 +70,7 @@ export default defineSchema({
 	threadRecords: defineTable({
 		userId: v.string(),
 		submissionId: v.string(),
-		status: vRunStatus,
+		status: v.optional(vRunStatus),
 		repositoryKey: v.string(),
 		title: v.optional(v.string()),
 		selectedModel: v.string(),
@@ -99,7 +99,9 @@ export default defineSchema({
 	threadUsage: defineTable({
 		threadId: v.id('threadRecords'),
 		userId: v.string(),
-		contextTokens: v.optional(v.number())
+		contextTokens: v.optional(v.number()),
+		totalTokensProcessed: v.optional(v.number()),
+		usageLedgerMigratedAt: v.optional(v.number())
 	}).index('by_threadId', ['threadId']),
 	threadUsageEvents: defineTable({
 		threadId: v.id('threadRecords'),
@@ -123,6 +125,7 @@ export default defineSchema({
 		selectedModel: v.string(),
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
+		completionTransport: v.optional(v.literal('gateway')),
 		gatewayProtocolVersion: v.optional(v.number()),
 		agentVersion: v.optional(v.string()),
 		startedAt: v.number(),
@@ -248,7 +251,8 @@ export default defineSchema({
 		result: v.optional(vExecutorJobResult),
 		error: v.optional(v.string()),
 		sequence: v.number(),
-		cloudWorkId: v.optional(v.string())
+		cloudWorkId: v.optional(v.string()),
+		cloudWorkPool: v.optional(v.literal('firecrawlScrape'))
 	})
 		.index('by_threadId_sequence', ['threadId', 'sequence'])
 		.index('by_runId_sequence', ['runId', 'sequence'])

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -125,7 +125,7 @@ export default defineSchema({
 		selectedModel: v.string(),
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
-		completionTransport: v.optional(v.literal('gateway')),
+		completionTransport: v.optional(v.union(v.literal('convex-action'), v.literal('gateway'))),
 		gatewayProtocolVersion: v.optional(v.number()),
 		agentVersion: v.optional(v.string()),
 		startedAt: v.number(),

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -67,6 +67,12 @@ export default defineSchema({
 		userId: v.string(),
 		theme: v.union(v.literal('light'), v.literal('dark'))
 	}).index('by_userId', ['userId']),
+	migrationSchedules: defineTable({
+		name: v.string(),
+		notBefore: v.number(),
+		startedAt: v.optional(v.number()),
+		completedAt: v.optional(v.number())
+	}).index('by_name', ['name']),
 	threadRecords: defineTable({
 		userId: v.string(),
 		submissionId: v.string(),

--- a/apps/web/src/convex/schemaCompatibility.test.ts
+++ b/apps/web/src/convex/schemaCompatibility.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('schema rollout compatibility', () => {
+	it('accepts rows written by the previous production deployment', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+
+		const legacy = await t.run(async (ctx) => {
+			const run = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
+				.unique();
+			const usage = await ctx.db
+				.query('threadUsage')
+				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
+				.unique();
+			if (!run || !usage) throw new Error('Missing test fixture.');
+
+			await ctx.db.patch('threadRecords', threadId, { status: undefined });
+			await ctx.db.patch('runs', run._id, { completionTransport: 'gateway' });
+			await ctx.db.patch('threadUsage', usage._id, {
+				totalTokensProcessed: 42,
+				usageLedgerMigratedAt: 1
+			});
+			const jobId = await ctx.db.insert('executorJobs', {
+				threadId,
+				runId: run._id,
+				kind: 'web_search',
+				payload: { query: 'compatibility' },
+				hidden: false,
+				status: 'pending',
+				enqueuedAt: 1,
+				sequence: 0,
+				cloudWorkPool: 'firecrawlScrape'
+			});
+
+			return {
+				thread: await ctx.db.get('threadRecords', threadId),
+				run: await ctx.db.get('runs', run._id),
+				usage: await ctx.db.get('threadUsage', usage._id),
+				job: await ctx.db.get('executorJobs', jobId)
+			};
+		});
+
+		expect(legacy.thread?.status).toBeUndefined();
+		expect(legacy.run?.completionTransport).toBe('gateway');
+		expect(legacy.usage).toMatchObject({ totalTokensProcessed: 42, usageLedgerMigratedAt: 1 });
+		expect(legacy.job?.cloudWorkPool).toBe('firecrawlScrape');
+
+		await expect(asUser.mutation(api.threads.archiveForLocalCache, { threadId })).resolves.toEqual({
+			userId: legacy.thread?.userId,
+			repositoryKey: legacy.thread?.repositoryKey
+		});
+	});
+});

--- a/apps/web/src/convex/threads.ts
+++ b/apps/web/src/convex/threads.ts
@@ -25,7 +25,7 @@ async function archiveOwnedThread(ctx: MutationCtx, threadId: Id<'threadRecords'
 	const userId = await getUserId(ctx);
 	const record = await getOwnedThreadRecord(ctx.db, userId, threadId);
 
-	if (['queued', 'running', 'awaiting_executor'].includes(record.status)) {
+	if (record.status && ['queued', 'running', 'awaiting_executor'].includes(record.status)) {
 		throw new Error('Cannot archive a thread while a run is active.');
 	}
 

--- a/apps/web/src/lib/local/client.test.ts
+++ b/apps/web/src/lib/local/client.test.ts
@@ -7,6 +7,7 @@ import {
 	transcriptUploadPath,
 	workspaceLaunchHash
 } from '$lib/local/client';
+import { threadRecordToSummary } from '$lib/project/threads';
 
 function threadRecordId(value: string): Id<'threadRecords'> {
 	// SAFETY: fixture strings are only compared as opaque Convex document ids.
@@ -255,7 +256,7 @@ describe('watchLiveCompletion', () => {
 });
 
 describe('thread cache local API', () => {
-	it('parses snapshot threads and watch status events', async () => {
+	it('parses historical snapshot threads without status and watch status events', async () => {
 		const snapshot = {
 			threads: [
 				{
@@ -268,8 +269,7 @@ describe('thread cache local API', () => {
 					selectedModel: 'gpt-5.6-sol',
 					reasoningEffort: 'medium',
 					serviceTier: 'standard',
-					lastMessageAt: 10,
-					status: 'completed'
+					lastMessageAt: 10
 				}
 			],
 			status: 'live',
@@ -299,7 +299,8 @@ describe('thread cache local API', () => {
 		);
 
 		const client = createLocalClient('http://127.0.0.1:7731');
-		expect(await client.fetchThreadSnapshot({ userId: 'user-1' })).toEqual({
+		const parsedSnapshot = await client.fetchThreadSnapshot({ userId: 'user-1' });
+		expect(parsedSnapshot).toEqual({
 			threads: [
 				{
 					_id: 'thread-1',
@@ -311,13 +312,13 @@ describe('thread cache local API', () => {
 					selectedModel: 'gpt-5.6-sol',
 					reasoningEffort: 'medium',
 					serviceTier: 'standard',
-					lastMessageAt: 10,
-					status: 'completed'
+					lastMessageAt: 10
 				}
 			],
 			status: 'live',
 			lastSyncedAt: 20
 		});
+		expect(threadRecordToSummary(parsedSnapshot.threads[0]!).status).toBe('completed');
 
 		const events: unknown[] = [];
 		await client.watchThreadCache(

--- a/apps/web/src/lib/local/client.ts
+++ b/apps/web/src/lib/local/client.ts
@@ -151,7 +151,9 @@ const threadSummarySchema = z.object({
 	contextSummaryThroughRunId: z.string().optional(),
 	lastMessageAt: z.number(),
 	archivedAt: z.number().optional(),
-	status: z.enum(['queued', 'running', 'awaiting_executor', 'completed', 'failed', 'cancelled'])
+	status: z
+		.enum(['queued', 'running', 'awaiting_executor', 'completed', 'failed', 'cancelled'])
+		.optional()
 });
 const threadCacheWatchEventSchema = z.object({
 	status: z.enum(['loading', 'live', 'reconnecting', 'offline', 'error']),

--- a/apps/web/src/lib/project/threads.ts
+++ b/apps/web/src/lib/project/threads.ts
@@ -37,7 +37,7 @@ export function threadRecordToSummary(record: Doc<'threadRecords'>): ThreadSumma
 		serviceTier: record.serviceTier,
 		lastMessageAt: record.lastMessageAt,
 		threadStatus: record.archivedAt === undefined ? 'active' : 'archived',
-		status: record.status
+		status: record.status ?? 'completed'
 	});
 }
 


### PR DESCRIPTION
## Summary

- restore optional stored fields still present in production or writable by the previous deployment
- accept historical thread records without `status` across Convex, the local cache parser, and summary projection
- add resumable cleanup migrations for every restored field, including a status backfill that preserves runless threads
- start the cleanup automatically from an hourly cron after a 48-hour safety delay, then retry until every migration completes
- document why each compatibility path is required and the production checks that gate its removal

## Root cause

PR #345 removed compatibility fields before the previous production deployment had stopped writing them and before all historical rows were clean. Schema validation then rejected production data such as `runs.completionTransport` and `threadUsage.totalTokensProcessed`, which blocked Convex deploys.

This change keeps both historical completion transport values and the other retired fields in the stored schema through the rolling deployment. The first cron invocation records a cleanup time 48 hours later. This exceeds the old gateway token and hosted parse lifetimes. Once due, the cron starts or resumes the cleanup migrations and records completion after all four finish.

No manual migration command is required. This PR does not deploy or mutate production directly.

## Checks

- `nix develop -c bun run check`
- `nix develop -c prek run -a`
- Convex codegen against the development deployment
- targeted compatibility and migration tests, 45 tests passed

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62899707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previous transport-validator finding is resolved and no new actionable failure remains.

<details open><summary><h3>Summary</h3></summary>

- Restores optional legacy fields and both historical completion transport values.
- Treats missing historical thread status as completed while preserving active-status checks.
- Automatically starts cleanup after a 48-hour writer-expiration window and retries through the hourly cron.
- Adds compatibility and migration coverage plus operational removal guidance.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Hourly cleanup cron] --> B{Schedule exists?}
  B -- No --> C[Record notBefore = now + 48 hours]
  B -- Yes --> D{Completed or before notBefore?}
  D -- Yes --> E[No action]
  D -- No --> F[Read migration statuses]
  F --> G{All migrations complete?}
  G -- Yes --> H[Record completedAt]
  G -- No --> I[Record startedAt if absent]
  I --> J[Start or resume serial migrations]
  J --> K[Backfill missing thread status]
  K --> L[Remove run completionTransport]
  L --> M[Remove legacy usage fields]
  M --> N[Remove executor cloudWorkPool]
  N --> A
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(convex): automate rollout cleanup"](https://github.com/spikonado/sprocket/commit/7173fa64521c744cdf6f3c1d270a17ff6c395930)</sub>

<!-- /greptile_comment -->