### PR TITLE
fix(ui): Stabilize thread scrolling

### DIFF
--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -90,11 +90,12 @@
 		const movingUp = viewport.scrollTop < lastScrollTop;
 		lastScrollTop = viewport.scrollTop;
 		const distanceToBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-		stickToBottom = distanceToBottom <= SCROLL_EPSILON_PX;
-		if (movingUp) loadOlderOnUpwardIntent();
+		stickToBottom = !movingUp && distanceToBottom <= SCROLL_EPSILON_PX;
+		if (movingUp) handleUpwardIntent();
 	}
 
-	function loadOlderOnUpwardIntent() {
+	function handleUpwardIntent() {
+		stickToBottom = false;
 		const viewport = scrollViewport;
 		if (
 			viewport &&
@@ -103,7 +104,6 @@
 			viewport.clientHeight > 0 &&
 			viewport.scrollTop <= viewport.clientHeight
 		) {
-			stickToBottom = false;
 			onLoadOlder?.();
 		}
 	}
@@ -142,8 +142,13 @@
 		) {
 			return;
 		}
-		if (event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
-			loadOlderOnUpwardIntent();
+		if (
+			event.key === 'ArrowUp' ||
+			event.key === 'PageUp' ||
+			event.key === 'Home' ||
+			(event.key === ' ' && event.shiftKey)
+		) {
+			handleUpwardIntent();
 		}
 	}
 
@@ -206,11 +211,17 @@
 		if (!viewport || !stickToBottom) {
 			return;
 		}
-		setScrollTop(viewport, viewport.scrollHeight);
+		const bottom = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+		// A scrollbar drag can reach layout before its scroll event. Shrinking content also clamps scrollTop.
+		if (viewport.scrollTop < Math.min(lastScrollTop, bottom)) {
+			stickToBottom = false;
+			return;
+		}
+		setScrollTop(viewport, bottom);
 	}
 
 	function setScrollTop(viewport: HTMLDivElement, top: number) {
-		viewport.scrollTop = top;
+		if (viewport.scrollTop !== top) viewport.scrollTop = top;
 		lastScrollTop = viewport.scrollTop;
 	}
 
@@ -284,7 +295,7 @@
 		bind:this={scrollViewport}
 		onscroll={updateStickToBottom}
 		onwheel={(event) => {
-			if (event.deltaY < 0) loadOlderOnUpwardIntent();
+			if (event.deltaY < 0) handleUpwardIntent();
 		}}
 		onkeydown={handleHistoryKey}
 		ontouchstart={(event) => {
@@ -293,7 +304,7 @@
 		ontouchmove={(event) => {
 			const nextY = event.touches[0]?.clientY;
 			if (nextY !== undefined && touchY !== undefined && nextY > touchY) {
-				loadOlderOnUpwardIntent();
+				handleUpwardIntent();
 			}
 			touchY = nextY;
 		}}
@@ -608,10 +619,3 @@
 		viewerImage = null;
 	}}
 />
-
-<style>
-	[data-message-id] {
-		content-visibility: auto;
-		contain-intrinsic-size: auto 300px;
-	}
-</style>

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -87,9 +87,10 @@
 	function updateStickToBottom() {
 		const viewport = scrollViewport;
 		if (!viewport || viewport.scrollTop === lastScrollTop) return;
-		const movingUp = viewport.scrollTop < lastScrollTop;
+		const bottom = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+		const movingUp = viewport.scrollTop < Math.min(lastScrollTop, bottom);
 		lastScrollTop = viewport.scrollTop;
-		const distanceToBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+		const distanceToBottom = bottom - viewport.scrollTop;
 		stickToBottom = !movingUp && distanceToBottom <= SCROLL_EPSILON_PX;
 		if (movingUp) handleUpwardIntent();
 	}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -88,8 +88,11 @@
 		const viewport = scrollViewport;
 		if (!viewport || viewport.scrollTop === lastScrollTop) return;
 		const bottom = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-		const movingUp = viewport.scrollTop < Math.min(lastScrollTop, bottom);
+		const movingUp = viewport.scrollTop < lastScrollTop;
+		const clampedToBottom = lastScrollTop > bottom && Math.abs(viewport.scrollTop - bottom) < 1;
 		lastScrollTop = viewport.scrollTop;
+		// A shorter scroll range must preserve the reader's existing follow state.
+		if (clampedToBottom) return;
 		const distanceToBottom = bottom - viewport.scrollTop;
 		stickToBottom = !movingUp && distanceToBottom <= SCROLL_EPSILON_PX;
 		if (movingUp) handleUpwardIntent();
