### PR TITLE
fix(ui): Prevent horizontal transcript scrolling

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -395,7 +395,10 @@ body::after {
 }
 
 .chat-markdown table {
+	display: block;
 	width: 100%;
+	max-width: 100%;
+	overflow-x: auto;
 	border-collapse: collapse;
 	font-size: 0.92em;
 }

--- a/apps/web/src/lib/components/home/thread-transcript.svelte
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte
@@ -318,7 +318,7 @@
 <div class="relative min-h-0 flex-1">
 	<!-- svelte-ignore a11y_no_noninteractive_tabindex, a11y_no_noninteractive_element_interactions (Keyboard users must be able to page history even when it does not overflow.) -->
 	<div
-		class="hide-scrollbar h-full overflow-auto"
+		class="hide-scrollbar h-full overflow-x-hidden overflow-y-auto"
 		role="region"
 		aria-label="Conversation history"
 		tabindex="0"

--- a/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
+++ b/apps/web/src/lib/components/home/thread-transcript.svelte.test.ts
@@ -62,7 +62,7 @@ async function renderTranscript(messages: TranscriptMessage[], viewportHeight = 
 	});
 	const component = mount(ThreadTranscript, { target: document.body, props });
 	cleanup = () => unmount(component);
-	const viewport = document.querySelector<HTMLDivElement>('.overflow-auto');
+	const viewport = document.querySelector<HTMLDivElement>('[aria-label="Conversation history"]');
 	if (!viewport) throw new Error('Missing transcript viewport');
 	const messageElements = () => [
 		...viewport.querySelectorAll<HTMLElement>('[data-transcript-anchor]')
@@ -130,6 +130,14 @@ afterEach(async () => {
 });
 
 describe('transcript viewport paging', () => {
+	it('scrolls vertically without allowing the transcript viewport to scroll horizontally', async () => {
+		const { viewport } = await renderTranscript([message(1)]);
+
+		expect(viewport.classList.contains('overflow-y-auto')).toBe(true);
+		expect(viewport.classList.contains('overflow-x-hidden')).toBe(true);
+		expect(viewport.classList.contains('overflow-auto')).toBe(false);
+	});
+
 	it.each(['live', 'persisted'] as const)(
 		'uses the same patch and failure disclosures for %s tools',
 		async (kind) => {


### PR DESCRIPTION
## Summary
- constrain the transcript viewport to vertical scrolling
- keep horizontal scrolling local to content such as code blocks
- cover the viewport overflow classes in the component test

## Checks
- pre-commit suite: cargo-check, eslint, oxlint, svelte-check, prettier, and related checks
- targeted transcript test was attempted but the Vitest worker did not complete in this environment

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63483559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previous wide-table accessibility issue is fully addressed and no new actionable defects were identified.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Wide tables become inaccessible** <a href="https://github.com/spikonado/sprocket/pull/368#discussion_r3997462513">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
apps/web/src/lib/components/home/thread-transcript.svelte:undefined-321
When an assistant response contains a wide GFM table, `overflow-x-hidden` clips the table at the transcript viewport. Code blocks have their own horizontal scroller, but rendered tables do not, so users cannot reach columns beyond the viewport. Add local horizontal scrolling for tables or otherwise constrain them before hiding horizontal overflow here.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details open><summary><h3>Summary</h3></summary>

- Splits transcript overflow into hidden horizontal and automatic vertical behavior.
- Makes rendered Markdown tables horizontally scrollable within their own bounds.
- Updates the component test to select the viewport by its accessible label and verify its overflow classes.
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(ui): Prevent horizontal transcript s..."](https://github.com/spikonado/sprocket/commit/4494787e9e27dd0f29fa9436a3e0c9389d4b15d7)</sub>

<!-- /greptile_comment -->