### PR TITLE
feat(cli): Add shared device authentication

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -1,5 +1,34 @@
 # Backwards compatibility
 
+## CLI authentication
+
+CLI clients send their exact semantic release version to local `/api/cli/*`
+endpoints. The local server rejects every mismatch, including canary identifiers
+and dev commit hashes, so a newly installed CLI cannot reuse a stale server.
+Existing app launch, native login, and agent-run endpoints keep their request
+formats. Older local servers return an update-and-restart error rather than
+receiving a fallback authentication request.
+
+CLI discovery and bootstrap proofs bind to a random server-process ID. The CLI
+never sends the reusable pairing credential over HTTP. CLI sessions stay in
+memory and cannot resume after a server restart. Existing app pairing and
+persisted app sessions keep their formats.
+
+Profiles without a credential-store selection continue using the existing
+deployment-and-data-directory-scoped keyring entry. No credentials are copied to
+file storage automatically. The keyring default has no removal gate; it remains
+the default storage backend.
+
+Older apps do not subscribe to `/api/auth/changes`; their existing session-token
+reads still observe the shared login. Keep those endpoints until all supported
+installed apps use the session-change subscription. Native tokens remain
+restricted to the existing local-app endpoint; CLI control uses local pairing
+sessions and never returns refresh tokens.
+
+New servers take an exclusive data-directory lock. Stop older server processes
+before upgrading a profile, since those binaries do not take that lock. Separate
+profiles must use separate data directories.
+
 We ship breaking changes ahead of our users' installed clients and keep the old behavior working until those clients age out. That debt is easy to accumulate and easier to forget. This file lists every backwards-compatibility layer we currently ship, what it protects, how to remove it, and the signal that says removal is safe. When a removal PR merges, remove its entry from this document.
 
 ## Stored transcript work metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7836,6 +7836,8 @@ dependencies = [
  "clap",
  "open",
  "reqwest 0.13.4",
+ "serde",
+ "serde_json",
  "sprocket-server",
  "sprocket-workspace",
  "tokio",
@@ -7890,6 +7892,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
  "workos",
 ]
 

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -142,6 +142,36 @@ describe('installed and hosted auth', () => {
 		vi.unstubAllGlobals();
 	});
 