@@ -214,7 +217,7 @@
 		}
 		const bottom = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
 		// A scrollbar drag can reach layout before its scroll event. Shrinking content also clamps scrollTop.
-		if (viewport.scrollTop < Math.min(lastScrollTop, bottom)) {
+		if (viewport.scrollTop + 1 < Math.min(lastScrollTop, bottom)) {
 			stickToBottom = false;
 			return;
 		}

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -56,7 +56,10 @@ async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600)
 		scrollHeight: { get: () => Math.max(viewportHeight, messageElements().length * 300) },
 		scrollTop: {
 			configurable: true,
-			get: () => Math.min(scrollTop, viewport.scrollHeight - viewport.clientHeight),
+			get: () => {
+				scrollTop = Math.min(scrollTop, viewport.scrollHeight - viewport.clientHeight);
+				return scrollTop;
+			},
 			set: (top: number) => {
 				scrollTop = Math.max(0, Math.min(top, viewport.scrollHeight - viewport.clientHeight));
 			}
@@ -215,6 +218,8 @@ describe('transcript viewport paging', () => {
 	it('keeps following when shrinking content clamps the scroll position', async () => {
 		const { props, viewport } = await renderTranscript([1, 2, 3, 4, 5].map(message));
 		props.messages = props.messages.slice(0, 3);
+		flushSync();
+		viewport.dispatchEvent(new Event('scroll'));
 		await settle();
 		resize();
 		expect(viewport.scrollTop).toBe(300);

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -215,18 +215,22 @@ describe('transcript viewport paging', () => {
 		expect(writeScrollTop).not.toHaveBeenCalled();
 	});
 
-	it('keeps following when shrinking content clamps the scroll position', async () => {
-		const { props, viewport } = await renderTranscript([1, 2, 3, 4, 5].map(message));
-		props.messages = props.messages.slice(0, 3);
-		flushSync();
-		viewport.dispatchEvent(new Event('scroll'));
-		await settle();
-		resize();
-		expect(viewport.scrollTop).toBe(300);
-		props.messages = [...props.messages, message(4)];
-		await settle();
-		expect(viewport.scrollTop).toBe(600);
-	});
+	it.each([true, false])(
+		'preserves bottom-following state %s when shrinking content clamps the scroll position',
+		async (following) => {
+			const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+			if (!following) scrollTo(700);
+			props.messages = props.messages.slice(0, 3);
+			flushSync();
+			viewport.dispatchEvent(new Event('scroll'));
+			await settle();
+			resize();
+			expect(viewport.scrollTop).toBe(300);
+			props.messages = [...props.messages, message(4)];
+			await settle();
+			expect(viewport.scrollTop).toBe(following ? 600 : 300);
+		}
+	);
 
 	it('opens a newly mounted thread at the bottom rather than reusing the previous reading position', async () => {
 		const first = await renderTranscript([1, 2, 3, 4].map(message));

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -55,7 +55,8 @@ async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600)
 		clientHeight: { get: () => viewportHeight },
 		scrollHeight: { get: () => Math.max(viewportHeight, messageElements().length * 300) },
 		scrollTop: {
-			get: () => scrollTop,
+			configurable: true,
+			get: () => Math.min(scrollTop, viewport.scrollHeight - viewport.clientHeight),
 			set: (top: number) => {
 				scrollTop = Math.max(0, Math.min(top, viewport.scrollHeight - viewport.clientHeight));
 			}
@@ -67,7 +68,7 @@ async function renderTranscript(messages: ThreadMessage[], viewportHeight = 600)
 		const index = messageElements().indexOf(this);
 		return new DOMRect(
 			0,
-			index < 0 ? 0 : index * 300 - scrollTop,
+			index < 0 ? 0 : index * 300 - viewport.scrollTop,
 			800,
 			index < 0 ? viewportHeight : 300
 		);
@@ -144,6 +145,82 @@ describe('transcript viewport paging', () => {
 		props.messages = [...props.messages, message(7)];
 		await settle();
 		expect(viewport.scrollTop).toBe(1500);
+	});
+
+	it.each(['wheel', 'touch', 'ArrowUp', 'PageUp', 'Home', 'Shift+Space'])(
+		'stops following on upward %s input before a scroll event, even without older pages',
+		async (input) => {
+			const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+			props.nextBefore = undefined;
+			await settle();
+			if (input === 'wheel') {
+				viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -10 }));
+			} else if (input === 'touch') {
+				for (const [type, clientY] of [
+					['touchstart', 100],
+					['touchmove', 110]
+				] as const) {
+					const event = new Event(type, { bubbles: true });
+					Object.defineProperty(event, 'touches', { value: [{ clientY }] });
+					viewport.dispatchEvent(event);
+				}
+			} else {
+				viewport.dispatchEvent(
+					new KeyboardEvent('keydown', {
+						key: input === 'Shift+Space' ? ' ' : input,
+						shiftKey: input === 'Shift+Space',
+						bubbles: true
+					})
+				);
+			}
+			props.messages = [...props.messages, message(6)];
+			await settle();
+			resize();
+			expect(viewport.scrollTop).toBe(900);
+			expect(props.onLoadOlder).not.toHaveBeenCalled();
+			scrollTo(1200);
+			props.messages = [...props.messages, message(7)];
+			await settle();
+			expect(viewport.scrollTop).toBe(1500);
+		}
+	);
+
+	it('does not pull a small upward scroll back into the bottom tolerance', async () => {
+		const { props, viewport, scrollTo } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+		scrollTo(890);
+		props.messages = [...props.messages, message(6)];
+		await settle();
+		resize();
+		expect(viewport.scrollTop).toBe(890);
+	});
+
+	it('respects a scrollbar move before its scroll event reaches the component', async () => {
+		const { props, viewport } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+		viewport.scrollTop = 700;
+		resize();
+		expect(viewport.scrollTop).toBe(700);
+		props.messages = [...props.messages, message(6)];
+		await settle();
+		expect(viewport.scrollTop).toBe(700);
+	});
+
+	it('does not write the scroll position for a resize that leaves the bottom unchanged', async () => {
+		const { viewport } = await renderTranscript([1, 2, 3, 4].map(message));
+		const writeScrollTop = vi.spyOn(viewport, 'scrollTop', 'set');
+		resize();
+		resize();
+		expect(writeScrollTop).not.toHaveBeenCalled();
+	});
+
+	it('keeps following when shrinking content clamps the scroll position', async () => {
+		const { props, viewport } = await renderTranscript([1, 2, 3, 4, 5].map(message));
+		props.messages = props.messages.slice(0, 3);
+		await settle();
+		resize();
+		expect(viewport.scrollTop).toBe(300);
+		props.messages = [...props.messages, message(4)];
+		await settle();
+		expect(viewport.scrollTop).toBe(600);
 	});
 
 	it('opens a newly mounted thread at the bottom rather than reusing the previous reading position', async () => {


### PR DESCRIPTION
## Summary
- Remove off-screen message size estimates. Revealing skipped messages changed the scroll height and caused visible jumps.
- Stop bottom-following on upward wheel, touch, and keyboard input, including small movements within the bottom tolerance. Respect scrollbar movement before its scroll event arrives.
- Avoid redundant scroll-position writes and keep following when content shrinks. Preserve existing history paging and section anchoring.

## Validation
- Chromium/Electron check with 60 variable-height messages and 100 upward scroll steps. Before removing the CSS optimization, scroll height took 38 distinct values and one unexpected jump exceeded 2,800 pixels. After removal, the height stayed constant with no unexpected movement.
- Nine new scroll regressions failed before the behavioral fix and passed afterward. Added a further regression for shrinking content.
- Svelte check, web production build, targeted ESLint/Oxlint, Prettier, and basic commit hooks passed.
- Full frontend and component suites passed, 245 tests across 25 files.

Requested Grok cleanup and review agents were blocked by the account usage limit.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62902527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previously reported content-shrink behavior is resolved and no actionable new regression was established.

<details open><summary><h3>Summary</h3></summary>

- Removes intrinsic off-screen message-size estimates that changed scroll height as messages became visible.
- Detaches bottom-following immediately on upward wheel, touch, and keyboard intent.
- Preserves the existing follow state when shrinking content clamps the viewport.
- Avoids redundant scroll-position writes and adds targeted regression coverage.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Viewport or content changes] --> B{Upward user intent?}
    B -->|Yes| C[Disable bottom following]
    B -->|No| D{Content shrink clamped viewport?}
    D -->|Yes| E[Preserve existing follow state]
    D -->|No| F[Recalculate proximity to bottom]
    C --> G{Near history boundary?}
    G -->|Yes| H[Request older messages]
    G -->|No| I[Keep current position]
    E --> J{Following enabled?}
    F --> J
    J -->|Yes| K[Scroll to current bottom]
    J -->|No| I
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(ui): Keep detached readers detached ..."](https://github.com/spikonado/sprocket/commit/56af48c869b0d91674604c50a0f6bf25cdb91523)</sub>

<!-- /greptile_comment -->
