### PR TITLE
feat(cli): Run agents from the terminal

### DIFF
--- a/BACKWARDS_COMPATIBILITY.md
+++ b/BACKWARDS_COMPATIBILITY.md
@@ -1,18 +1,30 @@
 # Backwards compatibility
 
-## CLI authentication
+## CLI authentication and run control
 
 CLI clients send their exact semantic release version to local `/api/cli/*`
 endpoints. The local server rejects every mismatch, including canary identifiers
 and dev commit hashes, so a newly installed CLI cannot reuse a stale server.
 Existing app launch, native login, and agent-run endpoints keep their request
-formats. Older local servers return an update-and-restart error rather than
-receiving a fallback authentication request.
+formats and interactive tool set. Deploy the finalization response support before
+releasing the new CLI. Older local servers return an update-and-restart error
+rather than receiving a fallback run request.
 
 CLI discovery and bootstrap proofs bind to a random server-process ID. The CLI
 never sends the reusable pairing credential over HTTP. CLI sessions stay in
 memory and cannot resume after a server restart. Existing app pairing and
 persisted app sessions keep their formats.
+
+`agentRuntime:finalizeExecutorRun` and `agentRuntime:finalizeClaimFailure` accept
+optional `includeOutput`. Without it, the mutation returns only whether that
+executor's finalization was accepted. With it, the same transaction also returns
+the run's committed terminal status and error. This matters when cancellation or
+another executor wins the finalization race: the CLI reports the state Convex
+committed rather than the state its executor tried to write. The response does
+not contain model text; the CLI reads that from the local transcript cache.
+Requests without `includeOutput` retain the boolean response. Keep this response
+compatibility until all supported installed executors request the structured
+result. No stored-data migration is needed.
 
 Profiles without a credential-store selection continue using the existing
 deployment-and-data-directory-scoped keyring entry. No credentials are copied to

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ To always open a tab in your browser when using Sprocket, use the `--web` flag:
 sprocket --web
 ```
 
+### Run an agent from the CLI
+
+```sh
+sprocket login
+sprocket run "Fix the failing tests"
+sprocket run --thread <thread-id> "Add regression coverage"
+```
+
+Inline prompts, `--prompt-file`, and stdin report only the current run. `--thread`
+uses its history as context without replaying it. Progress goes to stderr, the
+final answer to stdout, and full transcripts remain in the data directory and app.
+
 ### Workspaces
 
 Pass a directory to open or reconnect that workspace in a new thread:

--- a/apps/web/src/convex/agentRuntime.output.test.ts
+++ b/apps/web/src/convex/agentRuntime.output.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { api } from '@convex/_generated/api';
+import { createQueuedRun, initConvexTest, seedOwnedThread } from './test.setup';
+
+describe('executor finalization acknowledgments', () => {
+	it('returns the committed cancellation rather than a requested failure or stale completion', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'output-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'output-cancel', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'claim' });
+		await asUser.mutation(api.agentRuntime.requestCancellation, { runId });
+		const result = await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+			runId,
+			executionSecret,
+			expectedClaimId: 'claim',
+			status: 'failed',
+			text: '',
+			includeOutput: true
+		});
+		expect(result).toEqual({ accepted: true, outcome: { status: 'cancelled', error: null } });
+		expect(
+			await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+				runId,
+				executionSecret,
+				expectedClaimId: 'claim',
+				status: 'completed',
+				text: 'done',
+				includeOutput: true
+			})
+		).toEqual({ accepted: false, outcome: { status: 'cancelled', error: null } });
+	});
+
+	it('preserves boolean responses for installed clients and does not invent a terminal result after losing ownership', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'output-compat-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'output-compat', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'owner' });
+		expect(
+			await asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
+				runId,
+				executionSecret,
+				claimId: 'other',
+				text: '',
+				lastError: 'lost',
+				includeOutput: true
+			})
+		).toEqual({ accepted: false, outcome: null });
+		expect(
+			await asUser.mutation(api.agentRuntime.finalizeExecutorRun, {
+				runId,
+				executionSecret,
+				expectedClaimId: 'owner',
+				status: 'completed',
+				text: 'done'
+			})
+		).toBe(true);
+	});
+
+	it('returns a committed failure and keeps execution capability checks', async () => {
+		const t = initConvexTest();
+		const { asUser, threadId } = await seedOwnedThread(t);
+		const executionSecret = 'output-failure-secret';
+		const { runId } = await createQueuedRun(t, asUser, threadId, 'output-failure', executionSecret);
+		await asUser.mutation(api.agentRuntime.start, { runId, executionSecret, claimId: 'owner' });
+		await expect(
+			asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
+				runId,
+				executionSecret: 'wrong',
+				claimId: 'owner',
+				text: '',
+				lastError: 'lost',
+				includeOutput: true
+			})
+		).rejects.toThrow();
+		expect(
+			await asUser.mutation(api.agentRuntime.finalizeClaimFailure, {
+				runId,
+				executionSecret,
+				claimId: 'owner',
+				text: '',
+				lastError: 'lost',
+				includeOutput: true
+			})
+		).toEqual({ accepted: true, outcome: { status: 'failed', error: 'lost' } });
+	});
+});

--- a/apps/web/src/convex/agentRuntime.ts
+++ b/apps/web/src/convex/agentRuntime.ts
@@ -21,7 +21,12 @@ import {
 	recordThreadUsageEvent,
 	usageEventId
 } from '@convex/lib/threadUsage';
-import { finalizeRunRecord, matchesFinalizeExpectations } from '@convex/lib/runFinalize';
+import {
+	executorFinalizationResult,
+	finalizeRunRecord,
+	matchesFinalizeExpectations,
+	vExecutorFinalizationResult
+} from '@convex/lib/runFinalize';
 import { requestRunCancellation } from './runLifecycle';
 import {
 	recordCompletionTranscript,
@@ -529,6 +534,7 @@ export const reopenRun = mutation({
 
 export const finalizeExecutorRun = mutation({
 	args: {
+		includeOutput: v.optional(v.boolean()),
 		expectedStatus: v.optional(vRunStatus),
 		expectedClaimId: v.optional(v.string()),
 		runId: v.id('runs'),
@@ -537,13 +543,12 @@ export const finalizeExecutorRun = mutation({
 		lastError: v.optional(v.string()),
 		executionSecret: v.string()
 	},
-	returns: v.boolean(),
+	returns: vExecutorFinalizationResult,
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (!matchesFinalizeExpectations(run, args)) {
-			return false;
-		}
-		return finalizeRunRecord(ctx, run, args);
+		const accepted =
+			matchesFinalizeExpectations(run, args) && (await finalizeRunRecord(ctx, run, args));
+		return executorFinalizationResult(ctx, run, accepted, args.includeOutput);
 	}
 });
 
@@ -572,23 +577,24 @@ export const finalizeFailedStart = mutation({
 
 export const finalizeClaimFailure = mutation({
 	args: {
+		includeOutput: v.optional(v.boolean()),
 		claimId: v.string(),
 		runId: v.id('runs'),
 		text: v.string(),
 		lastError: v.string(),
 		executionSecret: v.string()
 	},
-	returns: v.boolean(),
+	returns: vExecutorFinalizationResult,
 	handler: async (ctx, args) => {
 		const run = await getExecutionRun(ctx, args.runId, args.executionSecret);
-		if (!canFinalizeAfterClaimFailure(run, args.claimId)) {
-			return false;
-		}
-		return finalizeRunRecord(ctx, run, {
-			text: args.text,
-			status: 'failed',
-			lastError: args.lastError
-		});
+		const accepted =
+			canFinalizeAfterClaimFailure(run, args.claimId) &&
+			(await finalizeRunRecord(ctx, run, {
+				text: args.text,
+				status: 'failed',
+				lastError: args.lastError
+			}));
+		return executorFinalizationResult(ctx, run, accepted, args.includeOutput);
 	}
 });
 

--- a/apps/web/src/convex/lib/runFinalize.ts
+++ b/apps/web/src/convex/lib/runFinalize.ts
@@ -1,6 +1,6 @@
 import type { MutationCtx } from '@convex/_generated/server';
-import type { Infer } from 'convex/values';
-import { isRunFinalStatus, type vRunFinalStatus, type vRunStatus } from '@convex/lib/validators';
+import { v, type Infer } from 'convex/values';
+import { isRunFinalStatus, vRunFinalStatus, type vRunStatus } from '@convex/lib/validators';
 import { reconcileTerminalRunPages } from '@convex/lib/runTerminal';
 import { cancelWebToolWork } from '@convex/webToolPool';
 import { isClaimedRunStatus, isRunClaimLeaseActive } from '@convex/lib/runLease';
@@ -19,6 +19,34 @@ type FinalizeRunArgs = {
 	status: Infer<typeof vRunFinalStatus>;
 	lastError?: string;
 };
+
+export const vExecutorFinalizationResult = v.union(
+	v.boolean(),
+	v.object({
+		accepted: v.boolean(),
+		outcome: v.union(
+			v.null(),
+			v.object({ status: vRunFinalStatus, error: v.union(v.null(), v.string()) })
+		)
+	})
+);
+
+export async function executorFinalizationResult(
+	ctx: MutationCtx,
+	run: ExecutionRun,
+	accepted: boolean,
+	includeOutput: boolean | undefined
+) {
+	if (!includeOutput) return accepted;
+	const finalized = accepted ? await ctx.db.get('runs', run._id) : run;
+	return {
+		accepted,
+		outcome:
+			finalized && isRunFinalStatus(finalized.status)
+				? { status: finalized.status, error: finalized.lastError ?? null }
+				: null
+	};
+}
 
 type FinalizeExpectationArgs = {
 	expectedStatus?: Infer<typeof vRunStatus>;

--- a/crates/sprocket-agent/src/context_handoff.rs
+++ b/crates/sprocket-agent/src/context_handoff.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use crate::hooks::AGENT_TOOL_NAMES;
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, ModelTurnAction,
     ModelTurnFinished, RequestPatch, StepEventKind,
@@ -39,7 +38,12 @@ struct HandoffState {
 }
 
 impl HandoffState {
-    fn prepare(&mut self, event: CompletionCallEvent<'_>, limit: u64) -> CompletionCallAction {
+    fn prepare(
+        &mut self,
+        event: CompletionCallEvent<'_>,
+        limit: u64,
+        active_tools: &[&'static str],
+    ) -> CompletionCallAction {
         if self.writing {
             return CompletionCallAction::patch(
                 RequestPatch::new()
@@ -64,9 +68,7 @@ impl HandoffState {
             return CompletionCallAction::stop(HANDOFF_REQUESTED);
         }
         self.first_call = false;
-        CompletionCallAction::patch(
-            RequestPatch::new().active_tools(AGENT_TOOL_NAMES.iter().copied()),
-        )
+        CompletionCallAction::patch(RequestPatch::new().active_tools(active_tools.iter().copied()))
     }
 
     fn submit(&mut self, document: String) -> Result<(), ToolExecutionError> {
@@ -86,13 +88,20 @@ impl HandoffState {
 #[derive(Clone)]
 pub(crate) struct ContextHandoffHook {
     token_limit: u64,
+    active_tools: Arc<[&'static str]>,
     state: Arc<Mutex<HandoffState>>,
 }
 
 impl ContextHandoffHook {
-    pub(crate) fn new(token_limit: u64, context_tokens: u64, defer_prompt: bool) -> Self {
+    pub(crate) fn new(
+        token_limit: u64,
+        context_tokens: u64,
+        defer_prompt: bool,
+        active_tools: Vec<&'static str>,
+    ) -> Self {
         Self {
             token_limit,
+            active_tools: active_tools.into(),
             state: Arc::new(Mutex::new(HandoffState {
                 context_tokens,
                 first_call: true,
@@ -164,7 +173,7 @@ impl AgentHook for ContextHandoffHook {
                         "The agent reached its completion call limit.",
                     );
                 }
-                let action = state.prepare(event, self.token_limit);
+                let action = state.prepare(event, self.token_limit, &self.active_tools);
                 if !matches!(action, CompletionCallAction::Stop(_)) {
                     state.calls += 1;
                 }
@@ -277,7 +286,7 @@ mod tests {
 
     #[test]
     fn missing_usage_preserves_the_last_observation_until_restart() {
-        let hook = ContextHandoffHook::new(100, 120, true);
+        let hook = ContextHandoffHook::new(100, 120, true, vec!["exec_command"]);
         assert_eq!(hook.record_usage(Usage::default()), 0);
         assert_eq!(hook.state.lock().unwrap().context_tokens, 120);
         hook.restart();
@@ -301,7 +310,8 @@ mod tests {
                     prompt: &prompt,
                     turn: 1
                 },
-                100
+                100,
+                &["exec_command"],
             ),
             CompletionCallAction::Stop(_)
         ));
@@ -326,6 +336,7 @@ mod tests {
                 turn: 2,
             },
             100,
+            &["exec_command"],
         );
         let request = state.request.unwrap();
         assert_eq!(request.history, vec![history[0].clone(), prompt]);
@@ -345,7 +356,8 @@ mod tests {
                     prompt: &prompt,
                     turn: 1
                 },
-                100
+                100,
+                &["exec_command"],
             ),
             CompletionCallAction::Patch(_)
         ));

--- a/crates/sprocket-agent/src/context_handoff_integration_tests.rs
+++ b/crates/sprocket-agent/src/context_handoff_integration_tests.rs
@@ -20,7 +20,7 @@ use super::{
     ContextHandoffHook, HANDOFF_PROMPT, HANDOFF_REQUESTED, HandoffRequest, HandoffTool,
     context_summary_text,
 };
-use crate::hooks::AGENT_TOOL_NAMES;
+use crate::hooks::{AGENT_TOOL_NAMES, available_agent_tool_names};
 
 const MODEL: &str = "gateway-model";
 const OLD_CONTEXT: &str = "UNIQUE_OLD_CONTEXT xyz-arm-bus";
@@ -356,6 +356,14 @@ fn stub_tool(name: &'static str) -> DynamicTool {
 }
 
 fn test_agent(base_url: &str, hook: &ContextHandoffHook) -> rig::Agent {
+    test_agent_with_tools(base_url, hook, AGENT_TOOL_NAMES)
+}
+
+fn test_agent_with_tools(
+    base_url: &str,
+    hook: &ContextHandoffHook,
+    tool_names: &[&'static str],
+) -> rig::Agent {
     let client = openai::Client::builder()
         .api_key("test-key")
         .base_url(base_url)
@@ -365,10 +373,30 @@ fn test_agent(base_url: &str, hook: &ContextHandoffHook) -> rig::Agent {
         .agent(MODEL)
         .preamble("context handoff fixture")
         .tool(hook.tool());
-    for name in AGENT_TOOL_NAMES {
+    for name in tool_names {
         builder = builder.dynamic_tool(stub_tool(name));
     }
     builder.build()
+}
+
+#[tokio::test]
+async fn noninteractive_turn_only_activates_registered_tools() {
+    let (base_url, server) = spawn_responses_sse(vec![text_sse("done", 4, 4)]);
+    let active_tools = available_agent_tool_names(false, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false, active_tools.clone());
+    let agent = test_agent_with_tools(&base_url, &hook, &active_tools);
+
+    match drive(&agent, &hook, Message::user("work"), Vec::new()).await {
+        DriveEnd::Finished(text) => assert_eq!(text, "done"),
+        other => panic!("noninteractive turn should complete, got {other:?}"),
+    }
+
+    let captured = server.join().expect("responses mock thread");
+    assert_eq!(captured.len(), 1);
+    let advertised = advertised_tools(&parse_request(&captured[0]));
+    assert!(!advertised.contains(&"ask_question".to_string()));
+    assert!(!advertised.contains(&"await_question".to_string()));
+    assert!(!advertised.contains(&"mandate_setup".to_string()));
 }
 
 fn parse_request(body: &[u8]) -> JsonValue {
@@ -523,7 +551,7 @@ fn take_handoff(hook: &ContextHandoffHook) -> HandoffRequest {
 #[tokio::test]
 async fn unsolicited_handoff_is_not_executed_or_emitted_as_a_tool_call() {
     let (base_url, server) = spawn_responses_sse(vec![handoff_document_sse(FIRST_SUMMARY)]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, true, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     tokio::time::timeout(DRIVE_TIMEOUT, async {
         let mut stream = agent
@@ -562,7 +590,7 @@ async fn over_budget_turn_is_replaced_by_the_hidden_handoff_prompt() {
         handoff_document_sse(FIRST_SUMMARY),
         text_sse("continued from handoff", 4, 4),
     ]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     let history = vec![Message::user(OLD_CONTEXT)];
     let prompt = Message::user(DEFERRED_PROMPT);
@@ -653,7 +681,7 @@ async fn mid_run_handoff_keeps_the_pending_tool_result() {
         exec_command_sse(80, 20),
         handoff_document_sse(FIRST_SUMMARY),
     ]);
-    let hook = ContextHandoffHook::new(50, 0, false);
+    let hook = ContextHandoffHook::new(50, 0, false, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     let history = vec![Message::user(OLD_CONTEXT)];
     let prompt = Message::user("run pwd");
@@ -729,7 +757,7 @@ async fn context_handoff_repeats_after_restart() {
         exec_command_sse(90, 20),
         handoff_document_sse(SECOND_SUMMARY),
     ]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, OVER_LIMIT, true, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     let prompt = Message::user(DEFERRED_PROMPT);
 
@@ -801,7 +829,7 @@ async fn context_handoff_repeats_after_restart() {
 #[tokio::test]
 async fn empty_handoff_document_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![handoff_document_sse("   ")]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -819,7 +847,7 @@ async fn empty_handoff_document_is_rejected() {
 #[tokio::test]
 async fn truncated_handoff_turn_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![truncated_handoff_sse()]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -834,7 +862,7 @@ async fn truncated_handoff_turn_is_rejected() {
 #[tokio::test]
 async fn text_only_handoff_turn_is_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![text_sse("I will summarise in prose", 8, 8)]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 
@@ -849,7 +877,7 @@ async fn text_only_handoff_turn_is_rejected() {
 #[tokio::test]
 async fn two_handoff_tool_calls_are_rejected() {
     let (base_url, server) = spawn_responses_sse(vec![two_tool_calls_sse()]);
-    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false);
+    let hook = ContextHandoffHook::new(OVER_LIMIT, 0, false, AGENT_TOOL_NAMES.to_vec());
     let agent = test_agent(&base_url, &hook);
     hook.start_handoff();
 

--- a/crates/sprocket-agent/src/convex.rs
+++ b/crates/sprocket-agent/src/convex.rs
@@ -14,6 +14,12 @@ use crate::types::{
 const CREATE_RUN_MAX_ATTEMPTS: usize = 3;
 const CREATE_RUN_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
 
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct CompletionPartNumber(
+    #[serde(deserialize_with = "sprocket_convex::deserialize_convex_u32")] u32,
+);
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum FailedStartCleanup {
@@ -24,6 +30,7 @@ pub(crate) enum FailedStartCleanup {
 
 #[derive(Clone)]
 pub(crate) struct RuntimeClient {
+    pub(crate) output: Option<std::sync::Arc<crate::RunOutput>>,
     pub(crate) client: ConvexRpcClient,
     execution_secret: String,
 }
@@ -43,6 +50,7 @@ impl RuntimeClient {
             request.thread_id
         );
         Ok(Self {
+            output: None,
             client,
             execution_secret: request.execution_secret.clone(),
         })
@@ -245,6 +253,7 @@ impl RuntimeClient {
         stream_id: &str,
         items: Vec<serde_json::Value>,
     ) -> anyhow::Result<()> {
+        let local_items = self.output.as_ref().map(|_| items.clone());
         let mut args = self.run_args_with_claim(run_id, claim_id);
         args.insert("attemptSeq".to_string(), Value::Float64(attempt_seq as f64));
         args.insert("streamId".to_string(), stream_id.to_string().into());
@@ -253,9 +262,33 @@ impl RuntimeClient {
             "items".to_string(),
             Value::try_from(serde_json::Value::Array(items))?,
         );
-        let _: serde_json::Value = self
+        let number: Option<CompletionPartNumber> = self
             .mutation_json("agentRuntime:finalizeCompletionCall", args)
             .await?;
+        if local_items.as_ref().is_some_and(Vec::is_empty) {
+            if let Some(output) = &self.output {
+                output.empty_completion();
+            }
+        }
+        if let (Some(output), Some(CompletionPartNumber(number)), Some(items)) =
+            (&self.output, number, local_items)
+        {
+            output
+                .record_part(crate::TranscriptPart {
+                    number,
+                    source_key: format!("completion:{run_id}:{stream_id}"),
+                    kind: crate::TranscriptPartKind::Completion,
+                    run_id: run_id.into(),
+                    created_at: None,
+                    prompt: None,
+                    tool: None,
+                    completion: Some(crate::transcript::types::TranscriptCompletionBody {
+                        stream_id: Some(stream_id.into()),
+                        items,
+                    }),
+                })
+                .await;
+        }
         Ok(())
     }
 
@@ -300,7 +333,7 @@ impl RuntimeClient {
         let mut args = self.run_args_with_claim(run_id, claim_id);
         args.insert("text".to_string(), text.to_string().into());
         args.insert("lastError".to_string(), last_error.to_string().into());
-        self.mutation_json("agentRuntime:finalizeClaimFailure", args)
+        self.finalize_mutation("agentRuntime:finalizeClaimFailure", args)
             .await
     }
 
@@ -439,8 +472,29 @@ impl RuntimeClient {
         if let Some(last_error) = last_error {
             args.insert("lastError".to_string(), last_error.to_string().into());
         }
-        self.mutation_json("agentRuntime:finalizeExecutorRun", args)
+        self.finalize_mutation("agentRuntime:finalizeExecutorRun", args)
             .await
+    }
+
+    async fn finalize_mutation(
+        &self,
+        function: &str,
+        mut args: BTreeMap<String, Value>,
+    ) -> anyhow::Result<bool> {
+        let Some(output) = &self.output else {
+            return self.mutation_json(function, args).await;
+        };
+        args.insert("includeOutput".into(), Value::Boolean(true));
+        #[derive(Deserialize)]
+        struct Response {
+            accepted: bool,
+            outcome: Option<crate::RunOutcome>,
+        }
+        let response: Response = self.mutation_json(function, args).await?;
+        if let Some(outcome) = response.outcome {
+            output.finalized(outcome, response.accepted);
+        }
+        Ok(response.accepted)
     }
 
     fn run_args(&self, run_id: &str) -> BTreeMap<String, Value> {
@@ -465,4 +519,32 @@ impl RuntimeClient {
 
 fn string_array(ids: &[String]) -> Value {
     Value::Array(ids.iter().cloned().map(Value::from).collect())
+}
+
+#[cfg(test)]
+mod output_tests {
+    use super::*;
+
+    #[test]
+    fn completion_acknowledgments_decode_convex_numbers_and_null() {
+        let number: Option<CompletionPartNumber> = decode_function_result(
+            FunctionResult::Value(Value::Float64(7.0)),
+            "finalizeCompletionCall",
+        )
+        .unwrap();
+        assert_eq!(number.unwrap().0, 7);
+        let empty: Option<CompletionPartNumber> =
+            decode_function_result(FunctionResult::Value(Value::Null), "finalizeCompletionCall")
+                .unwrap();
+        assert!(empty.is_none());
+        for value in [-1.0, 0.5, f64::from(u32::MAX) + 1.0] {
+            assert!(
+                decode_function_result::<Option<CompletionPartNumber>>(
+                    FunctionResult::Value(Value::Float64(value)),
+                    "finalizeCompletionCall"
+                )
+                .is_err()
+            );
+        }
+    }
 }

--- a/crates/sprocket-agent/src/hooks.rs
+++ b/crates/sprocket-agent/src/hooks.rs
@@ -30,6 +30,21 @@ pub(crate) const AGENT_TOOL_NAMES: &[&str] = &[
     "write_stdin",
 ];
 
+pub(crate) fn available_agent_tool_names(
+    allow_interaction: bool,
+    supports_images: bool,
+) -> Vec<&'static str> {
+    AGENT_TOOL_NAMES
+        .iter()
+        .copied()
+        .filter(|name| {
+            (allow_interaction
+                || !matches!(*name, "ask_question" | "await_question" | "mandate_setup"))
+                && (supports_images || *name != "screenshot_url")
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug)]
 struct TrackedToolCall {
     call_id: Option<String>,
@@ -250,6 +265,18 @@ mod tests {
         assert_repaired("apply-patch", "apply_patch");
         assert_repaired("writestdin", "write_stdin");
         assert_repaired("parse-file", "parse_file");
+    }
+
+    #[test]
+    fn available_tools_match_run_capabilities() {
+        let cli = available_agent_tool_names(false, false);
+        assert!(!cli.contains(&"ask_question"));
+        assert!(!cli.contains(&"await_question"));
+        assert!(!cli.contains(&"mandate_setup"));
+        assert!(!cli.contains(&"screenshot_url"));
+        assert!(cli.contains(&"exec_command"));
+
+        assert_eq!(available_agent_tool_names(true, true), AGENT_TOOL_NAMES);
     }
 
     #[test]

--- a/crates/sprocket-agent/src/lib.rs
+++ b/crates/sprocket-agent/src/lib.rs
@@ -5,6 +5,7 @@ mod context_handoff;
 mod convex;
 mod hooks;
 mod live;
+mod output;
 mod provider;
 mod reasoning;
 mod run;
@@ -17,6 +18,7 @@ pub use live::{
     LiveAssistantPart, LiveCompletionHub, LiveCompletionOverlay, LiveCompletionSubscription,
     LiveCompletionWatchEvent,
 };
+pub use output::{RunOutcome, RunOutput};
 pub use run::{AgentRun, finalize_failed_start, run_agent, start_agent_run};
 pub use sprocket_convex::AuthTokenFetcher;
 pub use transcript::sections;

--- a/crates/sprocket-agent/src/output.rs
+++ b/crates/sprocket-agent/src/output.rs
@@ -1,0 +1,449 @@
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
+
+use crate::{TranscriptPart, TranscriptStore};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RunOutcome {
+    pub status: String,
+    pub error: Option<String>,
+}
+
+#[derive(Default)]
+struct State {
+    numbers: BTreeSet<u32>,
+    outcome: Option<RunOutcome>,
+    finished: bool,
+    error: Option<String>,
+    output_error: Option<String>,
+    answer: String,
+    revision: u64,
+}
+
+struct Scope {
+    store: Arc<TranscriptStore>,
+    user_id: String,
+    thread_id: String,
+    run_id: String,
+}
+
+pub struct RunOutput {
+    scope: OnceLock<Scope>,
+    state: Mutex<State>,
+    changed: watch::Sender<u64>,
+}
+
+pub struct RunOutputPage {
+    pub revision: u64,
+    pub parts: Vec<TranscriptPart>,
+    pub has_more: bool,
+    pub finished: bool,
+    pub outcome: Option<RunOutcome>,
+    pub answer: String,
+    pub output_error: Option<String>,
+}
+
+impl Default for RunOutput {
+    fn default() -> Self {
+        Self {
+            scope: OnceLock::new(),
+            state: Mutex::new(State::default()),
+            changed: watch::channel(0).0,
+        }
+    }
+}
+
+impl RunOutput {
+    pub fn initialize(
+        &self,
+        store: Arc<TranscriptStore>,
+        user_id: String,
+        thread_id: String,
+        run_id: String,
+    ) {
+        assert!(
+            self.scope
+                .set(Scope {
+                    store,
+                    user_id,
+                    thread_id,
+                    run_id
+                })
+                .is_ok(),
+            "run output already initialized"
+        );
+    }
+
+    fn update(&self, update: impl FnOnce(&mut State)) {
+        let mut state = self.state.lock().unwrap();
+        update(&mut state);
+        state.revision += 1;
+        self.changed.send_replace(state.revision);
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.changed.subscribe()
+    }
+
+    pub(crate) async fn record_part(&self, part: TranscriptPart) {
+        let Some(scope) = self.scope.get() else {
+            return;
+        };
+        if part.run_id != scope.run_id {
+            return;
+        }
+        let saved = scope
+            .store
+            .append_parts(
+                &scope.user_id,
+                &scope.thread_id,
+                std::slice::from_ref(&part),
+            )
+            .await;
+        self.update(|state| {
+            if state.numbers.insert(part.number) {
+                if let Some(completion) = &part.completion {
+                    state.answer = completion
+                        .items
+                        .iter()
+                        .filter(|item| item["type"] == "text")
+                        .filter_map(|item| item["text"].as_str())
+                        .collect();
+                    if completion
+                        .items
+                        .iter()
+                        .any(|item| item["type"] == "tool-call")
+                    {
+                        state.answer.clear();
+                    }
+                }
+            }
+            if let Err(error) = saved {
+                state.output_error = Some(format!("Could not cache local run output: {error}"));
+            }
+        });
+    }
+
+    pub(crate) fn notify_live_update(&self) {
+        self.update(|_| {});
+    }
+
+    pub(crate) fn empty_completion(&self) {
+        self.update(|state| state.answer.clear());
+    }
+
+    pub(crate) fn finalized(&self, outcome: RunOutcome, accepted: bool) {
+        self.update(|state| {
+            if outcome.status == "completed" && !accepted && state.outcome.is_none() {
+                state.answer.clear();
+                state.output_error = Some("The run completed without accepting this executor's finalization. Its final answer could not be confirmed.".into());
+            }
+            state.outcome = Some(outcome);
+        });
+    }
+
+    pub fn finish(&self, error: Option<String>) {
+        self.update(|state| {
+            state.finished = true;
+            if state.outcome.is_none() && state.error.is_none() {
+                state.error = Some(error.unwrap_or_else(|| "Execution stopped without a confirmed terminal result. Check the thread in Sprocket.".into()));
+            }
+        });
+    }
+
+    pub async fn page(&self, after_part: i64) -> anyhow::Result<RunOutputPage> {
+        anyhow::ensure!(
+            (-1..=i64::from(u32::MAX)).contains(&after_part),
+            "invalid transcript cursor"
+        );
+        let scope = self.scope.get().context("run output has not started")?;
+        let (numbers, mut page) = {
+            let state = self.state.lock().unwrap();
+            let lower = if after_part == -1 {
+                std::ops::Bound::Included(0)
+            } else {
+                std::ops::Bound::Excluded(after_part as u32)
+            };
+            let numbers: Vec<_> = if state.output_error.is_none() {
+                state
+                    .numbers
+                    .range((lower, std::ops::Bound::Unbounded))
+                    .copied()
+                    .take(17)
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            let outcome = if state.finished {
+                Some(state.outcome.clone().unwrap_or(RunOutcome {
+                    status: "unknown".into(),
+                    error: state.error.clone(),
+                }))
+            } else {
+                None
+            };
+            let answer = if outcome
+                .as_ref()
+                .is_some_and(|outcome| outcome.status == "completed")
+            {
+                state.answer.clone()
+            } else {
+                String::new()
+            };
+            let page = RunOutputPage {
+                revision: state.revision,
+                has_more: numbers.len() > 16,
+                parts: Vec::new(),
+                finished: state.finished,
+                outcome,
+                answer,
+                output_error: state.output_error.clone(),
+            };
+            (numbers.into_iter().take(16).collect::<Vec<_>>(), page)
+        };
+        if page.output_error.is_some() || numbers.is_empty() {
+            return Ok(page);
+        }
+        let parts = scope
+            .store
+            .read_parts(&scope.user_id, &scope.thread_id, &numbers)
+            .await
+            .and_then(|parts| {
+                anyhow::ensure!(
+                    parts.len() == numbers.len()
+                        && parts.iter().all(|part| part.run_id == scope.run_id),
+                    "local run transcript is missing or belongs to another run"
+                );
+                Ok(parts)
+            });
+        match parts {
+            Ok(parts) => page.parts = parts,
+            Err(error) => {
+                let error = format!("Could not read local run output: {error}");
+                self.update(|state| state.output_error = Some(error.clone()));
+                page.output_error = Some(error);
+                page.has_more = false;
+            }
+        }
+        Ok(page)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::types::{TranscriptCompletionBody, TranscriptPartKind};
+
+    fn completion(number: u32, text: &str) -> TranscriptPart {
+        TranscriptPart {
+            number,
+            source_key: format!("completion:run:{number}"),
+            kind: TranscriptPartKind::Completion,
+            run_id: "run".into(),
+            created_at: None,
+            prompt: None,
+            tool: None,
+            completion: Some(TranscriptCompletionBody {
+                stream_id: None,
+                items: vec![serde_json::json!({"type": "text", "text": text})],
+            }),
+        }
+    }
+
+    fn output(directory: &std::path::Path) -> RunOutput {
+        let output = RunOutput::default();
+        output.initialize(
+            TranscriptStore::new(directory.to_owned()),
+            "user".into(),
+            "thread".into(),
+            "run".into(),
+        );
+        output
+    }
+
+    #[tokio::test]
+    async fn caches_committed_parts_and_replays_bounded_pages_without_network_reads() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        for number in 0..18 {
+            output
+                .record_part(completion(number * 2, &format!("answer {number}")))
+                .await;
+        }
+        output
+            .record_part(completion(0, "duplicate must not replace answer"))
+            .await;
+        let first = output.page(-1).await.unwrap();
+        assert_eq!(first.parts.len(), 16);
+        assert!(first.has_more);
+        assert_eq!(first.parts[0].number, 0);
+        assert_eq!(first.parts[15].number, 30);
+        assert!(first.answer.is_empty());
+        let replay = output.page(-1).await.unwrap();
+        assert_eq!(first.parts, replay.parts);
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            true,
+        );
+        assert!(!output.page(30).await.unwrap().finished);
+        output.finish(None);
+        let last = output.page(30).await.unwrap();
+        assert_eq!(last.parts.len(), 2);
+        assert!(!last.has_more);
+        assert!(last.finished);
+        assert_eq!(last.answer, "answer 17");
+        assert!(output.page(-2).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn clearing_live_output_does_not_complete_a_run_and_unconfirmed_exit_is_unknown() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        let mut changed = output.subscribe();
+        output.notify_live_update();
+        changed.changed().await.unwrap();
+        assert!(!output.page(-1).await.unwrap().finished);
+        output
+            .record_part(completion(1, "unconfirmed answer"))
+            .await;
+        output.finish(Some("finalization timed out".into()));
+        let page = output.page(-1).await.unwrap();
+        assert!(page.finished);
+        assert_eq!(page.outcome.unwrap().status, "unknown");
+        assert!(page.answer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelled_and_empty_completions_do_not_return_earlier_commentary() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        output.record_part(completion(1, "earlier answer")).await;
+        output.empty_completion();
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            true,
+        );
+        output.finish(None);
+        assert!(output.page(-1).await.unwrap().answer.is_empty());
+
+        let directory = tempfile::tempdir().unwrap();
+        let cancelled = self::output(directory.path());
+        cancelled
+            .record_part(completion(1, "answer before cancellation race"))
+            .await;
+        cancelled.finalized(
+            RunOutcome {
+                status: "cancelled".into(),
+                error: None,
+            },
+            false,
+        );
+        cancelled.finish(None);
+        let page = cancelled.page(-1).await.unwrap();
+        assert!(page.answer.is_empty());
+        assert_eq!(page.outcome.unwrap().status, "cancelled");
+    }
+
+    #[tokio::test]
+    async fn tool_commentary_and_other_runs_cannot_become_the_final_answer() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        let mut part = completion(2, "I'll run the tests.");
+        part.completion.as_mut().unwrap().items.push(serde_json::json!({"type": "tool-call", "callId": "call", "name": "exec_command", "input": {}}));
+        output.record_part(part).await;
+        let mut other = completion(3, "another run's answer");
+        other.run_id = "other".into();
+        output.record_part(other).await;
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            true,
+        );
+        output.finish(None);
+        let page = output.page(-1).await.unwrap();
+        assert_eq!(page.parts.len(), 1);
+        assert!(page.answer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn another_executors_completion_cannot_confirm_the_local_answer() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        output
+            .record_part(completion(1, "stale local answer"))
+            .await;
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            false,
+        );
+        output.finish(Some("claim ownership was lost".into()));
+        let page = output.page(-1).await.unwrap();
+        assert_eq!(page.outcome.unwrap().status, "completed");
+        assert!(
+            page.output_error
+                .unwrap()
+                .contains("final answer could not be confirmed")
+        );
+        assert!(page.answer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_cache_writes_preserve_the_acknowledged_answer_and_terminal_status() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let output = output(file.path());
+        output.record_part(completion(1, "Confirmed answer.")).await;
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            true,
+        );
+        output.finish(None);
+        let page = output.page(-1).await.unwrap();
+        assert_eq!(page.outcome.unwrap().status, "completed");
+        assert_eq!(page.answer, "Confirmed answer.");
+        assert!(page.output_error.unwrap().contains("Could not cache"));
+        assert!(page.parts.is_empty());
+        assert!(!page.has_more);
+    }
+
+    #[tokio::test]
+    async fn lost_cache_files_do_not_erase_a_confirmed_result_or_restart_paging() {
+        let directory = tempfile::tempdir().unwrap();
+        let output = output(directory.path());
+        output.record_part(completion(1, "Confirmed answer.")).await;
+        output.finalized(
+            RunOutcome {
+                status: "completed".into(),
+                error: None,
+            },
+            true,
+        );
+        output.finish(None);
+        tokio::fs::remove_dir_all(directory.path()).await.unwrap();
+        for _ in 0..2 {
+            let page = output.page(-1).await.unwrap();
+            assert_eq!(page.outcome.unwrap().status, "completed");
+            assert_eq!(page.answer, "Confirmed answer.");
+            assert!(page.output_error.unwrap().contains("Could not read"));
+            assert!(page.parts.is_empty());
+            assert!(!page.has_more);
+        }
+    }
+}

--- a/crates/sprocket-agent/src/provider.rs
+++ b/crates/sprocket-agent/src/provider.rs
@@ -14,7 +14,7 @@ use tokio::time::{sleep, timeout};
 
 use crate::context_handoff::{ContextHandoffHook, HANDOFF_PROMPT, context_summary_text};
 use crate::convex::RuntimeClient;
-use crate::hooks::{AgentPromptHook, ToolCallTracker};
+use crate::hooks::{AgentPromptHook, ToolCallTracker, available_agent_tool_names};
 use crate::live::{
     LiveAssistantPart, LiveAssistantParts, LiveCompletionHub, LiveCompletionOverlay,
     join_assistant_text_parts, now_ms,
@@ -70,6 +70,8 @@ pub(crate) struct AgentProvider {
 }
 
 pub(crate) struct AgentProviderRequest {
+    pub(crate) allow_interaction: bool,
+    pub(crate) cancellation: sprocket_workspace::WorkspaceCancellation,
     pub(crate) run_id: String,
     pub(crate) claim_id: String,
     pub(crate) thread_id: String,
@@ -188,14 +190,13 @@ where
         request.context_budget.auto_handoff_token_limit,
         request.context_tokens,
         request.defer_prompt_for_context_handoff,
+        available_agent_tool_names(request.allow_interaction, request.supports_images),
     );
     let agent = completion_client
         .agent(model)
         .preamble(&request.base_instructions)
         .additional_params(additional_params)
         .tool(tools.apply_patch)
-        .tool(tools.ask_question)
-        .tool(tools.await_question)
         .tool(tools.exec_command)
         .tool(tools.read_skill)
         .tool(tools.scrape_url)
@@ -207,13 +208,20 @@ where
         .tool(tools.save_artifact)
         .tool(tools.browser_interact)
         .tool(tools.browser_screenshot)
-        .tool(tools.mandate_setup)
         .tool(tools.mandate_status)
         .tool(tools.mandate_list)
         .tool(tools.mandate_charge)
         .tool(tools.mandate_report)
         .tool(tools.parse_file)
         .tool(context_handoff_hook.tool());
+    let agent = if request.allow_interaction {
+        agent
+            .tool(tools.ask_question)
+            .tool(tools.await_question)
+            .tool(tools.mandate_setup)
+    } else {
+        agent
+    };
     let agent = if request.supports_images {
         agent.tool(tools.screenshot_url)
     } else {
@@ -291,6 +299,11 @@ where
             loop {
                 tokio::select! {
                     biased;
+                    _ = request.cancellation.cancelled() => {
+                        break 'agent_run AgentProviderResult::Cancelled {
+                            text: if final_text.is_empty() { streamed_text } else { final_text },
+                        };
+                    }
                     _ = sleep(transcript.publish_delay()), if transcript.has_unpublished() => {
                         transcript.publish_if_needed(true);
                     }
@@ -687,7 +700,7 @@ impl TranscriptSink {
     fn publish(&mut self) {
         self.unpublished = 0;
         self.last_publish = Instant::now();
-        self.live.publish(LiveCompletionOverlay {
+        let overlay = LiveCompletionOverlay {
             thread_id: self.thread_id.clone(),
             run_id: self.run_id.clone(),
             run_status: "running".to_string(),
@@ -695,7 +708,11 @@ impl TranscriptSink {
             text: join_assistant_text_parts(&self.parts.parts),
             parts: visible_live_parts(&self.parts.parts),
             run_started_at: self.run_started_at,
-        });
+        };
+        self.live.publish(overlay);
+        if let Some(output) = &self.runtime.output {
+            output.notify_live_update();
+        }
     }
 
     fn apply_text_delta(
@@ -730,6 +747,9 @@ impl Drop for TranscriptSink {
     fn drop(&mut self) {
         self.publish_if_needed(true);
         self.live.clear(&self.thread_id);
+        if let Some(output) = &self.runtime.output {
+            output.notify_live_update();
+        }
     }
 }
 

--- a/crates/sprocket-agent/src/run.rs
+++ b/crates/sprocket-agent/src/run.rs
@@ -60,6 +60,23 @@ pub struct AgentRun {
 }
 
 impl AgentRun {
+    pub async fn observe_output(
+        &mut self,
+        output: Arc<crate::RunOutput>,
+        store: Arc<TranscriptStore>,
+    ) {
+        output.initialize(
+            store,
+            self.user_id.clone(),
+            self.request.thread_id.clone(),
+            self.run_id.clone(),
+        );
+        if let Some(part) = &self.prompt_part {
+            output.record_part(part.clone()).await;
+        }
+        self.runtime.output = Some(output);
+    }
+
     pub fn run_id(&self) -> &str {
         &self.run_id
     }
@@ -804,6 +821,10 @@ pub async fn run_agent(
         loop {
             tokio::select! {
                 biased;
+                _ = request.cancellation.cancelled() => {
+                    runtime.finalize_queued_run(&run_id, "", RunFinalStatus::Cancelled.as_str(), None).await?;
+                    return Ok(());
+                }
                 update = updates.next() => {
                     match update.map(RuntimeClient::decode_run_finished_update) {
                         Some(Ok(true)) => return Ok(()),
@@ -887,6 +908,11 @@ pub async fn run_agent(
         return Ok(());
     };
 
+    if request.cancellation.is_cancelled() {
+        acknowledge_stop(&runtime, &run_id, &claim_id).await?;
+        return Ok(());
+    }
+
     eprintln!("sprocket-agent: selected provider gateway for run {run_id}");
 
     match timeout(RUN_CLAIM_ATTEMPT_TIMEOUT, runtime.run_finished(&run_id)).await {
@@ -912,6 +938,8 @@ pub async fn run_agent(
             .run(
                 runtime.clone(),
                 AgentProviderRequest {
+                    allow_interaction: request.allow_interaction,
+                    cancellation: request.cancellation,
                     run_id: run_id.clone(),
                     claim_id: claim_id.clone(),
                     thread_id: request.thread_id.clone(),

--- a/crates/sprocket-agent/src/types.rs
+++ b/crates/sprocket-agent/src/types.rs
@@ -13,6 +13,8 @@ pub(crate) fn gateway_api_v1_url(gateway_url: &str) -> String {
 
 #[derive(Clone)]
 pub struct RunAgentRequest {
+    pub allow_interaction: bool,
+    pub cancellation: sprocket_workspace::WorkspaceCancellation,
     pub deployment_url: String,
     pub auth_token_fetcher: AuthTokenFetcher,
     pub execution_secret: String,

--- a/crates/sprocket-cli/src/commands.rs
+++ b/crates/sprocket-cli/src/commands.rs
@@ -1,5 +1,8 @@
 mod connection;
+mod output;
 
+use std::io::Read;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -8,6 +11,51 @@ use sprocket_server::ServerConfig;
 use sprocket_server::cli_protocol::*;
 
 use connection::Connection;
+use output::Output;
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub(crate) struct RunArgs {
+    /// Task to send to the agent
+    #[arg(conflicts_with = "prompt_file")]
+    pub(crate) prompt: Option<String>,
+    /// Read the prompt from a UTF-8 file, or - for stdin
+    #[arg(long)]
+    prompt_file: Option<PathBuf>,
+    /// Working directory, defaulting to the current directory
+    #[arg(long, short = 'C')]
+    directory: Option<PathBuf>,
+    /// Send a follow-up to this thread instead of creating a new one
+    #[arg(long)]
+    thread: Option<String>,
+    #[arg(long)]
+    model: Option<String>,
+    #[arg(long)]
+    reasoning: Option<String>,
+    #[arg(long, conflicts_with = "no_fast")]
+    fast: bool,
+    #[arg(long)]
+    no_fast: bool,
+    /// Cancel after a duration such as 30s, 10m, or 2h
+    #[arg(long, value_parser = parse_duration)]
+    timeout: Option<Duration>,
+    /// List models available to this account and their reasoning efforts
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "prompt",
+            "prompt_file",
+            "directory",
+            "thread",
+            "model",
+            "reasoning",
+            "fast",
+            "no_fast",
+            "timeout"
+        ]
+    )]
+    pub(crate) list_models: bool,
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct LoginArgs {
@@ -16,10 +64,227 @@ pub(crate) struct LoginArgs {
     credential_store: Option<CredentialStore>,
 }
 
+fn parse_duration(value: &str) -> Result<Duration, String> {
+    let (number, multiplier) = if let Some(number) = value.strip_suffix('s') {
+        (number, 1)
+    } else if let Some(number) = value.strip_suffix('m') {
+        (number, 60)
+    } else if let Some(number) = value.strip_suffix('h') {
+        (number, 3600)
+    } else {
+        (value, 1)
+    };
+    let seconds = number
+        .parse::<u64>()
+        .ok()
+        .and_then(|number| number.checked_mul(multiplier))
+        .filter(|seconds| *seconds > 0 && *seconds <= 365 * 24 * 3600)
+        .ok_or_else(|| {
+            "use a positive duration up to one year, such as 30s, 10m, or 2h".to_string()
+        })?;
+    Ok(Duration::from_secs(seconds))
+}
+
+fn prompt(args: &RunArgs) -> anyhow::Result<String> {
+    const MAX_PROMPT_BYTES: u64 = 1024 * 1024;
+    let prompt = if let Some(prompt) = &args.prompt {
+        prompt.clone()
+    } else {
+        let path = args.prompt_file.as_ref().context("a prompt is required")?;
+        let reader: Box<dyn Read> = if path.as_os_str() == "-" {
+            Box::new(std::io::stdin())
+        } else {
+            Box::new(
+                std::fs::File::open(path)
+                    .with_context(|| format!("cannot read {}", path.display()))?,
+            )
+        };
+        let mut text = String::new();
+        reader
+            .take(MAX_PROMPT_BYTES + 1)
+            .read_to_string(&mut text)
+            .context("prompt must be UTF-8")?;
+        text
+    };
+    anyhow::ensure!(!prompt.trim().is_empty(), "prompt is empty");
+    anyhow::ensure!(
+        prompt.len() as u64 <= MAX_PROMPT_BYTES,
+        "prompt exceeds 1 MiB"
+    );
+    Ok(prompt)
+}
+
 fn runtime() -> anyhow::Result<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?)
+}
+
+pub(crate) fn run(args: RunArgs) -> anyhow::Result<u8> {
+    if args.list_models {
+        return list_models();
+    }
+    let mut output = Output::new();
+    let result = runtime()?.block_on(async {
+        let prompt = prompt(&args)?;
+        let directory = args
+            .directory
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(std::env::current_dir)?;
+        let directory = crate::resolve_launch_workspace(&directory)?;
+        let connection = Connection::open(ServerConfig::try_parse_from(["sprocket"])?).await?;
+        let result = run_connected(&connection, &args, prompt, directory, &mut output).await;
+        connection.close().await;
+        result
+    });
+    match result {
+        Ok(code) => Ok(code),
+        Err(error) => {
+            output.failure(format!("{error:#}"))?;
+            Ok(1)
+        }
+    }
+}
+
+fn list_models() -> anyhow::Result<u8> {
+    runtime()?.block_on(async {
+        let connection = Connection::open(ServerConfig::try_parse_from(["sprocket"])?).await?;
+        let result = async {
+            require_login(&connection).await?;
+            let response: CliModelsResponse = connection
+                .call("models", &connection.client_request())
+                .await?;
+            print!("{}", models_text(&response));
+            Ok(0)
+        }
+        .await;
+        connection.close().await;
+        result
+    })
+}
+
+fn models_text(response: &CliModelsResponse) -> String {
+    let mut output = String::new();
+    for model in &response.models {
+        let default_model = if model.id == response.default_model_id {
+            " (default)"
+        } else {
+            ""
+        };
+        output.push_str(&format!(
+            "{} - {}{}\n",
+            model.id, model.label, default_model
+        ));
+        let efforts = model
+            .reasoning_efforts
+            .iter()
+            .map(|effort| {
+                if effort == &model.default_reasoning_effort {
+                    format!("{effort} (default)")
+                } else {
+                    effort.clone()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        output.push_str(&format!("  Reasoning: {efforts}\n"));
+    }
+    output
+}
+
+async fn run_connected(
+    connection: &Connection,
+    args: &RunArgs,
+    prompt: String,
+    directory: String,
+    output: &mut Output,
+) -> anyhow::Result<u8> {
+    require_login(connection).await?;
+    let request = CliRunRequest {
+        client_id: connection.client_id.clone(),
+        prompt,
+        directory,
+        thread_id: args.thread.clone(),
+        model: args.model.clone(),
+        reasoning: args.reasoning.clone(),
+        fast: if args.fast {
+            Some(true)
+        } else if args.no_fast {
+            Some(false)
+        } else {
+            None
+        },
+    };
+    let interrupted = {
+        let operation = execute_run(connection, &request, output);
+        tokio::pin!(operation);
+        tokio::select! {
+            result = &mut operation => return result,
+            code = interrupt() => code,
+            _ = async {
+                match args.timeout {
+                    Some(duration) => tokio::time::sleep(duration).await,
+                    None => std::future::pending().await,
+                }
+            } => 124,
+        }
+    };
+    if let Err(error) = connection
+        .call::<bool>("cancel", &connection.client_request())
+        .await
+    {
+        output.unknown(format!(
+            "Could not confirm cancellation request; the run may still be active: {error}"
+        ))?;
+        return Ok(interrupted);
+    }
+    let confirmation = tokio::time::timeout(
+        Duration::from_secs(15),
+        execute_run(connection, &request, output),
+    )
+    .await;
+    match confirmation {
+        Ok(Ok(_)) => Ok(interrupted),
+        _ => {
+            output.unknown("Cancellation requested, but the final state could not be confirmed. Check the thread in Sprocket.".into())?;
+            Ok(interrupted)
+        }
+    }
+}
+
+async fn execute_run(
+    connection: &Connection,
+    request: &CliRunRequest,
+    output: &mut Output,
+) -> anyhow::Result<u8> {
+    if output.started().is_none() {
+        let started: RunStarted = connection.retry("run", request).await?;
+        output.start(started)?;
+    }
+    loop {
+        let snapshot: CliRunSnapshot = connection
+            .retry(
+                "output",
+                &CliOutputRequest {
+                    client_id: connection.client_id.clone(),
+                    after_part: output.after_part(),
+                    after_revision: output.after_revision(),
+                },
+            )
+            .await?;
+        let done = snapshot.execution_finished && !snapshot.has_more;
+        output.update(&snapshot)?;
+        if done {
+            let code = if snapshot.status == "completed" && snapshot.error.is_none() {
+                0
+            } else {
+                1
+            };
+            output.finish(snapshot.status, snapshot.error)?;
+            return Ok(code);
+        }
+    }
 }
 
 pub(crate) fn login(args: LoginArgs) -> anyhow::Result<u8> {
@@ -59,7 +324,7 @@ async fn login_connected(connection: &Connection, args: LoginArgs) -> anyhow::Re
         "Open {} in a browser and approve code {}",
         authorization.verification_uri, authorization.user_code
     );
-    tokio::select! {
+    let result = tokio::select! {
         code = interrupt() => Ok(code),
         result = tokio::time::timeout(Duration::from_secs(authorization.expires_in + 5), async {
             loop {
@@ -74,7 +339,8 @@ async fn login_connected(connection: &Connection, args: LoginArgs) -> anyhow::Re
                 }
             }
         }) => result.context("device login expired")?,
-    }
+    };
+    result
 }
 
 pub(crate) fn logout() -> anyhow::Result<u8> {
@@ -88,6 +354,19 @@ pub(crate) fn logout() -> anyhow::Result<u8> {
         eprintln!("Signed out of this local Sprocket profile.");
         Ok(0)
     })
+}
+
+async fn require_login(connection: &Connection) -> anyhow::Result<()> {
+    match connection
+        .call("auth", &connection.client_request())
+        .await?
+    {
+        LoginStatus::Authenticated { .. } => Ok(()),
+        LoginStatus::Unavailable { error } | LoginStatus::Failed { error } => anyhow::bail!(
+            "{error}. Run sprocket login, or use --credential-store file on a headless machine."
+        ),
+        _ => anyhow::bail!("not signed in; run sprocket login"),
+    }
 }
 
 async fn interrupt() -> u8 {
@@ -106,5 +385,18 @@ async fn interrupt() -> u8 {
     {
         let _ = tokio::signal::ctrl_c().await;
         130
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deadlines_are_positive_bounded_and_overflow_checked() {
+        assert_eq!(parse_duration("2m").unwrap(), Duration::from_secs(120));
+        for value in ["0", "-1", "1.5s", "1d", "18446744073709551615h"] {
+            assert!(parse_duration(value).is_err(), "{value}");
+        }
     }
 }

--- a/crates/sprocket-cli/src/commands/output.rs
+++ b/crates/sprocket-cli/src/commands/output.rs
@@ -1,0 +1,183 @@
+use std::collections::HashSet;
+use std::io::Write;
+
+use sprocket_server::cli_protocol::{CliRunSnapshot, RunStarted};
+
+pub(super) struct Output {
+    started: Option<RunStarted>,
+    after_part: i64,
+    after_revision: Option<u64>,
+    answer: String,
+    tools: HashSet<String>,
+    live: Option<serde_json::Value>,
+    finished: bool,
+}
+
+impl Output {
+    pub fn new() -> Self {
+        Self {
+            started: None,
+            after_part: -1,
+            after_revision: None,
+            answer: String::new(),
+            tools: HashSet::new(),
+            live: None,
+            finished: false,
+        }
+    }
+
+    pub fn started(&self) -> Option<&RunStarted> {
+        self.started.as_ref()
+    }
+    pub fn after_part(&self) -> i64 {
+        self.after_part
+    }
+
+    pub fn after_revision(&self) -> Option<u64> {
+        self.after_revision
+    }
+
+    pub fn start(&mut self, started: RunStarted) -> anyhow::Result<()> {
+        eprintln!("Thread {} | Run {}", started.thread_id, started.run_id);
+        self.started = Some(started);
+        Ok(())
+    }
+
+    pub fn update(&mut self, snapshot: &CliRunSnapshot) -> anyhow::Result<()> {
+        let started = self
+            .started
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("run has not started"))?;
+        anyhow::ensure!(
+            snapshot.run_id == started.run_id && snapshot.thread_id == started.thread_id,
+            "server returned a different run"
+        );
+        for part in &snapshot.parts {
+            if i64::from(part.number) <= self.after_part {
+                continue;
+            }
+            anyhow::ensure!(
+                part.run_id == snapshot.run_id,
+                "transcript part belongs to another run"
+            );
+            if let Some(completion) = &part.completion {
+                for item in &completion.items {
+                    self.tool_progress(item);
+                }
+            }
+            self.after_part = i64::from(part.number);
+        }
+        self.after_revision = (!snapshot.has_more).then_some(snapshot.revision);
+        self.answer = snapshot.answer.clone();
+        let live = snapshot
+            .live
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+        if live != self.live {
+            if let Some(live) = &live {
+                if let Some(parts) = live.get("parts").and_then(|parts| parts.as_array()) {
+                    for part in parts {
+                        self.tool_progress(part);
+                    }
+                }
+            }
+            self.live = live;
+        }
+        Ok(())
+    }
+
+    fn tool_progress(&mut self, item: &serde_json::Value) {
+        let Some(call_id) = item.get("callId").and_then(|id| id.as_str()) else {
+            return;
+        };
+        let Some(name) = item.get("name").and_then(|name| name.as_str()) else {
+            return;
+        };
+        if self.tools.insert(call_id.to_owned()) {
+            eprintln!("{name}");
+        }
+    }
+
+    pub fn finish(&mut self, status: String, error: Option<String>) -> anyhow::Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        if status == "completed" && !self.answer.is_empty() {
+            let mut stdout = std::io::stdout().lock();
+            writeln!(stdout, "{}", self.answer)?;
+            stdout.flush()?;
+        }
+        if let Some(error) = error {
+            eprintln!("{error}");
+        }
+        self.finished = true;
+        Ok(())
+    }
+
+    pub fn failure(&mut self, error: String) -> anyhow::Result<()> {
+        self.finish("failed".into(), Some(error))
+    }
+
+    pub fn unknown(&mut self, error: String) -> anyhow::Result<()> {
+        self.finish("unknown".into(), Some(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(parts: serde_json::Value) -> CliRunSnapshot {
+        serde_json::from_value(serde_json::json!({
+            "runId": "run", "threadId": "thread", "status": "running",
+            "error": null, "parts": parts, "hasMore": false, "executionFinished": false, "live": null,
+            "revision": 1, "answer": "",
+        })).unwrap()
+    }
+
+    #[test]
+    fn final_answer_comes_from_the_confirmed_result_not_transcript_commentary() {
+        let mut output = Output::new();
+        output.started = Some(RunStarted {
+            run_id: "run".into(),
+            thread_id: "thread".into(),
+        });
+        let commentary = snapshot(serde_json::json!([{
+            "number": 1, "sourceKey": "one", "kind": "completion", "runId": "run",
+            "completion": {"items": [{"type": "text", "text": "I'll inspect the files."}, {"type": "tool-call"}]}
+        }]));
+        output.update(&commentary).unwrap();
+        assert!(output.answer.is_empty());
+        output.update(&snapshot(serde_json::json!([{
+            "number": 3, "sourceKey": "three", "kind": "completion", "runId": "run",
+            "completion": {"items": [{"type": "reasoning", "text": "private"}, {"type": "text", "text": "Done."}]}
+        }]))).unwrap();
+        assert!(output.answer.is_empty());
+        assert_eq!(output.after_part(), 3);
+        let mut result = snapshot(serde_json::json!([]));
+        result.answer = "Confirmed answer.".into();
+        result.execution_finished = true;
+        output.update(&result).unwrap();
+        assert_eq!(output.answer, "Confirmed answer.");
+        assert_eq!(output.after_revision(), Some(result.revision));
+        result.has_more = true;
+        output.update(&result).unwrap();
+        assert_eq!(output.after_revision(), None);
+    }
+
+    #[test]
+    fn rejects_another_runs_transcript_without_advancing_cursor() {
+        let mut output = Output::new();
+        output.started = Some(RunStarted {
+            run_id: "run".into(),
+            thread_id: "thread".into(),
+        });
+        let page = snapshot(serde_json::json!([{
+            "number": 1, "sourceKey": "one", "kind": "completion", "runId": "other",
+            "completion": {"items": [{"type": "text", "text": "wrong answer"}]}
+        }]));
+        assert!(output.update(&page).is_err());
+        assert_eq!(output.after_part(), -1);
+    }
+}

--- a/crates/sprocket-cli/src/main.rs
+++ b/crates/sprocket-cli/src/main.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 
 const DESKTOP_EXECUTABLE_ENV: &str = "SPROCKET_DESKTOP_EXECUTABLE";
 const DESKTOP_WORKSPACE_ARG: &str = "--sprocket-workspace";
-
 #[derive(Debug, Parser)]
 #[command(
     name = "sprocket",
@@ -41,6 +40,9 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Run an agent locally and wait for its result
+    Run(commands::RunArgs),
+
     /// Sign in using a browser on any device
     Login(commands::LoginArgs),
 
@@ -103,6 +105,13 @@ fn entry() -> anyhow::Result<u8> {
         .map(resolve_launch_workspace)
         .transpose()?;
     match cli.command {
+        Some(Commands::Run(args)) => {
+            anyhow::ensure!(
+                !cli.web && workspace_path.is_none(),
+                "run does not accept app launch arguments; use run --directory instead"
+            );
+            return commands::run(args);
+        }
         Some(Commands::Login(args)) => {
             anyhow::ensure!(
                 !cli.web && workspace_path.is_none(),
@@ -342,6 +351,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn run_requires_one_explicit_prompt_source() {
+        assert!(Cli::try_parse_from(["sprocket", "run"]).is_err());
+        assert!(
+            Cli::try_parse_from(["sprocket", "run", "task", "--prompt-file", "task.md"]).is_err()
+        );
+        assert!(Cli::try_parse_from(["sprocket", "run", "--prompt-file", "-"]).is_ok());
+        assert!(Cli::try_parse_from(["sprocket", "run", "task", "--directory", "."]).is_ok());
+        let list_models = Cli::try_parse_from(["sprocket", "run", "--list-models"]).unwrap();
+        assert!(matches!(
+            list_models.command,
+            Some(Commands::Run(commands::RunArgs {
+                prompt: None,
+                list_models: true,
+                ..
+            }))
+        ));
+        assert!(Cli::try_parse_from(["sprocket", "run", "task", "--list-models"]).is_err());
+        assert!(Cli::try_parse_from(["sprocket", "run", "task", "--json"]).is_err());
+        assert!(Cli::try_parse_from(["sprocket", "run", "task", "--stream-json"]).is_err());
+        assert!(Cli::try_parse_from(["sprocket", "run", "task", "--fast", "--no-fast"]).is_err());
+    }
+
+    #[test]
     fn parses_launch_server_and_update_modes() {
         let desktop = Cli::try_parse_from(["sprocket"]).unwrap();
         assert!(!desktop.web);
@@ -361,13 +393,6 @@ mod tests {
         assert!(!server.web);
         assert!(server.directory.is_none());
         assert!(matches!(server.command, Some(Commands::Serve(_))));
-
-        let login =
-            Cli::try_parse_from(["sprocket", "login", "--credential-store", "file"]).unwrap();
-        assert!(matches!(login.command, Some(Commands::Login(_))));
-
-        let logout = Cli::try_parse_from(["sprocket", "logout"]).unwrap();
-        assert!(matches!(logout.command, Some(Commands::Logout)));
 
         let update = Cli::try_parse_from(["sprocket", "upgrade", "--check"]).unwrap();
         assert!(matches!(

--- a/crates/sprocket-server/src/cli_protocol.rs
+++ b/crates/sprocket-server/src/cli_protocol.rs
@@ -92,3 +92,61 @@ pub struct DeviceLoginResponse {
     pub user_code: String,
     pub expires_in: u64,
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliRunRequest {
+    pub client_id: String,
+    pub prompt: String,
+    pub directory: String,
+    pub thread_id: Option<String>,
+    pub model: Option<String>,
+    pub reasoning: Option<String>,
+    pub fast: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CliModel {
+    pub id: String,
+    pub label: String,
+    pub reasoning_efforts: Vec<String>,
+    pub default_reasoning_effort: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CliModelsResponse {
+    pub default_model_id: String,
+    pub models: Vec<CliModel>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunStarted {
+    pub run_id: String,
+    pub thread_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliOutputRequest {
+    pub client_id: String,
+    pub after_part: i64,
+    pub after_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliRunSnapshot {
+    pub revision: u64,
+    pub answer: String,
+    pub run_id: String,
+    pub thread_id: String,
+    pub status: String,
+    pub error: Option<String>,
+    pub parts: Vec<sprocket_agent::TranscriptPart>,
+    pub has_more: bool,
+    pub execution_finished: bool,
+    pub live: Option<sprocket_agent::LiveCompletionOverlay>,
+}

--- a/crates/sprocket-server/src/cli_sessions.rs
+++ b/crates/sprocket-server/src/cli_sessions.rs
@@ -3,12 +3,25 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use sprocket_workspace::WorkspaceCancellation;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::cli_protocol::{CliRunRequest, RunStarted};
 
 const CLIENT_GRACE: Duration = Duration::from_secs(60);
 const STARTUP_GRACE: Duration = Duration::from_secs(30);
 
+#[derive(Default)]
+pub(crate) struct Submission {
+    pub request: Option<CliRunRequest>,
+    pub result: Option<Result<RunStarted, String>>,
+    pub user_id: Option<String>,
+}
+
 pub(crate) struct CliSession {
     pub session_token: String,
+    pub cancellation: WorkspaceCancellation,
+    pub submission: AsyncMutex<Submission>,
+    pub output: Arc<sprocket_agent::RunOutput>,
 }
 
 struct ClientLease {
@@ -75,6 +88,9 @@ impl ServerLifetime {
                 expires_at: Instant::now() + CLIENT_GRACE,
                 session: Arc::new(CliSession {
                     session_token: session_token.to_owned(),
+                    cancellation: WorkspaceCancellation::new(),
+                    submission: AsyncMutex::new(Submission::default()),
+                    output: Arc::new(sprocket_agent::RunOutput::default()),
                 }),
             },
         );
@@ -86,7 +102,7 @@ impl ServerLifetime {
         let lease = state
             .clients
             .get_mut(client_id)
-            .ok_or_else(|| anyhow::anyhow!("CLI session was lost; retry the command"))?;
+            .ok_or_else(|| anyhow::anyhow!("CLI session was lost; the run was not resubmitted"))?;
         anyhow::ensure!(
             lease.session.session_token == session_token,
             "CLI client belongs to another session"
@@ -106,6 +122,7 @@ impl ServerLifetime {
                 lease.session.session_token == session_token,
                 "CLI client belongs to another session"
             );
+            lease.session.cancellation.cancel();
             state.clients.remove(client_id);
         }
         Ok(())
@@ -125,6 +142,7 @@ impl ServerLifetime {
             if lease.expires_at > now {
                 return true;
             }
+            lease.session.cancellation.cancel();
             expired.push(lease.session.session_token.clone());
             false
         });
@@ -153,31 +171,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn temporary_server_waits_for_all_clients_and_activity() {
+    fn temporary_server_waits_for_all_clients_and_runs() {
         let lifetime = ServerLifetime::new(true);
         let first = uuid::Uuid::new_v4().to_string();
         let second = uuid::Uuid::new_v4().to_string();
         lifetime.connect(&first, "a").unwrap();
         lifetime.connect(&second, "b").unwrap();
-        let activity = lifetime.run_guard().unwrap();
+        let run = lifetime.run_guard().unwrap();
         lifetime.release(&first, "a").unwrap();
         assert!(!lifetime.tick(Instant::now()).0);
         lifetime.release(&second, "b").unwrap();
         assert!(!lifetime.tick(Instant::now()).0);
-        drop(activity);
+        drop(run);
         assert!(lifetime.tick(Instant::now()).0);
         assert!(lifetime.connect(&first, "a").is_err());
     }
 
     #[test]
-    fn expired_clients_do_not_stop_a_shared_server() {
+    fn lost_clients_cancel_their_run_but_not_the_shared_server() {
         let lifetime = ServerLifetime::new(false);
         let id = uuid::Uuid::new_v4().to_string();
         lifetime.connect(&id, "a").unwrap();
+        let client = lifetime.client(&id, "a").unwrap();
         assert!(lifetime.client(&id, "b").is_err());
         let (stop, expired) = lifetime.tick(Instant::now() + CLIENT_GRACE);
         assert!(!stop);
         assert_eq!(expired, ["a"]);
+        assert!(client.cancellation.is_cancelled());
         assert!(lifetime.client(&id, "a").is_err());
     }
 }

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -207,6 +207,9 @@ pub(crate) async fn launch_agent(
                 let _ = start_result_sender.send(Ok((run_id.clone(), thread_id.clone())));
                 let mut transcript_watch = transcript_watchers.open(&user_id, &thread_id).await;
                 let result = run_agent(run, live, transcript).await;
+                if let Some(output) = &output {
+                    output.finish(result.as_ref().err().map(ToString::to_string));
+                }
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(30),
                     transcript_watch.wait_for_run(&run_id),
@@ -228,9 +231,6 @@ pub(crate) async fn launch_agent(
                 }
                 drop(artifact_watch);
                 drop(transcript_watch);
-                if let Some(output) = &output {
-                    output.finish(result.as_ref().err().map(ToString::to_string));
-                }
                 if let Err(error) = result {
                     eprintln!("sprocket-server: agent run failed: {error:#}");
                 }

--- a/crates/sprocket-server/src/routes/agent.rs
+++ b/crates/sprocket-server/src/routes/agent.rs
@@ -24,35 +24,39 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::auth::require_session_user;
+use crate::cli_protocol::RunStarted;
 use crate::routes::api_error::ApiError;
 
 const AGENT_START_TIMEOUT: Duration = Duration::from_secs(20);
 const AGENT_START_CLEANUP_TIMEOUT: Duration = Duration::from_secs(12);
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct RunAgentApiRequest {
-    user_id: String,
-    submission_id: String,
-    #[serde(default)]
-    thread_id: Option<String>,
-    #[serde(default)]
-    repository_key: Option<String>,
-    prompt: String,
-    storage_ids: Vec<String>,
-    selected_model: String,
-    reasoning_effort: String,
-    fast_mode: bool,
-    workspace_path: String,
-    #[serde(default)]
-    continuation_of_run_id: Option<String>,
+struct FinishedOnDrop(Option<Arc<sprocket_agent::RunOutput>>);
+
+impl Drop for FinishedOnDrop {
+    fn drop(&mut self) {
+        if let Some(finished) = &self.0 {
+            finished.finish(None);
+        }
+    }
 }
 
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct RunAgentStartResponse {
-    run_id: String,
-    thread_id: String,
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RunAgentApiRequest {
+    pub user_id: String,
+    pub submission_id: String,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    #[serde(default)]
+    pub repository_key: Option<String>,
+    pub prompt: String,
+    pub storage_ids: Vec<String>,
+    pub selected_model: String,
+    pub reasoning_effort: String,
+    pub fast_mode: bool,
+    pub workspace_path: String,
+    #[serde(default)]
+    pub continuation_of_run_id: Option<String>,
 }
 
 pub fn routes() -> axum::Router<AppState> {
@@ -66,10 +70,22 @@ async fn run_agent_handler(
     headers: HeaderMap,
     jar: CookieJar,
     Json(payload): Json<RunAgentApiRequest>,
-) -> Result<(StatusCode, Json<RunAgentStartResponse>), ApiError> {
+) -> Result<(StatusCode, Json<RunStarted>), ApiError> {
     require_session_user(&state.auth, &headers, &jar, &payload.user_id)
         .await
         .map_err(ApiError::unauthorized)?;
+    let started = launch_agent(state, payload, true, Default::default(), None).await?;
+    Ok((StatusCode::ACCEPTED, Json(started)))
+}
+
+pub(crate) async fn launch_agent(
+    state: AppState,
+    payload: RunAgentApiRequest,
+    allow_interaction: bool,
+    cancellation: sprocket_workspace::WorkspaceCancellation,
+    output: Option<Arc<sprocket_agent::RunOutput>>,
+) -> Result<RunStarted, ApiError> {
+    let guard = state.lifetime.run_guard().map_err(ApiError::bad_request)?;
     state
         .native_auth
         .require_user(&payload.user_id)
@@ -100,6 +116,8 @@ async fn run_agent_handler(
         .native_auth
         .auth_token_fetcher_for_user(payload.user_id.clone());
     let request = RunAgentRequest {
+        allow_interaction,
+        cancellation,
         deployment_url: state.convex_deployment_url.clone(),
         auth_token_fetcher: auth_token_fetcher.clone(),
         execution_secret: format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple()),
@@ -127,6 +145,8 @@ async fn run_agent_handler(
     // may drop this handler when the browser closes the tab; the executor must
     // still either run or durably reconcile the submitted run.
     tokio::spawn(async move {
+        let _guard = guard;
+        let _finished = FinishedOnDrop(output.clone());
         let run = await_agent_start(
             start_agent_run(request),
             AGENT_START_TIMEOUT,
@@ -140,7 +160,11 @@ async fn run_agent_handler(
         .await;
 
         match run {
-            Ok(run) => {
+            Ok(mut run) => {
+                if let Some(output) = &output {
+                    run.observe_output(Arc::clone(output), Arc::clone(&transcript))
+                        .await;
+                }
                 let run_id = run.run_id().to_string();
                 let thread_id = run.thread_id().to_string();
                 let user_id = run.user_id().to_string();
@@ -204,6 +228,9 @@ async fn run_agent_handler(
                 }
                 drop(artifact_watch);
                 drop(transcript_watch);
+                if let Some(output) = &output {
+                    output.finish(result.as_ref().err().map(ToString::to_string));
+                }
                 if let Err(error) = result {
                     eprintln!("sprocket-server: agent run failed: {error:#}");
                 }
@@ -226,10 +253,7 @@ async fn run_agent_handler(
             )
         })?
         .map_err(|error| ApiError::internal_with("failed to start agent run", anyhow!(error)))?;
-    Ok((
-        StatusCode::ACCEPTED,
-        Json(RunAgentStartResponse { run_id, thread_id }),
-    ))
+    Ok(RunStarted { run_id, thread_id })
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sprocket-server/src/routes/cli.rs
+++ b/crates/sprocket-server/src/routes/cli.rs
@@ -1,19 +1,29 @@
+mod models;
 #[cfg(test)]
 mod tests;
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
+use anyhow::Context;
 use axum::extract::{ConnectInfo, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::post;
 use axum::{Json, Router};
+use convex::Value;
+use serde::Deserialize;
 
 use crate::AppState;
 use crate::auth::bearer_token;
 use crate::cli_protocol::*;
 use crate::cli_sessions::CliSession;
+use crate::project_attachments::{AttachProjectRequest, repository_key_matches};
+use crate::routes::agent::{RunAgentApiRequest, launch_agent};
 use crate::routes::api_error::ApiError;
+use crate::thread_cache::CachedThreadRecord;
+use crate::transcript_client::UserConvexClient;
 
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
@@ -25,6 +35,10 @@ pub(crate) fn routes() -> Router<AppState> {
         .route("/cli/login", post(login))
         .route("/cli/auth", post(auth_status))
         .route("/cli/logout", post(logout))
+        .route("/cli/models", post(list_models))
+        .route("/cli/run", post(start))
+        .route("/cli/output", post(output))
+        .route("/cli/cancel", post(cancel))
 }
 
 async fn discovery(
@@ -222,5 +236,300 @@ async fn logout(
         .sign_out()
         .await
         .map_err(ApiError::bad_request)?;
+    Ok(Json(true))
+}
+
+async fn list_models(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<CliModelsResponse>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    let user = state
+        .native_auth
+        .browser_session(false)
+        .await
+        .map_err(ApiError::internal)?
+        .ok_or_else(ApiError::authentication_required)?
+        .user;
+    state
+        .auth
+        .bind_session_user(&client.session_token, &user.id)
+        .await
+        .map_err(ApiError::internal)?;
+    let rpc = convex_client(&state, &user.id)
+        .await
+        .map_err(ApiError::internal)?;
+    let context = tokio::time::timeout(Duration::from_secs(20), run_context(&rpc, None))
+        .await
+        .map_err(|error| ApiError::internal(error.into()))?
+        .map_err(ApiError::internal)?;
+    let response = models::available(&context)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(response))
+}
+
+async fn start(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliRunRequest>,
+) -> Result<Json<RunStarted>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    let result = tokio::spawn(async move {
+        let mut submission = client.submission.lock().await;
+        if let Some(previous) = &submission.request {
+            anyhow::ensure!(
+                previous == &request,
+                "a CLI submission cannot be reused with different arguments"
+            );
+            return submission
+                .result
+                .clone()
+                .context("submission result is missing")?
+                .map_err(anyhow::Error::msg);
+        }
+        submission.request = Some(request.clone());
+        let result = tokio::select! {
+            biased;
+            _ = client.cancellation.cancelled() => Err(anyhow::anyhow!("CLI run was cancelled before submission")),
+            result = tokio::time::timeout(Duration::from_secs(45), prepare_run(&state, &client, &request)) => {
+                result.context("CLI run preparation timed out").and_then(|result| result)
+            }
+        };
+        let result = match result {
+            Ok(payload) => {
+                submission.user_id = Some(payload.user_id.clone());
+                if client.cancellation.is_cancelled() {
+                    Err(anyhow::anyhow!("CLI run was cancelled before submission"))
+                } else {
+                    launch_agent(
+                        state,
+                        payload,
+                        false,
+                        client.cancellation.clone(),
+                        Some(Arc::clone(&client.output)),
+                    )
+                    .await
+                    .map_err(anyhow::Error::from)
+                }
+            }
+            Err(error) => Err(error),
+        };
+        submission.result = Some(
+            result
+                .as_ref()
+                .map(Clone::clone)
+                .map_err(ToString::to_string),
+        );
+        result
+    })
+    .await
+    .map_err(|error| ApiError::internal(error.into()))?;
+    result.map(Json).map_err(ApiError::bad_request)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RunContext {
+    gateway_url: String,
+    tier: String,
+    thread: Option<ThreadSettings>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ThreadSettings {
+    repository_key: String,
+    selected_model: String,
+    reasoning_effort: String,
+    fast_mode: bool,
+}
+
+#[derive(Deserialize)]
+struct Subscription {
+    tier: String,
+}
+
+async fn convex_client(state: &AppState, user_id: &str) -> anyhow::Result<UserConvexClient> {
+    state.native_auth.require_user(user_id).await?;
+    UserConvexClient::connect_with_fetcher(
+        &state.convex_deployment_url,
+        state
+            .native_auth
+            .auth_token_fetcher_for_user(user_id.to_owned()),
+    )
+    .await
+}
+
+async fn run_context(
+    rpc: &UserConvexClient,
+    thread_id: Option<&str>,
+) -> anyhow::Result<RunContext> {
+    let subscription: Subscription = rpc
+        .query("billing:getMySubscription", BTreeMap::new())
+        .await?;
+    let thread = match thread_id {
+        Some(thread_id) => {
+            let args = BTreeMap::from([(
+                "selectedThreadId".into(),
+                Value::String(thread_id.to_owned()),
+            )]);
+            let threads: Vec<CachedThreadRecord> = rpc.query("threads:listRecent", args).await?;
+            let thread = threads
+                .into_iter()
+                .find(|thread| thread.id == thread_id)
+                .context("thread not found")?;
+            Some(ThreadSettings {
+                repository_key: thread
+                    .repository_key
+                    .context("thread has no repository key")?,
+                selected_model: thread.selected_model,
+                reasoning_effort: thread.reasoning_effort,
+                fast_mode: thread.fast_mode,
+            })
+        }
+        None => None,
+    };
+    Ok(RunContext {
+        gateway_url: models::gateway_url()?,
+        tier: subscription.tier,
+        thread,
+    })
+}
+
+async fn prepare_run(
+    state: &AppState,
+    client: &CliSession,
+    request: &CliRunRequest,
+) -> anyhow::Result<RunAgentApiRequest> {
+    anyhow::ensure!(!request.prompt.trim().is_empty(), "prompt is empty");
+    let user = state
+        .native_auth
+        .browser_session(false)
+        .await?
+        .context("not signed in; run sprocket login")?
+        .user;
+    state
+        .auth
+        .bind_session_user(&client.session_token, &user.id)
+        .await?;
+    let rpc = convex_client(state, &user.id).await?;
+    let context = tokio::time::timeout(
+        Duration::from_secs(20),
+        run_context(&rpc, request.thread_id.as_deref()),
+    )
+    .await??;
+    let attachment = state
+        .project_attachments
+        .attach(AttachProjectRequest {
+            workspace_path: request.directory.clone(),
+            replace_workspace_path: None,
+        })
+        .await?;
+    if let Some(thread) = &context.thread {
+        anyhow::ensure!(
+            repository_key_matches(&attachment, &thread.repository_key),
+            "thread belongs to a different repository"
+        );
+    }
+    let settings = models::resolve(&context, request).await?;
+    Ok(RunAgentApiRequest {
+        user_id: user.id,
+        submission_id: format!("cli:{}", request.client_id),
+        thread_id: request.thread_id.clone(),
+        repository_key: request
+            .thread_id
+            .is_none()
+            .then_some(attachment.repository_key),
+        prompt: request.prompt.clone(),
+        storage_ids: Vec::new(),
+        selected_model: settings.model,
+        reasoning_effort: settings.reasoning,
+        fast_mode: settings.fast,
+        workspace_path: attachment.workspace_path,
+        continuation_of_run_id: None,
+    })
+}
+
+async fn output(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliOutputRequest>,
+) -> Result<Json<CliRunSnapshot>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    let (started, user_id) = {
+        let submission = client.submission.lock().await;
+        let started = submission
+            .result
+            .as_ref()
+            .and_then(|result| result.as_ref().ok())
+            .cloned()
+            .ok_or_else(|| ApiError::bad_request(anyhow::anyhow!("CLI run has not started")))?;
+        (started, submission.user_id.clone().unwrap_or_default())
+    };
+    state
+        .auth
+        .require_session_user(&client.session_token, &user_id)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    let mut changed = client.output.subscribe();
+    let revision = *changed.borrow_and_update();
+    if request.after_revision == Some(revision) {
+        let _ = tokio::time::timeout(Duration::from_secs(15), changed.changed()).await;
+    }
+    state
+        .auth
+        .require_session_user(&client.session_token, &user_id)
+        .await
+        .map_err(ApiError::unauthorized)?;
+    let snapshot = client
+        .output
+        .page(request.after_part)
+        .await
+        .map_err(ApiError::bad_request)?;
+    let live = state
+        .live_completions
+        .snapshot(&started.thread_id)
+        .filter(|live| live.run_id == started.run_id);
+    Ok(Json(CliRunSnapshot {
+        run_id: started.run_id,
+        thread_id: started.thread_id,
+        revision: snapshot.revision,
+        answer: snapshot.answer,
+        status: snapshot
+            .outcome
+            .as_ref()
+            .map(|outcome| outcome.status.clone())
+            .unwrap_or_else(|| "running".into()),
+        error: match (
+            snapshot.outcome.and_then(|outcome| outcome.error),
+            snapshot.output_error,
+        ) {
+            (Some(run_error), Some(output_error)) => Some(format!("{run_error}\n{output_error}")),
+            (run_error, output_error) => run_error.or(output_error),
+        },
+        parts: snapshot.parts,
+        has_more: snapshot.has_more,
+        execution_finished: snapshot.finished,
+        live,
+    }))
+}
+
+async fn cancel(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(request): Json<CliClientRequest>,
+) -> Result<Json<bool>, ApiError> {
+    let client = client_session(&state, peer, &headers, &request.client_id).await?;
+    client.cancellation.cancel();
+    state
+        .native_auth
+        .cancel_device_login(&client.session_token)
+        .await;
     Ok(Json(true))
 }

--- a/crates/sprocket-server/src/routes/cli/models.rs
+++ b/crates/sprocket-server/src/routes/cli/models.rs
@@ -140,6 +140,7 @@ fn select(
     request: &CliRunRequest,
 ) -> anyhow::Result<Settings> {
     validate(&catalog)?;
+    let model_overridden = request.model.is_some();
     let inherited_model = request.model.clone().or_else(|| {
         context
             .thread
@@ -170,13 +171,17 @@ fn select(
         .reasoning
         .clone()
         .or_else(|| {
-            context
-                .thread
-                .as_ref()
-                .map(|thread| thread.reasoning_effort.clone())
+            if model_overridden {
+                None
+            } else {
+                context
+                    .thread
+                    .as_ref()
+                    .map(|thread| thread.reasoning_effort.clone())
+            }
         })
         .unwrap_or_else(|| {
-            if uses_tier_fallback {
+            if model_overridden || uses_tier_fallback {
                 entry.default_reasoning_effort.clone()
             } else {
                 catalog.default_reasoning_effort.clone()
@@ -284,5 +289,35 @@ mod tests {
         assert_eq!(settings.reasoning, "xhigh");
 
         assert!(available_for_tier(catalog(), "unknown").is_err());
+    }
+
+    #[test]
+    fn model_override_uses_the_selected_models_reasoning_default() {
+        let settings = select(
+            catalog(),
+            &RunContext {
+                gateway_url: String::new(),
+                tier: "paid".into(),
+                thread: Some(super::super::ThreadSettings {
+                    repository_key: "repo".into(),
+                    selected_model: "default".into(),
+                    reasoning_effort: "high".into(),
+                    fast_mode: false,
+                }),
+            },
+            &CliRunRequest {
+                client_id: "client".into(),
+                prompt: "task".into(),
+                directory: "/tmp".into(),
+                thread_id: Some("thread".into()),
+                model: Some("paid".into()),
+                reasoning: None,
+                fast: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(settings.model, "paid");
+        assert_eq!(settings.reasoning, "max");
     }
 }

--- a/crates/sprocket-server/src/routes/cli/models.rs
+++ b/crates/sprocket-server/src/routes/cli/models.rs
@@ -1,0 +1,288 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Context;
+use serde::Deserialize;
+
+use super::{CliRunRequest, RunContext};
+use crate::cli_protocol::{CliModel, CliModelsResponse};
+
+#[derive(Deserialize)]
+struct Response {
+    sprocket: Catalog,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Catalog {
+    protocol_version: u32,
+    default_model_id: String,
+    default_reasoning_effort: String,
+    models: Vec<Model>,
+    tier_allowed_models: HashMap<String, Vec<String>>,
+    tier_allowed_service_tiers: HashMap<String, Vec<String>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Model {
+    id: String,
+    label: String,
+    reasoning_efforts: Vec<String>,
+    default_reasoning_effort: String,
+    service_tiers: Vec<String>,
+}
+
+pub(super) struct Settings {
+    pub model: String,
+    pub reasoning: String,
+    pub fast: bool,
+}
+
+pub(super) fn gateway_url() -> anyhow::Result<String> {
+    let url = std::env::var("PUBLIC_MODEL_GATEWAY_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .or_else(|| {
+            crate::repo_env::compile_time_env_var("PUBLIC_MODEL_GATEWAY_URL").map(str::to_owned)
+        })
+        .filter(|url| !url.trim().is_empty())
+        .context("PUBLIC_MODEL_GATEWAY_URL must be set for model discovery")?;
+    Ok(url.trim().trim_end_matches('/').to_owned())
+}
+
+pub(super) async fn resolve(
+    context: &RunContext,
+    request: &CliRunRequest,
+) -> anyhow::Result<Settings> {
+    let catalog = fetch(&context.gateway_url).await?;
+    select(catalog, context, request)
+}
+
+pub(super) async fn available(context: &RunContext) -> anyhow::Result<CliModelsResponse> {
+    available_for_tier(fetch(&context.gateway_url).await?, &context.tier)
+}
+
+async fn fetch(gateway_url: &str) -> anyhow::Result<Catalog> {
+    let response: Response = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()?
+        .get(format!(
+            "{}/api/v1/models",
+            gateway_url.trim_end_matches('/')
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await
+        .context("invalid model catalog")?;
+    validate(&response.sprocket)?;
+    Ok(response.sprocket)
+}
+
+fn validate(catalog: &Catalog) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        catalog.protocol_version == 1,
+        "unsupported model catalog protocol"
+    );
+    Ok(())
+}
+
+fn available_for_tier(catalog: Catalog, tier: &str) -> anyhow::Result<CliModelsResponse> {
+    validate(&catalog)?;
+    let allowed = allowed_models(&catalog, tier)?;
+    let default_model_id = default_model_for_tier(&catalog, allowed)?.id.clone();
+    let models: Vec<CliModel> = catalog
+        .models
+        .iter()
+        .filter(|model| allowed.contains(&model.id))
+        .map(|model| CliModel {
+            id: model.id.clone(),
+            label: model.label.clone(),
+            reasoning_efforts: model.reasoning_efforts.clone(),
+            default_reasoning_effort: model.default_reasoning_effort.clone(),
+        })
+        .collect();
+    Ok(CliModelsResponse {
+        default_model_id,
+        models,
+    })
+}
+
+fn allowed_models<'a>(catalog: &'a Catalog, tier: &str) -> anyhow::Result<&'a [String]> {
+    catalog
+        .tier_allowed_models
+        .get(tier)
+        .map(Vec::as_slice)
+        .context("model catalog does not define this account tier")
+}
+
+fn default_model_for_tier<'a>(
+    catalog: &'a Catalog,
+    allowed: &[String],
+) -> anyhow::Result<&'a Model> {
+    catalog
+        .models
+        .iter()
+        .find(|model| model.id == catalog.default_model_id && allowed.contains(&model.id))
+        .or_else(|| {
+            allowed
+                .iter()
+                .find_map(|id| catalog.models.iter().find(|model| model.id == *id))
+        })
+        .context("no models are available for this account")
+}
+
+fn select(
+    catalog: Catalog,
+    context: &RunContext,
+    request: &CliRunRequest,
+) -> anyhow::Result<Settings> {
+    validate(&catalog)?;
+    let inherited_model = request.model.clone().or_else(|| {
+        context
+            .thread
+            .as_ref()
+            .map(|thread| thread.selected_model.clone())
+    });
+    let allowed = allowed_models(&catalog, &context.tier)?;
+    let uses_tier_fallback =
+        inherited_model.is_none() && !allowed.contains(&catalog.default_model_id);
+    let model = match inherited_model {
+        Some(model) => model,
+        None => default_model_for_tier(&catalog, allowed)?.id.clone(),
+    };
+    let fast = request
+        .fast
+        .or_else(|| context.thread.as_ref().map(|thread| thread.fast_mode))
+        .unwrap_or(false);
+    let entry = catalog
+        .models
+        .iter()
+        .find(|entry| entry.id == model)
+        .with_context(|| format!("unknown model {model}"))?;
+    anyhow::ensure!(
+        allowed.contains(&model),
+        "model {model} is unavailable for this account"
+    );
+    let reasoning = request
+        .reasoning
+        .clone()
+        .or_else(|| {
+            context
+                .thread
+                .as_ref()
+                .map(|thread| thread.reasoning_effort.clone())
+        })
+        .unwrap_or_else(|| {
+            if uses_tier_fallback {
+                entry.default_reasoning_effort.clone()
+            } else {
+                catalog.default_reasoning_effort.clone()
+            }
+        });
+    anyhow::ensure!(
+        entry.reasoning_efforts.contains(&reasoning),
+        "reasoning level {reasoning} is unavailable for {model}"
+    );
+    if fast {
+        anyhow::ensure!(
+            entry.service_tiers.iter().any(|tier| tier == "fast")
+                && catalog
+                    .tier_allowed_service_tiers
+                    .get(&context.tier)
+                    .is_some_and(|tiers| tiers.iter().any(|tier| tier == "fast")),
+            "fast mode is unavailable for this model or account"
+        );
+    }
+    Ok(Settings {
+        model,
+        reasoning,
+        fast,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn catalog() -> Catalog {
+        serde_json::from_value(serde_json::json!({
+            "protocolVersion": 1, "defaultModelId": "default", "defaultReasoningEffort": "high",
+            "models": [
+                {"id": "default", "label": "Default", "reasoningEfforts": ["medium", "high"], "defaultReasoningEffort": "high", "serviceTiers": ["standard", "fast"]},
+                {"id": "paid", "label": "Paid", "reasoningEfforts": ["max"], "defaultReasoningEffort": "max", "serviceTiers": ["standard"]},
+                {"id": "paid-first", "label": "Paid First", "reasoningEfforts": ["xhigh"], "defaultReasoningEffort": "xhigh", "serviceTiers": ["standard"]}
+            ],
+            "tierAllowedModels": {"free": ["default"], "paid": ["stale", "paid-first", "paid"]}, "tierAllowedServiceTiers": {"free": ["standard"]}
+        })).unwrap()
+    }
+
+    #[test]
+    fn defaults_do_not_enable_fast_and_invalid_overrides_never_fall_back() {
+        let context = RunContext {
+            gateway_url: String::new(),
+            tier: "free".into(),
+            thread: None,
+        };
+        let mut request = CliRunRequest {
+            client_id: "client".into(),
+            prompt: "task".into(),
+            directory: "/tmp".into(),
+            thread_id: None,
+            model: None,
+            reasoning: None,
+            fast: None,
+        };
+        assert!(!select(catalog(), &context, &request).unwrap().fast);
+        request.fast = Some(true);
+        assert!(select(catalog(), &context, &request).is_err());
+        request.fast = None;
+        request.model = Some("missing".into());
+        assert!(select(catalog(), &context, &request).is_err());
+        request.model = None;
+        request.reasoning = Some("unsupported".into());
+        assert!(select(catalog(), &context, &request).is_err());
+    }
+
+    #[test]
+    fn tier_filtering_uses_the_same_default_for_listing_and_runs() {
+        let response = available_for_tier(catalog(), "free").unwrap();
+        assert_eq!(response.default_model_id, "default");
+        assert_eq!(
+            response.models,
+            [CliModel {
+                id: "default".into(),
+                label: "Default".into(),
+                reasoning_efforts: vec!["medium".into(), "high".into()],
+                default_reasoning_effort: "high".into(),
+            }]
+        );
+        let paid = available_for_tier(catalog(), "paid").unwrap();
+        assert_eq!(paid.default_model_id, "paid-first");
+
+        let settings = select(
+            catalog(),
+            &RunContext {
+                gateway_url: String::new(),
+                tier: "paid".into(),
+                thread: None,
+            },
+            &CliRunRequest {
+                client_id: "client".into(),
+                prompt: "task".into(),
+                directory: "/tmp".into(),
+                thread_id: None,
+                model: None,
+                reasoning: None,
+                fast: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(settings.model, "paid-first");
+        assert_eq!(settings.reasoning, "xhigh");
+
+        assert!(available_for_tier(catalog(), "unknown").is_err());
+    }
+}

--- a/crates/sprocket-server/src/routes/cli/tests.rs
+++ b/crates/sprocket-server/src/routes/cli/tests.rs
@@ -4,8 +4,70 @@ use axum::http::Request;
 use tower::ServiceExt;
 
 #[tokio::test]
+async fn output_waits_for_local_execution_and_never_needs_a_backend_connection() {
+    let (_directory, state, token, request) = fixture().await;
+    let client = state.lifetime.client(&request.client_id, &token).unwrap();
+    client.output.initialize(
+        Arc::clone(&state.transcript),
+        "user".into(),
+        "thread".into(),
+        "run".into(),
+    );
+    state.auth.bind_session_user(&token, "user").await.unwrap();
+    {
+        let mut submission = client.submission.lock().await;
+        submission.user_id = Some("user".into());
+        submission.result = Some(Ok(RunStarted {
+            run_id: "run".into(),
+            thread_id: "thread".into(),
+        }));
+    }
+    let request = CliOutputRequest {
+        client_id: request.client_id,
+        after_part: -1,
+        after_revision: None,
+    };
+    let first = call(&state, &token, "output", &request, "127.0.0.1:1000").await;
+    assert_eq!(first.0, StatusCode::OK);
+    assert_eq!(first.1["status"], "running");
+    let mut request = request;
+    request.after_revision = first.1["revision"].as_u64();
+    let terminal = {
+        let waiting = call(&state, &token, "output", &request, "127.0.0.1:1000");
+        tokio::pin!(waiting);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut waiting)
+                .await
+                .is_err()
+        );
+        client
+            .output
+            .finish(Some("unconfirmed finalization".into()));
+        tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .unwrap()
+    };
+    assert_eq!(terminal.0, StatusCode::OK);
+    assert_eq!(terminal.1["status"], "unknown");
+    assert_eq!(terminal.1["executionFinished"], true);
+    assert_eq!(terminal.1["answer"], "");
+    request.after_revision = None;
+    state
+        .auth
+        .bind_session_user(&token, "other-user")
+        .await
+        .unwrap();
+    assert_eq!(
+        call(&state, &token, "output", &request, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
 async fn signed_bootstrap_and_cli_sessions_cannot_be_replayed_after_server_restart() {
-    let (directory, mut state, _, existing) = fixture().await;
+    let (directory, mut state, _, run) = fixture().await;
     let challenge = "fresh-challenge";
     let (status, discovered) = call(
         &state,
@@ -93,13 +155,15 @@ async fn signed_bootstrap_and_cli_sessions_cannot_be_replayed_after_server_resta
             .unwrap()
             .contains(&request.session_token)
     );
-    request.client.client_id = existing.client_id;
+    let original_client_id = request.client.client_id.clone();
+    request.client.client_id = run.client_id;
     assert_eq!(
         call(&state, "", "bootstrap", &request, "127.0.0.1:1000")
             .await
             .0,
         StatusCode::UNAUTHORIZED
     );
+    request.client.client_id = original_client_id;
     state.auth = crate::auth::AuthState::load(directory.path()).unwrap();
     assert_ne!(state.auth.instance_id, discovered.instance_id);
     assert!(
@@ -117,7 +181,7 @@ async fn signed_bootstrap_and_cli_sessions_cannot_be_replayed_after_server_resta
     );
 }
 
-async fn fixture() -> (tempfile::TempDir, AppState, String, CliClientRequest) {
+async fn fixture() -> (tempfile::TempDir, AppState, String, CliRunRequest) {
     let directory = tempfile::tempdir().unwrap();
     let auth = crate::auth::AuthState::load(directory.path()).unwrap();
     let (_, token) = auth.bootstrap(auth.pairing_credential()).await.unwrap();
@@ -134,8 +198,14 @@ async fn fixture() -> (tempfile::TempDir, AppState, String, CliClientRequest) {
         true,
         crate::package_update::PackageUpdateManager::disabled(),
     );
-    let request = CliClientRequest {
+    let request = CliRunRequest {
         client_id: uuid::Uuid::new_v4().to_string(),
+        prompt: "task".into(),
+        directory: directory.path().display().to_string(),
+        thread_id: None,
+        model: None,
+        reasoning: None,
+        fast: None,
     };
     state.lifetime.connect(&request.client_id, &token).unwrap();
     (directory, state, token, request)
@@ -169,12 +239,87 @@ async fn call(
 }
 
 #[tokio::test]
-async fn cli_control_requires_the_owning_local_session_and_matching_version() {
+async fn concurrent_retries_recover_the_same_submission_and_reject_argument_changes() {
     let (_directory, state, token, request) = fixture().await;
+    let client = state.lifetime.client(&request.client_id, &token).unwrap();
+    {
+        let mut submission = client.submission.lock().await;
+        submission.request = Some(request.clone());
+        submission.result = Some(Ok(RunStarted {
+            run_id: "run".into(),
+            thread_id: "thread".into(),
+        }));
+    }
+    let (first, second) = tokio::join!(
+        call(&state, &token, "run", &request, "127.0.0.1:1000"),
+        call(&state, &token, "run", &request, "127.0.0.1:1001"),
+    );
+    assert_eq!(first, second);
+    assert_eq!(first.0, StatusCode::OK);
+    assert_eq!(first.1["runId"], "run");
+    let mut changed = request;
+    changed.prompt = "different task".into();
     assert_eq!(
-        call(&state, &token, "heartbeat", &request, "192.168.1.10:1000")
+        call(&state, &token, "run", &changed, "127.0.0.1:1000")
             .await
             .0,
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn cancellation_before_submission_is_cached_and_release_invalidates_pairing() {
+    let (_directory, state, token, request) = fixture().await;
+    let client_request = CliClientRequest {
+        client_id: request.client_id.clone(),
+    };
+    assert_eq!(
+        call(&state, &token, "cancel", &client_request, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::OK
+    );
+    let first = call(&state, &token, "run", &request, "127.0.0.1:1000").await;
+    let second = call(&state, &token, "run", &request, "127.0.0.1:1000").await;
+    assert_eq!(first, second);
+    assert_eq!(first.0, StatusCode::BAD_REQUEST);
+    assert!(first.1["error"].as_str().unwrap().contains("cancelled"));
+    assert_eq!(
+        call(&state, &token, "release", &client_request, "127.0.0.1:1000")
+            .await
+            .0,
+        StatusCode::OK
+    );
+    assert_eq!(
+        call(
+            &state,
+            &token,
+            "heartbeat",
+            &client_request,
+            "127.0.0.1:1000"
+        )
+        .await
+        .0,
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn cli_control_requires_the_owning_local_session_and_matching_version() {
+    let (_directory, state, token, request) = fixture().await;
+    let client_request = CliClientRequest {
+        client_id: request.client_id.clone(),
+    };
+    assert_eq!(
+        call(
+            &state,
+            &token,
+            "cancel",
+            &client_request,
+            "192.168.1.10:1000"
+        )
+        .await
+        .0,
         StatusCode::FORBIDDEN
     );
     let (_, other_token) = state
@@ -186,8 +331,8 @@ async fn cli_control_requires_the_owning_local_session_and_matching_version() {
         call(
             &state,
             &other_token,
-            "heartbeat",
-            &request,
+            "cancel",
+            &client_request,
             "127.0.0.1:1000"
         )
         .await


### PR DESCRIPTION
## Summary

- Add `sprocket run` with local-directory execution, thread follow-ups, model and reasoning overrides, Fast mode selection, timeouts, and signal cancellation.
- Add `sprocket run --list-models` for the models and reasoning efforts available to the signed-in account.
- Reuse the existing agent launcher while removing interactive question and mandate-setup tools from noninteractive CLI runs.
- Stream progress from the local transcript cache and live-completion hub. Write progress to stderr and the confirmed final answer to stdout.
- Return committed terminal outcomes from finalization without adding a Convex polling loop or new stored schema.

This is 3 of 3 PRs split from #364 and is stacked on #371.

## Validation

- `cargo test -j 1 -p sprocket-agent -p sprocket-server -p sprocket-cli`
- Repository formatting, lint, and type checks through the pre-commit suite
- Full web tests and build are being rerun on this stack and in CI

No paid agent run was attempted.

## Rollout

Deploy the optional finalization response support before releasing the CLI. Existing callers keep the boolean response unless they request output.

Written by GPT-5.6 Sol (gpt-5.6-sol) through Sprocket.







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63587797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the previous model-override finding is resolved and no new actionable issue remains.

<details open><summary><h3>Summary</h3></summary>

- Adds `sprocket run` with new-thread and follow-up execution, model/reasoning overrides, Fast mode, timeouts, and signal cancellation.
- Streams transient and cached transcript progress to stderr while emitting the committed final answer to stdout.
- Restricts interactive-only tools during CLI runs.
- Extends Convex finalization responses so opted-in executors receive the committed terminal outcome while existing callers retain boolean responses.
- Correctly uses the selected model's default reasoning effort when `--model` overrides an inherited thread model.
- Adds coverage for model selection, CLI routing, output observation, and finalization races.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Terminal user
    participant C as sprocket CLI
    participant S as Local server
    participant A as Agent runtime
    participant X as Convex
    participant T as Transcript/live output

    U->>C: sprocket run [options] prompt
    C->>S: Authenticated CLI run request
    S->>X: Resolve thread and model settings
    S->>A: Launch noninteractive agent
    A->>X: Create/recover and claim run
    loop Model and tool work
        A->>X: Persist lifecycle and transcript updates
        A->>T: Publish live completion updates
        T-->>C: Progress events
        C-->>U: Progress on stderr
    end
    A->>X: Request terminal finalization
    X-->>A: Committed terminal outcome
    A-->>S: Finish output observer
    S-->>C: Final status and cached answer
    C-->>U: Final answer on stdout
```
</details>

<sub>Reviews (4) · Last reviewed commit: ["fix(cli): Preserve completed run results"](https://github.com/spikonado/sprocket/commit/7385b76ab9e683acec5b526e272b52ca9b17c204)</sub>

<!-- /greptile_comment -->