### PR TITLE
fix(ui): Load work details incrementally while scrolling

### DIFF
--- a/apps/web/src/lib/chat/transcript-section-keys.ts
+++ b/apps/web/src/lib/chat/transcript-section-keys.ts
@@ -1,4 +1,14 @@
-import { assistantTimelinePartKey, type AssistantTimelineSection } from './assistant-timeline';
+import {
+	assistantTimelinePartKey,
+	type AssistantTimelineSection,
+	type AssistantTimelineWorkBlock
+} from './assistant-timeline';
+
+function blockMembers(block: AssistantTimelineWorkBlock) {
+	return block.type === 'reasoning'
+		? [assistantTimelinePartKey(block)]
+		: block.tools.map((tool) => `tool:${tool.callId}`);
+}
 
 export class TranscriptSectionKeys {
 	private messages = new Map<string, Map<string, string>>();
@@ -12,18 +22,30 @@ export class TranscriptSectionKeys {
 	}
 
 	reconcile(messageId: string, sections: AssistantTimelineSection[]) {
+		const keys = this.reconcileMembers(
+			messageId,
+			sections.map((section) =>
+				section.type === 'text'
+					? [assistantTimelinePartKey(section)]
+					: section.blocks.flatMap(blockMembers)
+			)
+		);
+		return sections.map((section, index) => ({
+			...section,
+			renderKey: section.type === 'text' ? assistantTimelinePartKey(section) : keys[index]
+		}));
+	}
+
+	reconcileBlocks(messageId: string, blocks: AssistantTimelineWorkBlock[]) {
+		const keys = this.reconcileMembers(messageId, blocks.map(blockMembers));
+		return blocks.map((block, index) => ({ block, renderKey: keys[index] }));
+	}
+
+	private reconcileMembers(messageId: string, groups: string[][]) {
 		const previous = this.messages.get(messageId);
 		const next = new Map<string, string>();
 		const claimed = new Set<string>();
-		const keyed = sections.map((section) => {
-			if (section.type === 'text') {
-				return { ...section, renderKey: assistantTimelinePartKey(section) };
-			}
-			const members = section.blocks.flatMap((block) =>
-				block.type === 'reasoning'
-					? [assistantTimelinePartKey(block)]
-					: block.tools.map((tool) => `tool:${tool.callId}`)
-			);
+		const keyed = groups.map((members) => {
 			// Parts can arrive at either end; a split must not reuse one key for both sections.
 			const existing = members
 				.map((member) => previous?.get(member))
@@ -31,7 +53,7 @@ export class TranscriptSectionKeys {
 			const renderKey = existing ?? `work:${this.nextId++}`;
 			claimed.add(renderKey);
 			for (const member of members) next.set(member, renderKey);
-			return { ...section, renderKey };
+			return renderKey;
 		});
 		this.messages.set(messageId, next);
 		return keyed;

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -239,7 +239,9 @@
 	}
 
 	function firstVisibleAnchor(viewport: HTMLDivElement) {
-		const elements = viewport.querySelectorAll<HTMLElement>('[data-transcript-anchor]');
+		const elements = [
+			...viewport.querySelectorAll<HTMLElement>('[data-transcript-anchor], [data-work-detail]')
+		].filter((element) => !element.querySelector('[data-work-detail]'));
 		const top = viewport.getBoundingClientRect().top;
 		let low = 0;
 		let high = elements.length;
@@ -249,6 +251,21 @@
 			else high = mid;
 		}
 		return elements[low];
+	}
+
+	function beforeDetailChange(follow: boolean) {
+		if (!follow) stickToBottom = false;
+		const viewport = scrollViewport;
+		const anchor = viewport && !stickToBottom ? firstVisibleAnchor(viewport) : undefined;
+		const offset = anchor?.getBoundingClientRect().top;
+		const top = viewport?.scrollTop;
+		return () => {
+			if (!viewport || viewport !== scrollViewport) return;
+			if (stickToBottom) scrollToBottom();
+			else if (anchor?.isConnected && offset !== undefined && viewport.scrollTop === top) {
+				setScrollTop(viewport, viewport.scrollTop + anchor.getBoundingClientRect().top - offset);
+			}
+		};
 	}
 
 	$effect.pre(() => {
@@ -440,7 +457,13 @@
 									completedAtMs={row.completedAt}
 								>
 									{#if loadSectionDetails}
-										<WorkSectionDetails {row} load={loadSectionDetails} {inProgress} />
+										<WorkSectionDetails
+											{row}
+											load={loadSectionDetails}
+											{inProgress}
+											viewport={scrollViewport}
+											beforeChange={beforeDetailChange}
+										/>
 									{/if}
 								</WorkDisclosure>
 							</div>

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -379,7 +379,7 @@
 					</div>
 				{/if}
 			{:else}
-				<div class="space-y-8 pb-14">
+				<div class="transcript-messages space-y-8 pb-14">
 					{#each messages as message (message.id)}
 						{#if message.kind === 'prompt'}
 							<div
@@ -450,7 +450,11 @@
 							{@const row = message}
 							{@const inProgress =
 								row.runId === activeRunId && (!row.closed || row.pendingTools > 0)}
-							<div data-message-id={message.id} data-transcript-anchor={message.id}>
+							<div
+								data-message-id={message.id}
+								data-transcript-anchor={message.id}
+								data-message-kind="work"
+							>
 								<WorkDisclosure
 									{inProgress}
 									startedAtMs={row.startedAt}
@@ -477,7 +481,11 @@
 								</div>
 							{/if}
 						{:else if message.kind === 'text'}
-							<div data-message-id={message.id} data-transcript-anchor={message.id}>
+							<div
+								data-message-id={message.id}
+								data-transcript-anchor={message.id}
+								data-message-kind="text"
+							>
 								<ChatMarkdown content={message.text || ' '} className="text-foreground" />
 							</div>
 						{:else if message.kind === 'live'}
@@ -616,3 +624,10 @@
 		viewerImage = null;
 	}}
 />
+
+<style>
+	.transcript-messages > [data-message-kind='text']:has(+ [data-message-kind='work']),
+	.transcript-messages > [data-message-kind='work']:has(+ [data-message-kind='text']) {
+		margin-block-end: 0.5rem;
+	}
+</style>

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -3,6 +3,7 @@ import { flushSync, mount, tick, unmount, type ComponentProps } from 'svelte';
 import type { Id } from '$convex/_generated/dataModel';
 import type {
 	TranscriptMessage,
+	TranscriptDisplayDetails,
 	TranscriptDisplayRow,
 	LiveTranscriptMessage
 } from '$lib/types/sprocket';
@@ -70,7 +71,10 @@ async function renderTranscript(messages: TranscriptMessage[], viewportHeight = 
 	// jsdom has no layout. Model fixed-height rows while exercising the real DOM and effects.
 	Object.defineProperties(viewport, {
 		clientHeight: { get: () => viewportHeight },
-		scrollHeight: { get: () => Math.max(viewportHeight, messageElements().length * 300) },
+		scrollHeight: {
+			configurable: true,
+			get: () => Math.max(viewportHeight, messageElements().length * 300)
+		},
 		scrollTop: {
 			configurable: true,
 			get: () => {
@@ -236,13 +240,26 @@ describe('transcript viewport paging', () => {
 		});
 		const first = summary(1);
 		const { props, viewport } = await renderTranscript([message(0), first, summary(2)]);
-		const load = vi.fn().mockResolvedValue({
-			parts: [{ type: 'reasoning', id: 'detail', text: 'Requested detail' }],
-			nextAfter: 5,
-			revision: 1,
-			stale: false,
-			indexing: false
+		let edgeVisible = false;
+		const geometry = vi.mocked(HTMLElement.prototype.getBoundingClientRect).getMockImplementation();
+		if (!geometry) throw new Error('Missing viewport geometry');
+		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+			this: HTMLElement
+		) {
+			return this.hasAttribute('data-work-edge')
+				? new DOMRect(0, edgeVisible ? 500 : 1000, 800, 1)
+				: geometry.call(this);
 		});
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce({
+				parts: [{ type: 'reasoning', id: 'detail', text: 'Requested detail' }],
+				nextAfter: 5,
+				revision: 1,
+				stale: false,
+				indexing: false
+			})
+			.mockImplementation(() => new Promise(() => {}));
 		props.loadSectionDetails = load;
 		await settle();
 		expect(load).not.toHaveBeenCalled();
@@ -259,10 +276,9 @@ describe('transcript viewport paging', () => {
 		expect(load).toHaveBeenCalledTimes(1);
 		expect(load.mock.calls[0][0].id).toBe(first.id);
 		expect(load.mock.calls[0][1]).toEqual({});
-		const next = [...viewport.querySelectorAll<HTMLButtonElement>('button')].find(
-			(button) => button.textContent === 'Next details'
-		);
-		next?.click();
+		expect(viewport.textContent).not.toMatch(/Next details|Previous details/);
+		edgeVisible = true;
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
 		await settle();
 		expect(load.mock.calls[1][1]).toEqual({ after: 5 });
 		const signal: AbortSignal = load.mock.calls[1][2];
@@ -271,6 +287,101 @@ describe('transcript viewport paging', () => {
 		expect(signal.aborted).toBe(true);
 		expect(viewport.textContent).not.toContain('Next details');
 	});
+
+	it.each([false, true])(
+		'anchors the visible tool after prepending, including movement during the request: %s',
+		async (moveWhileLoading) => {
+			const work: TranscriptDisplayRow = {
+				...message(2),
+				id: 'work',
+				kind: 'work',
+				itemCount: 10,
+				closed: false
+			};
+			const { props, viewport, scrollTo } = await renderTranscript([
+				message(0),
+				message(1),
+				work,
+				message(3)
+			]);
+			props.nextBefore = undefined;
+			const rows = () =>
+				[...viewport.querySelectorAll<HTMLElement>('[data-work-detail]')].filter(
+					(element) => !element.querySelector('[data-work-detail]')
+				);
+			Object.defineProperty(viewport, 'scrollHeight', { get: () => 1200 + rows().length * 100 });
+			let olderVisible = false;
+			vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+				this: HTMLElement
+			) {
+				if (this === viewport) return new DOMRect(0, 0, 800, 600);
+				if (this.hasAttribute('data-work-edge'))
+					return new DOMRect(
+						0,
+						olderVisible && this.dataset.workEdge === 'older' ? 100 : 1000,
+						800,
+						1
+					);
+				const details = rows();
+				const detailIndex = details.indexOf(this);
+				if (detailIndex >= 0)
+					return new DOMRect(0, 650 + detailIndex * 100 - viewport.scrollTop, 800, 100);
+				const index = [...viewport.querySelectorAll('[data-transcript-anchor]')].indexOf(this);
+				return new DOMRect(
+					0,
+					index * 300 + (index === 3 ? details.length * 100 : 0) - viewport.scrollTop,
+					800,
+					300
+				);
+			});
+			function page(ids: number[], previousBefore?: number): TranscriptDisplayDetails {
+				return {
+					parts: ids.flatMap((id) => [
+						{
+							type: 'tool-call' as const,
+							callId: String(id),
+							name: 'exec_command',
+							input: { cmd: `echo ${id}` }
+						},
+						{ type: 'tool-result' as const, callId: String(id), name: 'exec_command', output: {} }
+					]),
+					previousBefore,
+					revision: 1,
+					indexing: false,
+					stale: false
+				};
+			}
+			let resolve!: (value: TranscriptDisplayDetails) => void;
+			const load = vi
+				.fn()
+				.mockResolvedValueOnce(page([6, 7], 6))
+				.mockImplementation(
+					() =>
+						new Promise<TranscriptDisplayDetails>((done) => {
+							resolve = done;
+						})
+				);
+			props.loadSectionDetails = load;
+			props.activeRunId = work.runId;
+			await settle();
+			expect(load).toHaveBeenCalledTimes(1);
+			scrollTo(700);
+			const anchor = rows()[0];
+			olderVisible = true;
+			viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -10 }));
+			await settle();
+			expect(load.mock.calls[1][1]).toEqual({ before: 6 });
+			if (moveWhileLoading) scrollTo(660);
+			const offset = anchor.getBoundingClientRect().top;
+			resolve(page([4, 5]));
+			await settle();
+			expect(anchor.isConnected).toBe(true);
+			expect(anchor.getBoundingClientRect().top).toBe(offset);
+			expect(viewport.scrollTop).toBe(moveWhileLoading ? 860 : 900);
+			resize();
+			expect(viewport.scrollTop).toBe(moveWhileLoading ? 860 : 900);
+		}
+	);
 
 	it('fills an initially empty thread after its first page arrives, and stops once it scrolls', async () => {
 		const { props, viewport } = await renderTranscript([]);

--- a/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
+++ b/apps/web/src/lib/components/home/tool-calls-disclosure.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ChevronRight, type LucideIcon } from '@lucide/svelte';
-	import type { Snippet } from 'svelte';
+	import { untrack, type Snippet } from 'svelte';
 	import type { AssistantTimelineTool } from '$lib/chat/assistant-timeline';
 
 	type Props = {
@@ -11,14 +11,26 @@
 		tools: AssistantTimelineTool[];
 		/** When set, overrides the default open-when-≤2 rule. */
 		defaultExpanded?: boolean;
+		preserveExpansion?: boolean;
 		toolRow: Snippet<[AssistantTimelineTool]>;
 	};
 
-	let { label, icon: Icon, iconClass, tools, defaultExpanded, toolRow }: Props = $props();
+	let {
+		label,
+		icon: Icon,
+		iconClass,
+		tools,
+		defaultExpanded,
+		preserveExpansion = false,
+		toolRow
+	}: Props = $props();
 
 	let manual = $state<boolean | null>(null);
 
-	const expanded = $derived(manual ?? defaultExpanded ?? tools.length <= 2);
+	const initiallyExpanded = untrack(() => defaultExpanded ?? tools.length <= 2);
+	const expanded = $derived(
+		manual ?? (preserveExpansion ? initiallyExpanded : (defaultExpanded ?? tools.length <= 2))
+	);
 
 	function toggle() {
 		manual = !expanded;
@@ -42,7 +54,7 @@
 	{#if expanded}
 		<div class="text-muted-foreground mt-1.5 space-y-1.5 text-[13px] leading-6">
 			{#each tools as tool (tool.callId)}
-				{@render toolRow(tool)}
+				<div data-work-detail>{@render toolRow(tool)}</div>
 			{/each}
 		</div>
 	{/if}

--- a/apps/web/src/lib/components/home/work-section-details.svelte
+++ b/apps/web/src/lib/components/home/work-section-details.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import type {
 		TranscriptDisplayDetails,
 		TranscriptDisplayRow,
@@ -12,13 +12,17 @@
 		partitionWorkSectionTools,
 		groupAssistantTimeline
 	} from '$lib/chat/assistant-timeline';
+	import { WorkDetails } from '$lib/project/work-details';
+	import { TranscriptSectionKeys } from '$lib/chat/transcript-section-keys';
 	import ReasoningDisclosure from './reasoning-disclosure.svelte';
 	import WorkTools from './work-tools.svelte';
 
 	let {
 		row,
 		load,
-		inProgress
+		inProgress,
+		viewport,
+		beforeChange
 	}: {
 		row: TranscriptDisplayRow;
 		load: (
@@ -27,16 +31,42 @@
 			signal: AbortSignal
 		) => Promise<TranscriptDisplayDetails>;
 		inProgress: boolean;
+		viewport: HTMLDivElement | null;
+		beforeChange: (follow: boolean) => () => void;
 	} = $props();
-	let page = $state.raw<TranscriptDisplayDetails | null>(null);
-	let loading = $state(false);
-	let error = $state(false);
-	let cursor = $state.raw<TranscriptDetailCursor | undefined>();
-	let pageKey = $state(0);
-	let shownCursor: TranscriptDetailCursor | undefined;
-	let request: AbortController | undefined;
-	let retry: ReturnType<typeof setTimeout> | undefined;
-	const timeline = $derived(buildAssistantTimeline(page?.parts ?? [], []));
+	let version = $state(0);
+	let top = $state<HTMLDivElement>();
+	let bottom = $state<HTMLDivElement>();
+	let lastTop = 0;
+	let automaticPages = 2;
+	let direction: 'older' | 'newer' = 'newer';
+	const history = new WorkDetails(
+		untrack(() => inProgress),
+		(cursor, signal) => load(row, cursor, signal),
+		() => {
+			version += 1;
+		},
+		async (update, edge) => {
+			const restore = beforeChange(inProgress && edge !== 'older');
+			update();
+			await tick();
+			restore();
+			lastTop = viewport?.scrollTop ?? 0;
+		}
+	);
+	const details = $derived.by(() => {
+		void version;
+		return {
+			parts: history.parts,
+			loading: history.loading,
+			indexing: history.indexing,
+			error: history.error,
+			stale: history.stale,
+			previousBefore: history.previousBefore,
+			nextAfter: history.nextAfter
+		};
+	});
+	const timeline = $derived(buildAssistantTimeline(details.parts, []));
 	const tools = $derived(timeline.filter((item) => item.type === 'tool'));
 	const grouped = $derived(
 		groupAssistantTimeline(timeline).filter((block) => block.type !== 'text')
@@ -45,88 +75,142 @@
 		partitionWorkSectionTools(grouped, inProgress, buildOpenExecCommandSessions(tools, inProgress))
 	);
 	const commands = $derived(buildCommandSessionCommandMap(tools));
+	const blockKeys = new TranscriptSectionKeys();
+	const settled = $derived(blockKeys.reconcileBlocks(row.id, partitioned.settledBlocks));
 
-	async function fetchPage(nextCursor: TranscriptDetailCursor) {
-		const changingPage = JSON.stringify(shownCursor) !== JSON.stringify(nextCursor);
-		cursor = nextCursor;
-		clearTimeout(retry);
-		request?.abort();
-		const controller = new AbortController();
-		request = controller;
-		loading = true;
-		error = false;
-		try {
-			const next = await load(row, nextCursor, controller.signal);
-			if (controller.signal.aborted) return;
-			if (next.indexing) {
-				retry = setTimeout(() => void fetchPage(nextCursor), 500);
-				return;
-			}
-			page = next;
-			shownCursor = nextCursor;
-			if (changingPage) pageKey += 1;
-			if (next.stale) retry = setTimeout(() => void fetchPage(nextCursor), 2_000);
-		} catch {
-			if (!controller.signal.aborted) error = true;
-		} finally {
-			if (!controller.signal.aborted) loading = false;
-		}
+	function loadVisible() {
+		if (
+			!viewport ||
+			viewport.clientHeight <= 0 ||
+			automaticPages <= 0 ||
+			history.loading ||
+			history.error ||
+			history.indexing
+		)
+			return;
+		const edge = direction === 'older' ? top : bottom;
+		const cursor = direction === 'older' ? history.previousBefore : history.nextAfter;
+		if (!edge || cursor === undefined) return;
+		const bounds = viewport.getBoundingClientRect();
+		const target = edge.getBoundingClientRect();
+		if (target.bottom < bounds.top - 160 || target.top > bounds.bottom + 160) return;
+		automaticPages -= 1;
+		void history.more(direction);
 	}
 
 	$effect(() => {
 		void row.revision;
-		untrack(() => {
-			void fetchPage(cursor ?? (inProgress ? { latest: true } : {}));
-		});
+		if (inProgress && direction === 'newer') automaticPages = 2;
+		untrack(() => void history.refresh());
+	});
+	$effect(() => () => history.stop());
+	$effect(() => {
+		void version;
+		untrack(loadVisible);
+	});
+	$effect(() => {
+		const root = viewport;
+		if (!root || !top || !bottom) return;
+		lastTop = root.scrollTop;
+		function intent(next: 'older' | 'newer') {
+			direction = next;
+			automaticPages = 2;
+			loadVisible();
+		}
+		function scroll() {
+			if (!root || root.scrollTop === lastTop) return;
+			const next = root.scrollTop < lastTop ? 'older' : 'newer';
+			lastTop = root.scrollTop;
+			intent(next);
+		}
+		function wheel(event: WheelEvent) {
+			if (event.deltaY) intent(event.deltaY < 0 ? 'older' : 'newer');
+		}
+		function key(event: KeyboardEvent) {
+			if (
+				event.target instanceof Element &&
+				event.target.closest('input, textarea, button, [contenteditable="true"]')
+			)
+				return;
+			if (
+				['ArrowUp', 'PageUp', 'Home'].includes(event.key) ||
+				(event.key === ' ' && event.shiftKey)
+			)
+				intent('older');
+			if (
+				['ArrowDown', 'PageDown', 'End'].includes(event.key) ||
+				(event.key === ' ' && !event.shiftKey)
+			)
+				intent('newer');
+		}
+		let touchY: number | undefined;
+		function touch(event: TouchEvent) {
+			const y = event.touches[0]?.clientY;
+			if (event.type === 'touchmove' && y !== undefined && touchY !== undefined && y !== touchY)
+				intent(y > touchY ? 'older' : 'newer');
+			touchY = y;
+		}
+		const observer = globalThis.IntersectionObserver
+			? new IntersectionObserver(loadVisible, { root, rootMargin: '160px 0px' })
+			: undefined;
+		observer?.observe(top);
+		observer?.observe(bottom);
+		root.addEventListener('scroll', scroll);
+		root.addEventListener('wheel', wheel, { passive: true });
+		root.addEventListener('keydown', key);
+		root.addEventListener('touchstart', touch, { passive: true });
+		root.addEventListener('touchmove', touch, { passive: true });
 		return () => {
-			request?.abort();
-			clearTimeout(retry);
+			observer?.disconnect();
+			root.removeEventListener('scroll', scroll);
+			root.removeEventListener('wheel', wheel);
+			root.removeEventListener('keydown', key);
+			root.removeEventListener('touchstart', touch);
+			root.removeEventListener('touchmove', touch);
 		};
 	});
 </script>
 
-<div aria-busy={loading}>
-	{#if error}
+<div aria-busy={details.loading || details.indexing}>
+	<div bind:this={top} data-work-edge="older" class="h-px" aria-hidden="true"></div>
+	{#if details.previousBefore !== undefined}<p class="text-xs">Scroll up for earlier work.</p>{/if}
+	{#if details.stale}<p role="status">Showing saved details while reconnecting.</p>{/if}
+	<div class="space-y-2">
+		{#each settled as { block, renderKey } (renderKey)}
+			<div data-work-detail>
+				{#if block.type === 'reasoning'}
+					<ReasoningDisclosure text={block.text} inProgress={false} />
+				{:else if block.type === 'tool-group'}
+					<WorkTools
+						tools={block.tools}
+						toolKey={block.toolKey}
+						preserveExpansion={true}
+						{inProgress}
+						{commands}
+					/>
+				{/if}
+			</div>
+		{/each}
+		{#if partitioned.runningTools.length}
+			<div data-work-detail>
+				<WorkTools tools={partitioned.runningTools} running={true} {inProgress} {commands} />
+			</div>
+		{/if}
+	</div>
+	{#if details.error}
 		<p role="status">
 			Could not load these details. <button
 				class="underline"
-				onclick={() => fetchPage(cursor ?? {})}>Retry</button
+				onclick={() => {
+					automaticPages = 2;
+					void history.retryFailed();
+				}}>Retry</button
 			>
 		</p>
-	{:else if loading && !page}
+	{:else if details.loading || details.indexing}
 		<p role="status">Loading details...</p>
+	{:else if details.nextAfter !== undefined}
+		<p class="text-xs">Scroll down for more work.</p>
 	{/if}
-	{#if page?.stale}<p role="status">Showing saved details while reconnecting.</p>{/if}
-	<div class="space-y-2">
-		{#each partitioned.settledBlocks as block, index (`${row.id}:${pageKey}:${index}`)}
-			{#if block.type === 'reasoning'}
-				<ReasoningDisclosure text={block.text} inProgress={false} />
-			{:else if block.type === 'tool-group'}
-				<WorkTools tools={block.tools} toolKey={block.toolKey} {inProgress} {commands} />
-			{/if}
-		{/each}
-		{#if partitioned.runningTools.length}
-			<WorkTools tools={partitioned.runningTools} running={true} {inProgress} {commands} />
-		{/if}
-	</div>
-	{#if page?.previousBefore !== undefined || page?.nextAfter !== undefined}
-		<nav aria-label="Work section details" class="mt-3 flex gap-4 text-sm">
-			<button
-				disabled={loading || page?.previousBefore === undefined}
-				class="underline disabled:opacity-40"
-				onclick={() => {
-					const before = page?.previousBefore;
-					if (before !== undefined) void fetchPage({ before });
-				}}>Previous details</button
-			>
-			<button
-				disabled={loading || page?.nextAfter === undefined}
-				class="underline disabled:opacity-40"
-				onclick={() => {
-					const after = page?.nextAfter;
-					if (after !== undefined) void fetchPage({ after });
-				}}>Next details</button
-			>
-		</nav>
-	{/if}
+	<div bind:this={bottom} data-work-edge="newer" class="h-px" aria-hidden="true"></div>
 </div>

--- a/apps/web/src/lib/components/home/work-section-details.svelte.test.ts
+++ b/apps/web/src/lib/components/home/work-section-details.svelte.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount, type ComponentProps } from 'svelte';
+import type { Id } from '$convex/_generated/dataModel';
+import type { TranscriptDisplayDetails } from '$lib/types/sprocket';
+import WorkSectionDetails from './work-section-details.svelte';
+
+let cleanup: (() => Promise<void>) | undefined;
+let intersection: () => void;
+let disconnect: ReturnType<typeof vi.fn>;
+
+function page(
+	ids: number[],
+	previousBefore?: number,
+	nextAfter?: number
+): TranscriptDisplayDetails {
+	return {
+		parts: ids.map((id) => ({ type: 'reasoning', id: String(id), text: `Reason ${id}` })),
+		previousBefore,
+		nextAfter,
+		revision: 1,
+		indexing: false,
+		stale: false
+	};
+}
+
+function tools(ids: number[], previousBefore?: number): TranscriptDisplayDetails {
+	return {
+		...page([], previousBefore),
+		parts: ids.flatMap((id) => [
+			{
+				type: 'tool-call' as const,
+				callId: String(id),
+				name: 'exec_command',
+				input: { cmd: `echo ${id}` }
+			},
+			{ type: 'tool-result' as const, callId: String(id), name: 'exec_command', output: {} }
+		])
+	};
+}
+
+async function settle() {
+	flushSync();
+	await tick();
+	await vi.advanceTimersByTimeAsync(16);
+}
+
+async function render(
+	load: ComponentProps<typeof WorkSectionDetails>['load'],
+	inProgress = false,
+	visible = false
+) {
+	const viewport = document.createElement('div');
+	document.body.append(viewport);
+	Object.defineProperty(viewport, 'clientHeight', { value: 600 });
+	const edges = { older: false, newer: visible };
+	vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+		this: HTMLElement
+	) {
+		if (this === viewport) return new DOMRect(0, 0, 800, 600);
+		const edge = this.dataset.workEdge;
+		return new DOMRect(0, (edge === 'older' ? edges.older : edges.newer) ? 300 : 1000, 800, 1);
+	});
+	const restore = vi.fn();
+	const props = $state<ComponentProps<typeof WorkSectionDetails>>({
+		row: {
+			id: 'work',
+			// SAFETY: Fixture IDs never leave the mounted component.
+			threadId: 'thread' as Id<'threadRecords'>,
+			// SAFETY: Fixture IDs never leave the mounted component.
+			runId: 'run' as Id<'runs'>,
+			kind: 'work',
+			text: '',
+			sequence: 1,
+			itemCount: 100,
+			pendingTools: 0,
+			closed: !inProgress,
+			revision: 1
+		},
+		load,
+		inProgress,
+		viewport,
+		beforeChange: vi.fn(() => restore)
+	});
+	const component = mount(WorkSectionDetails, { target: viewport, props });
+	cleanup = async () => {
+		await unmount(component);
+		viewport.remove();
+	};
+	await settle();
+	return { viewport, props, edges, restore };
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	disconnect = vi.fn();
+	vi.stubGlobal(
+		'IntersectionObserver',
+		class {
+			constructor(callback: () => void) {
+				intersection = callback;
+			}
+			observe = vi.fn();
+			disconnect = disconnect;
+		}
+	);
+});
+
+afterEach(async () => {
+	await cleanup?.();
+	cleanup = undefined;
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe('scrolling work details', () => {
+	it('appends completed work in the conversation viewport without replacing open reasoning', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1], undefined, 1))
+			.mockResolvedValueOnce(page([2], 2));
+		const { viewport, edges, props, restore } = await render(load);
+		expect(load.mock.calls[0][1]).toEqual({});
+		const reasoning = viewport.querySelector<HTMLButtonElement>('button');
+		reasoning?.click();
+		await settle();
+		edges.newer = true;
+		intersection();
+		await settle();
+		expect(load.mock.calls[1][1]).toEqual({ after: 1 });
+		expect(viewport.querySelector('button')).toBe(reasoning);
+		expect(reasoning?.getAttribute('aria-expanded')).toBe('true');
+		expect(viewport.textContent).toContain('Reason 1');
+		expect(viewport.querySelectorAll('[data-work-detail]')).toHaveLength(2);
+		expect(viewport.textContent).not.toMatch(/Previous details|Next details/);
+		expect(viewport.querySelector('[class*="overflow"]')).toBeNull();
+		expect(props.beforeChange).toHaveBeenLastCalledWith(false);
+		expect(restore).toHaveBeenCalledTimes(2);
+	});
+
+	it('opens active work at the latest page and preserves a tool group when older calls join it', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(tools([6, 7], 6))
+			.mockResolvedValueOnce(tools([4, 5], 4))
+			.mockResolvedValueOnce(tools([2, 3]));
+		const { viewport, edges, props } = await render(load, true);
+		expect(load.mock.calls[0][1]).toEqual({ latest: true });
+		expect(props.beforeChange).toHaveBeenLastCalledWith(true);
+		const group = viewport.querySelector<HTMLButtonElement>('button');
+		const originalTool = viewport.querySelector('[title="echo 6"]');
+		expect(originalTool).not.toBeNull();
+		expect(group?.getAttribute('aria-expanded')).toBe('true');
+		edges.older = true;
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -10 }));
+		await settle();
+		expect(load.mock.calls[1][1]).toEqual({ before: 6 });
+		expect(viewport.querySelector('button')).toBe(group);
+		expect(group?.getAttribute('aria-expanded')).toBe('true');
+		expect(viewport.querySelector('[title="echo 6"]')).toBe(originalTool);
+		expect(viewport.textContent).toContain('echo 2');
+		expect(props.beforeChange).toHaveBeenLastCalledWith(false);
+		group?.click();
+		await settle();
+		props.row = { ...props.row, revision: 2 };
+		load.mockResolvedValue(tools([2, 3, 4, 5, 6, 7]));
+		await settle();
+		expect(viewport.querySelector('button')).toBe(group);
+		expect(group?.getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it.each(['wheel', 'touch', 'scroll', 'ArrowDown', 'PageDown', 'End', ' '])(
+		'loads the visible edge after %s input',
+		async (input) => {
+			const load = vi
+				.fn()
+				.mockResolvedValueOnce(page([1], undefined, 1))
+				.mockResolvedValueOnce(page([2], 2));
+			const { viewport, edges } = await render(load);
+			edges.newer = true;
+			if (input === 'wheel') viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
+			else if (input === 'scroll') {
+				viewport.scrollTop = 100;
+				viewport.dispatchEvent(new Event('scroll'));
+			} else if (input === 'touch') {
+				for (const [type, clientY] of [
+					['touchstart', 100],
+					['touchmove', 90]
+				] as const) {
+					const event = new Event(type);
+					Object.defineProperty(event, 'touches', { value: [{ clientY }] });
+					viewport.dispatchEvent(event);
+				}
+			} else viewport.dispatchEvent(new KeyboardEvent('keydown', { key: input }));
+			await settle();
+			expect(load).toHaveBeenCalledTimes(2);
+		}
+	);
+
+	it('caps automatic filling when collapsed details do not make the section taller', async () => {
+		let id = 0;
+		const load = vi.fn().mockImplementation(async () => {
+			id += 1;
+			return page([id], id === 1 ? undefined : id, id);
+		});
+		const { viewport } = await render(load, false, true);
+		expect(load).toHaveBeenCalledTimes(3);
+		intersection();
+		await settle();
+		expect(load).toHaveBeenCalledTimes(3);
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
+		await settle();
+		expect(load).toHaveBeenCalledTimes(5);
+		await cleanup?.();
+		cleanup = undefined;
+		expect(disconnect).toHaveBeenCalledTimes(1);
+		expect(load.mock.calls[4][2].aborted).toBe(true);
+		viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
+		await settle();
+		expect(load).toHaveBeenCalledTimes(5);
+	});
+
+	it('continues loading live additions at the visible end without disabling bottom-following', async () => {
+		const load = vi.fn().mockResolvedValueOnce(page([1]));
+		const { props, viewport } = await render(load, true, true);
+		for (let revision = 2; revision <= 5; revision += 1) {
+			load
+				.mockResolvedValueOnce(
+					page(
+						Array.from({ length: revision - 1 }, (_, i) => i + 1),
+						undefined,
+						revision - 1
+					)
+				)
+				.mockResolvedValueOnce(page([revision], revision));
+			props.row = { ...props.row, revision };
+			await settle();
+			expect(viewport.querySelectorAll('[data-work-detail]')).toHaveLength(revision);
+			expect(props.beforeChange).toHaveBeenLastCalledWith(true);
+		}
+	});
+
+	it('keeps loaded work on an edge failure and retries that edge', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1], undefined, 1))
+			.mockRejectedValueOnce(new Error('offline'))
+			.mockResolvedValueOnce(page([2], 2));
+		const { viewport, edges } = await render(load);
+		edges.newer = true;
+		intersection();
+		await settle();
+		expect(viewport.querySelectorAll('[data-work-detail]')).toHaveLength(1);
+		expect(viewport.textContent).toContain('Could not load these details.');
+		[...viewport.querySelectorAll('button')]
+			.find((button) => button.textContent === 'Retry')
+			?.click();
+		await settle();
+		expect(load.mock.calls[2][1]).toEqual({ after: 1 });
+		expect(viewport.querySelectorAll('[data-work-detail]')).toHaveLength(2);
+	});
+});

--- a/apps/web/src/lib/components/home/work-tools.svelte
+++ b/apps/web/src/lib/components/home/work-tools.svelte
@@ -19,12 +19,14 @@
 		tools,
 		toolKey = '',
 		running = false,
+		preserveExpansion = false,
 		inProgress,
 		commands
 	}: {
 		tools: AssistantTimelineTool[];
 		toolKey?: string;
 		running?: boolean;
+		preserveExpansion?: boolean;
 		inProgress: boolean;
 		commands: ReadonlyMap<string, string>;
 	} = $props();
@@ -35,6 +37,7 @@
 	icon={running ? LoaderCircle : toolKindIcon(toolKey)}
 	iconClass={running ? 'animate-spin' : undefined}
 	{tools}
+	{preserveExpansion}
 	defaultExpanded={running
 		? true
 		: toolKey === 'apply_patch'

--- a/apps/web/src/lib/project/work-details.test.ts
+++ b/apps/web/src/lib/project/work-details.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TranscriptDetailCursor, TranscriptDisplayDetails } from '$lib/types/sprocket';
+import { WorkDetails } from './work-details';
+
+function page(
+	ids: number[],
+	previousBefore?: number,
+	nextAfter?: number
+): TranscriptDisplayDetails {
+	return {
+		parts: ids.map((id) => ({ type: 'reasoning', id: String(id), text: `Reason ${id}` })),
+		previousBefore,
+		nextAfter,
+		indexing: false,
+		stale: false,
+		revision: 1
+	};
+}
+
+function history(
+	load: (cursor: TranscriptDetailCursor, signal: AbortSignal) => Promise<TranscriptDisplayDetails>,
+	latest = false
+) {
+	return new WorkDetails(
+		latest,
+		load,
+		() => {},
+		async (update) => {
+			update();
+		}
+	);
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('WorkDetails', () => {
+	it('keeps both ends of an active section and refreshes from a fixed start, not a sliding latest page', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([6, 7], 6))
+			.mockResolvedValueOnce(page([4, 5], 4, 5))
+			.mockResolvedValueOnce(page([4, 5], 4, 5))
+			.mockResolvedValueOnce(page([6, 7], 6, 7))
+			.mockResolvedValueOnce(page([8, 9], 8));
+		const details = history(load, true);
+		await details.refresh();
+		await details.more('older');
+		expect(details.parts).toEqual(page([4, 5, 6, 7]).parts);
+		await details.refresh();
+		expect(details.parts).toEqual(page([4, 5, 6, 7]).parts);
+		await details.more('newer');
+		expect(details.parts).toEqual(page([4, 5, 6, 7, 8, 9]).parts);
+		expect(load.mock.calls.map(([cursor]) => cursor)).toEqual([
+			{ latest: true },
+			{ before: 6 },
+			{ after: 3 },
+			{ after: 5 },
+			{ after: 7 }
+		]);
+		details.stop();
+	});
+
+	it('refreshes all retained details together, including insertions and removed items', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1, 3], undefined, 3))
+			.mockResolvedValueOnce(page([4, 5], 4, 5))
+			.mockResolvedValueOnce(page([1, 2], undefined, 2))
+			.mockResolvedValueOnce(page([3, 4], 3, 4))
+			.mockResolvedValueOnce(page([6], 6));
+		const details = history(load);
+		await details.refresh();
+		await details.more('newer');
+		await details.refresh();
+		expect(details.parts).toEqual(page([1, 2, 3, 4, 6]).parts);
+		details.stop();
+	});
+
+	it('retries the failed edge without clearing already loaded details', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1], undefined, 1))
+			.mockRejectedValueOnce(new Error('offline'))
+			.mockResolvedValueOnce(page([2], 2));
+		const details = history(load);
+		await details.refresh();
+		await details.more('newer');
+		expect(details.error).toBe(true);
+		expect(details.parts).toEqual(page([1]).parts);
+		await details.retryFailed();
+		expect(details.error).toBe(false);
+		expect(details.parts).toEqual(page([1, 2]).parts);
+		expect(load.mock.calls[2][0]).toEqual({ after: 1 });
+		details.stop();
+	});
+
+	it('coalesces revision changes behind a pending page instead of cancelling it', async () => {
+		let resolve!: (page: TranscriptDisplayDetails) => void;
+		const load = vi
+			.fn()
+			.mockImplementationOnce(
+				() =>
+					new Promise<TranscriptDisplayDetails>((done) => {
+						resolve = done;
+					})
+			)
+			.mockResolvedValueOnce(page([1, 2]));
+		const details = history(load);
+		const pending = details.refresh();
+		void details.refresh();
+		void details.refresh();
+		resolve(page([1]));
+		await pending;
+		await vi.waitFor(() => expect(details.parts).toEqual(page([1, 2]).parts));
+		expect(load).toHaveBeenCalledTimes(2);
+		details.stop();
+	});
+
+	it('cancels indexing retries and ignores late results after collapse', async () => {
+		vi.useFakeTimers();
+		const load = vi.fn().mockResolvedValue({ ...page([]), indexing: true });
+		const details = history(load);
+		await details.refresh();
+		details.stop();
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(load).toHaveBeenCalledTimes(1);
+		expect(load.mock.calls[0][1].aborted).toBe(true);
+
+		let resolve!: (page: TranscriptDisplayDetails) => void;
+		const pending = history(
+			() =>
+				new Promise((done) => {
+					resolve = done;
+				})
+		);
+		const request = pending.refresh();
+		pending.stop();
+		resolve(page([1]));
+		await request;
+		expect(pending.parts).toEqual([]);
+	});
+
+	it('stops a non-advancing cursor without a request loop', async () => {
+		const load = vi.fn().mockResolvedValue(page([1], undefined, 1));
+		const details = history(load);
+		await details.refresh();
+		await details.more('newer');
+		expect(details.error).toBe(true);
+		expect(load).toHaveBeenCalledTimes(2);
+		details.stop();
+	});
+
+	it('retains loaded work if a later page comes from an older replica revision', async () => {
+		vi.useFakeTimers();
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1], undefined, 1))
+			.mockResolvedValueOnce(page([2], 2))
+			.mockResolvedValueOnce({ ...page([1], undefined, 1), revision: 2 })
+			.mockResolvedValueOnce(page([3], 3))
+			.mockResolvedValue({ ...page([1, 3]), revision: 2 });
+		const details = history(load);
+		await details.refresh();
+		await details.more('newer');
+		await details.refresh();
+		expect(details.parts).toEqual(page([1, 2]).parts);
+		await vi.advanceTimersByTimeAsync(500);
+		expect(details.parts).toEqual(page([1, 3]).parts);
+		details.stop();
+	});
+
+	it('refreshes a retained range while the active run keeps advancing its revision', async () => {
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1], undefined, 1))
+			.mockResolvedValueOnce(page([2], 2))
+			.mockResolvedValueOnce({ ...page([1], undefined, 1), revision: 2 })
+			.mockResolvedValueOnce({ ...page([2, 3], 2), revision: 3 });
+		const details = history(load);
+		await details.refresh();
+		await details.more('newer');
+		await details.refresh();
+		expect(details.parts).toEqual(page([1, 2, 3]).parts);
+		expect(details.indexing).toBe(false);
+		details.stop();
+	});
+
+	it('does not discard work on an empty stale response or lock an empty latest page to the start', async () => {
+		vi.useFakeTimers();
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce({ ...page([]), stale: true })
+			.mockResolvedValueOnce(page([9], 9))
+			.mockResolvedValueOnce({ ...page([]), stale: true })
+			.mockResolvedValueOnce(page([9], 9));
+		const details = history(load, true);
+		await details.refresh();
+		await vi.advanceTimersByTimeAsync(500);
+		expect(load.mock.calls[1][0]).toEqual({ latest: true });
+		await details.refresh();
+		expect(details.parts).toEqual(page([9]).parts);
+		await vi.advanceTimersByTimeAsync(500);
+		expect(details.stale).toBe(false);
+		details.stop();
+	});
+
+	it('bounds a refresh when its old tail disappears, retaining the screen on failure', async () => {
+		let id = 1;
+		const load = vi
+			.fn()
+			.mockResolvedValueOnce(page([1]))
+			.mockImplementation(async () => {
+				id += 1;
+				return page([id], id, id);
+			});
+		const details = history(load);
+		await details.refresh();
+		await details.refresh();
+		expect(details.error).toBe(true);
+		expect(details.parts).toEqual(page([1]).parts);
+		expect(load).toHaveBeenCalledTimes(3);
+		details.stop();
+	});
+});

