### PR TITLE
feat(tools): Auto-redirect to raw for scrape_url on GitHub files

### DIFF
--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -53,6 +53,16 @@ Convex component does not expose parsing.
 
 `scrape_url` downloads supported raster images and returns their pixels
 to image-capable models. Short text scrapes are not saved locally.
+GitHub repository file URLs using `/blob/`, `/raw/`, or `/blame/` map to
+`raw.githubusercontent.com` before any image or Markdown probe. Direct raw URLs
+use this route too. The mapping preserves refs, encoded paths, and query
+parameters, and drops line anchors. Rust reads source files as UTF-8, converts
+supported documents with AnyDoc, and returns supported images through the
+existing image cache. This route never calls Firecrawl, even after a download
+or parsing failure. It has a 30-second download timeout, five-redirect limit,
+and 64 MiB download limit. Image decoding retains the existing model limits.
+Repository landing pages, directories, and issue pages keep normal scraping.
+
 For extensionless paths, the agent first requests the URL path with `.md`
 appended, preserving query parameters and dropping the fragment. It removes
 trailing slashes before checking the last path segment. Paths with any file

--- a/crates/sprocket-agent/README.md
+++ b/crates/sprocket-agent/README.md
@@ -60,7 +60,9 @@ parameters, and drops line anchors. Rust reads source files as UTF-8, converts
 supported documents with AnyDoc, and returns supported images through the
 existing image cache. This route never calls Firecrawl, even after a download
 or parsing failure. It has a 30-second download timeout, five-redirect limit,
-and 64 MiB download limit. Image decoding retains the existing model limits.
+and 64 MiB download limit. Image signatures lower the download limit to 20 MiB
+during streaming, regardless of the response's content type. Image decoding
+retains the existing model limits.
 Repository landing pages, directories, and issue pages keep normal scraping.
 
 For extensionless paths, the agent first requests the URL path with `.md`

--- a/crates/sprocket-agent/src/tools/github_url.rs
+++ b/crates/sprocket-agent/src/tools/github_url.rs
@@ -6,7 +6,9 @@ use reqwest::Url;
 use serde_json::{Value, json};
 use sprocket_workspace::{WorkspaceCancellation, WorkspaceOperationCancelled};
 
