### PR TITLE
fix(convex): Restore remaining production schema compatibility

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -6,12 +6,13 @@ Current as of 2026-09-11.
 
 ## Production rollout cleanup
 
-PR #345 removed several stored fields before its code had deployed and before
-production data had been rewritten. The production deployment that remained
-active after that failed rollout could still write those fields, so merely
-cleaning existing rows would race with active mutations. This release restores
-the old schema shapes and ships the cleanup migrations in
-`convex/migrations.ts`.
+PR #345 removed stored project tables, project references, run fields,
+transcript migration state, message references, usage fields, and executor work
+pool state before production data had been rewritten. The production deployment
+that remained active after that failed rollout could still write some of those
+fields. Cleaning existing rows immediately would race with those writers. This
+release restores every known shape from that removal that still needs stored
+data cleanup and ships the cleanup migrations in `convex/migrations.ts`.
 
 The hourly cron calls `runProductionRolloutCleanupAutomatically`. Its first call
 records a cleanup time 48 hours later. That delay exceeds the preceding
@@ -32,6 +33,21 @@ It marks a runless thread as `completed` rather than deleting user data. Remove
 the optional schema and parser handling, and the summary default, after the
 migration completes and a production scan finds no thread without `status`.
 
+### Legacy projects and references
+
+Production may still contain rows in `projects` and `projectConnections`, plus
+`projectId` on `threadRecords`, `runs`, and `executorJobs`. Current code uses
+`repositoryKey` and does not read or write these tables or references. Their
+validators exist only so the stored rows survive schema validation.
+
+`removeThreadRecordProjectId`, `removeRunLegacyFields`, and
+`removeExecutorJobProjectId` unset all project references. The serial runner
+then executes `deleteProjectConnections` before `deleteProjects`. Remove the
+three optional fields and the two table definitions only after all five
+migrations complete and production scans find no project reference, connection,
+or project row. The project table deletions must remain last so no stored
+reference outlives its target table.
+
 ### Run completion transport
 
 The preceding schema accepted `runs.completionTransport` with either
@@ -41,6 +57,17 @@ accepted so stored rows and writes made during the rollout validate.
 
 `removeRunCompletionTransport` unsets the field. Remove it from the schema after
 the migration completes and a production scan finds no run carrying it.
+
+### Run catalog snapshots
+
+Historical runs may contain `catalogVersion`, `contextWindowTokens`, and
+`autoCompactTokenLimit`. Current code gets model limits from the gateway catalog
+and does not read or write these stored snapshots. The fields remain optional
+only so historical runs validate.
+
+`removeRunLegacyFields` unsets all three fields. Remove them from the schema
+after that migration completes and a production scan finds no run carrying any
+of them.
 
 ### Usage ledger fields
 
@@ -53,6 +80,27 @@ rows and writes made during the rollout.
 
 `removeThreadUsageLegacyFields` unsets both fields. Remove them from the schema
 after the migration completes and a production scan finds neither field.
+
+### Numbered transcript migration marker
+
+`threadTranscriptStates.migratedAt` was left by the completed numbered
+transcript backfill. Current code does not read or write it, but production still
+has rows carrying it.
+
+`removeTranscriptStateMigratedAt` unsets the field. Remove it from the schema
+after the migration completes and a production scan finds no transcript state
+carrying it.
+
+### Thread-message references
+
+Historical runs and uploads may contain `runs.promptMessageId` and
+`imageUploads.messageIds`. Prompts and attachment metadata now live in
+`threadTranscriptParts`; current code does not read or write either old field.
+
+`removeRunLegacyFields` unsets `promptMessageId`, and
+`removeImageUploadMessageIds` unsets `messageIds`. Remove each field from the
+schema only after its migration completes and a production scan finds no stored
+value for that field.
 
 ### Executor work pool
 

--- a/apps/web/src/convex/migrations.test.ts
+++ b/apps/web/src/convex/migrations.test.ts
@@ -43,10 +43,23 @@ describe('production rollout cleanup migrations', () => {
 		expect(records.runless?.status).toBe('completed');
 	});
 