--- a/apps/web/src/lib/project/work-details.ts
+++ b/apps/web/src/lib/project/work-details.ts
@@ -1,0 +1,162 @@
+import type { TranscriptDetailCursor, TranscriptDisplayDetails } from '$lib/types/sprocket';
+
+type Part = TranscriptDisplayDetails['parts'][number];
+type Direction = 'older' | 'newer';
+
+function partKey(part: Part) {
+	return part.type === 'tool-call' || part.type === 'tool-result'
+		? `${part.type}:${part.callId}`
+		: `${part.type}:${part.turnId ?? ''}:${part.id}`;
+}
+
+export class WorkDetails {
+	parts: Part[] = [];
+	previousBefore: number | undefined;
+	nextAfter: number | undefined;
+	loading = false;
+	indexing = false;
+	stale = false;
+	error = false;
+	private start: TranscriptDetailCursor;
+	private initialized = false;
+	private stopped = false;
+	private refreshPending = false;
+	private failedDirection: Direction | undefined;
+	private request: AbortController | undefined;
+	private retry: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(
+		latest: boolean,
+		private load: (
+			cursor: TranscriptDetailCursor,
+			signal: AbortSignal
+		) => Promise<TranscriptDisplayDetails>,
+		private changed: () => void,
+		private commit: (update: () => void, direction?: Direction) => Promise<void>
+	) {
+		this.start = latest ? { latest: true } : {};
+	}
+
+	stop() {
+		this.stopped = true;
+		this.request?.abort();
+		clearTimeout(this.retry);
+	}
+
+	refresh() {
+		if (this.loading) {
+			this.refreshPending = true;
+			return;
+		}
+		return this.fetch();
+	}
+
+	more(direction: Direction) {
+		if (!this.initialized || this.loading || this.error || this.indexing) return;
+		const cursor = direction === 'older' ? this.previousBefore : this.nextAfter;
+		if (cursor === undefined) return;
+		return this.fetch(direction);
+	}
+
+	retryFailed() {
+		if (!this.loading) return this.fetch(this.failedDirection);
+	}
+
+	private async fetch(direction?: Direction) {
+		if (this.stopped) return;
+		clearTimeout(this.retry);
+		const controller = new AbortController();
+		this.request = controller;
+		this.loading = true;
+		this.indexing = false;
+		this.error = false;
+		this.failedDirection = direction;
+		this.changed();
+		try {
+			let cursor =
+				direction === 'older'
+					? { before: this.previousBefore }
+					: direction === 'newer'
+						? { after: this.nextAfter }
+						: this.start;
+			const lastKey = this.parts.length ? partKey(this.parts[this.parts.length - 1]) : undefined;
+			const pages: TranscriptDisplayDetails[] = [];
+			while (true) {
+				const page = await this.load(cursor, controller.signal);
+				if (controller.signal.aborted) return;
+				if (
+					page.indexing ||
+					(page.stale && !page.parts.length) ||
+					(pages.length && page.revision < pages[pages.length - 1].revision)
+				) {
+					this.stale = page.stale;
+					this.indexing = true;
+					this.retry = setTimeout(() => void this.fetch(direction), 500);
+					return;
+				}
+				if (
+					(cursor.after !== undefined &&
+						page.nextAfter !== undefined &&
+						page.nextAfter <= cursor.after) ||
+					(cursor.before !== undefined &&
+						page.previousBefore !== undefined &&
+						page.previousBefore >= cursor.before)
+				) {
+					throw new Error('Work detail cursor did not advance.');
+				}
+				pages.push(page);
+				if (
+					direction ||
+					!lastKey ||
+					page.parts.some((part) => partKey(part) === lastKey) ||
+					page.nextAfter === undefined ||
+					(this.nextAfter !== undefined && page.nextAfter >= this.nextAfter)
+				)
+					break;
+				// A removed tail must not turn a refresh into a download of the whole section.
+				if (pages.length > this.parts.length)
+					throw new Error('Work detail range changed too much.');
+				cursor = { after: page.nextAfter };
+			}
+			const first = pages[0];
+			const last = pages[pages.length - 1];
+			const added = pages.flatMap((page) => page.parts);
+			await this.commit(() => {
+				if (controller.signal.aborted) return;
+				const combined =
+					direction === 'older'
+						? [...added, ...this.parts]
+						: direction === 'newer'
+							? [...this.parts, ...added]
+							: added;
+				const refreshed = new Map(added.map((part) => [partKey(part), part]));
+				this.parts = [
+					...new Map(
+						combined.map((part) => [partKey(part), refreshed.get(partKey(part)) ?? part])
+					).values()
+				];
+				if (direction !== 'newer') {
+					this.previousBefore = first.previousBefore;
+					this.start =
+						first.previousBefore === undefined ? {} : { after: first.previousBefore - 1 };
+				}
+				if (direction !== 'older') this.nextAfter = last.nextAfter;
+				this.initialized = true;
+				this.stale = pages.some((page) => page.stale);
+				this.changed();
+			}, direction);
+			if (!this.stopped && this.stale) this.retry = setTimeout(() => void this.refresh(), 2_000);
+		} catch {
+			if (!controller.signal.aborted) this.error = true;
+		} finally {
+			this.loading = false;
+			if (!this.stopped) {
+				this.changed();
+				if (this.refreshPending) {
+					this.refreshPending = false;
+					void this.refresh();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replace Previous details and Next details controls with bounded loading at the edges of expanded work sections, using the existing conversation scrollbar.
- Keep loaded details and disclosure state when work arrives at either end. Anchor the visible tool or reasoning block instead of jumping the conversation.
- Start completed sections at the beginning and active sections at the latest work. Preserve live bottom-following, retry failed edges, and abort requests on collapse.
- Refresh retained details without sliding the loaded window or downloading the entire section. Reuse membership-based keys for tool groups.

## Validation
- Work-details unit tests and transcript/component regressions pass.
- Svelte check, Oxlint, ESLint, and read-only Prettier checks pass. ESLint reports only existing generated-file warnings.
- Full web suite passes with `bun run test --maxWorkers=2 --testTimeout=30000`. The initial run hit unrelated Convex timeouts under machine load.
- Production web build passes with `bun run build`.
- Both pre-PR reviewer agents were blocked by Cursor authentication. Local review completed directly.

This is a follow-up to merged PR #363. It does not change the transcript API, stored-data compatibility, or background raw-transcript downloads.

Written by GPT-6 Astra (gpt-6-astra) through Sprocket.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63425937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable new defect or outstanding repository-rule violation identified.

<details open><summary><h3>Summary</h3></summary>

- Retains loaded detail pages and refreshes the retained range without downloading the entire section.
- Preserves disclosure identity and expansion state as reasoning and tool groups change.
- Anchors visible transcript content while details are prepended or appended.
- Retries stale, indexing, and failed requests while aborting outstanding work on collapse.
- Adds unit and component coverage for paging, refreshes, failures, anchoring, and input methods.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open work disclosure] --> B{Section active?}
  B -- Yes --> C[Load latest details]
  B -- No --> D[Load earliest details]
  C --> E[Retained detail window]
  D --> E
  E --> F{Visible edge and scroll intent}
  F -- Older edge --> G[Load previous page]
  F -- Newer edge --> H[Load next page]
  G --> I[Merge and preserve render keys]
  H --> I
  I --> J[Restore visible anchor or follow bottom]
  J --> E
  E --> K{Revision changed?}
  K -- Yes --> L[Refresh retained range]
  L --> I
  E --> M{Collapsed?}
  M -- Yes --> N[Abort request and retries]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(ui): Tighten spacing around work sum..."](https://github.com/spikonado/sprocket/commit/057aa4e64a33f5b15182ad37d01b5dde7e699a03)</sub>

<!-- /greptile_comment -->