### PR TITLE
perf(convex): Replace lifecycle workflows with deadline checks

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -4,6 +4,32 @@ We ship breaking changes ahead of our users' installed clients and keep the old 
 
 Current as of 2026-09-11.
 
+## Native run lifecycle scheduling
+
+New runs use `runLifecycle.checkRun` scheduled at the startup deadline or claim
+expiry. `runExecutionStates` owns the scheduled function ID and generation so
+timer updates do not invalidate thread-list subscriptions. Run finalization
+cancels the check and still performs terminal cleanup in its transaction.
+
+An hourly cron starts `migrateRunLifecycle`. It installs a native check for each
+active run before clearing `runs.lifecycleWorkflowId` in the same transaction.
+The existing Workflow then exits at its next `getWatchState` call. Completed runs
+need no new check. The migration is idempotent and also repairs active runs with
+no legacy workflow. To start the handoff immediately after deployment:
+
+```sh
+bunx convex run migrations:runNativeRunLifecycleMigration --prod
+```
+
+Keep the `workflow` component, its dependency and test registration, the optional
+`lifecycleWorkflowId` field, and the legacy `watchRun`, `getWatchState`,
+`abandonExpiredRun`, `reconcileTerminalPage`, and `finishLifecycle` functions until
+the migration completes on every deployment, no run retains a workflow ID, and
+no legacy workflow or scheduled workflow callback remains in progress. Preserve
+the old workflow's step order until then so stored journals can replay. After
+that gate passes, remove those functions, the component and dependency, and the
+migration runner and cron together. Do not remove the external-tool workpools.
+
 ## Fast mode schema migration
 
 Stored `threadRecords` and `runs` may use `serviceTier` with `standard` or

--- a/apps/web/src/convex/_generated/api.d.ts
+++ b/apps/web/src/convex/_generated/api.d.ts
@@ -58,6 +58,7 @@ import type * as lib_runCreate from "../lib/runCreate.js";
 import type * as lib_runExecution from "../lib/runExecution.js";
 import type * as lib_runFinalize from "../lib/runFinalize.js";
 import type * as lib_runLease from "../lib/runLease.js";
+import type * as lib_runLifecycleSchedule from "../lib/runLifecycleSchedule.js";
 import type * as lib_runResume from "../lib/runResume.js";
 import type * as lib_runTerminal from "../lib/runTerminal.js";
 import type * as lib_runs from "../lib/runs.js";
@@ -144,6 +145,7 @@ declare const fullApi: ApiFromModules<{
   "lib/runExecution": typeof lib_runExecution;
   "lib/runFinalize": typeof lib_runFinalize;
   "lib/runLease": typeof lib_runLease;
+  "lib/runLifecycleSchedule": typeof lib_runLifecycleSchedule;
   "lib/runResume": typeof lib_runResume;
   "lib/runTerminal": typeof lib_runTerminal;
   "lib/runs": typeof lib_runs;

--- a/apps/web/src/convex/crons.ts
+++ b/apps/web/src/convex/crons.ts
@@ -63,4 +63,11 @@ crons.interval(
 	{}
 );
 
+crons.interval(
+	'migrate run lifecycle scheduling',
+	{ hours: 1 },
+	internal.migrations.runNativeRunLifecycleMigrationAutomatically,
+	{}
+);
+
 export default crons;

--- a/apps/web/src/convex/lib/runCreate.ts
+++ b/apps/web/src/convex/lib/runCreate.ts
@@ -195,8 +195,7 @@ export async function createQueuedRunRecord(
 		lastMessageAt: recordsPrompt ? Date.now() : threadRecord.lastMessageAt
 	};
 	await ctx.db.patch('threadRecords', threadRecord._id, threadUpdates);
-	const lifecycleWorkflowId = await startRunLifecycle(ctx, runId);
-	await ctx.db.patch('runs', runId, { lifecycleWorkflowId });
+	await startRunLifecycle(ctx, runId);
 	return created;
 }
 
@@ -227,9 +226,8 @@ async function reconcileExistingQueuedRun(
 		throw new ConvexError('Submission belongs to a different or incomplete run.');
 	}
 