-	it('unsets fields retained for the rolling deployment', async () => {
+	it('removes data retained for the rolling deployment', async () => {
 		const t = initConvexTest();
 		const { threadId } = await seedOwnedThread(t);
 		const ids = await t.run(async (ctx) => {
+			const projectId = await ctx.db.insert('projects', {
+				userId: 'user_alice',
+				repositoryKey: 'alpha',
+				displayName: 'Alpha',
+				nextExecutorSequence: 1,
+				lastSeenAt: 1
+			});
+			const connectionId = await ctx.db.insert('projectConnections', {
+				projectId,
+				userId: 'user_alice',
+				clientId: 'legacy-client',
+				lastHeartbeatAt: 1
+			});
 			const run = await ctx.db
 				.query('runs')
 				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
@@ -56,14 +69,40 @@ describe('production rollout cleanup migrations', () => {
 				.withIndex('by_threadId', (query) => query.eq('threadId', threadId))
 				.unique();
 			if (!run || !usage) throw new Error('Missing test fixture.');
-			await ctx.db.patch('runs', run._id, { completionTransport: 'convex-action' });
+			await ctx.db.patch('threadRecords', threadId, { projectId });
+			await ctx.db.patch('runs', run._id, {
+				projectId,
+				catalogVersion: 'legacy-catalog',
+				completionTransport: 'convex-action',
+				contextWindowTokens: 100_000,
+				autoCompactTokenLimit: 80_000,
+				promptMessageId: 'legacy-prompt'
+			});
 			await ctx.db.patch('threadUsage', usage._id, {
 				totalTokensProcessed: 42,
 				usageLedgerMigratedAt: 1
 			});
+			const transcriptStateId = await ctx.db.insert('threadTranscriptStates', {
+				threadId,
+				userId: 'user_alice',
+				totalParts: 1,
+				migratedAt: 1
+			});
+			const storageId = await ctx.storage.store(new Blob(['legacy-image']));
+			const uploadId = await ctx.db.insert('imageUploads', {
+				userId: 'user_alice',
+				storageId,
+				name: 'legacy.png',
+				mediaType: 'image/png',
+				size: 1,
+				messageIds: ['legacy-message'],
+				attached: true,
+				threadId
+			});
 			const jobId = await ctx.db.insert('executorJobs', {
 				threadId,
 				runId: run._id,
+				projectId,
 				kind: 'web_search',
 				payload: { query: 'compatibility' },
 				hidden: false,
@@ -72,22 +111,53 @@ describe('production rollout cleanup migrations', () => {
 				sequence: 0,
 				cloudWorkPool: 'firecrawlScrape'
 			});
-			return { runId: run._id, usageId: usage._id, jobId };
+			return {
+				projectId,
+				connectionId,
+				runId: run._id,
+				usageId: usage._id,
+				transcriptStateId,
+				uploadId,
+				jobId
+			};
 		});
 
+		await t.mutation(internal.migrations.removeThreadRecordProjectId, oneBatch);
 		await t.mutation(internal.migrations.removeRunCompletionTransport, oneBatch);
+		await t.mutation(internal.migrations.removeRunLegacyFields, oneBatch);
 		await t.mutation(internal.migrations.removeThreadUsageLegacyFields, oneBatch);
+		await t.mutation(internal.migrations.removeTranscriptStateMigratedAt, oneBatch);
+		await t.mutation(internal.migrations.removeImageUploadMessageIds, oneBatch);
 		await t.mutation(internal.migrations.removeExecutorJobCloudWorkPool, oneBatch);
+		await t.mutation(internal.migrations.removeExecutorJobProjectId, oneBatch);
+		await t.mutation(internal.migrations.deleteProjectConnections, oneBatch);
+		await t.mutation(internal.migrations.deleteProjects, oneBatch);
 
 		const migrated = await t.run(async (ctx) => ({
+			thread: await ctx.db.get('threadRecords', threadId),
 			run: await ctx.db.get('runs', ids.runId),
 			usage: await ctx.db.get('threadUsage', ids.usageId),
-			job: await ctx.db.get('executorJobs', ids.jobId)
+			transcriptState: await ctx.db.get('threadTranscriptStates', ids.transcriptStateId),
+			upload: await ctx.db.get('imageUploads', ids.uploadId),
+			job: await ctx.db.get('executorJobs', ids.jobId),
+			project: await ctx.db.get('projects', ids.projectId),
+			connection: await ctx.db.get('projectConnections', ids.connectionId)
 		}));
+		expect(migrated.thread?.projectId).toBeUndefined();
 		expect(migrated.run?.completionTransport).toBeUndefined();
+		expect(migrated.run?.projectId).toBeUndefined();
+		expect(migrated.run?.catalogVersion).toBeUndefined();
+		expect(migrated.run?.contextWindowTokens).toBeUndefined();
+		expect(migrated.run?.autoCompactTokenLimit).toBeUndefined();
+		expect(migrated.run?.promptMessageId).toBeUndefined();
 		expect(migrated.usage?.totalTokensProcessed).toBeUndefined();
 		expect(migrated.usage?.usageLedgerMigratedAt).toBeUndefined();
+		expect(migrated.transcriptState?.migratedAt).toBeUndefined();
+		expect(migrated.upload?.messageIds).toBeUndefined();
 		expect(migrated.job?.cloudWorkPool).toBeUndefined();
+		expect(migrated.job?.projectId).toBeUndefined();
+		expect(migrated.project).toBeNull();
+		expect(migrated.connection).toBeNull();
 	});
 
 	it('waits for prior writers and then runs the cleanup automatically', async () => {

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -14,9 +14,16 @@ export const migrations = new Migrations(components.migrations, {
 
 const productionRolloutCleanupMigrations = [
 	internal.migrations.backfillMissingThreadStatus,
+	internal.migrations.removeThreadRecordProjectId,
 	internal.migrations.removeRunCompletionTransport,
+	internal.migrations.removeRunLegacyFields,
 	internal.migrations.removeThreadUsageLegacyFields,
-	internal.migrations.removeExecutorJobCloudWorkPool
+	internal.migrations.removeTranscriptStateMigratedAt,
+	internal.migrations.removeImageUploadMessageIds,
+	internal.migrations.removeExecutorJobCloudWorkPool,
+	internal.migrations.removeExecutorJobProjectId,
+	internal.migrations.deleteProjectConnections,
+	internal.migrations.deleteProjects
 ];
 
 export const runProductionRolloutCleanup = migrations.runner(productionRolloutCleanupMigrations);
@@ -76,6 +83,36 @@ export const removeRunCompletionTransport = migrations.define({
 	}
 });
 
+export const removeThreadRecordProjectId = migrations.define({
+	table: 'threadRecords',
+	migrateOne: (_ctx, thread) => {
+		if (thread.projectId === undefined) return;
+		return { projectId: undefined };
+	}
+});
+
+export const removeRunLegacyFields = migrations.define({
+	table: 'runs',
+	migrateOne: (_ctx, run) => {
+		if (
+			run.projectId === undefined &&
+			run.catalogVersion === undefined &&
+			run.contextWindowTokens === undefined &&
+			run.autoCompactTokenLimit === undefined &&
+			run.promptMessageId === undefined
+		) {
+			return;
+		}
+		return {
+			projectId: undefined,
+			catalogVersion: undefined,
+			contextWindowTokens: undefined,
+			autoCompactTokenLimit: undefined,
+			promptMessageId: undefined
+		};
+	}
+});
+
 export const removeThreadUsageLegacyFields = migrations.define({
 	table: 'threadUsage',
 	migrateOne: (_ctx, usage) => {
@@ -86,10 +123,48 @@ export const removeThreadUsageLegacyFields = migrations.define({
 	}
 });
 
+export const removeTranscriptStateMigratedAt = migrations.define({
+	table: 'threadTranscriptStates',
+	migrateOne: (_ctx, state) => {
+		if (state.migratedAt === undefined) return;
+		return { migratedAt: undefined };
+	}
+});
+
+export const removeImageUploadMessageIds = migrations.define({
+	table: 'imageUploads',
+	migrateOne: (_ctx, upload) => {
+		if (upload.messageIds === undefined) return;
+		return { messageIds: undefined };
+	}
+});
+
 export const removeExecutorJobCloudWorkPool = migrations.define({
 	table: 'executorJobs',
 	migrateOne: (_ctx, job) => {
 		if (job.cloudWorkPool === undefined) return;
 		return { cloudWorkPool: undefined };
+	}
+});
+
+export const removeExecutorJobProjectId = migrations.define({
+	table: 'executorJobs',
+	migrateOne: (_ctx, job) => {
+		if (job.projectId === undefined) return;
+		return { projectId: undefined };
+	}
+});
+
+export const deleteProjectConnections = migrations.define({
+	table: 'projectConnections',
+	migrateOne: async (ctx, connection) => {
+		await ctx.db.delete('projectConnections', connection._id);
+	}
+});
+
+export const deleteProjects = migrations.define({
+	table: 'projects',
+	migrateOne: async (ctx, project) => {
+		await ctx.db.delete('projects', project._id);
 	}
 });

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -73,11 +73,32 @@ export default defineSchema({
 		startedAt: v.optional(v.number()),
 		completedAt: v.optional(v.number())
 	}).index('by_name', ['name']),
+	// Stored-only until the production rollout cleanup deletes old rows and references.
+	projects: defineTable({
+		userId: v.string(),
+		repositoryKey: v.string(),
+		displayName: v.string(),
+		lastHeartbeatAt: v.optional(v.number()),
+		connectedClientId: v.optional(v.string()),
+		nextExecutorSequence: v.number(),
+		lastSeenAt: v.number()
+	})
+		.index('by_userId', ['userId'])
+		.index('by_user_repositoryKey', ['userId', 'repositoryKey']),
+	projectConnections: defineTable({
+		projectId: v.id('projects'),
+		userId: v.string(),
+		clientId: v.string(),
+		lastHeartbeatAt: v.number()
+	})
+		.index('by_projectId', ['projectId'])
+		.index('by_userId', ['userId']),
 	threadRecords: defineTable({
 		userId: v.string(),
 		submissionId: v.string(),
 		status: v.optional(vRunStatus),
 		repositoryKey: v.string(),
+		projectId: v.optional(v.id('projects')),
 		title: v.optional(v.string()),
 		selectedModel: v.string(),
 		reasoningEffort: vReasoningEffort,
@@ -120,6 +141,7 @@ export default defineSchema({
 		threadId: v.id('threadRecords'),
 		userId: v.string(),
 		submissionId: v.string(),
+		projectId: v.optional(v.id('projects')),
 		status: vRunStatus,
 		// Hash of the bearer capability held only by the local executor.
 		executionSecretHash: v.string(),
@@ -131,15 +153,19 @@ export default defineSchema({
 		selectedModel: v.string(),
 		reasoningEffort: vReasoningEffort,
 		serviceTier: vServiceTier,
+		catalogVersion: v.optional(v.string()),
 		completionTransport: v.optional(v.union(v.literal('convex-action'), v.literal('gateway'))),
 		gatewayProtocolVersion: v.optional(v.number()),
 		agentVersion: v.optional(v.string()),
+		contextWindowTokens: v.optional(v.number()),
+		autoCompactTokenLimit: v.optional(v.number()),
 		startedAt: v.number(),
 		completedAt: v.optional(v.number()),
 		lastError: v.optional(v.string()),
 		cancellationRequestedAt: v.optional(v.number()),
 		cancellationDeadlineAt: v.optional(v.number()),
 		activeJobId: v.optional(v.id('executorJobs')),
+		promptMessageId: v.optional(v.string()),
 		completionStreamStateId: v.optional(v.id('completionStreamStates')),
 		lifecycleWorkflowId: v.optional(v.string())
 	})
@@ -152,7 +178,8 @@ export default defineSchema({
 	threadTranscriptStates: defineTable({
 		threadId: v.id('threadRecords'),
 		userId: v.string(),
-		totalParts: v.number()
+		totalParts: v.number(),
+		migratedAt: v.optional(v.number())
 	}).index('by_threadId', ['threadId']),
 	threadTranscriptParts: defineTable({
 		threadId: v.id('threadRecords'),
@@ -180,6 +207,7 @@ export default defineSchema({
 		name: v.string(),
 		mediaType: v.string(),
 		size: v.number(),
+		messageIds: v.optional(v.array(v.string())),
 		attached: v.boolean(),
 		threadId: v.optional(v.id('threadRecords')),
 		storageDeletedAt: v.optional(v.number())
@@ -243,6 +271,7 @@ export default defineSchema({
 	executorJobs: defineTable({
 		threadId: v.id('threadRecords'),
 		runId: v.id('runs'),
+		projectId: v.optional(v.id('projects')),
 		kind: vStoredExecutorJobKind,
 		callId: v.optional(v.string()),
 		// Set on jobs created after tool progress events. Legacy rows omit it;

--- a/apps/web/src/convex/schemaCompatibility.test.ts
+++ b/apps/web/src/convex/schemaCompatibility.test.ts
@@ -3,11 +3,24 @@ import { api } from '@convex/_generated/api';
 import { initConvexTest, seedOwnedThread } from './test.setup';
 
 describe('schema rollout compatibility', () => {
-	it('accepts rows written by the previous production deployment', async () => {
+	it('accepts rows retained from production before cleanup', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 
 		const legacy = await t.run(async (ctx) => {
+			const projectId = await ctx.db.insert('projects', {
+				userId: 'user_alice',
+				repositoryKey: 'alpha',
+				displayName: 'Alpha',
+				nextExecutorSequence: 1,
+				lastSeenAt: 1
+			});
+			const connectionId = await ctx.db.insert('projectConnections', {
+				projectId,
+				userId: 'user_alice',
+				clientId: 'legacy-client',
+				lastHeartbeatAt: 1
+			});
 			const run = await ctx.db
 				.query('runs')
 				.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', threadId))
@@ -18,15 +31,40 @@ describe('schema rollout compatibility', () => {
 				.unique();
 			if (!run || !usage) throw new Error('Missing test fixture.');
 
-			await ctx.db.patch('threadRecords', threadId, { status: undefined });
-			await ctx.db.patch('runs', run._id, { completionTransport: 'gateway' });
+			await ctx.db.patch('threadRecords', threadId, { status: undefined, projectId });
+			await ctx.db.patch('runs', run._id, {
+				projectId,
+				catalogVersion: 'legacy-catalog',
+				completionTransport: 'gateway',
+				contextWindowTokens: 100_000,
+				autoCompactTokenLimit: 80_000,
+				promptMessageId: 'legacy-prompt'
+			});
 			await ctx.db.patch('threadUsage', usage._id, {
 				totalTokensProcessed: 42,
 				usageLedgerMigratedAt: 1
 			});
+			const transcriptStateId = await ctx.db.insert('threadTranscriptStates', {
+				threadId,
+				userId: 'user_alice',
+				totalParts: 1,
+				migratedAt: 1
+			});
+			const storageId = await ctx.storage.store(new Blob(['legacy-image']));
+			const uploadId = await ctx.db.insert('imageUploads', {
+				userId: 'user_alice',
+				storageId,
+				name: 'legacy.png',
+				mediaType: 'image/png',
+				size: 1,
+				messageIds: ['legacy-message'],
+				attached: true,
+				threadId
+			});
 			const jobId = await ctx.db.insert('executorJobs', {
 				threadId,
 				runId: run._id,
+				projectId,
 				kind: 'web_search',
 				payload: { query: 'compatibility' },
 				hidden: false,
@@ -40,14 +78,32 @@ describe('schema rollout compatibility', () => {
 				thread: await ctx.db.get('threadRecords', threadId),
 				run: await ctx.db.get('runs', run._id),
 				usage: await ctx.db.get('threadUsage', usage._id),
-				job: await ctx.db.get('executorJobs', jobId)
+				transcriptState: await ctx.db.get('threadTranscriptStates', transcriptStateId),
+				upload: await ctx.db.get('imageUploads', uploadId),
+				job: await ctx.db.get('executorJobs', jobId),
+				project: await ctx.db.get('projects', projectId),
+				connection: await ctx.db.get('projectConnections', connectionId)
 			};
 		});
 
 		expect(legacy.thread?.status).toBeUndefined();
-		expect(legacy.run?.completionTransport).toBe('gateway');
+		expect(legacy.thread?.projectId).toBe(legacy.project?._id);
+		expect(legacy.run).toMatchObject({
+			projectId: legacy.project?._id,
+			catalogVersion: 'legacy-catalog',
+			completionTransport: 'gateway',
+			contextWindowTokens: 100_000,
+			autoCompactTokenLimit: 80_000,
+			promptMessageId: 'legacy-prompt'
+		});
 		expect(legacy.usage).toMatchObject({ totalTokensProcessed: 42, usageLedgerMigratedAt: 1 });
-		expect(legacy.job?.cloudWorkPool).toBe('firecrawlScrape');
+		expect(legacy.transcriptState?.migratedAt).toBe(1);
+		expect(legacy.upload?.messageIds).toEqual(['legacy-message']);
+		expect(legacy.job).toMatchObject({
+			projectId: legacy.project?._id,
+			cloudWorkPool: 'firecrawlScrape'
+		});
+		expect(legacy.connection?.projectId).toBe(legacy.project?._id);
 
 		await expect(asUser.mutation(api.threads.archiveForLocalCache, { threadId })).resolves.toEqual({
 			userId: legacy.thread?.userId,


### PR DESCRIPTION
## Summary

- restore the remaining stored-only project tables and fields that PR #345 removed before their cleanup gates passed
- add those fields and tables to the delayed serial production cleanup introduced in #350, removing references before deleting project rows
- expand schema compatibility and migration coverage, and record exact removal gates in `BACKWARDS_COMPATIBILITY.md`

## Why

The production deployment for #350 reached schema validation, then rejected an existing `threadTranscriptStates` document containing `migratedAt`. The old compatibility contract also identified project references, run catalog snapshots, and thread-message references that still required rewrites. Restoring all of those known stored shapes avoids another sequence of one-field-at-a-time deployment failures.

No production deployment or manual production migration was run.

## Validation

- `bunx convex codegen` against the development deployment
- `bun run test -- src/convex/migrations.test.ts src/convex/schemaCompatibility.test.ts`
- `bun run check`
- `prek run -a`
- `bun run build`
- Full `bun run test`: 582 passed and 6 unrelated tests failed under parallel load. All 142 tests in the four affected files passed when rerun file by file.

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62930660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no outstanding or newly introduced actionable issues remain.

<details open><summary><h3>Summary</h3></summary>

- Reintroduces stored-only project tables, project references, run snapshots, transcript markers, message references, and executor state.
- Adds ordered cleanup migrations that remove references before deleting project rows.
- Expands migration and compatibility coverage and documents the production removal gates.
- No code changes were made since the previous review.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Wait 48 hours for prior writers] --> B[Backfill missing thread status]
  B --> C[Remove thread projectId]
  C --> D[Remove legacy run fields]
  D --> E[Remove usage and transcript fields]
  E --> F[Remove image upload messageIds]
  F --> G[Remove executor legacy fields]
  G --> H[Delete projectConnections]
  H --> I[Delete projects]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(convex): Restore remaining productio..."](https://github.com/spikonado/sprocket/commit/1a8807cbd9d8375ba28e20d88c246d972dd9d15a)</sub>

<!-- /greptile_comment -->