+	it('observes login and logout from another local client without creating a browser session', async () => {
+		stubInstalledWindow();
+		const connections: FakeEvents[] = [];
+		class FakeEvents {
+			onmessage: (() => void) | null = null;
+			close = vi.fn();
+			constructor() {
+				connections.push(this);
+			}
+		}
+		vi.stubGlobal('EventSource', FakeEvents);
+		let signedIn = false;
+		stubFetch({
+			token: () =>
+				jsonResponse(200, signedIn ? { accessToken: 'native-token', user: nativeUser } : null)
+		});
+		await initializeAuth(convexClient);
+		const events = connections[0];
+		if (!events) throw new Error('missing auth subscription');
+		signedIn = true;
+		events.onmessage?.();
+		await vi.waitFor(() => expect(get(authState).user?.id).toBe(nativeUser.id));
+		signedIn = false;
+		events.onmessage?.();
+		await vi.waitFor(() => expect(get(authState).user).toBeNull());
+		expect(createAuthKitClient).not.toHaveBeenCalled();
+		resetAuthRuntime();
+		expect(events.close).toHaveBeenCalledOnce();
+	});
+
 	it('resumes an installed native session without AuthKit JS', async () => {
 		stubInstalledWindow();
 		const fetch = stubFetch({

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -104,6 +104,7 @@ let isSigningOut = false;
 let desktopSignInAttempt: DesktopSignInAttempt | null = null;
 let desktopLoginStartQueue: Promise<void> = Promise.resolve();
 let authGeneration = 0;
+let nativeAuthEvents: EventSource | null = null;
 let nativeTokenInflight: {
 	generation: number;
 	forceRefreshToken: boolean;
@@ -111,6 +112,8 @@ let nativeTokenInflight: {
 } | null = null;
 
 export function resetAuthRuntime() {
+	nativeAuthEvents?.close();
+	nativeAuthEvents = null;
 	clearConvexRecovery();
 	desktopSignInAttempt?.abort.abort();
 	desktopSignInAttempt = null;
@@ -349,6 +352,7 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 				return;
 			}
 			await initializeInstalledAuth(generation);
+			watchNativeAuthentication();
 			return;
 		}
 
@@ -367,6 +371,18 @@ export async function initializeAuth(convexClient: AuthBootstrapClient) {
 			error: error instanceof Error ? error.message : 'Failed to initialize authentication.'
 		}));
 	}
+}
+
+function watchNativeAuthentication() {
+	if (nativeAuthEvents || !globalThis.EventSource) return;
+	const events = new EventSource('/api/auth/changes');
+	nativeAuthEvents = events;
+	events.onmessage = () => {
+		if (nativeAuthEvents !== events || isSigningOut) return;
+		invalidateAuthGeneration();
+		const generation = authGeneration;
+		void initializeInstalledAuth(generation);
+	};
 }
 
 async function initializeHostedAuth() {

--- a/crates/sprocket-cli/Cargo.toml
+++ b/crates/sprocket-cli/Cargo.toml
@@ -13,8 +13,10 @@ anyhow = "1.0.102"
 clap = { version = "4.5.60", features = ["derive", "env"] }
 open = "5.4.2"
 reqwest = { version = "0.13.4", default-features = false, features = ["json"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 sprocket-server = { path = "../sprocket-server" }
 sprocket-workspace = { path = "../sprocket-workspace" }
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 uuid = { version = "1.21.0", features = ["v4"] }

--- a/crates/sprocket-cli/src/commands.rs
+++ b/crates/sprocket-cli/src/commands.rs
@@ -1,0 +1,110 @@
+mod connection;
+
+use std::time::Duration;
+
+use anyhow::Context;
+use clap::{Args, Parser};
+use sprocket_server::ServerConfig;
+use sprocket_server::cli_protocol::*;
+
+use connection::Connection;
+
+#[derive(Debug, Args)]
+pub(crate) struct LoginArgs {
+    /// Credential storage for this local profile. File storage is not encrypted.
+    #[arg(long, value_enum)]
+    credential_store: Option<CredentialStore>,
+}
+
+fn runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+    Ok(tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?)
+}
+
+pub(crate) fn login(args: LoginArgs) -> anyhow::Result<u8> {
+    runtime()?.block_on(async {
+        let connection = Connection::open(ServerConfig::try_parse_from(["sprocket"])?).await?;
+        let result = login_connected(&connection, args).await;
+        connection.close().await;
+        result
+    })
+}
+
+async fn login_connected(connection: &Connection, args: LoginArgs) -> anyhow::Result<u8> {
+    if args.credential_store.is_none() {
+        if let LoginStatus::Authenticated { user } = connection
+            .call("auth", &connection.client_request())
+            .await?
+        {
+            eprintln!("Signed in as {}", user.email);
+            return Ok(0);
+        }
+    }
+    if args.credential_store == Some(CredentialStore::File) {
+        eprintln!(
+            "The refresh token will be stored unencrypted in a private file for this Sprocket profile."
+        );
+    }
+    let authorization: DeviceLoginResponse = connection
+        .call(
+            "login",
+            &CliLoginRequest {
+                client_id: connection.client_id.clone(),
+                credential_store: args.credential_store,
+            },
+        )
+        .await?;
+    eprintln!(
+        "Open {} in a browser and approve code {}",
+        authorization.verification_uri, authorization.user_code
+    );
+    tokio::select! {
+        code = interrupt() => Ok(code),
+        result = tokio::time::timeout(Duration::from_secs(authorization.expires_in + 5), async {
+            loop {
+                match connection.retry("auth", &connection.client_request()).await? {
+                    LoginStatus::Authenticated { user } => {
+                        eprintln!("Signed in as {}", user.email);
+                        return Ok(0);
+                    }
+                    LoginStatus::Failed { error } | LoginStatus::Unavailable { error } => anyhow::bail!("{error}"),
+                    LoginStatus::SignedOut => anyhow::bail!("login was cancelled or invalidated"),
+                    LoginStatus::Pending => tokio::time::sleep(Duration::from_secs(1)).await,
+                }
+            }
+        }) => result.context("device login expired")?,
+    }
+}
+
+pub(crate) fn logout() -> anyhow::Result<u8> {
+    runtime()?.block_on(async {
+        let connection = Connection::open(ServerConfig::try_parse_from(["sprocket"])?).await?;
+        let result = connection
+            .call::<bool>("logout", &connection.client_request())
+            .await;
+        connection.close().await;
+        result?;
+        eprintln!("Signed out of this local Sprocket profile.");
+        Ok(0)
+    })
+}
+
+async fn interrupt() -> u8 {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+        let mut hangup = signal(SignalKind::hangup()).expect("install SIGHUP handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => 130,
+            _ = terminate.recv() => 143,
+            _ = hangup.recv() => 129,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        130
+    }
+}

--- a/crates/sprocket-cli/src/commands/connection.rs
+++ b/crates/sprocket-cli/src/commands/connection.rs
@@ -238,51 +238,56 @@ async fn discover(
     http: &reqwest::Client,
     config: &ServerConfig,
 ) -> anyhow::Result<Option<CliDiscovery>> {
-    let mut candidates = Vec::new();
-    if let Some(address) = read_server_address(&config.resolve_data_dir())? {
-        candidates.push(address);
+    let configured_address = config.listen_url();
+    if let Some(published_address) = read_server_address(&config.resolve_data_dir())?
+        && published_address != configured_address
+        && let Ok(Some(discovery)) = discover_at(http, config, &published_address).await
+    {
+        return Ok(Some(discovery));
     }
-    if !candidates.contains(&config.listen_url()) {
-        candidates.push(config.listen_url());
-    }
-    for base_url in candidates {
-        validate_local_url(&base_url)?;
-        let challenge = uuid::Uuid::new_v4().to_string();
-        let response = match http
-            .post(format!("{base_url}/api/cli/discovery"))
-            .timeout(Duration::from_millis(750))
-            .json(&PairingProofRequest {
-                challenge: challenge.clone(),
-            })
-            .send()
-            .await
-        {
-            Ok(response) => response,
-            Err(error) if error.is_connect() || error.is_timeout() => continue,
-            Err(error) => return Err(error.into()),
-        };
-        anyhow::ensure!(
-            response.status().is_success(),
-            "{base_url} is occupied by an incompatible service. Update and restart the local Sprocket server."
-        );
-        let proof: CliDiscovery = response
-            .json()
-            .await
-            .context("invalid local server identity")?;
-        let credential = read_pairing_credential(config)?
-            .context("local server uses a different Sprocket data directory")?;
-        anyhow::ensure!(
-            proof.http_base_url.trim_end_matches('/') == base_url
-                && verify_pairing_proof(
-                    &credential,
-                    &cli_discovery_message(&challenge, &proof.instance_id, &proof.http_base_url),
-                    &proof.proof
-                ),
-            "local server identity does not match this Sprocket profile"
-        );
-        return Ok(Some(proof));
-    }
-    Ok(None)
+    discover_at(http, config, &configured_address).await
+}
+
+async fn discover_at(
+    http: &reqwest::Client,
+    config: &ServerConfig,
+    base_url: &str,
+) -> anyhow::Result<Option<CliDiscovery>> {
+    validate_local_url(base_url)?;
+    let challenge = uuid::Uuid::new_v4().to_string();
+    let response = match http
+        .post(format!("{base_url}/api/cli/discovery"))
+        .timeout(Duration::from_millis(750))
+        .json(&PairingProofRequest {
+            challenge: challenge.clone(),
+        })
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) if error.is_connect() || error.is_timeout() => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    anyhow::ensure!(
+        response.status().is_success(),
+        "{base_url} is occupied by an incompatible service. Update and restart the local Sprocket server."
+    );
+    let proof: CliDiscovery = response
+        .json()
+        .await
+        .context("invalid local server identity")?;
+    let credential = read_pairing_credential(config)?
+        .context("local server uses a different Sprocket data directory")?;
+    anyhow::ensure!(
+        proof.http_base_url.trim_end_matches('/') == base_url
+            && verify_pairing_proof(
+                &credential,
+                &cli_discovery_message(&challenge, &proof.instance_id, &proof.http_base_url),
+                &proof.proof
+            ),
+        "local server identity does not match this Sprocket profile"
+    );
+    Ok(Some(proof))
 }
 
 fn spawn_server(config: &ServerConfig) -> anyhow::Result<()> {
@@ -345,6 +350,8 @@ fn spawn_server(config: &ServerConfig) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+
     use super::*;
 
     #[test]
@@ -365,5 +372,46 @@ mod tests {
         ] {
             assert!(validate_local_url(url).is_err());
         }
+    }
+
+    #[tokio::test]
+    async fn stale_published_service_does_not_block_configured_address() {
+        let stale_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stale_address = format!("http://{}", stale_listener.local_addr().unwrap());
+        let stale_server = std::thread::spawn(move || {
+            let (mut stream, _) = stale_listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
+        });
+        let unused_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let unused_port = unused_listener.local_addr().unwrap().port();
+        drop(unused_listener);
+        let data_dir = std::env::temp_dir().join(format!(
+            "sprocket-cli-discovery-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(
+            data_dir.join("server-address.json"),
+            serde_json::json!({ "url": stale_address }).to_string(),
+        )
+        .unwrap();
+        let config = ServerConfig {
+            host: "127.0.0.1".into(),
+            port: unused_port,
+            data_dir: Some(data_dir.clone()),
+            static_dir: None,
+            api_only: true,
+            convex_deployment_url: None,
+        };
+        let http = reqwest::Client::builder().no_proxy().build().unwrap();
+
+        assert!(discover(&http, &config).await.unwrap().is_none());
+
+        stale_server.join().unwrap();
+        std::fs::remove_dir_all(data_dir).unwrap();
     }
 }

--- a/crates/sprocket-cli/src/commands/connection.rs
+++ b/crates/sprocket-cli/src/commands/connection.rs
@@ -1,0 +1,369 @@
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sprocket_server::cli_protocol::{
+    CliBootstrapRequest, CliBootstrapResponse, CliClientRequest, CliConnectRequest, CliDiscovery,
+    cli_bootstrap_message, cli_bootstrap_response_message, cli_discovery_message,
+};
+use sprocket_server::{
+    PairingProofRequest, ServerConfig, read_pairing_credential, read_server_address,
+    sign_pairing_proof, verify_pairing_proof,
+};
+
+pub(super) struct Connection {
+    http: reqwest::Client,
+    base_url: String,
+    session_token: String,
+    pub client_id: String,
+    heartbeat: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+struct HttpError {
+    status: reqwest::StatusCode,
+    message: String,
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.message)
+    }
+}
+
+impl std::error::Error for HttpError {}
+
+#[derive(Deserialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+impl Connection {
+    pub async fn open(config: ServerConfig) -> anyhow::Result<Self> {
+        let http = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .retry(reqwest::retry::never())
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(Duration::from_secs(20))
+            .build()?;
+        validate_local_url(&config.listen_url())?;
+        let discovered = if let Some(url) = discover(&http, &config).await? {
+            url
+        } else {
+            spawn_server(&config)?;
+            let deadline = Instant::now() + Duration::from_secs(20);
+            loop {
+                if let Some(url) = discover(&http, &config).await? {
+                    break url;
+                }
+                anyhow::ensure!(
+                    Instant::now() < deadline,
+                    "local server did not start; see {}",
+                    config.resolve_data_dir().join("cli-server.log").display()
+                );
+                tokio::time::sleep(Duration::from_millis(150)).await;
+            }
+        };
+        let credential = read_pairing_credential(&config)?
+            .context("local server pairing credential is missing")?;
+        let base_url = discovered.http_base_url;
+        let session_token = uuid::Uuid::new_v4().to_string();
+        let client_id = uuid::Uuid::new_v4().to_string();
+        let mut bootstrap = CliBootstrapRequest {
+            client: CliConnectRequest {
+                client_id: client_id.clone(),
+                client_version: sprocket_workspace::SPROCKET_VERSION.to_string(),
+                deployment_url: config.resolve_convex_deployment_url()?,
+            },
+            session_token: session_token.clone(),
+            proof: Vec::new(),
+        };
+        bootstrap.proof = sign_pairing_proof(
+            &credential,
+            &cli_bootstrap_message(&discovered.instance_id, &base_url, &bootstrap),
+        )?;
+        let response: CliBootstrapResponse =
+            post(&http, &base_url, "", "bootstrap", &bootstrap).await?;
+        anyhow::ensure!(
+            verify_pairing_proof(
+                &credential,
+                &cli_bootstrap_response_message(&discovered.instance_id, &base_url, &bootstrap),
+                &response.proof
+            ),
+            "local server identity changed during pairing"
+        );
+        let heartbeat = {
+            let http = http.clone();
+            let base_url = base_url.clone();
+            let token = session_token.clone();
+            let request = CliClientRequest {
+                client_id: client_id.clone(),
+            };
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    let _ = post::<bool>(&http, &base_url, &token, "heartbeat", &request).await;
+                }
+            })
+        };
+        Ok(Self {
+            http,
+            base_url,
+            session_token,
+            client_id,
+            heartbeat,
+        })
+    }
+
+    pub fn client_request(&self) -> CliClientRequest {
+        CliClientRequest {
+            client_id: self.client_id.clone(),
+        }
+    }
+
+    pub async fn call<T: DeserializeOwned>(
+        &self,
+        operation: &str,
+        request: &impl Serialize,
+    ) -> anyhow::Result<T> {
+        post(
+            &self.http,
+            &self.base_url,
+            &self.session_token,
+            operation,
+            request,
+        )
+        .await
+    }
+
+    pub async fn retry<T: DeserializeOwned>(
+        &self,
+        operation: &str,
+        request: &impl Serialize,
+    ) -> anyhow::Result<T> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut delay = Duration::from_millis(250);
+        loop {
+            match self.call(operation, request).await {
+                Ok(value) => return Ok(value),
+                Err(error) if transient(&error) && Instant::now() < deadline => {
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(2));
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("{operation} failed for submission cli:{}", self.client_id)
+                    });
+                }
+            }
+        }
+    }
+
+    pub async fn close(self) {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(3),
+            self.call::<bool>("release", &self.client_request()),
+        )
+        .await;
+        self.heartbeat.abort();
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.heartbeat.abort();
+    }
+}
+
+async fn post<T: DeserializeOwned>(
+    http: &reqwest::Client,
+    base_url: &str,
+    token: &str,
+    operation: &str,
+    request: &impl Serialize,
+) -> anyhow::Result<T> {
+    let response = http
+        .post(format!("{base_url}/api/cli/{operation}"))
+        .bearer_auth(token)
+        .json(request)
+        .send()
+        .await?;
+    let status = response.status();
+    if !status.is_success() {
+        let message = response
+            .json::<ErrorResponse>()
+            .await
+            .map(|response| response.error)
+            .unwrap_or_else(|_| format!("local server returned {status}"));
+        let message = if status == reqwest::StatusCode::NOT_FOUND {
+            format!("{message}. Update and restart the local Sprocket server to use CLI commands.")
+        } else {
+            message
+        };
+        return Err(HttpError { status, message }.into());
+    }
+    response
+        .json()
+        .await
+        .context("invalid response from the local server")
+}
+
+fn transient(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<reqwest::Error>()
+        .is_some_and(|error| error.is_timeout() || error.is_connect() || error.is_body())
+        || error
+            .downcast_ref::<HttpError>()
+            .is_some_and(|error| matches!(error.status.as_u16(), 408 | 429 | 500 | 502 | 503 | 504))
+}
+
+fn validate_local_url(value: &str) -> anyhow::Result<()> {
+    let url = reqwest::Url::parse(value)?;
+    anyhow::ensure!(
+        url.scheme() == "http"
+            && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "[::1]"))
+            && url.username().is_empty()
+            && url.password().is_none()
+            && url.query().is_none()
+            && url.fragment().is_none()
+            && url.path() == "/",
+        "CLI server address must be an HTTP loopback origin"
+    );
+    Ok(())
+}
+
+async fn discover(
+    http: &reqwest::Client,
+    config: &ServerConfig,
+) -> anyhow::Result<Option<CliDiscovery>> {
+    let mut candidates = Vec::new();
+    if let Some(address) = read_server_address(&config.resolve_data_dir())? {
+        candidates.push(address);
+    }
+    if !candidates.contains(&config.listen_url()) {
+        candidates.push(config.listen_url());
+    }
+    for base_url in candidates {
+        validate_local_url(&base_url)?;
+        let challenge = uuid::Uuid::new_v4().to_string();
+        let response = match http
+            .post(format!("{base_url}/api/cli/discovery"))
+            .timeout(Duration::from_millis(750))
+            .json(&PairingProofRequest {
+                challenge: challenge.clone(),
+            })
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) if error.is_connect() || error.is_timeout() => continue,
+            Err(error) => return Err(error.into()),
+        };
+        anyhow::ensure!(
+            response.status().is_success(),
+            "{base_url} is occupied by an incompatible service. Update and restart the local Sprocket server."
+        );
+        let proof: CliDiscovery = response
+            .json()
+            .await
+            .context("invalid local server identity")?;
+        let credential = read_pairing_credential(config)?
+            .context("local server uses a different Sprocket data directory")?;
+        anyhow::ensure!(
+            proof.http_base_url.trim_end_matches('/') == base_url
+                && verify_pairing_proof(
+                    &credential,
+                    &cli_discovery_message(&challenge, &proof.instance_id, &proof.http_base_url),
+                    &proof.proof
+                ),
+            "local server identity does not match this Sprocket profile"
+        );
+        return Ok(Some(proof));
+    }
+    Ok(None)
+}
+
+fn spawn_server(config: &ServerConfig) -> anyhow::Result<()> {
+    let data_dir = config.resolve_data_dir();
+    std::fs::create_dir_all(&data_dir)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let log = options.open(data_dir.join("cli-server.log"))?;
+    let mut command = Command::new(std::env::current_exe()?);
+    command
+        .args([
+            "serve",
+            "--quiet",
+            "--cli-temporary",
+            "--host",
+            &config.host,
+            "--port",
+            &config.port.to_string(),
+            "--convex-deployment-url",
+            &config.resolve_convex_deployment_url()?,
+            "--data-dir",
+        ])
+        .arg(&data_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(log);
+    match config.resolve_static_dir() {
+        Some(directory) => {
+            command.arg("--static-dir").arg(directory);
+        }
+        None => {
+            command.arg("--api-only");
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x00000008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+    let mut child = command
+        .spawn()
+        .context("failed to start the local Sprocket server")?;
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_discovery_never_sends_pairing_material_off_machine() {
+        for url in [
+            "http://127.0.0.1:17731",
+            "http://localhost:7731",
+            "http://[::1]:17731",
+        ] {
+            assert!(validate_local_url(url).is_ok());
+        }
+        for url in [
+            "https://example.com",
+            "http://127.0.0.1.evil.test",
+            "http://user@localhost",
+            "http://localhost/api",
+            "http://localhost?x=1",
+        ] {
+            assert!(validate_local_url(url).is_err());
+        }
+    }
+}

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -1,3 +1,5 @@
+mod commands;
+
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -16,6 +18,7 @@ use uuid::Uuid;
 
 const DESKTOP_EXECUTABLE_ENV: &str = "SPROCKET_DESKTOP_EXECUTABLE";
 const DESKTOP_WORKSPACE_ARG: &str = "--sprocket-workspace";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "sprocket",
@@ -38,6 +41,11 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Sign in using a browser on any device
+    Login(commands::LoginArgs),
+
+    /// Sign out of this local profile in the app and CLI
+    Logout,
     /// Start only the local Sprocket server
     Serve(ServeArgs),
 
@@ -48,6 +56,8 @@ enum Commands {
 
 #[derive(Debug, Args)]
 struct ServeArgs {
+    #[arg(long, hide = true)]
+    cli_temporary: bool,
     #[command(flatten)]
     server: ServerConfig,
 
@@ -63,13 +73,24 @@ struct UpdateArgs {
     check: bool,
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> std::process::ExitCode {
+    match entry() {
+        Ok(code) => std::process::ExitCode::from(code),
+        Err(error) => {
+            eprintln!("{error:#}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn entry() -> anyhow::Result<u8> {
     // SAFETY: this runs before the Tokio runtime is constructed.
     unsafe {
         load_repo_env();
     }
 
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             EnvFilter::from_default_env().add_directive("sprocket_server=error".parse()?),
         )
@@ -82,6 +103,20 @@ fn main() -> anyhow::Result<()> {
         .map(resolve_launch_workspace)
         .transpose()?;
     match cli.command {
+        Some(Commands::Login(args)) => {
+            anyhow::ensure!(
+                !cli.web && workspace_path.is_none(),
+                "login does not accept app launch arguments"
+            );
+            return commands::login(args);
+        }
+        Some(Commands::Logout) => {
+            anyhow::ensure!(
+                !cli.web && workspace_path.is_none(),
+                "logout does not accept app launch arguments"
+            );
+            return commands::logout();
+        }
         Some(Commands::Serve(serve)) => {
             if cli.web {
                 anyhow::bail!("`--web` cannot be combined with `serve`; run `sprocket --web`");
@@ -89,18 +124,18 @@ fn main() -> anyhow::Result<()> {
             if workspace_path.is_some() {
                 anyhow::bail!("a workspace directory cannot be combined with `serve`");
             }
-            serve_local(serve.server, serve.quiet, false, None)
+            serve_local(serve.server, serve.quiet, false, None, serve.cli_temporary)
         }
         Some(Commands::Update(_)) => {
             anyhow::bail!("`sprocket update` requires the @spikonado/sprocket package launcher")
         }
         None if cli.web => {
             let server = ServerConfig::try_parse_from(["sprocket"])?;
-            serve_local(server, false, true, workspace_path)
+            serve_local(server, false, true, workspace_path, false)
         }
         None => {
             if launch_desktop(workspace_path.as_deref())? {
-                return Ok(());
+                return Ok(0);
             }
 
             eprintln!(
@@ -108,9 +143,10 @@ fn main() -> anyhow::Result<()> {
                  Note: This has no impact on Sprocket's capabilities or performance."
             );
             let server = ServerConfig::try_parse_from(["sprocket"])?;
-            serve_local(server, false, true, workspace_path)
+            serve_local(server, false, true, workspace_path, false)
         }
-    }
+    }?;
+    Ok(0)
 }
 
 fn resolve_launch_workspace(path: &Path) -> anyhow::Result<String> {
@@ -128,6 +164,7 @@ fn serve_local(
     quiet: bool,
     open_browser: bool,
     workspace_path: Option<String>,
+    temporary: bool,
 ) -> anyhow::Result<()> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -149,6 +186,7 @@ fn serve_local(
             run(
                 server,
                 RunOptions {
+                    temporary,
                     quiet,
                     open_browser,
                     workspace_path,
@@ -323,6 +361,13 @@ mod tests {
         assert!(!server.web);
         assert!(server.directory.is_none());
         assert!(matches!(server.command, Some(Commands::Serve(_))));
+
+        let login =
+            Cli::try_parse_from(["sprocket", "login", "--credential-store", "file"]).unwrap();
+        assert!(matches!(login.command, Some(Commands::Login(_))));
+
+        let logout = Cli::try_parse_from(["sprocket", "logout"]).unwrap();
+        assert!(matches!(logout.command, Some(Commands::Logout)));
 
         let update = Cli::try_parse_from(["sprocket", "upgrade", "--check"]).unwrap();
         assert!(matches!(

--- a/crates/sprocket-server/Cargo.toml
+++ b/crates/sprocket-server/Cargo.toml
@@ -41,6 +41,9 @@ workos = "3.4.0"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.186"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization"] }
+
 [build-dependencies]
 dotenvy = "0.15.7"
 

--- a/crates/sprocket-server/src/auth.rs
+++ b/crates/sprocket-server/src/auth.rs
@@ -10,7 +10,7 @@ use cookie::{Cookie, SameSite};
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use tokio::sync::RwLock;
+use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
 use uuid::Uuid;
 
 use crate::config::SESSION_COOKIE_NAME;
@@ -42,9 +42,10 @@ pub struct BootstrapResponse {
 }
 
 pub struct AuthState {
+    pub(crate) instance_id: String,
     data_dir: PathBuf,
     pairing_credential: String,
-    sessions: RwLock<HashMap<String, SessionRecord>>,
+    sessions: Arc<RwLock<HashMap<String, SessionRecord>>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -73,6 +74,8 @@ pub fn peer_may_complete_desktop_login_callback(peer: std::net::SocketAddr) -> b
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SessionRecord {
+    #[serde(skip)]
+    ephemeral: bool,
     role: String,
     created_at: u64,
     #[serde(deserialize_with = "deserialize_session_user_id")]
@@ -95,9 +98,10 @@ impl AuthState {
         let sessions = load_sessions(&data_dir)?;
 
         Ok(Arc::new(Self {
+            instance_id: Uuid::new_v4().to_string(),
             data_dir: data_dir.to_path_buf(),
             pairing_credential,
-            sessions: RwLock::new(sessions),
+            sessions: Arc::new(RwLock::new(sessions)),
         }))
     }
 
@@ -115,10 +119,14 @@ impl AuthState {
     }
 
     pub fn pairing_proof(&self, message: &str) -> anyhow::Result<Vec<u8>> {
-        let mut mac = HmacSha256::new_from_slice(self.pairing_credential.as_bytes())?;
-        mac.update(message.as_bytes());
-        Ok(mac.finalize().into_bytes().to_vec())
+        sign_pairing_proof(&self.pairing_credential, message)
     }
+}
+
+pub fn sign_pairing_proof(credential: &str, message: &str) -> anyhow::Result<Vec<u8>> {
+    let mut mac = HmacSha256::new_from_slice(credential.as_bytes())?;
+    mac.update(message.as_bytes());
+    Ok(mac.finalize().into_bytes().to_vec())
 }
 
 /// Constant-time HMAC-SHA256 verification of a pairing proof.
@@ -131,6 +139,18 @@ pub fn verify_pairing_proof(credential: &str, message: &str, proof: &[u8]) -> bo
 }
 
 impl AuthState {
+    pub(crate) async fn create_cli_session(&self, token: String) {
+        self.sessions.write().await.insert(
+            token,
+            SessionRecord {
+                ephemeral: true,
+                role: "owner".into(),
+                created_at: crate::now_ms(),
+                user_id: None,
+            },
+        );
+    }
+
     pub async fn session_state(&self, session_token: Option<&str>) -> AuthSessionResponse {
         let Some(session_token) = session_token else {
             return AuthSessionResponse {
@@ -151,12 +171,7 @@ impl AuthState {
         };
 
         if session_is_expired(&session) {
-            let snapshot = {
-                let mut sessions = self.sessions.write().await;
-                sessions.remove(session_token);
-                sessions_snapshot(&sessions)
-            };
-            if let Err(error) = self.save_sessions(snapshot).await {
+            if let Err(error) = self.end_session(session_token).await {
                 tracing::warn!("failed to persist expired session removal: {error}");
             }
             return AuthSessionResponse {
@@ -175,15 +190,18 @@ impl AuthState {
         self.verify_pairing_credential(credential)?;
 
         let session_token = Uuid::new_v4().to_string();
-        self.sessions.write().await.insert(
+        let mut sessions = Arc::clone(&self.sessions).write_owned().await;
+        sessions.retain(|_, session| !session_is_expired(session));
+        sessions.insert(
             session_token.clone(),
             SessionRecord {
+                ephemeral: false,
                 role: "owner".to_string(),
                 created_at: crate::now_ms(),
                 user_id: None,
             },
         );
-        self.persist_sessions().await?;
+        self.save_sessions(sessions).await?;
 
         Ok((
             BootstrapResponse {
@@ -208,18 +226,26 @@ impl AuthState {
         session_token: &str,
         user_id: &str,
     ) -> anyhow::Result<()> {
-        let snapshot = {
-            let mut sessions = self.sessions.write().await;
-            let session = sessions
-                .get_mut(session_token)
-                .ok_or_else(|| anyhow::anyhow!("authentication required"))?;
-            if session_is_expired(session) {
-                anyhow::bail!("authentication required");
-            }
-            session.user_id = Some(user_id.to_string());
-            sessions_snapshot(&sessions)
-        };
-        self.save_sessions(snapshot).await
+        let mut sessions = Arc::clone(&self.sessions).write_owned().await;
+        let session = sessions
+            .get_mut(session_token)
+            .ok_or_else(|| anyhow::anyhow!("authentication required"))?;
+        if session_is_expired(session) {
+            anyhow::bail!("authentication required");
+        }
+        if session.user_id.as_deref() == Some(user_id) {
+            return Ok(());
+        }
+        session.user_id = Some(user_id.to_string());
+        self.save_sessions(sessions).await
+    }
+
+    pub(crate) async fn bind_all_sessions(&self, user_id: Option<&str>) -> anyhow::Result<()> {
+        let mut sessions = Arc::clone(&self.sessions).write_owned().await;
+        for session in sessions.values_mut() {
+            session.user_id = user_id.map(str::to_owned);
+        }
+        self.save_sessions(sessions).await
     }
 
     pub async fn require_session_user(
@@ -247,18 +273,26 @@ impl AuthState {
             .is_some_and(|session| !session_is_expired(session) && session.user_id.is_some())
     }
 
-    async fn persist_sessions(&self) -> anyhow::Result<()> {
-        let snapshot = {
-            let sessions = self.sessions.read().await;
-            sessions_snapshot(&sessions)
-        };
-        self.save_sessions(snapshot).await
+    pub(crate) async fn end_session(&self, token: &str) -> anyhow::Result<()> {
+        let mut sessions = Arc::clone(&self.sessions).write_owned().await;
+        if sessions.remove(token).is_some() {
+            self.save_sessions(sessions).await?;
+        }
+        Ok(())
     }
 
-    async fn save_sessions(&self, snapshot: Vec<PersistedSessionRecord>) -> anyhow::Result<()> {
+    async fn save_sessions(
+        &self,
+        sessions: OwnedRwLockWriteGuard<HashMap<String, SessionRecord>>,
+    ) -> anyhow::Result<()> {
         let sessions_path = self.data_dir.join(SESSIONS_FILE);
-        let payload = serde_json::to_string_pretty(&snapshot)?;
-        tokio::fs::write(sessions_path, payload).await?;
+        tokio::task::spawn_blocking(move || {
+            let payload = serde_json::to_vec(&sessions_snapshot(&sessions))?;
+            let result = crate::profile::write_private_file(&sessions_path, &payload);
+            drop(sessions);
+            result
+        })
+        .await??;
         Ok(())
     }
 }
@@ -276,10 +310,16 @@ fn load_or_create_pairing_credential(data_dir: &Path) -> anyhow::Result<String> 
         Uuid::new_v4()
     ));
 
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&tmp_path)?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&tmp_path)?;
+    #[cfg(windows)]
+    crate::profile::restrict_windows_file(&tmp_path)?;
     file.write_all(format!("{credential}\n").as_bytes())?;
     file.sync_all()?;
     drop(file);
@@ -476,7 +516,7 @@ fn load_sessions(data_dir: &Path) -> anyhow::Result<HashMap<String, SessionRecor
 fn sessions_snapshot(sessions: &HashMap<String, SessionRecord>) -> Vec<PersistedSessionRecord> {
     sessions
         .iter()
-        .filter(|(_, session)| !session_is_expired(session))
+        .filter(|(_, session)| !session.ephemeral && !session_is_expired(session))
         .map(|(token, session)| PersistedSessionRecord {
             token: token.clone(),
             session: session.clone(),
@@ -490,6 +530,43 @@ fn session_is_expired(session: &SessionRecord) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn cancelled_request_keeps_session_writes_serialized_until_persistence_finishes() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let directory = tempfile::tempdir().unwrap();
+            let state = super::AuthState::load(directory.path()).unwrap();
+            let (release, blocked) = std::sync::mpsc::channel();
+            let (ready, started) = tokio::sync::oneshot::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                ready.send(()).unwrap();
+                blocked.recv().unwrap();
+            });
+            started.await.unwrap();
+            let (saving, queued) = tokio::sync::oneshot::channel();
+            let writer = std::sync::Arc::clone(&state);
+            let request = tokio::spawn(async move {
+                let sessions = std::sync::Arc::clone(&writer.sessions).write_owned().await;
+                saving.send(()).unwrap();
+                writer.save_sessions(sessions).await
+            });
+            queued.await.unwrap();
+            request.abort();
+            let _ = request.await;
+            let locked = state.sessions.try_write().is_err();
+            release.send(()).unwrap();
+            blocker.await.unwrap();
+            let _finished = state.sessions.read().await;
+            assert!(locked);
+            assert!(directory.path().join(super::SESSIONS_FILE).is_file());
+        });
+    }
+
     use super::*;
     use std::thread;
 

--- a/crates/sprocket-server/src/bin/sprocket-server.rs
+++ b/crates/sprocket-server/src/bin/sprocket-server.rs
@@ -20,6 +20,7 @@ fn main() -> anyhow::Result<()> {
         .block_on(run(
             ServerConfig::parse(),
             RunOptions {
+                temporary: false,
                 quiet: true,
                 ..RunOptions::default()
             },

--- a/crates/sprocket-server/src/cli_protocol.rs
+++ b/crates/sprocket-server/src/cli_protocol.rs
@@ -1,0 +1,94 @@
+pub use crate::native_auth::{NativeLoginStatus as LoginStatus, NativeUser};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliDiscovery {
+    pub instance_id: String,
+    pub http_base_url: String,
+    pub proof: Vec<u8>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliBootstrapRequest {
+    pub client: CliConnectRequest,
+    pub session_token: String,
+    pub proof: Vec<u8>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct CliBootstrapResponse {
+    pub proof: Vec<u8>,
+}
+
+pub fn cli_bootstrap_response_message(
+    instance_id: &str,
+    url: &str,
+    request: &CliBootstrapRequest,
+) -> String {
+    serde_json::json!([
+        "sprocket-cli-bootstrap-accepted-v1",
+        instance_id,
+        url,
+        request.client,
+        request.session_token
+    ])
+    .to_string()
+}
+
+pub fn cli_discovery_message(challenge: &str, instance_id: &str, url: &str) -> String {
+    serde_json::json!(["sprocket-cli-discovery-v1", challenge, instance_id, url]).to_string()
+}
+
+pub fn cli_bootstrap_message(
+    instance_id: &str,
+    url: &str,
+    request: &CliBootstrapRequest,
+) -> String {
+    serde_json::json!([
+        "sprocket-cli-bootstrap-v1",
+        instance_id,
+        url,
+        request.client,
+        request.session_token
+    ])
+    .to_string()
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq, clap::ValueEnum)]
+#[serde(rename_all = "camelCase")]
+pub enum CredentialStore {
+    #[default]
+    Keyring,
+    File,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliConnectRequest {
+    pub client_id: String,
+    pub client_version: String,
+    pub deployment_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliClientRequest {
+    pub client_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliLoginRequest {
+    pub client_id: String,
+    pub credential_store: Option<CredentialStore>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceLoginResponse {
+    pub verification_uri: String,
+    pub user_code: String,
+    pub expires_in: u64,
+}

--- a/crates/sprocket-server/src/cli_sessions.rs
+++ b/crates/sprocket-server/src/cli_sessions.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use sprocket_workspace::WorkspaceCancellation;
+
+const CLIENT_GRACE: Duration = Duration::from_secs(60);
+const STARTUP_GRACE: Duration = Duration::from_secs(30);
+
+pub(crate) struct CliSession {
+    pub session_token: String,
+}
+
+struct ClientLease {
+    session: Arc<CliSession>,
+    expires_at: Instant,
+}
+
+struct LifetimeState {
+    clients: HashMap<String, ClientLease>,
+    active_runs: usize,
+    accepting: bool,
+    used: bool,
+}
+
+pub(crate) struct ServerLifetime {
+    pub shutdown: WorkspaceCancellation,
+    state: Mutex<LifetimeState>,
+    temporary: bool,
+    started_at: Instant,
+}
+
+impl ServerLifetime {
+    pub fn new(temporary: bool) -> Arc<Self> {
+        Arc::new(Self {
+            shutdown: WorkspaceCancellation::new(),
+            state: Mutex::new(LifetimeState {
+                clients: HashMap::new(),
+                active_runs: 0,
+                accepting: true,
+                used: false,
+            }),
+            temporary,
+            started_at: Instant::now(),
+        })
+    }
+
+    pub fn connect(&self, client_id: &str, session_token: &str) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            uuid::Uuid::parse_str(client_id).is_ok(),
+            "invalid CLI client ID"
+        );
+        let mut state = self.state.lock().unwrap();
+        anyhow::ensure!(
+            state.accepting,
+            "server is shutting down; retry the command"
+        );
+        if let Some(lease) = state.clients.get_mut(client_id) {
+            anyhow::ensure!(
+                lease.session.session_token == session_token,
+                "CLI client belongs to another session"
+            );
+            anyhow::ensure!(
+                lease.expires_at > Instant::now(),
+                "CLI client lease expired"
+            );
+            lease.expires_at = Instant::now() + CLIENT_GRACE;
+            return Ok(());
+        }
+        anyhow::ensure!(state.clients.len() < 256, "too many CLI clients");
+        state.used = true;
+        state.clients.insert(
+            client_id.to_owned(),
+            ClientLease {
+                expires_at: Instant::now() + CLIENT_GRACE,
+                session: Arc::new(CliSession {
+                    session_token: session_token.to_owned(),
+                }),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn client(&self, client_id: &str, session_token: &str) -> anyhow::Result<Arc<CliSession>> {
+        let mut state = self.state.lock().unwrap();
+        let lease = state
+            .clients
+            .get_mut(client_id)
+            .ok_or_else(|| anyhow::anyhow!("CLI session was lost; retry the command"))?;
+        anyhow::ensure!(
+            lease.session.session_token == session_token,
+            "CLI client belongs to another session"
+        );
+        anyhow::ensure!(
+            lease.expires_at > Instant::now(),
+            "CLI client lease expired"
+        );
+        lease.expires_at = Instant::now() + CLIENT_GRACE;
+        Ok(Arc::clone(&lease.session))
+    }
+
+    pub fn release(&self, client_id: &str, session_token: &str) -> anyhow::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(lease) = state.clients.get(client_id) {
+            anyhow::ensure!(
+                lease.session.session_token == session_token,
+                "CLI client belongs to another session"
+            );
+            state.clients.remove(client_id);
+        }
+        Ok(())
+    }
+
+    pub fn run_guard(self: &Arc<Self>) -> anyhow::Result<RunGuard> {
+        let mut state = self.state.lock().unwrap();
+        anyhow::ensure!(state.accepting, "server is shutting down");
+        state.active_runs += 1;
+        Ok(RunGuard(Arc::clone(self)))
+    }
+
+    pub fn tick(&self, now: Instant) -> (bool, Vec<String>) {
+        let mut state = self.state.lock().unwrap();
+        let mut expired = Vec::new();
+        state.clients.retain(|_, lease| {
+            if lease.expires_at > now {
+                return true;
+            }
+            expired.push(lease.session.session_token.clone());
+            false
+        });
+        if self.temporary
+            && state.clients.is_empty()
+            && state.active_runs == 0
+            && (state.used || now.duration_since(self.started_at) >= STARTUP_GRACE)
+        {
+            state.accepting = false;
+            self.shutdown.cancel();
+        }
+        (!state.accepting, expired)
+    }
+}
+
+pub(crate) struct RunGuard(Arc<ServerLifetime>);
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        self.0.state.lock().unwrap().active_runs -= 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temporary_server_waits_for_all_clients_and_activity() {
+        let lifetime = ServerLifetime::new(true);
+        let first = uuid::Uuid::new_v4().to_string();
+        let second = uuid::Uuid::new_v4().to_string();
+        lifetime.connect(&first, "a").unwrap();
+        lifetime.connect(&second, "b").unwrap();
+        let activity = lifetime.run_guard().unwrap();
+        lifetime.release(&first, "a").unwrap();
+        assert!(!lifetime.tick(Instant::now()).0);
+        lifetime.release(&second, "b").unwrap();
+        assert!(!lifetime.tick(Instant::now()).0);
+        drop(activity);
+        assert!(lifetime.tick(Instant::now()).0);
+        assert!(lifetime.connect(&first, "a").is_err());
+    }
+
+    #[test]
+    fn expired_clients_do_not_stop_a_shared_server() {
+        let lifetime = ServerLifetime::new(false);
+        let id = uuid::Uuid::new_v4().to_string();
+        lifetime.connect(&id, "a").unwrap();
+        assert!(lifetime.client(&id, "b").is_err());
+        let (stop, expired) = lifetime.tick(Instant::now() + CLIENT_GRACE);
+        assert!(!stop);
+        assert_eq!(expired, ["a"]);
+        assert!(lifetime.client(&id, "a").is_err());
+    }
+}

--- a/crates/sprocket-server/src/lib.rs
+++ b/crates/sprocket-server/src/lib.rs
@@ -1,10 +1,13 @@
 mod artifact_watch;
 mod auth;
+pub mod cli_protocol;
+mod cli_sessions;
 mod config;
 mod machine_identity;
 mod machines;
 mod native_auth;
 mod package_update;
+mod profile;
 mod project_attachments;
 pub mod repo_env;
 mod routes;
@@ -17,6 +20,7 @@ mod transcript_watch;
 mod work_sync;
 
 pub use config::{DEFAULT_DEV_WEB_URL, DEFAULT_PORT, SESSION_COOKIE_NAME, ServerConfig};
+pub use profile::read_server_address;
 use static_dir::is_valid_static_dir;
 pub use static_dir::{INSTALLED_WEB_DIR, resolve_static_dir};
 
@@ -50,6 +54,7 @@ pub struct RunOptions {
     pub quiet: bool,
     pub open_browser: bool,
     pub workspace_path: Option<String>,
+    pub temporary: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -86,6 +91,7 @@ impl StartupInfo {
 
 #[derive(Clone)]
 pub struct AppState {
+    pub(crate) lifetime: Arc<cli_sessions::ServerLifetime>,
     pub auth: Arc<auth::AuthState>,
     pub(crate) native_auth: Arc<native_auth::NativeAuthManager>,
     pub project_attachments: Arc<project_attachments::ProjectAttachmentStore>,
@@ -135,6 +141,7 @@ impl AppState {
         let machine_identity =
             Arc::new(machine_identity::MachineIdentity::load(&data_dir).expect("machine identity"));
         Self {
+            lifetime: cli_sessions::ServerLifetime::new(false),
             auth,
             native_auth: Arc::clone(&native_auth),
             project_attachments,
@@ -165,6 +172,7 @@ pub fn build_router(state: AppState, static_dir: Option<PathBuf>) -> Router {
         .merge(routes::health::routes())
         .merge(routes::config::routes())
         .merge(routes::auth::routes())
+        .merge(routes::cli::routes())
         .merge(routes::workspace::routes())
         .merge(routes::agent::routes())
         .merge(routes::transcript::routes())
@@ -183,12 +191,15 @@ pub fn build_router(state: AppState, static_dir: Option<PathBuf>) -> Router {
 pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()> {
     let convex_deployment_url = config.resolve_convex_deployment_url()?;
     let data_dir = config.resolve_data_dir();
+    let profile = profile::ProfileLock::acquire(&data_dir)?;
+    let auth = auth::AuthState::load(&data_dir)?;
     let native_auth = native_auth::NativeAuthManager::new(
         convex_deployment_url.clone(),
         auth::desktop_login_callback_url(config.port),
         &data_dir,
+        Arc::clone(&auth),
     );
-    let auth = auth::AuthState::load(&data_dir)?;
+    let lifetime = cli_sessions::ServerLifetime::new(options.temporary);
     let machine_identity = Arc::new(machine_identity::MachineIdentity::load(&data_dir)?);
     let machines = machines::MachineManager::new(
         convex_deployment_url.clone(),
@@ -226,8 +237,9 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         .map(|value| Arc::new(Mutex::new(Some(value))));
 
     let state = AppState {
+        lifetime: Arc::clone(&lifetime),
         auth,
-        native_auth,
+        native_auth: Arc::clone(&native_auth),
         project_attachments,
         transcript,
         transcript_watchers,
@@ -278,6 +290,8 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
         startup.print_startup(dev_web_url.as_deref());
     }
 
+    profile.publish(http_base_url.clone())?;
+
     if options.open_browser {
         let open_target =
             startup.browser_url(dev_web_url.as_deref().unwrap_or(&startup.listen_url));
@@ -301,18 +315,41 @@ pub async fn run(config: ServerConfig, options: RunOptions) -> anyhow::Result<()
             }
         }
     });
+    let lease_auth = Arc::clone(&state.auth);
     let router = build_router(state, static_dir);
     let shutdown_machines = Arc::clone(&machines);
 
-    let result = axum::serve(
+    let shutdown = lifetime.shutdown.clone();
+    let server = axum::serve(
         listener,
         router.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .with_graceful_shutdown(async move {
-        shutdown_signal().await;
+        tokio::select! {
+            _ = shutdown_signal() => {},
+            _ = async {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    let (stop, expired) = lifetime.tick(std::time::Instant::now());
+                    for session in expired {
+                        native_auth.cancel_device_login(&session).await;
+                        let _ = lease_auth.end_session(&session).await;
+                    }
+                    if stop { break; }
+                }
+            } => {},
+        }
+        lifetime.shutdown.cancel();
         shutdown_machines.stop_registration();
     })
-    .await;
+    .into_future();
+    tokio::pin!(server);
+    let result = tokio::select! {
+        result = &mut server => result,
+        _ = shutdown.cancelled() => {
+            tokio::time::timeout(Duration::from_secs(10), &mut server).await.unwrap_or(Ok(()))
+        }
+    };
     cleanup.abort();
     let _ = cleanup.await;
     machines.shutdown().await;
@@ -417,7 +454,7 @@ pub fn read_pairing_credential(config: &ServerConfig) -> anyhow::Result<Option<S
     auth::read_pairing_credential(&config.resolve_data_dir())
 }
 
-pub use auth::verify_pairing_proof;
+pub use auth::{sign_pairing_proof, verify_pairing_proof};
 pub use repo_env::load_repo_env;
 
 #[cfg(test)]

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -710,7 +710,7 @@ impl NativeAuthManager {
     }
 
     async fn accept_login(&self, response: AuthenticateResponse) -> anyhow::Result<NativeUser> {
-        let result = self.accept_authentication(response).await;
+        let user = self.accept_new_login(response).await?;
         let mut session = self.session.lock().await;
         session.login_generation = session.login_generation.wrapping_add(1);
         let invalidated =
@@ -723,12 +723,26 @@ impl NativeAuthManager {
             attempt.cancel.cancel();
             attempt.result = Some(Err(invalidated.into()));
         }
-        result
+        Ok(user)
+    }
+
+    async fn accept_new_login(&self, response: AuthenticateResponse) -> anyhow::Result<NativeUser> {
+        self.accept_authentication_with_persistence(response, true)
+            .await
     }
 
     async fn accept_authentication(
         &self,
         response: AuthenticateResponse,
+    ) -> anyhow::Result<NativeUser> {
+        self.accept_authentication_with_persistence(response, false)
+            .await
+    }
+
+    async fn accept_authentication_with_persistence(
+        &self,
+        response: AuthenticateResponse,
+        persist_before_acceptance: bool,
     ) -> anyhow::Result<NativeUser> {
         let user = NativeUser {
             id: response.user.id,
@@ -740,6 +754,9 @@ impl NativeAuthManager {
         let access_token = response.access_token.into_inner();
         let expires_at = jwt_expiration(&access_token)?;
         let refresh_token = response.refresh_token.into_inner();
+        if persist_before_acceptance {
+            self.save_refresh_token(refresh_token.clone()).await?;
+        }
         let changed = self
             .session
             .lock()
@@ -755,17 +772,16 @@ impl NativeAuthManager {
                 expires_at,
             });
             session.refresh_token = Some(refresh_token);
-            session.refresh_token_persisted = false;
+            session.refresh_token_persisted = persist_before_acceptance;
             session.refresh_generation = session.refresh_generation.wrapping_add(1);
             session.user = Some(user.clone());
             session.login_errors.clear();
             session.suppress_persisted_resume = false;
         }
-        let saved = self.flush_refresh_token().await;
+        self.flush_refresh_token().await?;
         if changed {
             self.publish_session_change(Some(&user.id)).await?;
         }
-        saved?;
         Ok(user)
     }
 
@@ -1482,6 +1498,49 @@ mod tests {
             manager.access_token(false).await.unwrap(),
             expected_access_token
         );
+    }
+
+    #[tokio::test]
+    async fn failed_login_persistence_does_not_change_local_sessions() {
+        let store = MemoryRefreshTokenStore::with_token("refresh-old");
+        let mut manager = manager_with_response(
+            Arc::clone(&store),
+            StatusCode::BAD_REQUEST,
+            serde_json::Value::Null,
+        )
+        .await;
+        let directory = tempfile::tempdir().unwrap();
+        let local = crate::auth::AuthState::load(directory.path()).unwrap();
+        let (_, local_session) = local.bootstrap(local.pairing_credential()).await.unwrap();
+        local
+            .bind_session_user(&local_session, "user_old")
+            .await
+            .unwrap();
+        Arc::get_mut(&mut manager).unwrap().local_sessions = Some(Arc::clone(&local));
+        let changes = manager.subscribe_changes();
+        let login_generation = manager.session.lock().await.login_generation;
+        store.fail_save.store(true, Ordering::SeqCst);
+
+        let error = manager
+            .accept_login(authentication_response(
+                access_token(unix_time_secs() + 3_600),
+                "refresh-new",
+            ))
+            .await
+            .expect_err("failed persistence must reject the login");
+
+        assert!(error.to_string().contains("credential store unavailable"));
+        assert_eq!(store.token().as_deref(), Some("refresh-old"));
+        assert!(manager.session.lock().await.user.is_none());
+        assert_eq!(
+            manager.session.lock().await.login_generation,
+            login_generation
+        );
+        assert!(!changes.has_changed().unwrap());
+        local
+            .require_session_user(&local_session, "user_old")
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/native_auth.rs
+++ b/crates/sprocket-server/src/native_auth.rs
@@ -1,3 +1,6 @@
+mod credentials;
+mod device;
+
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::path::Path;
@@ -11,7 +14,7 @@ use convex::{FunctionResult, Value};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sprocket_convex::{AuthSignedOut, AuthTokenFetcher, Client as ConvexClient};
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::{Mutex, OnceCell, watch};
 use tokio::time::timeout;
 use workos::helpers::AuthKitAuthorizationUrlParams;
 use workos::resources::user_management::{
@@ -34,7 +37,7 @@ pub(crate) struct NativeAuthConfig {
     pub workos_client_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeUser {
     pub id: String,
@@ -60,9 +63,9 @@ impl std::fmt::Debug for NativeBrowserSession {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(tag = "status", rename_all = "camelCase")]
-pub(crate) enum NativeLoginStatus {
+pub enum NativeLoginStatus {
     SignedOut,
     Pending,
     Authenticated { user: NativeUser },
@@ -85,6 +88,9 @@ pub(crate) enum NativeLoginFlow {
 }
 
 trait RefreshTokenStore: Send + Sync {
+    fn select(&self, _store: crate::cli_protocol::CredentialStore) -> anyhow::Result<()> {
+        anyhow::bail!("credential-store selection is unavailable")
+    }
     fn load(&self) -> anyhow::Result<Option<String>>;
     fn save(&self, refresh_token: &str) -> anyhow::Result<()>;
     fn clear(&self) -> anyhow::Result<()>;
@@ -181,6 +187,7 @@ struct AccessToken {
 }
 
 struct NativeSession {
+    devices: HashMap<String, device::PendingDeviceLogin>,
     pending: PendingLogins,
     access_token: Option<AccessToken>,
     refresh_token: Option<String>,
@@ -189,12 +196,13 @@ struct NativeSession {
     user: Option<NativeUser>,
     login_errors: HashMap<String, String>,
     suppress_persisted_resume: bool,
-    sign_out_generation: u64,
+    login_generation: u64,
 }
 
 impl Default for NativeSession {
     fn default() -> Self {
         Self {
+            devices: HashMap::new(),
             pending: PendingLogins::default(),
             access_token: None,
             refresh_token: None,
@@ -203,7 +211,7 @@ impl Default for NativeSession {
             user: None,
             login_errors: HashMap::new(),
             suppress_persisted_resume: false,
-            sign_out_generation: 0,
+            login_generation: 0,
         }
     }
 }
@@ -219,6 +227,8 @@ impl NativeSession {
 }
 
 pub(crate) struct NativeAuthManager {
+    changes: watch::Sender<u64>,
+    local_sessions: Option<Arc<crate::auth::AuthState>>,
     deployment_url: Option<String>,
     client: OnceCell<WorkOsClient>,
     callback_url: String,
@@ -228,9 +238,19 @@ pub(crate) struct NativeAuthManager {
 }
 
 impl NativeAuthManager {
-    pub fn new(deployment_url: String, callback_url: String, data_dir: &Path) -> Arc<Self> {
-        let refresh_tokens = Arc::new(KeyringRefreshTokenStore::new(&deployment_url, data_dir));
+    pub fn new(
+        deployment_url: String,
+        callback_url: String,
+        data_dir: &Path,
+        local_sessions: Arc<crate::auth::AuthState>,
+    ) -> Arc<Self> {
+        let refresh_tokens = Arc::new(credentials::ProfileCredentials::new(
+            &deployment_url,
+            data_dir,
+        ));
         Arc::new(Self {
+            changes: watch::channel(0).0,
+            local_sessions: Some(local_sessions),
             deployment_url: Some(deployment_url),
             client: OnceCell::new(),
             callback_url,
@@ -249,6 +269,8 @@ impl NativeAuthManager {
         let client_cell = OnceCell::new();
         assert!(client_cell.set(client).is_ok());
         Arc::new(Self {
+            changes: watch::channel(0).0,
+            local_sessions: None,
             deployment_url: None,
             client: client_cell,
             callback_url,
@@ -332,6 +354,7 @@ impl NativeAuthManager {
                 ..Default::default()
             })
             .context("failed to build WorkOS authorization URL")?;
+        let _operation = self.credential_operation.lock().await;
         let mut session = self.session.lock().await;
         purge_expired_logins(&mut session.pending);
         if let Some(previous_state) = session.pending.by_session.remove(session_token) {
@@ -377,7 +400,7 @@ impl NativeAuthManager {
     ) -> anyhow::Result<(NativeUser, String)> {
         let code = required_callback_value(code, "authorization code")?;
         let state = required_callback_value(state, "desktop login state")?;
-        let (code_verifier, pending_session_token, sign_out_generation) = {
+        let (code_verifier, pending_session_token, login_generation) = {
             let mut session = self.session.lock().await;
             purge_expired_logins(&mut session.pending);
             let pending = session
@@ -389,13 +412,13 @@ impl NativeAuthManager {
             (
                 pending.code_verifier,
                 pending.session_token,
-                session.sign_out_generation,
+                session.login_generation,
             )
         };
 
         let _credential_operation = self.credential_operation.lock().await;
-        if self.session.lock().await.sign_out_generation != sign_out_generation {
-            anyhow::bail!("desktop login attempt was invalidated by sign-out");
+        if self.session.lock().await.login_generation != login_generation {
+            anyhow::bail!("desktop login attempt was invalidated by another sign-in or sign-out");
         }
         let mut params = AuthenticateWithCodeParams::new(code);
         params.code_verifier = Some(code_verifier);
@@ -407,7 +430,7 @@ impl NativeAuthManager {
             .await
         {
             Ok(response) => self
-                .accept_authentication(response)
+                .accept_login(response)
                 .await
                 .map(|user| (user, pending_session_token)),
             Err(error) => {
@@ -494,17 +517,20 @@ impl NativeAuthManager {
 
     async fn sign_out_inner(&self) -> anyhow::Result<()> {
         let _credential_operation = self.credential_operation.lock().await;
-        let sign_out_generation = self
-            .session
-            .lock()
-            .await
-            .sign_out_generation
-            .wrapping_add(1);
+        let login_generation = self.session.lock().await.login_generation.wrapping_add(1);
         let mut session = NativeSession::default();
         session.suppress_persisted_resume = true;
-        session.sign_out_generation = sign_out_generation;
-        *self.session.lock().await = session;
-        self.clear_refresh_token().await
+        session.login_generation = login_generation;
+        {
+            let mut current = self.session.lock().await;
+            for attempt in current.devices.values() {
+                attempt.cancel.cancel();
+            }
+            *current = session;
+        }
+        let cleared = self.clear_refresh_token().await;
+        self.publish_session_change(None).await?;
+        cleared
     }
 
     pub fn auth_token_fetcher_for_user(
@@ -656,7 +682,9 @@ impl NativeAuthManager {
             }
             Err(error) if is_terminal_refresh_error(&error) => {
                 self.session.lock().await.clear_authenticated_state();
-                self.clear_refresh_token().await?;
+                let cleared = self.clear_refresh_token().await;
+                self.publish_session_change(None).await?;
+                cleared?;
                 Err(error).context(NATIVE_SESSION_EXPIRED)
             }
             Err(error) => {
@@ -681,6 +709,23 @@ impl NativeAuthManager {
         }
     }
 
+    async fn accept_login(&self, response: AuthenticateResponse) -> anyhow::Result<NativeUser> {
+        let result = self.accept_authentication(response).await;
+        let mut session = self.session.lock().await;
+        session.login_generation = session.login_generation.wrapping_add(1);
+        let invalidated =
+            "Another sign-in completed. Start sign-in again if you want to switch accounts.";
+        let pending = std::mem::take(&mut session.pending);
+        for token in pending.by_session.into_keys() {
+            session.login_errors.insert(token, invalidated.into());
+        }
+        for attempt in session.devices.values_mut() {
+            attempt.cancel.cancel();
+            attempt.result = Some(Err(invalidated.into()));
+        }
+        result
+    }
+
     async fn accept_authentication(
         &self,
         response: AuthenticateResponse,
@@ -695,6 +740,14 @@ impl NativeAuthManager {
         let access_token = response.access_token.into_inner();
         let expires_at = jwt_expiration(&access_token)?;
         let refresh_token = response.refresh_token.into_inner();
+        let changed = self
+            .session
+            .lock()
+            .await
+            .user
+            .as_ref()
+            .map(|user| user.id.as_str())
+            != Some(user.id.as_str());
         {
             let mut session = self.session.lock().await;
             session.access_token = Some(AccessToken {
@@ -708,8 +761,26 @@ impl NativeAuthManager {
             session.login_errors.clear();
             session.suppress_persisted_resume = false;
         }
-        self.flush_refresh_token().await?;
+        let saved = self.flush_refresh_token().await;
+        if changed {
+            self.publish_session_change(Some(&user.id)).await?;
+        }
+        saved?;
         Ok(user)
+    }
+
+    pub fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes.subscribe()
+    }
+
+    async fn publish_session_change(&self, user_id: Option<&str>) -> anyhow::Result<()> {
+        let result = match &self.local_sessions {
+            Some(sessions) => sessions.bind_all_sessions(user_id).await,
+            None => Ok(()),
+        };
+        self.changes
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        result
     }
 
     async fn load_refresh_token(&self) -> anyhow::Result<Option<String>> {
@@ -1052,7 +1123,12 @@ mod tests {
     where
         H: Fn(serde_json::Value) -> (StatusCode, serde_json::Value) + Clone + Send + Sync + 'static,
     {
-        let app = axum::Router::new().route(
+        let app = axum::Router::new().route("/user_management/authorize/device", post(|| async {
+            Json(serde_json::json!({
+                "device_code": "private-device-code", "user_code": "ABCD-EFGH",
+                "verification_uri": "https://auth.example.test/device", "expires_in": 300, "interval": 1
+            }))
+        })).route(
             "/user_management/authenticate",
             post(move |Json(body): Json<serde_json::Value>| {
                 let handler = handler.clone();
@@ -1089,11 +1165,139 @@ mod tests {
         manager_with_handler(store, move |_| (status, body.clone())).await
     }
 
+    #[tokio::test]
+    async fn credential_selection_cannot_skip_a_persisted_login() {
+        let store = MemoryRefreshTokenStore::with_token("persisted");
+        let manager =
+            manager_with_response(store.clone(), StatusCode::OK, serde_json::Value::Null).await;
+        let error = manager
+            .select_credential_store(crate::cli_protocol::CredentialStore::File)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("sign out"));
+        assert_eq!(store.token().as_deref(), Some("persisted"));
+    }
+
+    #[tokio::test]
+    async fn accepting_a_login_invalidates_other_pending_browser_and_device_flows() {
+        let manager = manager_with_response(
+            MemoryRefreshTokenStore::empty(),
+            StatusCode::BAD_REQUEST,
+            serde_json::Value::Null,
+        )
+        .await;
+        let pending = manager
+            .start_login("browser", NativeLoginFlow::SignIn)
+            .await
+            .unwrap();
+        manager.start_device_login("cli".into()).await.unwrap();
+        let generation = manager.session.lock().await.login_generation;
+        manager
+            .accept_login(authentication_response(
+                access_token(unix_time_secs() + 3600),
+                "fresh",
+            ))
+            .await
+            .unwrap();
+        assert!(
+            manager
+                .complete_login("stale", &pending.login_id)
+                .await
+                .is_err()
+        );
+        assert!(matches!(
+            manager.device_status("cli").await,
+            NativeLoginStatus::Failed { .. }
+        ));
+        assert_ne!(manager.session.lock().await.login_generation, generation);
+    }
+
     fn config_result(client_id: Value) -> FunctionResult {
         FunctionResult::Value(Value::Object(BTreeMap::from([(
             "workosClientId".to_string(),
             client_id,
         )])))
+    }
+
+    #[tokio::test]
+    async fn device_login_uses_the_shared_session_and_never_discloses_the_device_secret() {
+        let store = MemoryRefreshTokenStore::empty();
+        let response = serde_json::to_value(authentication_response(
+            access_token(unix_time_secs() + 3600),
+            "device-refresh",
+        ))
+        .unwrap();
+        let mut manager = manager_with_response(store.clone(), StatusCode::OK, response).await;
+        let directory = tempfile::tempdir().unwrap();
+        let local = crate::auth::AuthState::load(directory.path()).unwrap();
+        let (_, desktop_session) = local.bootstrap(local.pairing_credential()).await.unwrap();
+        let (_, browser_session) = local.bootstrap(local.pairing_credential()).await.unwrap();
+        Arc::get_mut(&mut manager).unwrap().local_sessions = Some(Arc::clone(&local));
+        let mut changes = manager.subscribe_changes();
+        let login = manager
+            .start_device_login("cli-session".into())
+            .await
+            .unwrap();
+        assert!(
+            !serde_json::to_string(&login)
+                .unwrap()
+                .contains("private-device-code")
+        );
+        tokio::time::timeout(Duration::from_secs(5), changes.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        let session = manager.browser_session(false).await.unwrap().unwrap();
+        local
+            .require_session_user(&desktop_session, &session.user.id)
+            .await
+            .unwrap();
+        local
+            .require_session_user(&browser_session, &session.user.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.token.lock().unwrap().as_deref(),
+            Some("device-refresh")
+        );
+        assert!(
+            matches!(manager.device_status("cli-session").await, NativeLoginStatus::Authenticated { user } if user.id == session.user.id)
+        );
+        manager.sign_out().await.unwrap();
+        assert!(manager.browser_session(false).await.unwrap().is_none());
+        assert!(
+            local
+                .require_session_user(&desktop_session, &session.user.id)
+                .await
+                .is_err()
+        );
+        assert!(
+            local
+                .require_session_user(&browser_session, &session.user.id)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_device_login_cannot_restore_a_session() {
+        let store = MemoryRefreshTokenStore::empty();
+        let manager = manager_with_response(
+            store.clone(),
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({"error": "authorization_pending"}),
+        )
+        .await;
+        manager
+            .start_device_login("cli-session".into())
+            .await
+            .unwrap();
+        manager.cancel_device_login("cli-session").await;
+        assert!(matches!(
+            manager.device_status("cli-session").await,
+            NativeLoginStatus::SignedOut
+        ));
+        assert!(store.token.lock().unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/sprocket-server/src/native_auth/credentials.rs
+++ b/crates/sprocket-server/src/native_auth/credentials.rs
@@ -1,0 +1,151 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use super::{KeyringRefreshTokenStore, RefreshTokenStore};
+use crate::cli_protocol::CredentialStore;
+use crate::profile::write_private_file;
+
+pub(super) struct ProfileCredentials {
+    keyring: KeyringRefreshTokenStore,
+    directory: PathBuf,
+}
+
+impl ProfileCredentials {
+    pub fn new(deployment: &str, data_dir: &Path) -> Self {
+        let keyring = KeyringRefreshTokenStore::new(deployment, data_dir);
+        let directory = data_dir.join("credentials").join(&keyring.account);
+        Self { keyring, directory }
+    }
+
+    fn selected(&self) -> anyhow::Result<CredentialStore> {
+        match std::fs::read(self.directory.join("store.json")) {
+            Ok(bytes) => {
+                serde_json::from_slice(&bytes).context("invalid credential-store selection")
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Ok(CredentialStore::Keyring)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn token_path(&self) -> PathBuf {
+        self.directory.join("refresh-token")
+    }
+}
+
+impl RefreshTokenStore for ProfileCredentials {
+    fn select(&self, store: CredentialStore) -> anyhow::Result<()> {
+        if self.selected()? != store {
+            match store {
+                CredentialStore::Keyring => self.keyring.clear()?,
+                CredentialStore::File => match std::fs::remove_file(self.token_path()) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error.into()),
+                },
+            }
+            write_private_file(
+                &self.directory.join("store.json"),
+                &serde_json::to_vec(&store)?,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn load(&self) -> anyhow::Result<Option<String>> {
+        match self.selected()? {
+            CredentialStore::Keyring => self.keyring.load(),
+            CredentialStore::File => {
+                let path = self.token_path();
+                let metadata = match std::fs::symlink_metadata(&path) {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                    Err(error) => return Err(error.into()),
+                };
+                anyhow::ensure!(metadata.is_file(), "credential file must be a regular file");
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    anyhow::ensure!(
+                        metadata.permissions().mode() & 0o077 == 0,
+                        "credential file must have owner-only permissions"
+                    );
+                }
+                let token = std::fs::read_to_string(path)?;
+                anyhow::ensure!(!token.trim().is_empty(), "stored refresh token is empty");
+                Ok(Some(token))
+            }
+        }
+    }
+
+    fn save(&self, token: &str) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !token.trim().is_empty(),
+            "refusing to store an empty refresh token"
+        );
+        match self.selected()? {
+            CredentialStore::Keyring => self.keyring.save(token),
+            CredentialStore::File => write_private_file(&self.token_path(), token.as_bytes()),
+        }
+    }
+
+    fn clear(&self) -> anyhow::Result<()> {
+        match self.selected()? {
+            CredentialStore::Keyring => self.keyring.clear(),
+            CredentialStore::File => match std::fs::remove_file(self.token_path()) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_file_selection_survives_restart_and_rotation() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileCredentials::new("https://test.convex.cloud", dir.path());
+        assert_eq!(store.selected().unwrap(), CredentialStore::Keyring);
+        store.select(CredentialStore::File).unwrap();
+        store.save("first").unwrap();
+        let restarted = ProfileCredentials::new("https://test.convex.cloud", dir.path());
+        assert_eq!(restarted.load().unwrap().as_deref(), Some("first"));
+        restarted.save("rotated").unwrap();
+        assert_eq!(store.load().unwrap().as_deref(), Some("rotated"));
+        restarted.clear().unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn switching_back_to_file_storage_does_not_restore_an_old_login() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileCredentials::new("https://test.convex.cloud", dir.path());
+        store.select(CredentialStore::File).unwrap();
+        store.save("old-session").unwrap();
+        write_private_file(&store.directory.join("store.json"), b"\"keyring\"").unwrap();
+        store.select(CredentialStore::File).unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_shared_permissions_and_symlinks() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileCredentials::new("https://test.convex.cloud", dir.path());
+        store.select(CredentialStore::File).unwrap();
+        store.save("secret").unwrap();
+        std::fs::set_permissions(store.token_path(), std::fs::Permissions::from_mode(0o644))
+            .unwrap();
+        assert!(store.load().is_err());
+        std::fs::remove_file(store.token_path()).unwrap();
+        symlink("/etc/passwd", store.token_path()).unwrap();
+        assert!(store.load().is_err());
+    }
+}

--- a/crates/sprocket-server/src/native_auth/device.rs
+++ b/crates/sprocket-server/src/native_auth/device.rs
@@ -1,0 +1,154 @@
+use super::*;
+use crate::cli_protocol::{CredentialStore, DeviceLoginResponse};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+pub(super) struct PendingDeviceLogin {
+    id: String,
+    pub cancel: CancellationToken,
+    pub result: Option<Result<NativeUser, String>>,
+}
+
+impl NativeAuthManager {
+    pub async fn select_credential_store(
+        self: &Arc<Self>,
+        store: CredentialStore,
+    ) -> anyhow::Result<()> {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move { manager.select_credential_store_inner(store).await })
+            .await
+            .context("credential-store selection task failed")?
+    }
+
+    async fn select_credential_store_inner(&self, store: CredentialStore) -> anyhow::Result<()> {
+        let _operation = self.credential_operation.lock().await;
+        {
+            let session = self.session.lock().await;
+            anyhow::ensure!(
+                session.user.is_none() && session.refresh_token.is_none(),
+                "sign out before changing the credential store"
+            );
+            anyhow::ensure!(
+                session.devices.is_empty() && session.pending.by_state.is_empty(),
+                "cancel pending sign-ins before changing the credential store"
+            );
+        }
+        let credentials = Arc::clone(&self.refresh_tokens);
+        tokio::task::spawn_blocking(move || {
+            anyhow::ensure!(
+                !matches!(credentials.load(), Ok(Some(_))),
+                "sign out before changing the credential store"
+            );
+            credentials.select(store)
+        })
+        .await??;
+        let mut session = self.session.lock().await;
+        session.login_generation = session.login_generation.wrapping_add(1);
+        Ok(())
+    }
+
+    pub async fn start_device_login(
+        self: &Arc<Self>,
+        session_token: String,
+    ) -> anyhow::Result<DeviceLoginResponse> {
+        let client = self.client().await?.clone();
+        let generation = self.session.lock().await.login_generation;
+        let authorization = timeout(
+            CLIENT_CONFIG_TIMEOUT,
+            client.authkit().start_device_authorization(),
+        )
+        .await
+        .context("device authorization timed out")??;
+        let expires = Duration::try_from_secs_f64(authorization.expires_in)
+            .context("invalid device authorization lifetime")?
+            .min(Duration::from_secs(900));
+        anyhow::ensure!(!expires.is_zero(), "device authorization already expired");
+        let interval = Duration::try_from_secs_f64(authorization.interval.unwrap_or(5.0))
+            .context("invalid device polling interval")?
+            .max(Duration::from_secs(1));
+        let response = DeviceLoginResponse {
+            verification_uri: authorization.verification_uri,
+            user_code: authorization.user_code,
+            expires_in: expires.as_secs(),
+        };
+        let id = Uuid::new_v4().to_string();
+        let cancel = CancellationToken::new();
+        {
+            let _operation = self.credential_operation.lock().await;
+            let mut session = self.session.lock().await;
+            anyhow::ensure!(
+                session.login_generation == generation,
+                "login was invalidated by another authentication operation"
+            );
+            if let Some(previous) = session.devices.insert(
+                session_token.clone(),
+                PendingDeviceLogin {
+                    id: id.clone(),
+                    cancel: cancel.clone(),
+                    result: None,
+                },
+            ) {
+                previous.cancel.cancel();
+            }
+        }
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let authkit = client.authkit();
+            let polled = tokio::select! {
+                _ = cancel.cancelled() => return,
+                result = timeout(expires, authkit.poll_device_code(&authorization.device_code, interval)) => result,
+            };
+            let _operation = manager.credential_operation.lock().await;
+            {
+                let session = manager.session.lock().await;
+                if cancel.is_cancelled()
+                    || session.login_generation != generation
+                    || !session
+                        .devices
+                        .get(&session_token)
+                        .is_some_and(|attempt| attempt.id == id)
+                {
+                    return;
+                }
+            }
+            let result = match polled {
+                Ok(Ok(response)) => manager
+                    .accept_login(response)
+                    .await
+                    .map_err(|error| error.to_string()),
+                Ok(Err(_)) => {
+                    Err("Device login failed or was denied. Run sprocket login again.".to_string())
+                }
+                Err(_) => Err("Device login expired. Run sprocket login again.".to_string()),
+            };
+            if let Some(attempt) = manager.session.lock().await.devices.get_mut(&session_token) {
+                attempt.result = Some(result);
+            }
+        });
+        Ok(response)
+    }
+
+    pub async fn device_status(self: &Arc<Self>, session_token: &str) -> NativeLoginStatus {
+        {
+            let session = self.session.lock().await;
+            if let Some(attempt) = session.devices.get(session_token) {
+                match &attempt.result {
+                    None => return NativeLoginStatus::Pending,
+                    Some(Ok(_)) => {}
+                    Some(Err(error)) => {
+                        return NativeLoginStatus::Failed {
+                            error: error.clone(),
+                        };
+                    }
+                }
+            }
+        }
+        self.status(session_token).await
+    }
+
+    pub async fn cancel_device_login(&self, session_token: &str) {
+        if let Some(attempt) = self.session.lock().await.devices.remove(session_token) {
+            attempt.cancel.cancel();
+        }
+    }
+}

--- a/crates/sprocket-server/src/profile.rs
+++ b/crates/sprocket-server/src/profile.rs
@@ -1,0 +1,124 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct ServerAddress {
+    url: String,
+}
+
+pub(crate) struct ProfileLock {
+    _file: File,
+    directory: PathBuf,
+}
+
+impl ProfileLock {
+    pub fn acquire(directory: &Path) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(directory)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(directory.join("server.lock"))?;
+        file.try_lock().context(
+            "another Sprocket server owns this data directory; connect to it or use a different SPROCKET_DATA_DIR",
+        )?;
+        Ok(Self {
+            _file: file,
+            directory: directory.to_owned(),
+        })
+    }
+
+    pub fn publish(&self, url: String) -> anyhow::Result<()> {
+        write_private_file(
+            &self.directory.join("server-address.json"),
+            &serde_json::to_vec(&ServerAddress { url })?,
+        )
+    }
+}
+
+pub fn read_server_address(directory: &Path) -> anyhow::Result<Option<String>> {
+    match std::fs::read(directory.join("server-address.json")) {
+        Ok(bytes) => Ok(Some(serde_json::from_slice::<ServerAddress>(&bytes)?.url)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn write_private_file(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let parent = path.parent().context("file has no parent directory")?;
+    std::fs::create_dir_all(parent)?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(windows)]
+    restrict_windows_file(file.path())?;
+    file.write_all(bytes)?;
+    file.as_file().sync_all()?;
+    file.persist(path)
+        .context("failed to persist private file")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn restrict_windows_file(path: &Path) -> anyhow::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, SetFileSecurityW,
+    };
+    let path: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let sddl: Vec<u16> = "D:P(A;;FA;;;OW)".encode_utf16().chain(Some(0)).collect();
+    let mut descriptor = std::ptr::null_mut();
+    // SAFETY: both strings are NUL-terminated; LocalFree releases the allocated descriptor.
+    unsafe {
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        ) == 0
+        {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let result = SetFileSecurityW(
+            path.as_ptr(),
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            descriptor,
+        );
+        let error = (result == 0).then(std::io::Error::last_os_error);
+        LocalFree(descriptor);
+        if let Some(error) = error {
+            return Err(error.into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_server_owns_a_profile_until_it_stops() {
+        let dir = tempfile::tempdir().unwrap();
+        let owner = ProfileLock::acquire(dir.path()).unwrap();
+        assert!(ProfileLock::acquire(dir.path()).is_err());
+        owner.publish("http://127.0.0.1:17731".into()).unwrap();
+        assert_eq!(
+            read_server_address(dir.path()).unwrap().as_deref(),
+            Some("http://127.0.0.1:17731")
+        );
+        drop(owner);
+        assert!(ProfileLock::acquire(dir.path()).is_ok());
+    }
+}

--- a/crates/sprocket-server/src/routes/api_error.rs
+++ b/crates/sprocket-server/src/routes/api_error.rs
@@ -8,6 +8,14 @@ pub(crate) struct ApiError {
     message: String,
 }
 
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ApiError {}
+
 impl ApiError {
     pub(crate) fn with_status(status: StatusCode, error: anyhow::Error) -> Self {
         Self {

--- a/crates/sprocket-server/src/routes/auth.rs
+++ b/crates/sprocket-server/src/routes/auth.rs
@@ -54,6 +54,7 @@ struct NativeSessionTokenRequest {
 
 pub fn routes() -> axum::Router<AppState> {
     axum::Router::new()
+        .route("/auth/changes", get(session_changes))
         .route("/auth/session", get(session))
         .route("/auth/bootstrap", post(bootstrap))
         .route("/auth/pairing-proof", post(pairing_proof))
@@ -67,6 +68,44 @@ pub fn routes() -> axum::Router<AppState> {
             axum::routing::delete(native_sign_out),
         )
         .route("/auth/native-session/token", post(native_session_token))
+}
+
+async fn session_changes(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> Result<
+    axum::response::Sse<
+        impl futures::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>,
+    >,
+    ApiError,
+> {
+    if !crate::auth::cookie_get_is_csrf_safe(&headers) {
+        return Err(ApiError::authentication_required());
+    }
+    require_session(&state.auth, &headers, &jar)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    let receiver = state.native_auth.subscribe_changes();
+    let shutdown = state.lifetime.shutdown.clone();
+    let guard = state.lifetime.run_guard().map_err(ApiError::bad_request)?;
+    let stream = futures::stream::unfold(
+        (receiver, true, shutdown, guard),
+        |(mut receiver, initial, shutdown, guard)| async move {
+            if !initial {
+                tokio::select! {
+                    _ = shutdown.cancelled() => return None,
+                    changed = receiver.changed() => if changed.is_err() { return None; },
+                }
+            }
+            let generation = *receiver.borrow_and_update();
+            Some((
+                Ok(axum::response::sse::Event::default().data(generation.to_string())),
+                (receiver, false, shutdown, guard),
+            ))
+        },
+    );
+    Ok(axum::response::Sse::new(stream).keep_alive(axum::response::sse::KeepAlive::default()))
 }
 
 async fn session(
@@ -309,6 +348,10 @@ async fn native_session_token(
     jar: CookieJar,
     Json(payload): Json<NativeSessionTokenRequest>,
 ) -> Response {
+    let _activity = match state.lifetime.run_guard() {
+        Ok(guard) => guard,
+        Err(error) => return ApiError::bad_request(error).into_response(),
+    };
     let result = native_session_token_response(&state, peer, &headers, &jar, payload).await;
     let mut response = result.into_response();
     response

--- a/crates/sprocket-server/src/routes/cli.rs
+++ b/crates/sprocket-server/src/routes/cli.rs
@@ -1,0 +1,226 @@
+#[cfg(test)]
+mod tests;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::post;
+use axum::{Json, Router};
+
+use crate::AppState;
+use crate::auth::bearer_token;
+use crate::cli_protocol::*;
+use crate::cli_sessions::CliSession;
+use crate::routes::api_error::ApiError;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/cli/discovery", post(discovery))
+        .route("/cli/bootstrap", post(bootstrap))
+        .route("/cli/connect", post(connect))
+        .route("/cli/heartbeat", post(heartbeat))
+        .route("/cli/release", post(release))
+        .route("/cli/login", post(login))
+        .route("/cli/auth", post(auth_status))
+        .route("/cli/logout", post(logout))
+}
+
+async fn discovery(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(request): Json<crate::PairingProofRequest>,
+) -> Result<Json<CliDiscovery>, ApiError> {
+    if !peer.ip().is_loopback() {
+        return Err(ApiError::authentication_required());
+    }
+    let proof = state
+        .auth
+        .pairing_proof(&cli_discovery_message(
+            &request.challenge,
+            &state.auth.instance_id,
+            &state.http_base_url,
+        ))
+        .map_err(ApiError::internal)?;
+    Ok(Json(CliDiscovery {
+        instance_id: state.auth.instance_id.clone(),
+        http_base_url: state.http_base_url,
+        proof,
+    }))
+}
+
+async fn bootstrap(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(request): Json<CliBootstrapRequest>,
+) -> Result<Json<CliBootstrapResponse>, ApiError> {
+    if !peer.ip().is_loopback()
+        || uuid::Uuid::parse_str(&request.session_token).is_err()
+        || request.client.client_version != sprocket_workspace::SPROCKET_VERSION
+        || request.client.deployment_url.trim_end_matches('/')
+            != state.convex_deployment_url.trim_end_matches('/')
+        || !crate::verify_pairing_proof(
+            state.auth.pairing_credential(),
+            &cli_bootstrap_message(&state.auth.instance_id, &state.http_base_url, &request),
+            &request.proof,
+        )
+    {
+        return Err(ApiError::authentication_required());
+    }
+    let proof = state
+        .auth
+        .pairing_proof(&cli_bootstrap_response_message(
+            &state.auth.instance_id,
+            &state.http_base_url,
+            &request,
+        ))
+        .map_err(ApiError::internal)?;
+    state
+        .lifetime
+        .connect(&request.client.client_id, &request.session_token)
+        .map_err(ApiError::bad_request)?;
+    state.auth.create_cli_session(request.session_token).await;
+    Ok(Json(CliBootstrapResponse { proof }))
+}
+
+async fn session(
+    state: &AppState,
+    peer: SocketAddr,
+    headers: &HeaderMap,
+) -> Result<String, ApiError> {
+    if !peer.ip().is_loopback() {
+        return Err(ApiError::with_status(
+            StatusCode::FORBIDDEN,
+            anyhow::anyhow!("CLI access is local-only"),
+        ));
+    }
+    let token = bearer_token(headers).ok_or_else(ApiError::authentication_required)?;
+    if !state.auth.session_state(Some(&token)).await.authenticated {
+        return Err(ApiError::authentication_required());
+    }
+    Ok(token)
+}
+
+async fn client_session(
+    state: &AppState,
+    peer: SocketAddr,
+    headers: &HeaderMap,
+    client_id: &str,
+) -> Result<Arc<CliSession>, ApiError> {
+    let token = session(state, peer, headers).await?;
+    state
+        .lifetime
+        .client(client_id, &token)
+        .map_err(|error| ApiError::with_status(StatusCode::CONFLICT, error))
+}
+
+async fn connect(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliConnectRequest>,
+) -> Result<Json<bool>, ApiError> {
+    let token = session(&state, peer, &headers).await?;
+    if request.client_version != sprocket_workspace::SPROCKET_VERSION
+        || request.deployment_url.trim_end_matches('/')
+            != state.convex_deployment_url.trim_end_matches('/')
+    {
+        return Err(ApiError::with_status(
+            StatusCode::CONFLICT,
+            anyhow::anyhow!(
+                "incompatible Sprocket server; update it or select a different data directory"
+            ),
+        ));
+    }
+    state
+        .lifetime
+        .connect(&request.client_id, &token)
+        .map_err(ApiError::bad_request)?;
+    Ok(Json(true))
+}
+
+async fn heartbeat(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<bool>, ApiError> {
+    client_session(&state, peer, &headers, &request.client_id).await?;
+    Ok(Json(true))
+}
+
+async fn release(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<bool>, ApiError> {
+    let token = session(&state, peer, &headers).await?;
+    state
+        .lifetime
+        .release(&request.client_id, &token)
+        .map_err(ApiError::bad_request)?;
+    state.native_auth.cancel_device_login(&token).await;
+    state
+        .auth
+        .end_session(&token)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(true))
+}
+
+async fn auth_status(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<LoginStatus>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    let status = state.native_auth.device_status(&client.session_token).await;
+    if let LoginStatus::Authenticated { user } = &status {
+        state
+            .auth
+            .bind_session_user(&client.session_token, &user.id)
+            .await
+            .map_err(ApiError::internal)?;
+    }
+    Ok(Json(status))
+}
+
+async fn login(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliLoginRequest>,
+) -> Result<Json<DeviceLoginResponse>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    if let Some(store) = request.credential_store {
+        state
+            .native_auth
+            .select_credential_store(store)
+            .await
+            .map_err(ApiError::bad_request)?;
+    }
+    let response = state
+        .native_auth
+        .start_device_login(client.session_token.clone())
+        .await
+        .map_err(ApiError::bad_request)?;
+    Ok(Json(response))
+}
+
+async fn logout(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<bool>, ApiError> {
+    client_session(&state, peer, &headers, &request.client_id).await?;
+    state
+        .native_auth
+        .sign_out()
+        .await
+        .map_err(ApiError::bad_request)?;
+    Ok(Json(true))
+}

--- a/crates/sprocket-server/src/routes/cli/tests.rs
+++ b/crates/sprocket-server/src/routes/cli/tests.rs
@@ -1,0 +1,213 @@
+use super::*;
+use axum::body::Body;
+use axum::http::Request;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn signed_bootstrap_and_cli_sessions_cannot_be_replayed_after_server_restart() {
+    let (directory, mut state, _, existing) = fixture().await;
+    let challenge = "fresh-challenge";
+    let (status, discovered) = call(
+        &state,
+        "",
+        "discovery",
+        &crate::PairingProofRequest {
+            challenge: challenge.into(),
+        },
+        "127.0.0.1:1000",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let discovered: CliDiscovery = serde_json::from_value(discovered).unwrap();
+    assert!(crate::verify_pairing_proof(
+        state.auth.pairing_credential(),
+        &cli_discovery_message(
+            challenge,
+            &discovered.instance_id,
+            &discovered.http_base_url
+        ),
+        &discovered.proof
+    ));
+    let mut request = CliBootstrapRequest {
+        client: CliConnectRequest {
+            client_id: uuid::Uuid::new_v4().to_string(),
+            client_version: sprocket_workspace::SPROCKET_VERSION.to_string(),
+            deployment_url: state.convex_deployment_url.clone(),
+        },
+        session_token: uuid::Uuid::new_v4().to_string(),
+        proof: Vec::new(),
+    };
+    request.proof = state
+        .auth
+        .pairing_proof(&cli_bootstrap_message(
+            &discovered.instance_id,
+            &discovered.http_base_url,
+            &request,
+        ))
+        .unwrap();
+    let (status, accepted) = call(&state, "", "bootstrap", &request, "127.0.0.1:1000").await;
+    assert_eq!(status, StatusCode::OK);
+    let accepted: CliBootstrapResponse = serde_json::from_value(accepted).unwrap();
+    assert!(crate::verify_pairing_proof(
+        state.auth.pairing_credential(),
+        &cli_bootstrap_response_message(
+            &discovered.instance_id,
+            &discovered.http_base_url,
+            &request
+        ),
+        &accepted.proof
+    ));
+    assert!(
+        state
+            .auth
+            .session_state(Some(&request.session_token))
+            .await
+            .authenticated
+    );
+    let mut incompatible = CliBootstrapRequest {
+        client: CliConnectRequest {
+            client_id: uuid::Uuid::new_v4().to_string(),
+            client_version: "999.0.0".into(),
+            deployment_url: state.convex_deployment_url.clone(),
+        },
+        session_token: uuid::Uuid::new_v4().to_string(),
+        proof: Vec::new(),
+    };
+    incompatible.proof = state
+        .auth
+        .pairing_proof(&cli_bootstrap_message(
+            &discovered.instance_id,
+            &discovered.http_base_url,
+            &incompatible,
+        ))
+        .unwrap();
+    assert_eq!(
+        call(&state, "", "bootstrap", &incompatible, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::UNAUTHORIZED
+    );
+    state.auth.bind_all_sessions(Some("user")).await.unwrap();
+    assert!(
+        !std::fs::read_to_string(directory.path().join("sessions.json"))
+            .unwrap()
+            .contains(&request.session_token)
+    );
+    request.client.client_id = existing.client_id;
+    assert_eq!(
+        call(&state, "", "bootstrap", &request, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::UNAUTHORIZED
+    );
+    state.auth = crate::auth::AuthState::load(directory.path()).unwrap();
+    assert_ne!(state.auth.instance_id, discovered.instance_id);
+    assert!(
+        !state
+            .auth
+            .session_state(Some(&request.session_token))
+            .await
+            .authenticated
+    );
+    assert_eq!(
+        call(&state, "", "bootstrap", &request, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+async fn fixture() -> (tempfile::TempDir, AppState, String, CliClientRequest) {
+    let directory = tempfile::tempdir().unwrap();
+    let auth = crate::auth::AuthState::load(directory.path()).unwrap();
+    let (_, token) = auth.bootstrap(auth.pairing_credential()).await.unwrap();
+    let native_auth = crate::native_auth::NativeAuthManager::configured_for_test(
+        crate::native_auth::NativeAuthConfig {
+            workos_client_id: "client_test".into(),
+        },
+        "http://127.0.0.1/callback".into(),
+    );
+    let state = AppState::for_test(
+        auth,
+        native_auth,
+        directory.path().to_owned(),
+        true,
+        crate::package_update::PackageUpdateManager::disabled(),
+    );
+    let request = CliClientRequest {
+        client_id: uuid::Uuid::new_v4().to_string(),
+    };
+    state.lifetime.connect(&request.client_id, &token).unwrap();
+    (directory, state, token, request)
+}
+
+async fn call(
+    state: &AppState,
+    token: &str,
+    operation: &str,
+    body: &impl serde::Serialize,
+    peer: &str,
+) -> (StatusCode, serde_json::Value) {
+    let response = crate::build_router(state.clone(), None)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/cli/{operation}"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .extension(ConnectInfo(peer.parse::<SocketAddr>().unwrap()))
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    (status, serde_json::from_slice(&body).unwrap())
+}
+
+#[tokio::test]
+async fn cli_control_requires_the_owning_local_session_and_matching_version() {
+    let (_directory, state, token, request) = fixture().await;
+    assert_eq!(
+        call(&state, &token, "heartbeat", &request, "192.168.1.10:1000")
+            .await
+            .0,
+        StatusCode::FORBIDDEN
+    );
+    let (_, other_token) = state
+        .auth
+        .bootstrap(state.auth.pairing_credential())
+        .await
+        .unwrap();
+    assert_eq!(
+        call(
+            &state,
+            &other_token,
+            "heartbeat",
+            &request,
+            "127.0.0.1:1000"
+        )
+        .await
+        .0,
+        StatusCode::CONFLICT
+    );
+    assert_eq!(
+        call(
+            &state,
+            &token,
+            "connect",
+            &CliConnectRequest {
+                client_id: request.client_id,
+                client_version: "999.0.0".into(),
+                deployment_url: state.convex_deployment_url.clone(),
+            },
+            "127.0.0.1:1000"
+        )
+        .await
+        .0,
+        StatusCode::CONFLICT
+    );
+}

--- a/crates/sprocket-server/src/routes/mod.rs
+++ b/crates/sprocket-server/src/routes/mod.rs
@@ -3,6 +3,7 @@ mod api_error;
 pub mod artifacts;
 mod attachment_upload;
 pub mod auth;
+pub(crate) mod cli;
 pub mod config;
 pub mod health;
 pub mod threads;


### PR DESCRIPTION
## Summary

- Add `sprocket login` and `sprocket logout` with WorkOS device authorization.
- Share native authentication state between the CLI, desktop app, and local browser app.
- Keep the OS credential store as the default and add explicit private-file storage for headless machines.
- Reuse or start the local server through authenticated loopback discovery, process-bound proofs, ephemeral sessions, client leases, and an exclusive profile lock.
- Notify an open app when another local client signs in or out.

This is 2 of 3 PRs split from #364 and is stacked on #370.

## Validation

- `cargo check -p sprocket-server -p sprocket-cli`
- `cargo test -p sprocket-server -p sprocket-cli`, with the one flaky profile-lock test passing on an immediate isolated rerun
- `bun run --cwd apps/web test src/lib/auth.test.ts --maxWorkers=2`
- Repository lint and type checks through the pre-commit suite

No live sign-in was attempted.

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63587209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding findings in the unchanged tree since the previous review.

<details open><summary><h3>Summary</h3></summary>

- Introduces `sprocket login` and `sprocket logout` using WorkOS device authorization.
- Adds authenticated loopback discovery, ephemeral CLI sessions, client leases, and temporary server lifecycle management.
- Shares native authentication state across local clients and notifies the web application of authentication changes.
- Adds profile locking and private credential-file support for headless environments.
- The current tree is unchanged from the previous review, and both previous findings are resolved.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as Sprocket CLI
    participant Server as Local Sprocket Server
    participant WorkOS
    participant App as Desktop / Browser App

    CLI->>Server: Discover and verify process-bound identity
    CLI->>Server: Bootstrap ephemeral authenticated session
    CLI->>Server: Start device login
    Server->>WorkOS: Request device authorization
    WorkOS-->>CLI: Verification URL and user code
    CLI->>Server: Poll authentication status
    Server->>WorkOS: Complete device authorization
    Server->>Server: Persist refresh token
    Server->>Server: Bind local sessions to user
    Server-->>App: Emit authentication-change event
    App->>Server: Refresh native authentication state
    Server-->>CLI: Authenticated user
```
</details>

<sub>Reviews (5) · Last reviewed commit: ["fix(auth): Harden discovery and login pe..."](https://github.com/spikonado/sprocket/commit/31559ebf517ee0c2c9f5cb72a000491616c0e56a)</sub>

<!-- /greptile_comment -->