### PR TITLE
fix(ui): Stabilize ask-question lifecycle

### DIFF
--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -79,8 +79,7 @@ describe('agentQuestions', () => {
 		});
 
 		const head = await asUser.query(api.agentQuestions.headPendingForThread, {
-			threadId,
-			now: Date.now()
+			threadId
 		});
 		expect(head?.questionId).toBe(first.questionId);
 
@@ -111,8 +110,7 @@ describe('agentQuestions', () => {
 		expect(
 			(
 				await asUser.query(api.agentQuestions.headPendingForThread, {
-					threadId,
-					now: Date.now()
+					threadId
 				})
 			)?.questionId
 		).toBe(second.questionId);
@@ -146,7 +144,7 @@ describe('agentQuestions', () => {
 		vi.useRealTimers();
 	});
 
-	it('cancels pending questions when the run finalizes', async () => {
+	it('cancels pending questions when the run is cancelled', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
 		const { executionSecret, claimId, runId } = await startRun(t, threadId);
@@ -174,7 +172,45 @@ describe('agentQuestions', () => {
 		expect(snapshot?.status).toBe('cancelled');
 	});
 
-	it('expires overdue heads on answer so FIFO can advance before the scheduler', async () => {
+	it('keeps pending questions after the run completes', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const created = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Still open?',
+			options: [{ id: 'yes', label: 'Yes' }],
+			executionSecret
+		});
+
+		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId,
+			text: '',
+			status: 'completed',
+			executionSecret
+		});
+
+		await expect(
+			asUser.query(api.agentQuestions.headPendingForThread, { threadId })
+		).resolves.toMatchObject({
+			questionId: created.questionId,
+			status: 'pending'
+		});
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: created.questionId,
+				optionId: 'yes'
+			})
+		).resolves.toMatchObject({
+			status: 'answered',
+			answer: { optionId: 'yes', optionLabel: 'Yes' }
+		});
+	});
+
+	it('keeps a pending head answerable until its timeout mutation runs', async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-07-26T12:00:00.000Z'));
 		const t = initConvexTest();
@@ -201,13 +237,8 @@ describe('agentQuestions', () => {
 		vi.setSystemTime(new Date('2026-07-26T12:00:02.000Z'));
 
 		expect(
-			(
-				await asUser.query(api.agentQuestions.headPendingForThread, {
-					threadId,
-					now: Date.now()
-				})
-			)?.questionId
-		).toBe(next.questionId);
+			(await asUser.query(api.agentQuestions.headPendingForThread, { threadId }))?.questionId
+		).toBe(overdue.questionId);
 
 		await expect(
 			asUser.mutation(api.agentQuestions.answer, {
@@ -215,7 +246,14 @@ describe('agentQuestions', () => {
 				questionId: overdue.questionId,
 				optionId: 'old'
 			})
-		).rejects.toThrow(/no longer awaiting/);
+		).resolves.toMatchObject({
+			status: 'answered',
+			answer: { optionId: 'old', optionLabel: 'Old' }
+		});
+
+		expect(
+			(await asUser.query(api.agentQuestions.headPendingForThread, { threadId }))?.questionId
+		).toBe(next.questionId);
 
 		await expect(
 			asUser.mutation(api.agentQuestions.answer, {
@@ -227,14 +265,6 @@ describe('agentQuestions', () => {
 			status: 'answered',
 			answer: { optionId: 'new', optionLabel: 'New' }
 		});
-
-		const overdueSnapshot = await t.query(api.agentQuestions.getForExecutor, {
-			runId,
-			questionId: overdue.questionId,
-			executionSecret
-		});
-		expect(overdueSnapshot?.status).toBe('timedOut');
-
 		vi.useRealTimers();
 	});
 });

--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -106,8 +106,7 @@ describe('agentQuestions', () => {
 					optionLabel: 'Two',
 					text: 'with detail'
 				}
-			},
-			startContinuation: false
+			}
 		});
 
 		expect(
@@ -218,8 +217,7 @@ describe('agentQuestions', () => {
 			question: {
 				status: 'answered',
 				answer: { optionId: 'yes', optionLabel: 'Yes' }
-			},
-			startContinuation: false
+			}
 		});
 		await expect(
 			asUser.mutation(api.agentQuestions.answer, {
@@ -232,7 +230,7 @@ describe('agentQuestions', () => {
 				status: 'answered',
 				answer: { optionId: 'ship', optionLabel: 'Ship it' }
 			},
-			startContinuation: true
+			continuationOfRunId: runId
 		});
 	});
 
@@ -276,8 +274,7 @@ describe('agentQuestions', () => {
 			question: {
 				status: 'answered',
 				answer: { optionId: 'old', optionLabel: 'Old' }
-			},
-			startContinuation: false
+			}
 		});
 
 		expect(
@@ -294,8 +291,7 @@ describe('agentQuestions', () => {
 			question: {
 				status: 'answered',
 				answer: { optionId: 'new', optionLabel: 'New' }
-			},
-			startContinuation: false
+			}
 		});
 		vi.useRealTimers();
 	});

--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -174,7 +174,43 @@ describe('agentQuestions', () => {
 		expect(snapshot?.status).toBe('cancelled');
 	});
 
-	it('keeps pending questions after the run completes', async () => {
+	it('uses the answer as the continuation prompt for one terminal question', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const question = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Which database?',
+			options: [{ id: 'postgres', label: 'PostgreSQL' }],
+			executionSecret
+		});
+
+		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId,
+			text: '',
+			status: 'failed',
+			lastError: 'Stopped before receiving the answer.',
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: question.questionId,
+				optionId: 'postgres',
+				text: 'Use the existing container'
+			})
+		).resolves.toMatchObject({
+			continuation: {
+				runId,
+				prompt: 'PostgreSQL: Use the existing container'
+			}
+		});
+	});
+
+	it('keeps pending questions after completion and aggregates their answers', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
 		const { executionSecret, claimId, runId } = await startRun(t, threadId);
@@ -207,30 +243,39 @@ describe('agentQuestions', () => {
 			questionId: first.questionId,
 			status: 'pending'
 		});
-		await expect(
-			asUser.mutation(api.agentQuestions.answer, {
-				threadId,
-				questionId: first.questionId,
-				optionId: 'yes'
-			})
-		).resolves.toMatchObject({
+		const firstAnswer = await asUser.mutation(api.agentQuestions.answer, {
+			threadId,
+			questionId: first.questionId,
+			optionId: 'yes'
+		});
+		expect(firstAnswer).toMatchObject({
 			question: {
 				status: 'answered',
 				answer: { optionId: 'yes', optionLabel: 'Yes' }
 			}
 		});
+		expect(firstAnswer).not.toHaveProperty('continuation');
 		await expect(
 			asUser.mutation(api.agentQuestions.answer, {
 				threadId,
 				questionId: second.questionId,
-				optionId: 'ship'
+				optionId: 'ship',
+				text: 'include the release notes'
 			})
 		).resolves.toMatchObject({
 			question: {
 				status: 'answered',
-				answer: { optionId: 'ship', optionLabel: 'Ship it' }
+				answer: {
+					optionId: 'ship',
+					optionLabel: 'Ship it',
+					text: 'include the release notes'
+				}
 			},
-			continuationOfRunId: runId
+			continuation: {
+				runId,
+				prompt:
+					'Answers to your questions:\n\n1. First open question?\n   Yes\n\n2. Second open question?\n   Ship it: include the release notes'
+			}
 		});
 	});
 

--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -210,6 +210,52 @@ describe('agentQuestions', () => {
 		});
 	});
 
