### PR TITLE
chore(release): Bump version to v0.3.7

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             source_sha="$TESTED_SHA"
-            version="0.3.6-dev.$source_sha"
+            version="0.3.7-dev.$source_sha"
           elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
             source_sha="$GITHUB_SHA"
             version="${GITHUB_REF_NAME#v}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7804,7 +7804,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-agent"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anydoc",
  "anyhow",
@@ -7830,7 +7830,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-convex"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-server"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket-workspace"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "diffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 

--- a/npm/RELEASING.md
+++ b/npm/RELEASING.md
@@ -55,7 +55,7 @@ Before tagging, a manual workflow run with publishing disabled can be used to bu
 
 ## Development releases
 
-After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.3.6-dev.<full-commit-sha>` with the npm `dev` dist-tag.
+After **Build and Test** succeeds for a commit on `main`, the npm workflow automatically publishes a development release as `0.3.7-dev.<full-commit-sha>` with the npm `dev` dist-tag.
 
 Install the newest development build with:
 

--- a/npm/sprocket/package.json
+++ b/npm/sprocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@spikonado/sprocket",
-	"version": "0.3.6",
+	"version": "0.3.7",
 	"description": "Agentic platform for streamlining hardware and software development",
 	"license": "FSL-1.1-ALv2",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the Rust workspace and npm package to 0.3.7
- update the npm development-release version and release documentation
- keep Cargo.lock package metadata in sync

## Checks

- `nix develop -c cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- `nix develop -c bun run build` *(blocked because `svelte-kit` is not installed in the worktree dependencies)*

Written by GPT-5.6 Luna (gpt-5.6-luna) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63565368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because all release-relevant Rust and npm version references are synchronized.

<details open><summary><h3>Summary</h3></summary>

- Updates the Rust workspace version and corresponding lockfile package metadata.
- Updates the npm package and development-release version.
- Aligns the npm release documentation with the new development version.
</details>

<sub>Reviews (1) · Last reviewed commit: ["chore(release): Bump version to v0.3.7"](https://github.com/spikonado/sprocket/commit/40ece24b1427d3299dc1c06a538a5bee42551197)</sub>

<!-- /greptile_comment -->