### PR TITLE
fix: Use the release version everywhere

### DIFF
--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -154,7 +154,7 @@ impl RuntimeClient {
         args.insert("fastMode".to_string(), request.fast_mode.into());
         args.insert(
             "agentVersion".to_string(),
-            env!("CARGO_PKG_VERSION").to_string().into(),
+            sprocket_workspace::SPROCKET_VERSION.to_string().into(),
         );
         args.insert(
             "machineId".to_string(),

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -10,22 +10,17 @@ use sprocket_server::{
     browser_launch_url, load_repo_env, pairing_proof_message, read_pairing_credential, run,
     verify_pairing_proof,
 };
-use sprocket_workspace::resolve_workspace_root;
+use sprocket_workspace::{SPROCKET_VERSION, resolve_workspace_root};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
 const DESKTOP_EXECUTABLE_ENV: &str = "SPROCKET_DESKTOP_EXECUTABLE";
 const DESKTOP_WORKSPACE_ARG: &str = "--sprocket-workspace";
-const VERSION: &str = match option_env!("SPROCKET_VERSION") {
-    Some(version) => version,
-    None => env!("CARGO_PKG_VERSION"),
-};
-
 #[derive(Debug, Parser)]
 #[command(
     name = "sprocket",
     about = "The best and only AI agent for developing both hardware and software",
-    version = VERSION,
+    version = SPROCKET_VERSION,
     arg_required_else_help = false
 )]
 struct Cli {

--- a/crates/sprocket-server/src/machines.rs
+++ b/crates/sprocket-server/src/machines.rs
@@ -271,7 +271,7 @@ impl MachineManager {
             ("hostname".into(), self.identity.hostname.clone().into()),
             (
                 "appVersion".into(),
-                env!("CARGO_PKG_VERSION").to_string().into(),
+                sprocket_workspace::SPROCKET_VERSION.to_string().into(),
             ),
         ])
     }

--- a/crates/sprocket-workspace/src/lib.rs
+++ b/crates/sprocket-workspace/src/lib.rs
@@ -16,6 +16,11 @@ mod text;
 mod unified_diff;
 mod workspace;
 
+pub const SPROCKET_VERSION: &str = match option_env!("SPROCKET_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 pub use agents::{WorkspaceInstruction, WorkspaceInstructionSource, load_workspace_instructions};
 pub use artifacts::{ArtifactContentType, ArtifactFile, MAX_ARTIFACT_BYTES, read_artifact_file};
 pub use browse::{


### PR DESCRIPTION
## Summary

- Define one shared Sprocket version for the Rust workspace.
- Use the exact release version for CLI output, machine registration, and agent runtime metadata.
- Preserve canary and dev prerelease identifiers supplied by `SPROCKET_VERSION`, with the Cargo package version as the local-build fallback.

This is 1 of 3 PRs split from #364.

## Validation

- Rust workspace checks through the pre-commit suite.
- ESLint, Oxlint, Svelte checks, Prettier, and Mermaid linting through the pre-commit suite.

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63586946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issues remain.

<details open><summary><h3>Summary</h3></summary>

- Adds a shared `SPROCKET_VERSION` constant with a Cargo package-version fallback.
- Uses the shared value for CLI version output.
- Uses the shared value for machine registration and agent runtime metadata.
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(version): Use the release version ev..."](https://github.com/spikonado/sprocket/commit/d8f9e112e348e44b17ed294949a798c61e2a3a80)</sub>

<!-- /greptile_comment -->