+	it('does not repeat answers consumed before the run finished', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
+		const { executionSecret, claimId, runId } = await startRun(t, threadId);
+
+		const consumed = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Which database?',
+			options: [{ id: 'postgres', label: 'PostgreSQL' }],
+			executionSecret
+		});
+		await asUser.mutation(api.agentQuestions.answer, {
+			threadId,
+			questionId: consumed.questionId,
+			optionId: 'postgres'
+		});
+		const pending = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Where should I deploy it?',
+			options: [{ id: 'fly', label: 'Fly.io' }],
+			executionSecret
+		});
+
+		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId,
+			text: '',
+			status: 'completed',
+			executionSecret
+		});
+
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: pending.questionId,
+				optionId: 'fly'
+			})
+		).resolves.toMatchObject({
+			continuation: {
+				runId,
+				prompt: 'Fly.io'
+			}
+		});
+	});
+
 	it('keeps pending questions after completion and aggregates their answers', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');

--- a/apps/web/src/convex/agentQuestions.test.ts
+++ b/apps/web/src/convex/agentQuestions.test.ts
@@ -99,12 +99,15 @@ describe('agentQuestions', () => {
 				text: 'with detail'
 			})
 		).resolves.toMatchObject({
-			status: 'answered',
-			answer: {
-				optionId: 'two',
-				optionLabel: 'Two',
-				text: 'with detail'
-			}
+			question: {
+				status: 'answered',
+				answer: {
+					optionId: 'two',
+					optionLabel: 'Two',
+					text: 'with detail'
+				}
+			},
+			startContinuation: false
 		});
 
 		expect(
@@ -177,11 +180,18 @@ describe('agentQuestions', () => {
 		const { asUser, threadId } = await seedOwnedThread(t, 'user_alice');
 		const { executionSecret, claimId, runId } = await startRun(t, threadId);
 
-		const created = await t.mutation(api.agentQuestions.create, {
+		const first = await t.mutation(api.agentQuestions.create, {
 			runId,
 			claimId,
-			question: 'Still open?',
+			question: 'First open question?',
 			options: [{ id: 'yes', label: 'Yes' }],
+			executionSecret
+		});
+		const second = await t.mutation(api.agentQuestions.create, {
+			runId,
+			claimId,
+			question: 'Second open question?',
+			options: [{ id: 'ship', label: 'Ship it' }],
 			executionSecret
 		});
 
@@ -195,18 +205,34 @@ describe('agentQuestions', () => {
 		await expect(
 			asUser.query(api.agentQuestions.headPendingForThread, { threadId })
 		).resolves.toMatchObject({
-			questionId: created.questionId,
+			questionId: first.questionId,
 			status: 'pending'
 		});
 		await expect(
 			asUser.mutation(api.agentQuestions.answer, {
 				threadId,
-				questionId: created.questionId,
+				questionId: first.questionId,
 				optionId: 'yes'
 			})
 		).resolves.toMatchObject({
-			status: 'answered',
-			answer: { optionId: 'yes', optionLabel: 'Yes' }
+			question: {
+				status: 'answered',
+				answer: { optionId: 'yes', optionLabel: 'Yes' }
+			},
+			startContinuation: false
+		});
+		await expect(
+			asUser.mutation(api.agentQuestions.answer, {
+				threadId,
+				questionId: second.questionId,
+				optionId: 'ship'
+			})
+		).resolves.toMatchObject({
+			question: {
+				status: 'answered',
+				answer: { optionId: 'ship', optionLabel: 'Ship it' }
+			},
+			startContinuation: true
 		});
 	});
 
@@ -247,8 +273,11 @@ describe('agentQuestions', () => {
 				optionId: 'old'
 			})
 		).resolves.toMatchObject({
-			status: 'answered',
-			answer: { optionId: 'old', optionLabel: 'Old' }
+			question: {
+				status: 'answered',
+				answer: { optionId: 'old', optionLabel: 'Old' }
+			},
+			startContinuation: false
 		});
 
 		expect(
@@ -262,8 +291,11 @@ describe('agentQuestions', () => {
 				optionId: 'new'
 			})
 		).resolves.toMatchObject({
-			status: 'answered',
-			answer: { optionId: 'new', optionLabel: 'New' }
+			question: {
+				status: 'answered',
+				answer: { optionId: 'new', optionLabel: 'New' }
+			},
+			startContinuation: false
 		});
 		vi.useRealTimers();
 	});

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -140,7 +140,7 @@ export const answer = mutation({
 	},
 	returns: v.object({
 		question: vAgentQuestionSnapshot,
-		startContinuation: v.boolean()
+		continuationOfRunId: v.optional(v.id('runs'))
 	}),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
@@ -184,13 +184,15 @@ export const answer = mutation({
 			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', args.threadId))
 			.order('desc')
 			.first();
-		const startContinuation =
+		const continuationOfRunId =
 			nextQuestion === null &&
 			run !== null &&
 			latestRun?._id === run._id &&
 			isRunFinalStatus(run.status) &&
-			run.status !== 'cancelled';
-		return { question: snapshot, startContinuation };
+			run.status !== 'cancelled'
+				? run._id
+				: undefined;
+		return { question: snapshot, continuationOfRunId };
 	}
 });
 

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -11,6 +11,7 @@ import { v, type Infer } from 'convex/values';
 import { getOwnedThreadRecord } from '@convex/lib/access';
 import {
 	finalizeQuestionOptions,
+	formatQuestionContinuationPrompt,
 	MAX_QUESTION_TIMEOUT_MS,
 	normalizeQuestionAnswer,
 	validateQuestionText
@@ -140,7 +141,12 @@ export const answer = mutation({
 	},
 	returns: v.object({
 		question: vAgentQuestionSnapshot,
-		continuationOfRunId: v.optional(v.id('runs'))
+		continuation: v.optional(
+			v.object({
+				runId: v.id('runs'),
+				prompt: v.string()
+			})
+		)
 	}),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
@@ -192,7 +198,24 @@ export const answer = mutation({
 			run.status !== 'cancelled'
 				? run._id
 				: undefined;
-		return { question: snapshot, continuationOfRunId };
+		if (!continuationOfRunId) {
+			return { question: snapshot };
+		}
+
+		const runQuestions = await ctx.db
+			.query('agentQuestions')
+			.withIndex('by_runId_sequence', (query) => query.eq('runId', continuationOfRunId))
+			.order('asc')
+			.collect();
+		const prompt = formatQuestionContinuationPrompt(
+			runQuestions.flatMap((entry) =>
+				entry.answer ? [{ question: entry.question, answer: entry.answer }] : []
+			)
+		);
+		return {
+			question: snapshot,
+			continuation: { runId: continuationOfRunId, prompt }
+		};
 	}
 });
 

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -19,7 +19,7 @@ import { getExecutionRun, getUserId } from '@convex/lib/auth';
 import { assertRunAcceptsModelCompletion, toAgentToolConvexError } from '@convex/lib/agentErrors';
 import { vAgentQuestionSnapshot } from '@convex/lib/docs';
 import { isRunClaimLeaseActive } from '@convex/lib/runLease';
-import { vAskQuestionOption } from '@convex/lib/validators';
+import { isRunFinalStatus, vAskQuestionOption } from '@convex/lib/validators';
 
 const DEFAULT_QUESTION_TIMEOUT_MS = 30 * 60 * 1000;
 const MIN_QUESTION_TIMEOUT_MS = 1_000;
@@ -138,7 +138,10 @@ export const answer = mutation({
 		optionId: v.optional(v.string()),
 		text: v.optional(v.string())
 	},
-	returns: vAgentQuestionSnapshot,
+	returns: v.object({
+		question: vAgentQuestionSnapshot,
+		startContinuation: v.boolean()
+	}),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
@@ -168,12 +171,26 @@ export const answer = mutation({
 			answeredAt
 		});
 
-		return toSnapshot({
+		const snapshot = toSnapshot({
 			...question,
 			status: 'answered',
 			answer,
 			answeredAt
 		});
+		const nextQuestion = await headPendingQuestion(ctx, args.threadId);
+		const run = await ctx.db.get('runs', question.runId);
+		const latestRun = await ctx.db
+			.query('runs')
+			.withIndex('by_threadId_startedAt', (query) => query.eq('threadId', args.threadId))
+			.order('desc')
+			.first();
+		const startContinuation =
+			nextQuestion === null &&
+			run !== null &&
+			latestRun?._id === run._id &&
+			isRunFinalStatus(run.status) &&
+			run.status !== 'cancelled';
+		return { question: snapshot, startContinuation };
 	}
 });
 

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -209,7 +209,9 @@ export const answer = mutation({
 			.collect();
 		const prompt = formatQuestionContinuationPrompt(
 			runQuestions.flatMap((entry) =>
-				entry.answer ? [{ question: entry.question, answer: entry.answer }] : []
+				entry.requiresContinuation && entry.answer
+					? [{ question: entry.question, answer: entry.answer }]
+					: []
 			)
 		);
 		return {

--- a/apps/web/src/convex/agentQuestions.ts
+++ b/apps/web/src/convex/agentQuestions.ts
@@ -54,53 +54,17 @@ async function nextThreadSequence(
 	return (latest?.sequence ?? 0) + 1;
 }
 
-async function listPendingQuestions(
+async function headPendingQuestion(
 	ctx: QueryCtx | MutationCtx,
 	threadId: Id<'threadRecords'>
-): Promise<Doc<'agentQuestions'>[]> {
+): Promise<Doc<'agentQuestions'> | null> {
 	return await ctx.db
 		.query('agentQuestions')
 		.withIndex('by_threadId_status_sequence', (query) =>
 			query.eq('threadId', threadId).eq('status', 'pending')
 		)
 		.order('asc')
-		.collect();
-}
-
-async function headPendingQuestion(
-	ctx: QueryCtx | MutationCtx,
-	threadId: Id<'threadRecords'>
-): Promise<Doc<'agentQuestions'> | null> {
-	const pending = await listPendingQuestions(ctx, threadId);
-	return pending[0] ?? null;
-}
-
-/** First pending question that has not yet reached timeoutAt (UI head). */
-async function headLivePendingQuestion(
-	ctx: QueryCtx | MutationCtx,
-	threadId: Id<'threadRecords'>,
-	now: number
-): Promise<Doc<'agentQuestions'> | null> {
-	const pending = await listPendingQuestions(ctx, threadId);
-	return pending.find((question) => question.timeoutAt > now) ?? null;
-}
-
-/** Mark past-due pending questions timedOut so FIFO can advance before the scheduler fires. */
-async function expireOverduePendingQuestions(
-	ctx: MutationCtx,
-	threadId: Id<'threadRecords'>,
-	now: number
-): Promise<void> {
-	const pending = await listPendingQuestions(ctx, threadId);
-	for (const question of pending) {
-		if (question.timeoutAt > now) {
-			continue;
-		}
-		await ctx.db.patch('agentQuestions', question._id, {
-			status: 'timedOut',
-			answeredAt: now
-		});
-	}
+		.first();
 }
 
 export const create = mutation({
@@ -179,9 +143,6 @@ export const answer = mutation({
 		const userId = await getUserId(ctx);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
 
-		const now = Date.now();
-		await expireOverduePendingQuestions(ctx, args.threadId, now);
-
 		const question = await ctx.db.get('agentQuestions', args.questionId);
 		if (!question || question.threadId !== args.threadId) {
 			throw new Error('Question not found.');
@@ -200,17 +161,18 @@ export const answer = mutation({
 			optionId: args.optionId,
 			text: args.text
 		});
+		const answeredAt = Date.now();
 		await ctx.db.patch('agentQuestions', question._id, {
 			status: 'answered',
 			answer,
-			answeredAt: now
+			answeredAt
 		});
 
 		return toSnapshot({
 			...question,
 			status: 'answered',
 			answer,
-			answeredAt: now
+			answeredAt
 		});
 	}
 });
@@ -256,14 +218,13 @@ export const getForExecutor = query({
 
 export const headPendingForThread = query({
 	args: {
-		threadId: v.id('threadRecords'),
-		now: v.number()
+		threadId: v.id('threadRecords')
 	},
 	returns: v.union(vAgentQuestionSnapshot, v.null()),
 	handler: async (ctx, args) => {
 		const userId = await getUserId(ctx);
 		await getOwnedThreadRecord(ctx.db, userId, args.threadId);
-		const head = await headLivePendingQuestion(ctx, args.threadId, args.now);
+		const head = await headPendingQuestion(ctx, args.threadId);
 		return head ? toSnapshot(head) : null;
 	}
 });

--- a/apps/web/src/convex/agentRuntime.continuation.test.ts
+++ b/apps/web/src/convex/agentRuntime.continuation.test.ts
@@ -16,7 +16,6 @@ describe('new-run continuation', { timeout: 30_000 }, () => {
 			lastError: 'boom',
 			executionSecret: 'parent-secret'
 		});
-
 		const args = {
 			threadId,
 			submissionId: 'sub-continue',
@@ -59,7 +58,74 @@ describe('new-run continuation', { timeout: 30_000 }, () => {
 		expect(context.run.continuationOfRunId).toBe(parent.runId);
 	});
 
-	it('rejects active, completed, and non-latest parents', async () => {
+	it('creates a linked continuation with a visible prompt from a completed run', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const parent = await createQueuedRun(
+			t,
+			asUser,
+			threadId,
+			'sub-answered-parent',
+			'parent-secret'
+		);
+		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId: parent.runId,
+			text: '',
+			status: 'completed',
+			executionSecret: 'parent-secret'
+		});
+		await expect(
+			insertQueuedRun(t, asUser, {
+				threadId,
+				submissionId: 'sub-empty-completed-continuation',
+				executionSecret: 'empty-completed-continuation-secret',
+				prompt: '',
+				continuationOfRunId: parent.runId
+			})
+		).rejects.toThrow(RUN_CANNOT_CONTINUE);
+
+		const args = {
+			threadId,
+			submissionId: 'sub-answered-continuation',
+			executionSecret: 'answered-continuation-secret',
+			prompt: 'Ship it: include the release notes',
+			continuationOfRunId: parent.runId
+		};
+		const created = await insertQueuedRun(t, asUser, args);
+		expect(created).toMatchObject({
+			created: true,
+			promptPart: {
+				kind: 'prompt',
+				prompt: { text: args.prompt }
+			}
+		});
+		expect(await t.run(async (ctx) => ctx.db.get('runs', created.runId))).toMatchObject({
+			continuationOfRunId: parent.runId
+		});
+		expect(
+			await asUser.query(api.agentRuntime.getContext, {
+				runId: created.runId,
+				executionSecret: args.executionSecret
+			})
+		).toMatchObject({ prompt: args.prompt });
+
+		await expect(insertQueuedRun(t, asUser, args)).resolves.toMatchObject({
+			created: false,
+			runId: created.runId,
+			promptPart: { prompt: { text: args.prompt } }
+		});
+		await expect(
+			insertQueuedRun(t, asUser, { ...args, prompt: 'A different answer' })
+		).rejects.toThrow('Submission prompt does not match the existing run.');
+
+		const parts = await asUser.query(api.transcript.getParts, { threadId, numbers: [0, 1] });
+		expect(parts.parts.map((part) => [part.runId, part.prompt?.text])).toEqual([
+			[parent.runId, 'Do the thing'],
+			[created.runId, args.prompt]
+		]);
+	});
+
+	it('rejects active and non-latest parents', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
 		const active = await createQueuedRun(t, asUser, threadId, 'sub-active', 'active-secret');
@@ -79,15 +145,6 @@ describe('new-run continuation', { timeout: 30_000 }, () => {
 			status: 'completed',
 			executionSecret: 'active-secret'
 		});
-		await expect(
-			insertQueuedRun(t, asUser, {
-				threadId,
-				submissionId: 'sub-continue-completed',
-				executionSecret: 'continue-completed-secret',
-				prompt: '',
-				continuationOfRunId: active.runId
-			})
-		).rejects.toThrow(RUN_CANNOT_CONTINUE);
 
 		const failed = await createQueuedRun(t, asUser, threadId, 'sub-failed', 'failed-secret');
 		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {

--- a/apps/web/src/convex/lib/agentQuestions.ts
+++ b/apps/web/src/convex/lib/agentQuestions.ts
@@ -19,6 +19,11 @@ export type AgentQuestionAnswer = {
 	text?: string;
 };
 
+export type AnsweredAgentQuestion = {
+	question: string;
+	answer: AgentQuestionAnswer;
+};
+
 function agentDecideOption(): AgentQuestionOption {
 	return {
 		id: AGENT_DECIDE_OPTION_ID,
@@ -104,6 +109,25 @@ export function normalizeQuestionAnswer(args: {
 	};
 	if (text) answer.text = text;
 	return answer;
+}
+
+function formatAnswer(answer: AgentQuestionAnswer): string {
+	return [answer.optionLabel, answer.text]
+		.filter((part): part is string => Boolean(part))
+		.join(': ');
+}
+
+export function formatQuestionContinuationPrompt(questions: AnsweredAgentQuestion[]): string {
+	if (questions.length === 1) {
+		return formatAnswer(questions[0].answer);
+	}
+
+	const entries = questions.map((question, index) => {
+		const questionText = question.question.replaceAll('\n', '\n   ');
+		const answerText = formatAnswer(question.answer).replaceAll('\n', '\n   ');
+		return `${index + 1}. ${questionText}\n   ${answerText}`;
+	});
+	return `Answers to your questions:\n\n${entries.join('\n\n')}`;
 }
 
 export function canSubmitQuestionAnswer(args: {

--- a/apps/web/src/convex/lib/runCreate.ts
+++ b/apps/web/src/convex/lib/runCreate.ts
@@ -72,9 +72,8 @@ export async function createQueuedRunRecord(
 	if (!continuationOfRunId && !prompt && args.imageUploadIds.length === 0) {
 		throw new Error('Message cannot be empty.');
 	}
-	const imageUploads = continuationOfRunId
-		? []
-		: await getOwnedImageUploads(ctx, args.userId, args.imageUploadIds);
+	const imageUploads = await getOwnedImageUploads(ctx, args.userId, args.imageUploadIds);
+	const recordsPrompt = !continuationOfRunId || Boolean(prompt) || imageUploads.length > 0;
 	const machineId = args.machineId;
 	let machine = null;
 	if (machineId) {
@@ -138,7 +137,7 @@ export async function createQueuedRunRecord(
 		assertThreadCanStartRun(latestRun?.status);
 	}
 	if (continuationOfRunId) {
-		assertContinuableParent(latestRun, continuationOfRunId);
+		assertContinuableParent(latestRun, continuationOfRunId, recordsPrompt);
 	}
 	if (machine && machine.runIds.length >= MAX_ACTIVE_MACHINE_RUNS) {
 		throw new Error('Machine has too many active runs.');
@@ -180,7 +179,7 @@ export async function createQueuedRunRecord(
 		threadId: threadRecord._id,
 		userId: args.userId
 	};
-	if (!continuationOfRunId) {
+	if (recordsPrompt) {
 		await markImageUploadsAttached(ctx, imageUploads, threadRecord._id);
 		created.promptPart = await recordPromptTranscript(ctx, {
 			threadId: threadRecord._id,
@@ -197,7 +196,7 @@ export async function createQueuedRunRecord(
 		selectedModel: args.selectedModel,
 		reasoningEffort: args.reasoningEffort,
 		fastMode: args.fastMode,
-		lastMessageAt: continuationOfRunId ? threadRecord.lastMessageAt : Date.now()
+		lastMessageAt: recordsPrompt ? Date.now() : threadRecord.lastMessageAt
 	};
 	await ctx.db.patch('threadRecords', threadRecord._id, threadUpdates);
 	const lifecycleWorkflowId = await startRunLifecycle(ctx, runId);
@@ -238,42 +237,41 @@ async function reconcileExistingQueuedRun(
 		await ctx.db.patch('runs', existingRun._id, { lifecycleWorkflowId });
 	}
 
-	if (args.continuationOfRunId) {
-		return {
-			created: false,
-			runId: existingRun._id,
-			threadId: existingRun.threadId,
-			userId: args.userId
-		};
-	}
-
 	const existingPrompt = await getPromptPart(ctx, existingRun.threadId, existingRun._id);
 	const requestedStorageIds = await storageIdsForImageUploadIds(ctx, args.imageUploadIds);
-	if (
-		!existingPrompt?.prompt ||
-		existingPrompt.prompt.text !== prompt ||
-		requestedStorageIds === null ||
-		!areStorageIdsEqual(
-			existingPrompt.prompt.imageUploads.map((upload) => upload.storageId),
-			requestedStorageIds
-		)
-	) {
+	const recordsPrompt =
+		!args.continuationOfRunId || Boolean(prompt) || args.imageUploadIds.length > 0;
+	if (recordsPrompt) {
+		if (
+			!existingPrompt?.prompt ||
+			existingPrompt.prompt.text !== prompt ||
+			requestedStorageIds === null ||
+			!areStorageIdsEqual(
+				existingPrompt.prompt.imageUploads.map((upload) => upload.storageId),
+				requestedStorageIds
+			)
+		) {
+			throw new Error('Submission prompt does not match the existing run.');
+		}
+	} else if (existingPrompt !== null || requestedStorageIds === null) {
 		throw new Error('Submission prompt does not match the existing run.');
 	}
-	const promptPart = await recordPromptTranscript(ctx, {
-		threadId: existingRun.threadId,
-		userId: args.userId,
-		runId: existingRun._id,
-		text: prompt,
-		imageUploadIds: args.imageUploadIds
-	});
-	return {
+	const reconciled: CreatedGatewayRun = {
 		created: false,
 		runId: existingRun._id,
 		threadId: existingRun.threadId,
-		userId: args.userId,
-		promptPart
+		userId: args.userId
 	};
+	if (recordsPrompt) {
+		reconciled.promptPart = await recordPromptTranscript(ctx, {
+			threadId: existingRun.threadId,
+			userId: args.userId,
+			runId: existingRun._id,
+			text: prompt,
+			imageUploadIds: args.imageUploadIds
+		});
+	}
+	return reconciled;
 }
 
 export async function finalizeFailedQueuedStart(
@@ -326,11 +324,13 @@ export async function finalizeFailedQueuedStart(
 	) {
 		return 'standDown';
 	}
-	if (!isContinuation) {
-		const promptPart = await getPromptPart(ctx, run.threadId, run._id);
+	const prompt = args.prompt.trim();
+	const promptPart = await getPromptPart(ctx, run.threadId, run._id);
+	const recordsPrompt = !isContinuation || Boolean(prompt) || args.storageIds.length > 0;
+	if (recordsPrompt) {
 		if (
 			!promptPart?.prompt ||
-			promptPart.prompt.text !== args.prompt.trim() ||
+			promptPart.prompt.text !== prompt ||
 			!areStorageIdsEqual(
 				promptPart.prompt.imageUploads.map((upload) => upload.storageId),
 				args.storageIds
@@ -338,6 +338,8 @@ export async function finalizeFailedQueuedStart(
 		) {
 			return 'standDown';
 		}
+	} else if (promptPart !== null) {
+		return 'standDown';
 	}
 	await finalizeRunRecord(ctx, run, {
 		text: args.text,

--- a/apps/web/src/convex/lib/runResume.ts
+++ b/apps/web/src/convex/lib/runResume.ts
@@ -5,18 +5,19 @@ export const RUN_CANNOT_CONTINUE = 'This run cannot continue.';
 export const ONLY_LATEST_RUN_CAN_CONTINUE = 'Only the latest run can continue.';
 
 export function isContinuableRunStatus(
-	status: Doc<'runs'>['status']
-): status is 'failed' | 'cancelled' {
-	return status === 'failed' || status === 'cancelled';
+	status: Doc<'runs'>['status'],
+	recordsPrompt: boolean
+): status is 'completed' | 'failed' | 'cancelled' {
+	return status === 'failed' || status === 'cancelled' || (status === 'completed' && recordsPrompt);
 }
 
 export function assertContinuableParent<
 	T extends { _id: Id<'runs'>; status: Doc<'runs'>['status'] }
->(latest: T | null, parentRunId: Id<'runs'>): T {
+>(latest: T | null, parentRunId: Id<'runs'>, recordsPrompt: boolean): T {
 	if (!latest || latest._id !== parentRunId) {
 		throw new ConvexError(ONLY_LATEST_RUN_CAN_CONTINUE);
 	}
-	if (!isContinuableRunStatus(latest.status)) {
+	if (!isContinuableRunStatus(latest.status, recordsPrompt)) {
 		throw new ConvexError(RUN_CANNOT_CONTINUE);
 	}
 	return latest;

--- a/apps/web/src/convex/lib/runTerminal.ts
+++ b/apps/web/src/convex/lib/runTerminal.ts
@@ -52,8 +52,16 @@ async function cancelExecutorJobsPage(
 
 async function cancelPendingQuestionsPage(
 	ctx: MutationCtx,
-	args: { runId: Id<'runs'>; completedAt: number; afterSequence: number }
+	args: {
+		runId: Id<'runs'>;
+		runStatus: Infer<typeof vRunStatus>;
+		completedAt: number;
+		afterSequence: number;
+	}
 ): Promise<TerminalCleanupResult> {
+	if (args.runStatus !== 'cancelled') {
+		return { done: true, nextSequence: args.afterSequence };
+	}
 	const questions = await ctx.db
 		.query('agentQuestions')
 		.withIndex('by_runId_sequence', (query) =>
@@ -139,6 +147,7 @@ export async function advanceTerminalCleanup(
 	}
 	const questions = await cancelPendingQuestionsPage(ctx, {
 		runId: args.run._id,
+		runStatus: args.run.status,
 		completedAt: args.completedAt,
 		afterSequence: args.questionCursor
 	});

--- a/apps/web/src/convex/lib/runTerminal.ts
+++ b/apps/web/src/convex/lib/runTerminal.ts
@@ -50,7 +50,7 @@ async function cancelExecutorJobsPage(
 	};
 }
 
-async function cancelPendingQuestionsPage(
+async function finalizePendingQuestionsPage(
 	ctx: MutationCtx,
 	args: {
 		runId: Id<'runs'>;
@@ -59,9 +59,6 @@ async function cancelPendingQuestionsPage(
 		afterSequence: number;
 	}
 ): Promise<TerminalCleanupResult> {
-	if (args.runStatus !== 'cancelled') {
-		return { done: true, nextSequence: args.afterSequence };
-	}
 	const questions = await ctx.db
 		.query('agentQuestions')
 		.withIndex('by_runId_sequence', (query) =>
@@ -69,10 +66,15 @@ async function cancelPendingQuestionsPage(
 		)
 		.take(TERMINAL_CLEANUP_PAGE_SIZE);
 	for (const question of questions) {
-		if (question.status === 'pending') {
+		if (question.status !== 'pending') continue;
+		if (args.runStatus === 'cancelled') {
 			await ctx.db.patch('agentQuestions', question._id, {
 				status: 'cancelled',
 				answeredAt: args.completedAt
+			});
+		} else {
+			await ctx.db.patch('agentQuestions', question._id, {
+				requiresContinuation: true
 			});
 		}
 	}
@@ -145,7 +147,7 @@ export async function advanceTerminalCleanup(
 			transcriptCursor: args.transcriptCursor
 		};
 	}
-	const questions = await cancelPendingQuestionsPage(ctx, {
+	const questions = await finalizePendingQuestionsPage(ctx, {
 		runId: args.run._id,
 		runStatus: args.run.status,
 		completedAt: args.completedAt,

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -304,6 +304,7 @@ export default defineSchema({
 		options: v.array(vAskQuestionOption),
 		status: vAgentQuestionStatus,
 		answer: v.optional(vAskQuestionAnswer),
+		requiresContinuation: v.optional(v.boolean()),
 		createdAt: v.number(),
 		timeoutAt: v.number(),
 		answeredAt: v.optional(v.number()),

--- a/apps/web/src/lib/home/desktop.test.ts
+++ b/apps/web/src/lib/home/desktop.test.ts
@@ -28,7 +28,8 @@ const recoveredSubmission = {
 	reasoningEffort: 'medium' as const,
 	fastMode: false,
 	selectedModel: 'gpt-5.6-sol' as const,
-	submissionId: 'recovered-id'
+	submissionId: 'recovered-id',
+	continuationOfRunId: runId('parent-run')
 };
 
 function createDesktopApi(runAgent: DesktopApi['runAgent']): DesktopApi {
@@ -90,6 +91,7 @@ function resolveRecoveredSubmission(
 		storageIds: recoveredSubmission.storageIds,
 		reasoningEffort: recoveredSubmission.reasoningEffort,
 		fastMode: recoveredSubmission.fastMode,
+		continuationOfRunId: recoveredSubmission.continuationOfRunId,
 		recoveredSubmission,
 		selectedModel: recoveredSubmission.selectedModel,
 		...overrides
@@ -162,6 +164,7 @@ describe('resolveSubmissionId', () => {
 		expect(resolveRecoveredSubmission({ prompt: 'Inspect and fix the robot' })).toBe('new-id');
 		expect(resolveRecoveredSubmission({ reasoningEffort: 'high' })).toBe('new-id');
 		expect(resolveRecoveredSubmission({ fastMode: true })).toBe('new-id');
+		expect(resolveRecoveredSubmission({ continuationOfRunId: undefined })).toBe('new-id');
 	});
 
 	it('reuses a submission only when its attachments are unchanged', () => {
@@ -174,12 +177,21 @@ describe('resolveSubmissionId', () => {
 		).toBe('new-id');
 	});
 
-	it('uses a fresh id when the visible latest submission has finished or supersedes recovery', () => {
+	it('reuses only for the expected parent or the same unfinished run', () => {
 		expect(
 			resolveRecoveredSubmission({
 				latestRun: { status: 'failed', submissionId: 'recovered-id' }
 			})
 		).toBe('new-id');
+		expect(
+			resolveRecoveredSubmission({
+				latestRun: {
+					runId: recoveredSubmission.continuationOfRunId,
+					status: 'completed',
+					submissionId: 'parent-id'
+				}
+			})
+		).toBe('recovered-id');
 		expect(
 			resolveRecoveredSubmission({
 				latestRun: { status: 'queued', submissionId: 'recovered-id' }

--- a/apps/web/src/lib/home/desktop.ts
+++ b/apps/web/src/lib/home/desktop.ts
@@ -40,17 +40,22 @@ export function resolveSubmissionId(args: {
 		fastMode: AgentRunRequest['fastMode'];
 		selectedModel: AgentRunRequest['selectedModel'];
 		submissionId: string;
+		continuationOfRunId?: Id<'runs'>;
 	};
 	latestRun: {
+		runId?: Id<'runs'>;
 		status: RunState['status'];
 		submissionId: string;
 	} | null;
 	selectedModel: AgentRunRequest['selectedModel'];
+	continuationOfRunId?: Id<'runs'>;
 }) {
 	const recoveredSubmission = args.recoveredSubmission;
 	const latestRun = args.latestRun;
 	const canReuseRecoveredSubmission =
 		latestRun === null ||
+		(latestRun.runId !== undefined &&
+			latestRun.runId === recoveredSubmission?.continuationOfRunId) ||
 		(latestRun.submissionId === recoveredSubmission?.submissionId &&
 			!isRunFinalStatus(latestRun.status));
 	return canReuseRecoveredSubmission &&
@@ -58,6 +63,7 @@ export function resolveSubmissionId(args: {
 		recoveredSubmission.selectedModel === args.selectedModel &&
 		recoveredSubmission.reasoningEffort === args.reasoningEffort &&
 		recoveredSubmission.fastMode === args.fastMode &&
+		recoveredSubmission.continuationOfRunId === args.continuationOfRunId &&
 		areStorageIdsEqual(recoveredSubmission.storageIds, args.storageIds)
 		? recoveredSubmission.submissionId
 		: args.newSubmissionId;

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -212,6 +212,7 @@
 		fastMode?: boolean;
 		selectedModel?: CatalogModelId;
 		submissionId?: string;
+		continuationOfRunId?: Id<'runs'>;
 	};
 	let desktopApi = $state<DesktopApi | null>(null);
 	let desktopApiResolved = $state(false);
@@ -226,6 +227,7 @@
 	let prompt = $state('');
 	let selectedQuestionOptionId = $state<string | null>(null);
 	let answeringAgentQuestion = $state(false);
+	let composerContinuationOfRunId = $state<Id<'runs'> | null>(null);
 	let composerAttachments = $state<ComposerAttachment[]>([]);
 	let currentError = $state<string | null>(null);
 	const submittingPromptScopes = new SvelteMap<string, number>();
@@ -239,6 +241,7 @@
 			fastMode: boolean;
 			selectedModel: CatalogModelId;
 			submissionId: string;
+			continuationOfRunId?: Id<'runs'>;
 		}
 	>();
 	const latestSubmissionSequencesByRecoveryScope = new SvelteMap<string, number>();
@@ -1583,6 +1586,7 @@
 		const submittedOptionId = selectedQuestionOptionId;
 		const answerText = submittedPrompt.trim();
 		let continuationPrompt: string | null = null;
+		let continuationOfRunId: Id<'runs'> | undefined;
 		prompt = '';
 		selectedQuestionOptionId = null;
 		try {
@@ -1593,11 +1597,13 @@
 				text: answerText || undefined
 			};
 			const result = await answerAgentQuestion(answer);
-			if (result.startContinuation) {
+			if (result.continuationOfRunId) {
 				continuationPrompt =
 					[result.question.answer?.optionLabel, result.question.answer?.text]
 						.filter((part): part is string => Boolean(part))
 						.join(': ') || 'Continue.';
+				continuationOfRunId = result.continuationOfRunId;
+				composerContinuationOfRunId = result.continuationOfRunId;
 			}
 		} catch (error) {
 			if (
@@ -1613,17 +1619,23 @@
 		}
 		if (continuationPrompt !== null) {
 			prompt = continuationPrompt;
-			await submitPrompt(question.questionId);
+			await submitPrompt({ answeredQuestionId: question.questionId, continuationOfRunId });
 		}
 	}
 
-	async function submitPrompt(answeredQuestionId?: Id<'agentQuestions'>) {
+	async function submitPrompt(options?: {
+		answeredQuestionId: Id<'agentQuestions'>;
+		continuationOfRunId: Id<'runs'> | undefined;
+	}) {
 		if (pendingAgentQuestion) {
-			if (answeredQuestionId && pendingAgentQuestion.questionId !== answeredQuestionId) {
+			if (
+				options?.answeredQuestionId &&
+				pendingAgentQuestion.questionId !== options.answeredQuestionId
+			) {
 				currentError = 'Answer the new agent question before continuing.';
 				return;
 			}
-			if (!answeredQuestionId) {
+			if (!options?.answeredQuestionId) {
 				await submitAgentQuestionAnswer();
 				return;
 			}
@@ -1689,6 +1701,8 @@
 		const submittedModel = selectedModel;
 		const submittedReasoningEffort = selectedReasoningEffort;
 		const submittedFastMode = fastMode;
+		const submittedContinuationOfRunId =
+			options?.continuationOfRunId ?? composerContinuationOfRunId ?? undefined;
 		const previousRunId = selectedThreadId ? (runState?.runId ?? null) : null;
 		let submissionScope = selectedThreadId
 			? `thread:${selectedThreadId}`
@@ -1706,6 +1720,7 @@
 				!selectedThreadId || !currentLifecycle || currentLifecycle.phase === 'idle'
 					? null
 					: {
+							runId: runState?.runId,
 							status: isLifecycleInProgress(currentLifecycle.phase) ? 'queued' : 'completed',
 							submissionId: currentRecoveredSubmission?.submissionId ?? ''
 						},
@@ -1714,6 +1729,7 @@
 			storageIds: submittedStorageIds,
 			reasoningEffort: submittedReasoningEffort,
 			fastMode: submittedFastMode,
+			continuationOfRunId: submittedContinuationOfRunId,
 			recoveredSubmission: recoveredSubmission
 				? {
 						...recoveredSubmission,
@@ -1744,6 +1760,7 @@
 				reasoningEffort: submittedReasoningEffort,
 				fastMode: submittedFastMode,
 				selectedModel: submittedModel,
+				continuationOfRunId: submittedContinuationOfRunId,
 				submissionId:
 					!selectedThreadId && recoveryScope === originatingRecoveryScope
 						? threadSubmissionId
@@ -1888,6 +1905,9 @@
 							remoteChangeNotices.set(createdThreadId, REMOTE_CHANGE_NOTICE);
 					}
 					clearComposerAttachments({ discard: false });
+					if (composerContinuationOfRunId === submittedContinuationOfRunId) {
+						composerContinuationOfRunId = null;
+					}
 				},
 				threadId: threadId ?? undefined,
 				repositoryKey: threadId ? undefined : submittedRepositoryKey,
@@ -1897,7 +1917,8 @@
 				submissionId: runSubmissionId,
 				reasoningEffort: submittedReasoningEffort,
 				fastMode: submittedFastMode,
-				workspacePath
+				workspacePath,
+				continuationOfRunId: submittedContinuationOfRunId
 			});
 		} catch (error) {
 			if (launchedThreadId && agentLaunchId !== null) {
@@ -2028,6 +2049,7 @@
 		threadSnapshotPullGeneration += 1;
 		projectSelectionGeneration += 1;
 		prompt = '';
+		composerContinuationOfRunId = null;
 		clearComposerAttachments({
 			discard: true,
 			userId: previousUserId,
@@ -2101,6 +2123,7 @@
 		const threadId = thread?._id ?? null;
 		if (threadId === lastSyncedComposerThreadId) return;
 		lastSyncedComposerThreadId = threadId;
+		composerContinuationOfRunId = null;
 		if (!thread) return;
 		selectedModel = thread.selectedModel;
 		selectedReasoningEffort = thread.reasoningEffort;
@@ -2133,6 +2156,7 @@
 			composerAttachments = recovery.attachments.map((attachment) => ({ ...attachment }));
 		}
 		if (prompt === recovery.prompt) {
+			composerContinuationOfRunId = recovery.continuationOfRunId ?? null;
 			if (
 				recovery.submissionId &&
 				(recovery.prompt || recovery.storageIds?.length) &&
@@ -2145,7 +2169,8 @@
 					reasoningEffort: recovery.reasoningEffort,
 					fastMode: recovery.fastMode ?? false,
 					selectedModel: recovery.selectedModel,
-					submissionId: recovery.submissionId
+					submissionId: recovery.submissionId,
+					continuationOfRunId: recovery.continuationOfRunId
 				});
 			}
 		}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1785,6 +1785,7 @@
 				fastMode: submittedFastMode,
 				selectedModel: submittedModel,
 				continuationOfRunId: submittedContinuationOfRunId,
+				autoSubmit: false,
 				submissionId:
 					!selectedThreadId && recoveryScope === originatingRecoveryScope
 						? threadSubmissionId

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1582,6 +1582,7 @@
 		const submittedPrompt = prompt;
 		const submittedOptionId = selectedQuestionOptionId;
 		const answerText = submittedPrompt.trim();
+		let continuationPrompt: string | null = null;
 		prompt = '';
 		selectedQuestionOptionId = null;
 		try {
@@ -1591,7 +1592,13 @@
 				optionId: submittedOptionId ?? undefined,
 				text: answerText || undefined
 			};
-			await answerAgentQuestion(answer);
+			const result = await answerAgentQuestion(answer);
+			if (result.startContinuation) {
+				continuationPrompt =
+					[result.question.answer?.optionLabel, result.question.answer?.text]
+						.filter((part): part is string => Boolean(part))
+						.join(': ') || 'Continue.';
+			}
 		} catch (error) {
 			if (
 				currentThreadId === threadId &&
@@ -1604,12 +1611,22 @@
 		} finally {
 			answeringAgentQuestion = false;
 		}
+		if (continuationPrompt !== null) {
+			prompt = continuationPrompt;
+			await submitPrompt(question.questionId);
+		}
 	}
 
-	async function submitPrompt() {
+	async function submitPrompt(answeredQuestionId?: Id<'agentQuestions'>) {
 		if (pendingAgentQuestion) {
-			await submitAgentQuestionAnswer();
-			return;
+			if (answeredQuestionId && pendingAgentQuestion.questionId !== answeredQuestionId) {
+				currentError = 'Answer the new agent question before continuing.';
+				return;
+			}
+			if (!answeredQuestionId) {
+				await submitAgentQuestionAnswer();
+				return;
+			}
 		}
 
 		if (isSubmittingPrompt) {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1603,7 +1603,6 @@
 						.filter((part): part is string => Boolean(part))
 						.join(': ') || 'Continue.';
 				continuationOfRunId = result.continuationOfRunId;
-				composerContinuationOfRunId = result.continuationOfRunId;
 			}
 		} catch (error) {
 			if (
@@ -1617,7 +1616,8 @@
 		} finally {
 			answeringAgentQuestion = false;
 		}
-		if (continuationPrompt !== null) {
+		if (continuationPrompt !== null && currentThreadId === threadId) {
+			composerContinuationOfRunId = continuationOfRunId ?? null;
 			prompt = continuationPrompt;
 			await submitPrompt({ answeredQuestionId: question.questionId, continuationOfRunId });
 		}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1607,12 +1607,9 @@
 				text: answerText || undefined
 			};
 			const result = await answerAgentQuestion(answer);
-			if (result.continuationOfRunId) {
-				continuationPrompt =
-					[result.question.answer?.optionLabel, result.question.answer?.text]
-						.filter((part): part is string => Boolean(part))
-						.join(': ') || 'Continue.';
-				continuationOfRunId = result.continuationOfRunId;
+			if (result.continuation) {
+				continuationPrompt = result.continuation.prompt;
+				continuationOfRunId = result.continuation.runId;
 			}
 		} catch (error) {
 			if (

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -521,10 +521,10 @@
 		api.browserSessions.liveViewForThread,
 		authenticatedThreadQueryArgs
 	);
-	const pendingAgentQuestionQuery = useQuery(api.agentQuestions.headPendingForThread, () => {
-		const args = authenticatedThreadQueryArgs();
-		return args === 'skip' ? args : { ...args, now: tickingNow() };
-	});
+	const pendingAgentQuestionQuery = useQuery(
+		api.agentQuestions.headPendingForThread,
+		authenticatedThreadQueryArgs
+	);
 	const queryError = $derived.by(() => {
 		for (const query of [
 			uiPreferencesQuery,

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -213,6 +213,7 @@
 		selectedModel?: CatalogModelId;
 		submissionId?: string;
 		continuationOfRunId?: Id<'runs'>;
+		autoSubmit?: boolean;
 	};
 	let desktopApi = $state<DesktopApi | null>(null);
 	let desktopApiResolved = $state(false);
@@ -228,6 +229,7 @@
 	let selectedQuestionOptionId = $state<string | null>(null);
 	let answeringAgentQuestion = $state(false);
 	let composerContinuationOfRunId = $state<Id<'runs'> | null>(null);
+	let autoSubmitComposerContinuation = $state(false);
 	let composerAttachments = $state<ComposerAttachment[]>([]);
 	let currentError = $state<string | null>(null);
 	const submittingPromptScopes = new SvelteMap<string, number>();
@@ -1573,7 +1575,8 @@
 	async function submitAgentQuestionAnswer() {
 		const question = pendingAgentQuestion;
 		const threadId = currentThreadId;
-		if (!question || !threadId || answeringAgentQuestion) {
+		const userId = getCurrentUserId();
+		if (!question || !threadId || !userId || answeringAgentQuestion) {
 			return;
 		}
 		if (!selectedQuestionOptionId && !prompt.trim()) {
@@ -1585,6 +1588,13 @@
 		const submittedPrompt = prompt;
 		const submittedOptionId = selectedQuestionOptionId;
 		const answerText = submittedPrompt.trim();
+		const submittedAttachments = composerAttachments.map((attachment) => ({ ...attachment }));
+		const submittedStorageIds = submittedAttachments.flatMap((attachment) =>
+			attachment.storageId ? [attachment.storageId] : []
+		);
+		const submittedModel = selectedModel;
+		const submittedReasoningEffort = selectedReasoningEffort;
+		const submittedFastMode = fastMode;
 		let continuationPrompt: string | null = null;
 		let continuationOfRunId: Id<'runs'> | undefined;
 		prompt = '';
@@ -1616,7 +1626,21 @@
 		} finally {
 			answeringAgentQuestion = false;
 		}
-		if (continuationPrompt !== null && currentThreadId === threadId) {
+		if (continuationPrompt !== null && currentThreadId !== threadId) {
+			storeComposerRecovery(userId, `thread:${threadId}`, {
+				message: 'Continuing from your answer when you return to this thread.',
+				prompt: continuationPrompt,
+				attachments: submittedAttachments,
+				storageIds: submittedStorageIds,
+				reasoningEffort: submittedReasoningEffort,
+				fastMode: submittedFastMode,
+				selectedModel: submittedModel,
+				continuationOfRunId,
+				autoSubmit: true
+			});
+			return;
+		}
+		if (continuationPrompt !== null) {
 			composerContinuationOfRunId = continuationOfRunId ?? null;
 			prompt = continuationPrompt;
 			await submitPrompt({ answeredQuestionId: question.questionId, continuationOfRunId });
@@ -1907,6 +1931,7 @@
 					clearComposerAttachments({ discard: false });
 					if (composerContinuationOfRunId === submittedContinuationOfRunId) {
 						composerContinuationOfRunId = null;
+						autoSubmitComposerContinuation = false;
 					}
 				},
 				threadId: threadId ?? undefined,
@@ -2050,6 +2075,7 @@
 		projectSelectionGeneration += 1;
 		prompt = '';
 		composerContinuationOfRunId = null;
+		autoSubmitComposerContinuation = false;
 		clearComposerAttachments({
 			discard: true,
 			userId: previousUserId,
@@ -2124,6 +2150,7 @@
 		if (threadId === lastSyncedComposerThreadId) return;
 		lastSyncedComposerThreadId = threadId;
 		composerContinuationOfRunId = null;
+		autoSubmitComposerContinuation = false;
 		if (!thread) return;
 		selectedModel = thread.selectedModel;
 		selectedReasoningEffort = thread.reasoningEffort;
@@ -2142,6 +2169,9 @@
 		if (!recovery) {
 			return;
 		}
+		if (recovery.autoSubmit && prompt !== '' && prompt !== recovery.prompt) {
+			return;
+		}
 
 		composerRecoveries.delete(recoveryKey);
 		const canRestorePrompt = prompt === '';
@@ -2157,6 +2187,8 @@
 		}
 		if (prompt === recovery.prompt) {
 			composerContinuationOfRunId = recovery.continuationOfRunId ?? null;
+			autoSubmitComposerContinuation =
+				recovery.autoSubmit === true && recovery.continuationOfRunId !== undefined;
 			if (
 				recovery.submissionId &&
 				(recovery.prompt || recovery.storageIds?.length) &&
@@ -2176,6 +2208,22 @@
 		}
 
 		currentError = recovery.message;
+	});
+
+	$effect(() => {
+		if (
+			!autoSubmitComposerContinuation ||
+			!composerContinuationOfRunId ||
+			!canSend ||
+			pendingAgentQuestion ||
+			!desktopApi ||
+			!prompt.trim() ||
+			composerAttachments.some((attachment) => attachment.status !== 'ready')
+		) {
+			return;
+		}
+		autoSubmitComposerContinuation = false;
+		void submitPrompt();
 	});
 
 	$effect(() => {

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -672,6 +672,14 @@ struct PriorHistory {
     current_prompt: Option<String>,
 }
 
+fn should_continue_without_prompt(
+    continue_from_finished_turns: bool,
+    is_continuation: bool,
+    prompt_text: &str,
+) -> bool {
+    continue_from_finished_turns || (is_continuation && prompt_text.is_empty())
+}
+
 async fn load_prior_history(
     runtime: &RuntimeClient,
     store: &TranscriptStore,
@@ -746,8 +754,7 @@ async fn load_prior_history(
             .and_then(|part| part.prompt.as_ref())
             .map(prompt_text_with_attachments),
         messages: deserialize_agent_history(history)?,
-        continue_from_finished_turns: context.run.continuation_of_run_id.is_some()
-            || current_run_had_context_handoff
+        continue_from_finished_turns: current_run_had_context_handoff
             || current_run_has_finished_turns(&parts, run_id),
     })
 }
@@ -848,21 +855,31 @@ pub async fn run_agent(
             &capabilities.label,
             &context.run.selected_model,
         );
-        Ok((prompt, provider, prompt_context, skills))
+        let continue_without_prompt = should_continue_without_prompt(
+            prior_history.continue_from_finished_turns,
+            is_continuation,
+            prompt_text,
+        );
+        Ok((
+            prompt,
+            provider,
+            prompt_context,
+            skills,
+            continue_without_prompt,
+        ))
     })();
 
-    let (prompt, provider, prompt_context, skills) = match prepared {
+    let (prompt, provider, prompt_context, skills, continue_without_prompt) = match prepared {
         Ok(values) => values,
         Err(error) => return abort_before_start(&runtime, &run_id, error).await,
     };
-    let prompt =
-        if prior_history.continue_from_finished_turns || request.continuation_of_run_id.is_some() {
-            Message::User {
-                content: vec![UserContent::text(CONTINUE_FROM_FINISHED_TURNS)],
-            }
-        } else {
-            prompt
-        };
+    let prompt = if continue_without_prompt {
+        Message::User {
+            content: vec![UserContent::text(CONTINUE_FROM_FINISHED_TURNS)],
+        }
+    } else {
+        prompt
+    };
 
     eprintln!("sprocket-agent: prepared assistant response {}", run_id);
 
@@ -918,9 +935,7 @@ pub async fn run_agent(
                     supports_images: capabilities.supports_images,
                     transcript_dir: store.thread_dir(&context.run.user_id, &context.run.thread_id),
                     context_tokens: context.context_tokens,
-                    defer_prompt_for_context_handoff: !prior_history.continue_from_finished_turns
-                        && context.run.continuation_of_run_id.is_none()
-                        && request.continuation_of_run_id.is_none(),
+                    defer_prompt_for_context_handoff: !continue_without_prompt,
                 },
             )
             .await;
@@ -956,10 +971,20 @@ mod tests {
         SkillSource, WorkspaceInstruction, WorkspaceInstructionSource, WorkspaceSkill,
     };
 
-    use super::{build_workspace_prompt_context, submission_owned_by_another_executor};
+    use super::{
+        build_workspace_prompt_context, should_continue_without_prompt,
+        submission_owned_by_another_executor,
+    };
 
     const MODEL_LABEL: &str = "GPT-5.6 Sol";
     const MODEL_ID: &str = "gpt-5.6-sol";
+
+    #[test]
+    fn prompted_continuations_use_their_user_prompt() {
+        assert!(!should_continue_without_prompt(false, true, "Ship it"));
+        assert!(should_continue_without_prompt(false, true, ""));
+        assert!(should_continue_without_prompt(true, true, "Ship it"));
+    }
 
     fn initial_context_text(message: &Message) -> &str {
         match message {


### PR DESCRIPTION
## Summary
- keep the pending-question Convex subscription on stable arguments and let the scheduled timeout mutation own expiry
- keep unanswered questions available when a run completes or fails
- start a follow-up run with the answer after the last pending question is answered, so a live worker consumes it
- query only the FIFO head instead of collecting every pending question
- supersede #279, whose ticking clock arguments are the source of the cache churn and UI blinking

## Validation
- `bun run --cwd apps/web test src/convex/agentQuestions.test.ts src/convex/chat.lifecycle.test.ts src/convex/runLifecycle.test.ts` (11 passed)
- `bun run --cwd apps/web check`
- `bun run --cwd apps/web build`
- `prek run -a`
- Full web test run: 485 passed; 5 unrelated failures in Firecrawl, payments, and web-tool tests

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.















<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62995570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previous repeated-answer defect is fixed and no new actionable failures remain.

<details open><summary><h3>Summary</h3></summary>

- Moves question expiration ownership to the scheduled timeout mutation.
- Preserves FIFO pending questions after completed or failed runs.
- Records which pending questions require a continuation and excludes previously consumed answers.
- Adds prompt-bearing continuation support across Convex run creation, browser recovery, and the Rust runtime.
- Adds lifecycle, continuation, recovery, and regression coverage.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Agent
  participant Convex
  participant UI
  participant Runtime

  Agent->>Convex: Create pending question
  Convex-->>UI: Publish FIFO head
  Agent->>Convex: Finalize completed or failed run
  Convex->>Convex: Mark pending questions requiresContinuation
  UI->>Convex: Answer FIFO questions
  Convex-->>UI: Return continuation after final answer
  UI->>Runtime: Launch linked run with answer prompt
  Runtime->>Convex: Load parent history and new prompt
  Runtime->>Agent: Continue using unanswered input
```
</details>

<sub>Reviews (9) · Last reviewed commit: ["fix(ui): Exclude consumed question answe..."](https://github.com/spikonado/sprocket/commit/372d813762a895d0698161b8ff62709ea0c1c97c)</sub>

<!-- /greptile_comment -->