-	if (!existingRun.lifecycleWorkflowId && !isRunFinalStatus(existingRun.status)) {
-		const lifecycleWorkflowId = await startRunLifecycle(ctx, existingRun._id);
-		await ctx.db.patch('runs', existingRun._id, { lifecycleWorkflowId });
+	if (!isRunFinalStatus(existingRun.status)) {
+		await startRunLifecycle(ctx, existingRun._id);
 	}
 
 	const existingPrompt = await getPromptPart(ctx, existingRun.threadId, existingRun._id);

--- a/apps/web/src/convex/lib/runExecution.ts
+++ b/apps/web/src/convex/lib/runExecution.ts
@@ -17,7 +17,7 @@ function executionFields(run: Doc<'runs'> | Doc<'runExecutionStates'>): Executio
 	};
 }
 
-async function findExecutionState(db: DatabaseReader, runId: Id<'runs'>) {
+export async function getRunExecutionState(db: DatabaseReader, runId: Id<'runs'>) {
 	return await db
 		.query('runExecutionStates')
 		.withIndex('by_runId', (query) => query.eq('runId', runId))
@@ -28,7 +28,7 @@ export async function withRunExecution(
 	db: DatabaseReader,
 	run: Doc<'runs'>
 ): Promise<ExecutionRun> {
-	const state = await findExecutionState(db, run._id);
+	const state = await getRunExecutionState(db, run._id);
 	return { ...run, ...executionFields(state ?? run) };
 }
 
@@ -44,7 +44,7 @@ export async function migrateRunExecution(
 	ctx: MutationCtx,
 	run: Doc<'runs'>
 ): Promise<Id<'runExecutionStates'>> {
-	const existing = await findExecutionState(ctx.db, run._id);
+	const existing = await getRunExecutionState(ctx.db, run._id);
 	const stateId =
 		existing?._id ??
 		(await ctx.db.insert('runExecutionStates', {
@@ -72,7 +72,7 @@ export async function patchRunExecution(
 	runId: Id<'runs'>,
 	patch: Partial<ExecutionFields>
 ): Promise<void> {
-	const state = await findExecutionState(ctx.db, runId);
+	const state = await getRunExecutionState(ctx.db, runId);
 	if (state) {
 		if (
 			('claimId' in patch && state.claimId !== patch.claimId) ||

--- a/apps/web/src/convex/lib/runFinalize.ts
+++ b/apps/web/src/convex/lib/runFinalize.ts
@@ -9,6 +9,7 @@ import { resolveRequestedFinalizeStatus } from '@convex/lib/runCancellation';
 import { setRunAndThreadStatus } from '@convex/lib/threadRunStatus';
 import { detachRunFromMachine } from '@convex/lib/machineRuns';
 import { getRunWithExecution, patchRunExecution } from '@convex/lib/runExecution';
+import { cancelRunLifecycleCheck } from '@convex/lib/runLifecycleSchedule';
 
 type FinalizeRunArgs = {
 	text: string;
@@ -50,6 +51,7 @@ export async function finalizeRunRecord(
 	const finalStatus = alreadyFinal ? run.status : resolveRequestedFinalizeStatus(run, args.status);
 	const completedAt = run.completedAt ?? Date.now();
 	const lastError = alreadyFinal ? run.lastError : args.lastError;
+	await cancelRunLifecycleCheck(ctx, run._id);
 	await cancelWebToolWork(ctx, run._id);
 	await detachRunFromMachine(ctx, run);
 

--- a/apps/web/src/convex/lib/runLifecycleSchedule.ts
+++ b/apps/web/src/convex/lib/runLifecycleSchedule.ts
@@ -1,0 +1,36 @@
+import { internal } from '@convex/_generated/api';
+import type { Doc, Id } from '@convex/_generated/dataModel';
+import type { MutationCtx } from '@convex/_generated/server';
+import { getRunExecutionState } from '@convex/lib/runExecution';
+import { isClaimedRunStatus, RUN_QUEUED_STARTUP_DEADLINE_MS } from '@convex/lib/runLease';
+
+export function runDeadline(run: Doc<'runs'>): number | null {
+	if (run.status === 'queued') return run.startedAt + RUN_QUEUED_STARTUP_DEADLINE_MS;
+	if (isClaimedRunStatus(run.status)) return run.claimExpiresAt ?? 0;
+	return null;
+}
+
+export async function scheduleRunLifecycleCheck(
+	ctx: MutationCtx,
+	state: Doc<'runExecutionStates'>,
+	deadline: number
+): Promise<void> {
+	const generation = (state.lifecycleGeneration ?? 0) + 1;
+	const lifecycleCheckId = await ctx.scheduler.runAt(
+		Math.max(deadline, Date.now()),
+		internal.runLifecycle.checkRun,
+		{ runId: state.runId, generation }
+	);
+	await ctx.db.patch('runExecutionStates', state._id, {
+		lifecycleCheckId,
+		lifecycleGeneration: generation
+	});
+}
+
+export async function cancelRunLifecycleCheck(ctx: MutationCtx, runId: Id<'runs'>): Promise<void> {
+	const state = await getRunExecutionState(ctx.db, runId);
+	if (!state?.lifecycleCheckId) return;
+	const scheduled = await ctx.db.system.get('_scheduled_functions', state.lifecycleCheckId);
+	if (scheduled?.state.kind === 'pending') await ctx.scheduler.cancel(state.lifecycleCheckId);
+	await ctx.db.patch('runExecutionStates', state._id, { lifecycleCheckId: undefined });
+}

--- a/apps/web/src/convex/machines.test.ts
+++ b/apps/web/src/convex/machines.test.ts
@@ -136,6 +136,11 @@ describe('machines', () => {
 			prompt: 'Run locally',
 			machineId: machine.machineId
 		});
+		await asUser.mutation(api.agentRuntime.start, {
+			runId: run.runId,
+			executionSecret: 'run-secret',
+			claimId: 'machine-claim'
+		});
 
 		vi.advanceTimersByTime(90_001);
 		await asUser.mutation(api.machines.tryRegister, {

--- a/apps/web/src/convex/migrations.ts
+++ b/apps/web/src/convex/migrations.ts
@@ -4,6 +4,7 @@ import { internalMutation } from '@convex/_generated/server';
 import schema from '@convex/schema';
 import { v } from 'convex/values';
 import { migrateRunExecution } from '@convex/lib/runExecution';
+import { startRunLifecycle } from '@convex/runLifecycle';
 
 export const AUTOMATIC_CLEANUP_DELAY_MS = 48 * 60 * 60 * 1_000;
 const PRODUCTION_ROLLOUT_CLEANUP = 'production-rollout-cleanup-2026-09';
@@ -12,6 +13,31 @@ const FAST_MODE_BACKFILL = 'fast-mode-backfill-2026-09';
 export const migrations = new Migrations(components.migrations, {
 	schema,
 	internalMutation
+});
+
+const nativeRunLifecycleMigrations = [internal.migrations.migrateRunLifecycle];
+
+export const runNativeRunLifecycleMigration = migrations.runner(nativeRunLifecycleMigrations);
+
+export const runNativeRunLifecycleMigrationAutomatically = internalMutation({
+	args: {},
+	returns: v.null(),
+	handler: async (ctx) => {
+		const statuses = await migrations.getStatus(ctx, { migrations: nativeRunLifecycleMigrations });
+		if (!statuses.every((status) => status.isDone)) {
+			await migrations.runSerially(ctx, nativeRunLifecycleMigrations);
+		}
+		return null;
+	}
+});
+
+export const migrateRunLifecycle = migrations.define({
+	table: 'runs',
+	migrateOne: async (ctx, run) => {
+		await startRunLifecycle(ctx, run._id);
+		// The old workflow exits at its next getWatchState after the native check is durable.
+		if (run.lifecycleWorkflowId !== undefined) return { lifecycleWorkflowId: undefined };
+	}
 });
 
 const productionRolloutCleanupMigrations = [

--- a/apps/web/src/convex/runLifecycle.test.ts
+++ b/apps/web/src/convex/runLifecycle.test.ts
@@ -1,10 +1,137 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowId } from '@convex-dev/workflow';
 import { api, internal } from '@convex/_generated/api';
 import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
-import { RUN_QUEUED_STARTUP_DEADLINE_MS } from '@convex/lib/runLease';
+import { RUN_CLAIM_LEASE_DURATION_MS, RUN_QUEUED_STARTUP_DEADLINE_MS } from '@convex/lib/runLease';
+import { getRunExecutionState, patchRunExecution } from '@convex/lib/runExecution';
+import { startRunLifecycle } from './runLifecycle';
 
-describe('run lifecycle workflow', () => {
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('native run lifecycle', () => {
+	it('schedules one startup check and expires an abandoned run without creating a workflow', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'native-queued', 'native-secret');
+		const run = await t.run((ctx) => ctx.db.get('runs', runId));
+		expect(run).not.toHaveProperty('lifecycleWorkflowId');
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!state?.lifecycleCheckId) throw new Error('Missing lifecycle check.');
+		const scheduledId = state.lifecycleCheckId;
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', scheduledId))
+		).toMatchObject({
+			scheduledTime: Date.now() + RUN_QUEUED_STARTUP_DEADLINE_MS,
+			state: { kind: 'pending' }
+		});
+		await t.run((ctx) => startRunLifecycle(ctx, runId));
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).toEqual(state);
+		await vi.advanceTimersByTimeAsync(RUN_QUEUED_STARTUP_DEADLINE_MS - 1);
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({ status: 'queued' });
+		await vi.advanceTimersByTimeAsync(1);
+		await t.finishInProgressScheduledFunctions();
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({
+			status: 'failed',
+			lastError: 'The local agent stopped responding before this run finished.'
+		});
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).not.toHaveProperty(
+			'lifecycleCheckId'
+		);
+	});
+
+	it('checks the current lease only at its deadline and ignores stale generations', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'native-renew-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'native-renew', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'live' });
+		await vi.advanceTimersByTimeAsync(RUN_QUEUED_STARTUP_DEADLINE_MS);
+		await t.finishInProgressScheduledFunctions();
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!state?.lifecycleCheckId || !state.claimExpiresAt) throw new Error('Missing lease check.');
+		const scheduledId = state.lifecycleCheckId;
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', scheduledId))
+		).toMatchObject({
+			scheduledTime: state.claimExpiresAt
+		});
+		await t.mutation(internal.runLifecycle.checkRun, { runId, generation: 1 });
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).toEqual(state);
+		const renewedDeadline = state.claimExpiresAt + RUN_CLAIM_LEASE_DURATION_MS;
+		await t.run((ctx) => patchRunExecution(ctx, runId, { claimExpiresAt: renewedDeadline }));
+		await vi.advanceTimersByTimeAsync(state.claimExpiresAt - Date.now());
+		await t.finishInProgressScheduledFunctions();
+		const renewed = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!renewed?.lifecycleCheckId) throw new Error('Missing renewed check.');
+		const renewedId = renewed.lifecycleCheckId;
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', renewedId))
+		).toMatchObject({
+			scheduledTime: renewedDeadline
+		});
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({ status: 'running' });
+		await vi.advanceTimersByTimeAsync(renewedDeadline - Date.now());
+		await t.finishInProgressScheduledFunctions();
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({ status: 'failed' });
+	});
+
+	it('cancels the pending deadline check when a run completes', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'native-complete-secret';
+		const { runId } = await createQueuedRun(
+			t,
+			asUser,
+			threadId,
+			'native-complete',
+			executionSecret
+		);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'live' });
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!state?.lifecycleCheckId) throw new Error('Missing lifecycle check.');
+		const scheduledId = state.lifecycleCheckId;
+		await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId,
+			executionSecret,
+			expectedStatus: 'running',
+			expectedClaimId: 'live',
+			text: 'done',
+			status: 'completed'
+		});
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', scheduledId))
+		).toMatchObject({
+			state: { kind: 'canceled' }
+		});
+		await t.mutation(internal.runLifecycle.checkRun, {
+			runId,
+			generation: state.lifecycleGeneration ?? 0
+		});
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).not.toHaveProperty(
+			'lifecycleCheckId'
+		);
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({ status: 'completed' });
+	});
+
+	it('replaces a canceled scheduler entry without accepting its old generation', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'native-repair', 'repair-secret');
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!state?.lifecycleCheckId) throw new Error('Missing lifecycle check.');
+		const scheduledId = state.lifecycleCheckId;
+		await t.run((ctx) => ctx.scheduler.cancel(scheduledId));
+		await t.run((ctx) => startRunLifecycle(ctx, runId));
+		const replacement = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		expect(replacement?.lifecycleCheckId).not.toBe(scheduledId);
+		expect(replacement?.lifecycleGeneration).toBe(2);
+		await t.mutation(internal.runLifecycle.checkRun, { runId, generation: 1 });
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).toEqual(replacement);
+	});
+});
+
+describe('legacy run lifecycle compatibility', () => {
 	it('materializes an abandoned queued run after the startup deadline', async () => {
 		const t = initConvexTest();
 		const { asUser, threadId } = await seedOwnedThread(t);
@@ -47,6 +174,9 @@ describe('run lifecycle workflow', () => {
 			claimId: 'claim-live',
 			executionSecret: 'claimed-secret'
 		});
+		await t.run((ctx) =>
+			ctx.db.patch('runs', created.runId, { lifecycleWorkflowId: 'legacy-workflow' })
+		);
 		expect(
 			await t.mutation(internal.runLifecycle.abandonExpiredRun, { runId: created.runId })
 		).toBe(false);
@@ -108,13 +238,13 @@ describe('run lifecycle workflow', () => {
 			'finish-secret',
 			'Hello'
 		);
-		const run = await t.run(async (ctx) => ctx.db.get('runs', created.runId));
-		const workflowId = run?.lifecycleWorkflowId;
-		expect(workflowId).toEqual(expect.any(String));
+		await t.run((ctx) =>
+			ctx.db.patch('runs', created.runId, { lifecycleWorkflowId: 'legacy-workflow' })
+		);
 		await t.mutation(internal.runLifecycle.finishLifecycle, {
 			runId: created.runId,
-			// SAFETY: stored by startRunLifecycle; convex-test uses the dummy id.
-			workflowId: workflowId as WorkflowId
+			// SAFETY: matches the legacy workflow ID stored by this fixture.
+			workflowId: 'legacy-workflow' as WorkflowId
 		});
 		const finished = await t.run(async (ctx) => ctx.db.get('runs', created.runId));
 		expect(finished?.lifecycleWorkflowId).toBeUndefined();

--- a/apps/web/src/convex/runLifecycle.ts
+++ b/apps/web/src/convex/runLifecycle.ts
@@ -1,19 +1,20 @@
-import { cancel, defineWorkflow, start, vWorkflowId, type WorkflowId } from '@convex-dev/workflow';
+import { defineWorkflow, vWorkflowId } from '@convex-dev/workflow';
 import { v } from 'convex/values';
-import { getRunWithExecution } from '@convex/lib/runExecution';
+import {
+	getRunExecutionState,
+	getRunWithExecution,
+	migrateRunExecution
+} from '@convex/lib/runExecution';
 import { components, internal } from '@convex/_generated/api';
 import { internalMutation, internalQuery, type MutationCtx } from '@convex/_generated/server';
 import type { Doc, Id } from '@convex/_generated/dataModel';
-import {
-	isClaimedRunStatus,
-	isRunClaimLeaseActive,
-	RUN_QUEUED_STARTUP_DEADLINE_MS
-} from '@convex/lib/runLease';
+import { RUN_QUEUED_STARTUP_DEADLINE_MS } from '@convex/lib/runLease';
 import { advanceTerminalCleanup } from '@convex/lib/runTerminal';
 import { finalizeRunRecord } from '@convex/lib/runFinalize';
 import { RUN_ABANDONED_BY_AGENT } from '@convex/lib/agentErrors';
 import { isRunFinalStatus } from '@convex/lib/validators';
 import { CANCELLATION_FORCE_AFTER_MS, isRunCancellationOpen } from '@convex/lib/runCancellation';
+import { runDeadline, scheduleRunLifecycleCheck } from '@convex/lib/runLifecycleSchedule';
 const MAX_SLEEP_MS = RUN_QUEUED_STARTUP_DEADLINE_MS;
 
 type RunWatchState =
@@ -22,36 +23,52 @@ type RunWatchState =
 	| { kind: 'wait'; waitMs: number };
 
 function watchStateForRun(run: Doc<'runs'>, now: number): RunWatchState {
-	if (isRunFinalStatus(run.status)) {
+	const deadline = runDeadline(run);
+	if (deadline === null) {
 		return { kind: 'terminal', completedAt: run.completedAt ?? now };
 	}
-	if (run.status === 'queued') {
-		const deadline = run.startedAt + RUN_QUEUED_STARTUP_DEADLINE_MS;
-		if (now >= deadline) {
-			return { kind: 'abandon' };
-		}
-		return { kind: 'wait', waitMs: Math.min(deadline - now, MAX_SLEEP_MS) };
-	}
-	if (isClaimedRunStatus(run.status)) {
-		if (!isRunClaimLeaseActive(run, now)) {
-			return { kind: 'abandon' };
-		}
-		const expiresAt = run.claimExpiresAt ?? now;
-		return { kind: 'wait', waitMs: Math.min(Math.max(expiresAt - now, 1), MAX_SLEEP_MS) };
-	}
-	return { kind: 'terminal', completedAt: run.completedAt ?? now };
+	if (now >= deadline) return { kind: 'abandon' };
+	return { kind: 'wait', waitMs: Math.min(deadline - now, MAX_SLEEP_MS) };
 }
 
-export async function startRunLifecycle(ctx: MutationCtx, runId: Id<'runs'>): Promise<WorkflowId> {
-	const deployment = await ctx.meta.getDeploymentMetadata();
-	// convex-test shares JS globals with the workflow runtime. Starting a
-	// workflow there deletes `process`/`crypto` and races later tests.
-	if (deployment.name === 'test' && deployment.class === 's16') {
-		// SAFETY: convex-test's dummy id is never passed to the workflow component.
-		return 'test-workflow' as WorkflowId;
+export async function startRunLifecycle(ctx: MutationCtx, runId: Id<'runs'>): Promise<void> {
+	const run = await ctx.db.get('runs', runId);
+	if (!run || isRunFinalStatus(run.status)) return;
+	const stateId = await migrateRunExecution(ctx, run);
+	const state = await ctx.db.get('runExecutionStates', stateId);
+	if (!state) throw new Error('Run execution state not found.');
+	if (state.lifecycleCheckId) {
+		const scheduled = await ctx.db.system.get('_scheduled_functions', state.lifecycleCheckId);
+		if (scheduled?.state.kind === 'pending') return;
 	}
-	return await start(ctx, internal.runLifecycle.watchRun, { runId }, { startAsync: true });
+	const deadline = runDeadline({ ...run, claimExpiresAt: state.claimExpiresAt });
+	if (deadline !== null) await scheduleRunLifecycleCheck(ctx, state, deadline);
 }
+
+export const checkRun = internalMutation({
+	args: { runId: v.id('runs'), generation: v.number() },
+	returns: v.null(),
+	handler: async (ctx, { runId, generation }) => {
+		const state = await getRunExecutionState(ctx.db, runId);
+		if (!state?.lifecycleCheckId || state.lifecycleGeneration !== generation) return null;
+		// Clear ownership before finalization so it cannot cancel this mutation's descendants.
+		await ctx.db.patch('runExecutionStates', state._id, { lifecycleCheckId: undefined });
+		const run = await getRunWithExecution(ctx.db, runId);
+		if (!run) return null;
+		const deadline = runDeadline(run);
+		if (deadline === null) return null;
+		if (deadline > Date.now()) {
+			await scheduleRunLifecycleCheck(ctx, state, deadline);
+		} else {
+			await finalizeRunRecord(ctx, run, {
+				text: RUN_ABANDONED_BY_AGENT,
+				status: 'failed',
+				lastError: RUN_ABANDONED_BY_AGENT
+			});
+		}
+		return null;
+	}
+});
 
 export async function requestRunCancellation(ctx: MutationCtx, run: Doc<'runs'>): Promise<boolean> {
 	if (isRunFinalStatus(run.status)) {
@@ -71,15 +88,6 @@ export async function requestRunCancellation(ctx: MutationCtx, run: Doc<'runs'>)
 	return true;
 }
 
-export async function cancelRunLifecycle(ctx: MutationCtx, workflowId: string): Promise<void> {
-	try {
-		// SAFETY: stored run ids come from workflow.start() or the convex-test dummy.
-		await cancel(ctx, components.workflow, workflowId as WorkflowId);
-	} catch {
-		// Already finished or never started.
-	}
-}
-
 export const getWatchState = internalQuery({
 	args: { runId: v.id('runs') },
 	returns: v.union(
@@ -90,7 +98,7 @@ export const getWatchState = internalQuery({
 	),
 	handler: async (ctx, args) => {
 		const run = await getRunWithExecution(ctx.db, args.runId);
-		if (!run) {
+		if (!run?.lifecycleWorkflowId) {
 			return { kind: 'missing' as const };
 		}
 		return watchStateForRun(run, Date.now());

--- a/apps/web/src/convex/runLifecycleMigration.test.ts
+++ b/apps/web/src/convex/runLifecycleMigration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api, internal } from '@convex/_generated/api';
+import { getRunExecutionState, patchRunExecution } from '@convex/lib/runExecution';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+
+const oneBatch = { cursor: null, dryRun: false, oneBatchOnly: true } as const;
+
+describe('native lifecycle migration', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('hands off a live legacy workflow without changing its lease or creating duplicate checks', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'lifecycle-migration-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'handoff', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'live' });
+		const lease = await t.run(async (ctx) => {
+			const state = await getRunExecutionState(ctx.db, runId);
+			if (!state?.lifecycleCheckId) throw new Error('Missing native check.');
+			await ctx.scheduler.cancel(state.lifecycleCheckId);
+			await ctx.db.patch('runExecutionStates', state._id, {
+				lifecycleCheckId: undefined,
+				lifecycleGeneration: undefined
+			});
+			await ctx.db.patch('runs', runId, { lifecycleWorkflowId: 'legacy-workflow' });
+			return state.claimExpiresAt;
+		});
+		expect(await t.query(internal.runLifecycle.getWatchState, { runId })).toMatchObject({
+			kind: 'wait'
+		});
+		await t.mutation(internal.migrations.migrateRunLifecycle, oneBatch);
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		expect(state).toMatchObject({ claimId: 'live', claimExpiresAt: lease, lifecycleGeneration: 1 });
+		if (!state?.lifecycleCheckId) throw new Error('Missing migrated check.');
+		const scheduledId = state.lifecycleCheckId;
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', scheduledId))
+		).toMatchObject({ scheduledTime: lease, state: { kind: 'pending' } });
+		expect(await t.query(internal.runLifecycle.getWatchState, { runId })).toEqual({
+			kind: 'missing'
+		});
+		await t.mutation(internal.migrations.migrateRunLifecycle, oneBatch);
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).toEqual(state);
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).toMatchObject({ status: 'running' });
+	});
+
+	it('repairs a missing legacy watcher and honors execution state instead of stale run fields', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'repair', 'repair-secret');
+		const deadline = Date.now() + 90_000;
+		await t.run(async (ctx) => {
+			const state = await getRunExecutionState(ctx.db, runId);
+			if (!state?.lifecycleCheckId) throw new Error('Missing native check.');
+			await ctx.scheduler.cancel(state.lifecycleCheckId);
+			await ctx.db.patch('runExecutionStates', state._id, { lifecycleCheckId: undefined });
+			await patchRunExecution(ctx, runId, { claimId: 'current', claimExpiresAt: deadline });
+			await ctx.db.patch('runs', runId, {
+				status: 'awaiting_executor',
+				claimId: 'stale',
+				claimExpiresAt: Date.now() - 1
+			});
+		});
+		await t.mutation(internal.migrations.migrateRunLifecycle, oneBatch);
+		const state = await t.run((ctx) => getRunExecutionState(ctx.db, runId));
+		if (!state?.lifecycleCheckId) throw new Error('Missing repaired check.');
+		const scheduledId = state.lifecycleCheckId;
+		expect(
+			await t.run((ctx) => ctx.db.system.get('_scheduled_functions', scheduledId))
+		).toMatchObject({ scheduledTime: deadline });
+		expect(state.claimId).toBe('current');
+	});
+
+	it('clears completed runs without scheduling new lifecycle work', async () => {
+		const t = initConvexTest();
+		const { threadId } = await seedOwnedThread(t);
+		const runId = await t.run(async (ctx) => {
+			const run = await ctx.db
+				.query('runs')
+				.withIndex('by_threadId_startedAt', (q) => q.eq('threadId', threadId))
+				.unique();
+			if (!run) throw new Error('Missing fixture run.');
+			await ctx.db.patch('runs', run._id, { lifecycleWorkflowId: 'finished-workflow' });
+			return run._id;
+		});
+		await t.mutation(internal.migrations.migrateRunLifecycle, oneBatch);
+		expect(await t.run((ctx) => ctx.db.get('runs', runId))).not.toHaveProperty(
+			'lifecycleWorkflowId'
+		);
+		expect(await t.run((ctx) => getRunExecutionState(ctx.db, runId))).toBeNull();
+		expect(await t.run((ctx) => ctx.db.system.query('_scheduled_functions').collect())).toEqual([]);
+	});
+});

--- a/apps/web/src/convex/schema.ts
+++ b/apps/web/src/convex/schema.ts
@@ -182,7 +182,9 @@ export default defineSchema({
 		claimId: v.optional(v.string()),
 		claimExpiresAt: v.optional(v.number()),
 		completionAttemptSeq: v.number(),
-		activeJobId: v.optional(v.id('executorJobs'))
+		activeJobId: v.optional(v.id('executorJobs')),
+		lifecycleCheckId: v.optional(v.id('_scheduled_functions')),
+		lifecycleGeneration: v.optional(v.number())
 	}).index('by_runId', ['runId']),
 	// Durable numbered transcript replica source. Kept off threadRecords so
 	// appends do not invalidate the thread list subscription.


### PR DESCRIPTION
## Summary

Replace the per-run lifecycle Workflow with native scheduled mutations. New runs no longer enqueue work under `workflow/workpool/batchWorker`.

- Schedule at the startup deadline or current claim expiry, then re-read the latest lease before expiring or rescheduling.
- Keep timer IDs and generation guards in `runExecutionStates`, away from thread-list subscriptions. Cancel pending checks during finalization.
- Install native checks for existing active runs before clearing their Workflow markers in the same transaction. Legacy workflows exit on their next state check. Preserve their functions and step order until stored journals drain.
- Leave the web-search and Firecrawl pools unchanged.

## Rollout

The hourly migration starts the handoff automatically. To start it immediately after deployment, run `bunx convex run migrations:runNativeRunLifecycleMigration --prod` from `apps/web`.

The Workflow component remains mounted temporarily for existing callbacks. Its removal gate is recorded in `BACKWARDS_COMPATIBILITY.md`. This PR does not deploy or run the production migration.

## Checks

- Convex codegen and its TypeScript check passed.
- 96 targeted lifecycle, migration, machine, Firecrawl browser and payment tests passed.
- `bun run build` passed.
- CI `bun run build`, `bun run test`, `cargo test`, and `prek run -a` passed. The web suite passed all 508 tests.
- Local full-suite retries encountered timing failures under memory pressure, and local `prek run -a` exceeded its time budget. The same commit passed the complete CI checks above.
- Convex preview creation is blocked by `DeploymentQuotaReached`, because the team has reached its 40-deployment limit. No deployments were deleted.
- Requested Grok cleanup and review agents were blocked by Cursor CLI authentication. Reviewed the changes directly.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63177764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the native scheduler preserves lifecycle expiry behavior and provides an atomic, compatibility-aware migration path.

<details open><summary><h3>Summary</h3></summary>

- New runs schedule checks at their startup deadline and re-evaluate the latest claim lease when each check executes.
- Finalization cancels pending lifecycle checks and preserves existing terminal cleanup.
- An hourly, idempotent migration atomically installs native checks before retiring legacy workflow markers.
- Legacy workflow functions and schema fields remain available until stored journals and callbacks have drained.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run created as queued] --> B[Schedule check at startup deadline]
    B --> C{Check generation still current?}
    C -- No --> D[Ignore stale callback]
    C -- Yes --> E[Reload run and execution state]
    E --> F{Run terminal?}
    F -- Yes --> G[Stop without rescheduling]
    F -- No --> H{Current deadline passed?}
    H -- No --> I[Schedule next check at current lease expiry]
    H -- Yes --> J[Finalize run as abandoned]
    J --> K[Cancel lifecycle check and perform terminal cleanup]

    L[Legacy active run] --> M[Migration installs native check]
    M --> N[Clear legacy workflow marker atomically]
    N --> O[Legacy workflow exits on next state check]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["perf(convex): Replace lifecycle workflow..."](https://github.com/spikonado/sprocket/commit/e3290f79ede6e331790566cc76bff24bf5da9902)</sub>

<!-- /greptile_comment -->