-use super::parse_file::{convert_file_bytes, sniff_supported_image_format};
+use super::parse_file::{
+    IMAGE_SNIFF_BYTES, MAX_PARSE_FILE_IMAGE_BYTES, convert_file_bytes, sniff_supported_image_format,
+};
 use super::scrape_files::MAX_SCRAPE_BYTES;
 
 pub(super) fn github_raw_url(url: &Url) -> Option<Url> {
@@ -76,21 +78,30 @@ pub(super) async fn fetch_github_file(
 async fn download_file(
     client: &reqwest::Client,
     url: Url,
-    max_bytes: u64,
+    mut max_bytes: u64,
 ) -> anyhow::Result<(Url, Vec<u8>)> {
     let mut response = client.get(url).send().await?.error_for_status()?;
     anyhow::ensure!(
         response.status() == reqwest::StatusCode::OK,
         "expected a complete GitHub file response"
     );
+    let content_length = response.content_length();
     anyhow::ensure!(
-        response
-            .content_length()
-            .is_none_or(|size| size <= max_bytes),
+        content_length.is_none_or(|size| size <= max_bytes),
         "GitHub file exceeds the download limit"
     );
     let mut bytes = Vec::new();
+    let mut prefix = Vec::with_capacity(IMAGE_SNIFF_BYTES);
     while let Some(chunk) = response.chunk().await? {
+        let prefix_bytes = chunk.len().min(IMAGE_SNIFF_BYTES - prefix.len());
+        prefix.extend_from_slice(&chunk[..prefix_bytes]);
+        if sniff_supported_image_format(&prefix).is_some() {
+            max_bytes = max_bytes.min(MAX_PARSE_FILE_IMAGE_BYTES as u64);
+        }
+        anyhow::ensure!(
+            content_length.is_none_or(|size| size <= max_bytes),
+            "GitHub file exceeds the download limit"
+        );
         anyhow::ensure!(
             bytes.len().saturating_add(chunk.len()) as u64 <= max_bytes,
             "GitHub file exceeds the download limit"
@@ -331,6 +342,35 @@ mod tests {
             let (url, server) = serve(vec![bytes]).await;
             let error = download_file(&client, url, 8).await.unwrap_err();
             assert!(error.to_string().contains("download limit"));
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn image_limit_applies_during_download_even_without_an_image_content_type() {
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let signature = b"\x89PNG\r\n\x1a\n";
+        let declared = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            MAX_PARSE_FILE_IMAGE_BYTES + 1
+        );
+        let mut oversized = declared.into_bytes();
+        oversized.extend_from_slice(signature);
+
+        let mut chunked = b"HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n".to_vec();
+        for byte in signature {
+            chunked.extend_from_slice(&[b'1', b'\r', b'\n', *byte, b'\r', b'\n']);
+        }
+        chunked.extend_from_slice(format!("{MAX_PARSE_FILE_IMAGE_BYTES:x}\r\n").as_bytes());
+        chunked.resize(chunked.len() + MAX_PARSE_FILE_IMAGE_BYTES, 0);
+        chunked.extend_from_slice(b"\r\n0\r\n\r\n");
+
+        for response in [oversized, chunked] {
+            let (url, server) = serve(vec![response]).await;
+            let error = download_file(&client, url, MAX_SCRAPE_BYTES)
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("download limit"), "{error:#}");
             server.await.unwrap();
         }
     }

--- a/crates/sprocket-agent/src/tools/github_url.rs
+++ b/crates/sprocket-agent/src/tools/github_url.rs
@@ -1,0 +1,359 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::Context;
+use reqwest::Url;
+use serde_json::{Value, json};
+use sprocket_workspace::{WorkspaceCancellation, WorkspaceOperationCancelled};
+
+use super::parse_file::{convert_file_bytes, sniff_supported_image_format};
+use super::scrape_files::MAX_SCRAPE_BYTES;
+
+pub(super) fn github_raw_url(url: &Url) -> Option<Url> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return None;
+    }
+    let mut raw = match url.host_str()? {
+        "raw.githubusercontent.com" => url.clone(),
+        "github.com" | "www.github.com" if url.port().is_none() => {
+            let segments: Vec<_> = url.path_segments()?.collect();
+            if segments.len() < 5
+                || segments.iter().any(|segment| segment.is_empty())
+                || !matches!(segments[2], "blob" | "raw" | "blame")
+            {
+                return None;
+            }
+            let mut raw = Url::parse("https://raw.githubusercontent.com").ok()?;
+            raw.set_path(&format!(
+                "/{}/{}/{}",
+                segments[0],
+                segments[1],
+                segments[3..].join("/")
+            ));
+            raw.set_query(url.query());
+            raw
+        }
+        _ => return None,
+    };
+    raw.set_fragment(None);
+    Some(raw)
+}
+
+pub(super) async fn fetch_github_file(
+    url: Url,
+    supports_images: bool,
+    cache_dir: &Path,
+    cancellation: &WorkspaceCancellation,
+) -> anyhow::Result<Value> {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(WorkspaceOperationCancelled.into()),
+        result = async {
+            let client = reqwest::Client::builder()
+                .no_proxy()
+                .timeout(Duration::from_secs(30))
+                .redirect(reqwest::redirect::Policy::limited(5))
+                .build()?;
+            let (url, bytes) = download_file(&client, url, MAX_SCRAPE_BYTES).await?;
+            if sniff_supported_image_format(&bytes).is_some() {
+                anyhow::ensure!(supports_images, "The selected model cannot view images.");
+                return super::web::persist_web_image(&bytes, &url, cache_dir).await;
+            }
+            let filename = url.path_segments().and_then(Iterator::last).unwrap_or("");
+            let path = PathBuf::from(percent_encoding::percent_decode_str(filename).decode_utf8_lossy().as_ref());
+            let (markdown, _) = tokio::task::spawn_blocking(move || convert_file_bytes(bytes, &path))
+                .await.context("GitHub file parser failed")??;
+            Ok(json!({
+                "url": url.as_str(),
+                "markdown": markdown,
+                "summary": "Summary not generated; file was read directly from GitHub.",
+                "images": [],
+            }))
+        } => result.context("failed to read GitHub file locally"),
+    }
+}
+
+async fn download_file(
+    client: &reqwest::Client,
+    url: Url,
+    max_bytes: u64,
+) -> anyhow::Result<(Url, Vec<u8>)> {
+    let mut response = client.get(url).send().await?.error_for_status()?;
+    anyhow::ensure!(
+        response.status() == reqwest::StatusCode::OK,
+        "expected a complete GitHub file response"
+    );
+    anyhow::ensure!(
+        response
+            .content_length()
+            .is_none_or(|size| size <= max_bytes),
+        "GitHub file exceeds the download limit"
+    );
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        anyhow::ensure!(
+            bytes.len().saturating_add(chunk.len()) as u64 <= max_bytes,
+            "GitHub file exceeds the download limit"
+        );
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok((response.url().clone(), bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn maps_file_views_without_changing_refs_or_encoded_paths() {
+        for (source, expected) in [
+            (
+                "https://github.com/owner/repo/blob/main/src/lib.rs#L10-L20",
+                "https://raw.githubusercontent.com/owner/repo/main/src/lib.rs",
+            ),
+            (
+                "http://www.github.com/owner/repo/blob/abc123/LICENSE",
+                "https://raw.githubusercontent.com/owner/repo/abc123/LICENSE",
+            ),
+            (
+                "https://github.com/owner/repo/blob/feature/docs/guide%20one%23two.md?plain=1#heading",
+                "https://raw.githubusercontent.com/owner/repo/feature/docs/guide%20one%23two.md?plain=1",
+            ),
+            (
+                "https://github.com/owner/repo/blob/feature%2Fdocs/.github/config%2Eyml",
+                "https://raw.githubusercontent.com/owner/repo/feature%2Fdocs/.github/config%2Eyml",
+            ),
+            (
+                "https://github.com/owner/repo/raw/refs/heads/main/data.csv",
+                "https://raw.githubusercontent.com/owner/repo/refs/heads/main/data.csv",
+            ),
+            (
+                "https://github.com/owner/repo/blame/v1.0/src/main.rs",
+                "https://raw.githubusercontent.com/owner/repo/v1.0/src/main.rs",
+            ),
+            (
+                "https://raw.githubusercontent.com/owner/repo/main/README.md?token=example#L1",
+                "https://raw.githubusercontent.com/owner/repo/main/README.md?token=example",
+            ),
+        ] {
+            assert_eq!(
+                github_raw_url(&Url::parse(source).unwrap())
+                    .unwrap()
+                    .as_str(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_non_file_pages_and_other_hosts_on_the_existing_route() {
+        for source in [
+            "https://github.com/owner/repo",
+            "https://github.com/owner/repo/tree/main/src",
+            "https://github.com/owner/repo/issues/123",
+            "https://github.com/owner/repo/blob/main",
+            "https://github.com/owner/repo/blob/main/",
+            "https://github.com/owner//blob/main/file.rs",
+            "https://github.com.example.com/owner/repo/blob/main/file.rs",
+            "https://example.com/owner/repo/blob/main/file.rs",
+            "https://github.com@evil.example/owner/repo/blob/main/file.rs",
+            "https://github.com:8443/owner/repo/blob/main/file.rs",
+            "ftp://github.com/owner/repo/blob/main/file.rs",
+        ] {
+            assert!(
+                github_raw_url(&Url::parse(source).unwrap()).is_none(),
+                "{source}"
+            );
+        }
+        assert!(
+            github_raw_url(&Url::parse("https://raw.githubusercontent.com/missing").unwrap())
+                .is_some()
+        );
+    }
+
+    async fn serve(responses: Vec<Vec<u8>>) -> (Url, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!("http://{}/source", listener.local_addr().unwrap())).unwrap();
+        let task = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = [0; 4096];
+                let count = stream.read(&mut request).await.unwrap();
+                requests.push(String::from_utf8_lossy(&request[..count]).into_owned());
+                let _ = stream.write_all(&response).await;
+            }
+            requests
+        });
+        (url, task)
+    }
+
+    fn response(status: u16, mime: &str, body: &[u8]) -> Vec<u8> {
+        let mut bytes = format!("HTTP/1.1 {status} Test\r\nContent-Type: {mime}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", body.len()).into_bytes();
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    #[tokio::test]
+    async fn reads_source_verbatim_with_one_get_and_no_markdown_probe() {
+        let cache = tempfile::tempdir().unwrap();
+        for (path, mime, body) in [
+            ("/src/lib.rs", "text/plain", "fn main() {}\n"),
+            ("/LICENSE", "application/octet-stream", "Copyright é\n"),
+            (
+                "/index.html",
+                "text/plain",
+                "<!doctype html><html>Hello</html>",
+            ),
+            (
+                "/README.md",
+                "text/plain",
+                "<!-- docs -->\n<div>Hello</div>",
+            ),
+            ("/data.json", "application/json", "{\"hello\": true}"),
+        ] {
+            let (mut url, server) = serve(vec![response(200, mime, body.as_bytes())]).await;
+            url.set_path(path);
+            let result = fetch_github_file(
+                url.clone(),
+                false,
+                cache.path(),
+                &WorkspaceCancellation::new(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result["url"], url.as_str());
+            assert_eq!(result["markdown"], body);
+            assert_eq!(result["images"], json!([]));
+            let requests = server.await.unwrap();
+            assert_eq!(requests.len(), 1);
+            assert!(requests[0].starts_with(&format!("GET {path} HTTP/1.1")));
+            assert!(!requests[0].to_lowercase().contains("authorization:"));
+            assert!(!requests[0].to_lowercase().contains("cookie:"));
+        }
+        assert_eq!(std::fs::read_dir(cache.path()).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn converts_documents_locally_after_redirects() {
+        let cache = tempfile::tempdir().unwrap();
+        let (url, server) = serve(vec![
+            b"HTTP/1.1 302 Found\r\nLocation: /table%2Ecsv\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec(),
+            response(200, "text/plain", b"name,value\nsprocket,42\n"),
+        ]).await;
+        let result = fetch_github_file(url, false, cache.path(), &WorkspaceCancellation::new())
+            .await
+            .unwrap();
+        assert!(result["url"].as_str().unwrap().ends_with("/table%2Ecsv"));
+        assert!(
+            result["markdown"]
+                .as_str()
+                .unwrap()
+                .contains("| sprocket | 42 |")
+        );
+        assert_eq!(server.await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn errors_are_returned_instead_of_allowing_hosted_fallback() {
+        let cache = tempfile::tempdir().unwrap();
+        for bytes in [
+            response(404, "text/plain", b"Not Found"),
+            response(403, "text/plain", b"Forbidden"),
+            response(429, "text/plain", b"Rate limited"),
+            response(500, "text/plain", b"Unavailable"),
+            response(206, "text/plain", b"Partial"),
+            response(200, "application/octet-stream", &[0xff, 0xfe]),
+            response(200, "text/plain", b"binary\0content"),
+            response(200, "text/plain", b""),
+            b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\nConnection: close\r\n\r\npartial".to_vec(),
+        ] {
+            let (url, server) = serve(vec![bytes]).await;
+            assert!(
+                fetch_github_file(url, false, cache.path(), &WorkspaceCancellation::new())
+                    .await
+                    .is_err()
+            );
+            assert_eq!(server.await.unwrap().len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn image_bytes_use_the_existing_model_and_cache_limits() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut png = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(1, 1)
+            .write_to(&mut png, image::ImageFormat::Png)
+            .unwrap();
+        for supports_images in [true, false] {
+            let (url, server) = serve(vec![response(
+                200,
+                "application/octet-stream",
+                png.get_ref(),
+            )])
+            .await;
+            let result = fetch_github_file(
+                url,
+                supports_images,
+                cache.path(),
+                &WorkspaceCancellation::new(),
+            )
+            .await;
+            if supports_images {
+                let result = result.unwrap();
+                assert_eq!(result["outputType"], "image");
+                assert_eq!(result["mediaType"], "image/png");
+                assert_eq!(
+                    tokio::fs::read(result["path"].as_str().unwrap())
+                        .await
+                        .unwrap(),
+                    *png.get_ref()
+                );
+                super::super::parse_file::replay_image_tool_output(&result)
+                    .await
+                    .unwrap();
+            } else {
+                assert!(format!("{:#}", result.unwrap_err()).contains("cannot view images"));
+            }
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn download_limit_applies_with_or_without_content_length() {
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        for bytes in [
+            response(200, "text/plain", b"123456789"),
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n9\r\n123456789\r\n0\r\n\r\n".to_vec(),
+        ] {
+            let (url, server) = serve(vec![bytes]).await;
+            let error = download_file(&client, url, 8).await.unwrap_err();
+            assert!(error.to_string().contains("download limit"));
+            server.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_aborts_the_request() {
+        let cache = tempfile::tempdir().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!("http://{}/slow", listener.local_addr().unwrap())).unwrap();
+        let cancellation = WorkspaceCancellation::new();
+        let cancel = cancellation.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).await.unwrap();
+            cancel.cancel();
+            let mut eof = [0];
+            assert_eq!(stream.read(&mut eof).await.unwrap(), 0);
+        });
+        let error = fetch_github_file(url, false, cache.path(), &cancellation)
+            .await
+            .unwrap_err();
+        assert!(error.is::<WorkspaceOperationCancelled>());
+        server.await.unwrap();
+    }
+}

--- a/crates/sprocket-agent/src/tools/mod.rs
+++ b/crates/sprocket-agent/src/tools/mod.rs
@@ -3,6 +3,7 @@ mod browser;
 mod commands;
 mod context;
 mod firecrawl;
+mod github_url;
 mod hosted_parse;
 mod job;
 mod mandates;

--- a/crates/sprocket-agent/src/tools/parse_file.rs
+++ b/crates/sprocket-agent/src/tools/parse_file.rs
@@ -26,7 +26,7 @@ pub(crate) const MAX_PARSE_FILE_IMAGE_PIXELS: u32 = 36_000_000;
 pub(crate) const MAX_PARSE_FILE_PREVIEW_CHARS: usize = 20_000;
 const MAX_PARSE_FILE_DOCUMENT_BYTES: u64 = 64 * 1024 * 1024;
 
-const IMAGE_SNIFF_BYTES: usize = 16;
+pub(super) const IMAGE_SNIFF_BYTES: usize = 16;
 
 #[derive(Clone)]
 pub(crate) struct ParseFileTool(pub(super) AgentToolContext);

--- a/crates/sprocket-agent/src/tools/parse_file.rs
+++ b/crates/sprocket-agent/src/tools/parse_file.rs
@@ -396,23 +396,26 @@ fn convert_non_image_blocking(
         .with_context(|| format!("failed to read {}", path.display()))?;
     ensure_document_size(bytes.len() as u64)?;
     ensure_not_cancelled(&cancellation)?;
+    let (text, format) = convert_file_bytes(bytes, &path)?;
+    persist_parsed_text(&cache_dir, &text, format, &cancellation)
+}
+
+pub(super) fn convert_file_bytes(
+    bytes: Vec<u8>,
+    path: &Path,
+) -> anyhow::Result<(String, &'static str)> {
     anyhow::ensure!(!bytes.is_empty(), "file is empty");
-    if let Some(format) = detect_anydoc_format(&bytes, &path) {
+    if let Some(format) = detect_anydoc_format(&bytes, path) {
         let markdown = anydoc::to_markdown_bytes(&bytes, format)
             .map_err(|error| LocalConversionFailed(map_anydoc_error(error).to_string()))?;
-        return persist_parsed_text(
-            &cache_dir,
-            &markdown,
-            anydoc_format_name(format),
-            &cancellation,
-        );
+        return Ok((markdown, anydoc_format_name(format)));
     }
     let text = String::from_utf8(bytes)
         .map_err(|_| LocalConversionFailed(unsupported_file_error().to_string()))?;
     if text.contains('\0') {
         return Err(LocalConversionFailed(unsupported_file_error().to_string()).into());
     }
-    persist_parsed_text(&cache_dir, &text, "text", &cancellation)
+    Ok((text, "text"))
 }
 
 pub(super) async fn persist_image_bytes(

--- a/crates/sprocket-agent/src/tools/web.rs
+++ b/crates/sprocket-agent/src/tools/web.rs
@@ -137,6 +137,14 @@ impl rig::tool::Tool for ScrapeUrlTool {
             &self.0.tool_call_tracker,
             payload,
             |cancellation, job_id| async move {
+                if let Some(raw_url) = super::github_url::github_raw_url(&url) {
+                    let result = super::github_url::fetch_github_file(raw_url, self.0.supports_images, &cache_dir, &cancellation).await.map_err(tool_error)?;
+                    return if result.get("outputType").and_then(serde_json::Value::as_str) == Some("image") {
+                        Ok(result)
+                    } else {
+                        super::scrape_files::localize_scrape(result, &cancellation, saved_file).await.map_err(tool_error)
+                    };
+                }
                 let image = tokio::select! {
                     biased;
                     _ = cancellation.cancelled() => return Err(super::context::cancelled_error()),
@@ -291,10 +299,18 @@ async fn download_image(
         );
         bytes.extend_from_slice(&chunk);
     }
-    let (media_type, width, height) = decode_image_info(&bytes)?;
-    let path = persist_image_bytes(cache_dir, &bytes, &media_type).await?;
+    persist_web_image(&bytes, response.url(), cache_dir).await
+}
+
+pub(super) async fn persist_web_image(
+    bytes: &[u8],
+    url: &reqwest::Url,
+    cache_dir: &Path,
+) -> anyhow::Result<serde_json::Value> {
+    let (media_type, width, height) = decode_image_info(bytes)?;
+    let path = persist_image_bytes(cache_dir, bytes, &media_type).await?;
     Ok(json!({
-        "outputType": "image", "url": response.url().as_str(),
+        "outputType": "image", "url": url.as_str(),
         "path": path,
         "mediaType": media_type.to_mime_type(), "byteSize": bytes.len(), "width": width, "height": height,
     }))


### PR DESCRIPTION
## Summary

GitHub repository file links now bypass Firecrawl entirely. The Rust agent maps GitHub blob, raw, and blame URLs to raw.githubusercontent.com before image discovery or Markdown probing. Direct raw URLs use the same route.

Source files stay verbatim UTF-8. Supported documents use the existing local AnyDoc conversion, and raster images use the existing model limits and image cache. Download and parsing failures return an error instead of falling back to Firecrawl. Large text results keep the existing saved-JSON behavior.

Repository landing pages, directories, and issues keep their existing scrape behavior. No tool arguments or persisted result formats changed.

## Checks

- Nine focused GitHub URL and local HTTP tests passed.
- All 197 sprocket-agent tests passed.
- Full `prek run -a` passed, including workspace Rust checks, formatting, and frontend lint/type checks.
- Rebased onto the latest main before opening this PR.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63191003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule issues identified.

<details open><summary><h3>Summary</h3></summary>

- Converts GitHub blob, raw, and blame links to `raw.githubusercontent.com`.
- Processes UTF-8 source, supported documents, and raster images locally.
- Applies download, redirect, timeout, image-size, and cancellation limits.
- Localizes large textual scrape results through the existing saved-file behavior.
- The change since the previous review now detects image signatures while streaming and lowers the active download limit to 20 MiB.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scrape_url request] --> B{GitHub file or raw URL?}
    B -- No --> C[Existing image probe and Firecrawl flow]
    B -- Yes --> D[Map to raw.githubusercontent.com]
    D --> E[Bounded HTTP download]
    E --> F{Supported image signature?}
    F -- Yes --> G[Lower stream limit to 20 MiB]
    G --> H[Validate and persist image]
    F -- No --> I[Parse document or verbatim UTF-8]
    I --> J[Localize large text result if needed]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(agent): Bound GitHub image downloads..."](https://github.com/spikonado/sprocket/commit/d183b2010a868a88774b6eb2bca73d6c6c0f38c1)</sub>

<!-- /greptile_comment -->